### PR TITLE
chore(shapes): sync clinical v1.9 from spec — permit AIExtracted provenance

### DIFF
--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -18,7 +18,7 @@
 #   No vocabulary additions; no row change.
 core=3.3
 health=2.4
-clinical=1.8
+clinical=1.9
 coverage=1.3
 checkup=3.2
 pots=1.4

--- a/src/shapes/clinical.shapes.ttl
+++ b/src/shapes/clinical.shapes.ttl
@@ -12,6 +12,14 @@
 # Apple HealthKit. Shapes accept multiple provenance values to support
 # different data sources (EHR, device, patient-reported).
 #
+# Changelog:
+# v1.9 (2026-06-17): Add cascade:AIExtracted to every dataProvenance sh:in enum.
+#     AIExtracted (a ClinicalGenerated subclass, core v3.3) was defined and
+#     referenced by the v3.0 AI-extraction infrastructure, but the validation
+#     enums omitted it — so a record carrying the correct provenance for
+#     AI-extracted clinical data failed validation. Clinical records may now be
+#     AIExtracted (e.g. from the Workbench's document-extraction pipeline).
+#
 # ============================================================================
 
 # ============================================================================
@@ -112,7 +120,7 @@ clinical:ClinicalDocumentShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en ;
@@ -367,7 +375,7 @@ clinical:MedicationShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en ;
@@ -570,7 +578,7 @@ clinical:AllergyShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en
@@ -648,7 +656,7 @@ clinical:LabResultShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en
@@ -727,7 +735,7 @@ clinical:ConditionShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en
@@ -814,7 +822,7 @@ clinical:ImmunizationShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en
@@ -903,7 +911,7 @@ clinical:ProcedureShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en
@@ -993,7 +1001,7 @@ clinical:VitalSignShape a sh:NodeShape ;
     # Required: provenance (accepts multiple valid sources)
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en
@@ -1173,7 +1181,7 @@ clinical:MedicationUseEpisodeShape a sh:NodeShape ;
     # Required: provenance
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:Reconciled) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:Reconciled cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en ;
@@ -1311,7 +1319,7 @@ clinical:SupplementShape a sh:NodeShape ;
     # Required: provenance
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en

--- a/src/shapes/clinical.ttl
+++ b/src/shapes/clinical.ttl
@@ -20,8 +20,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-03-28"^^xsd:date ;
-    owl:versionInfo "1.8" ;
+    dct:modified "2026-06-17"^^xsd:date ;
+    owl:versionInfo "1.9" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -1297,6 +1297,15 @@ clinical:isActive a owl:DatatypeProperty ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.9 (2026-06-17)
+# - SHACL: added cascade:AIExtracted to every dataProvenance sh:in enum in
+#   clinical.shapes.ttl. AIExtracted (ClinicalGenerated subclass, core v3.3)
+#   was defined and referenced by the v3.0 AI-extraction infrastructure
+#   (AIExtractionActivity, extractionConfidence, sourceNarrativeSection,
+#   requiresUserReview) but the validation enums omitted it, so a clinical
+#   record carrying the correct provenance for AI-extracted data failed
+#   validation. No ontology classes/properties changed (shapes-only).
 #
 # Version 1.8 (2026-03-28)
 # - Added clinical:SocialHistoryRecord class (EHR-extracted social history)


### PR DESCRIPTION
Syncs `clinical.shapes.ttl` + `clinical.ttl` from spec `vocab/clinical-v1.9` (the-cascade-protocol/spec#2): every `cascade:dataProvenance` `sh:in` enum now includes `cascade:AIExtracted`, so a clinical record carrying AI-extraction provenance validates.

`VOCAB_VERSIONS` clinical `1.8 → 1.9`. `check-downstream-versions.sh` reports cascade-cli up to date with spec for clinical.

**Verified:** against a rebuilt local cli, a Metformin record that failed as `AIExtracted` on the old shapes now passes. Full test suite: 859 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)