### PR TITLE
feat(cli): route AIExtractionActivity + SocialHistoryRecord to their own pod files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.11] - 2026-06-17
+
+### Added
+
+- **`cascade:AIExtractionActivity` now routes to `clinical/ai-extraction-activities.ttl`.** When `cascade pod import` ingests an AI-extraction Turtle batch (a clinical record plus the `cascade:AIExtractionActivity` it links to via `prov:wasGeneratedBy`), the activity node previously fell through to the `fhir-passthrough` bucket because it had no `DATA_TYPES` route. That mis-filed the activity as a FHIR resource and, as a side effect, wrote a `solid:forClass fhir:` registration into `settings/publicTypeIndex.ttl` using a `fhir:` prefix that file never declares, leaving the type index unparseable. The activity now has its own registry entry, so it lands in `clinical/ai-extraction-activities.ttl`, registers cleanly, and is queryable via `pod query --all`. (Needed by the Cascade Workbench document-extraction write path.)
+- **`clinical:SocialHistoryRecord` now routes to `clinical/social-history.ttl`.** Same class of bug: social-history records had no `DATA_TYPES` route and fell to `fhir-passthrough`. They now route to their own file and register cleanly.
+
+### Shapes
+
+- Synced clinical v1.9 from spec (`vocab/clinical-v1.9`): every `dataProvenance` `sh:in` enum now includes `cascade:AIExtracted`, so a clinical record carrying AI-extraction provenance validates. `VOCAB_VERSIONS` clinical 1.8 -> 1.9.
+
 ## [0.5.10] - 2026-06-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"

--- a/src/commands/pod/helpers.ts
+++ b/src/commands/pod/helpers.ts
@@ -165,6 +165,18 @@ export const DATA_TYPES: Record<string, DataTypeInfo> = {
     directory: 'clinical',
     filename: 'benefits.ttl',
   },
+  'social-history': {
+    label: 'Social History',
+    rdfTypes: [CASCADE_NAMESPACES.clinical + 'SocialHistoryRecord'],
+    directory: 'clinical',
+    filename: 'social-history.ttl',
+  },
+  'ai-extraction-activities': {
+    label: 'AI Extraction Activities',
+    rdfTypes: [CASCADE_NAMESPACES.cascade + 'AIExtractionActivity'],
+    directory: 'clinical',
+    filename: 'ai-extraction-activities.ttl',
+  },
   'fhir-passthrough': {
     label: 'FHIR Passthrough',
     rdfTypes: ['http://hl7.org/fhir/'],

--- a/tests/pod-import.test.ts
+++ b/tests/pod-import.test.ts
@@ -316,6 +316,88 @@ describe('pod import', () => {
     expect(content).toContain('@prefix');
   });
 
+  // ─── Test 6b: AI extraction activity routes to its own file, not passthrough ─
+
+  it('should route cascade:AIExtractionActivity to clinical/ai-extraction-activities.ttl', async () => {
+    // An AI-extraction Turtle batch: a clinical:Medication record carrying
+    // AIExtracted provenance + an AIExtractionActivity it links to. The activity
+    // must NOT land in fhir-passthrough (a non-FHIR class that also poisons the
+    // publicTypeIndex with an undeclared `fhir:` prefix).
+    const ttl = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:cascade:ai-activity:batch-1> a cascade:AIExtractionActivity ;
+    cascade:extractionModel "qwen3.5-4b-q4_k_m" ;
+    cascade:extractionConfidence "0.92"^^xsd:decimal ;
+    cascade:sourceNarrativeSection "medications" ;
+    cascade:requiresUserReview false .
+
+<urn:cascade:ai:medications-1> a clinical:Medication ;
+    clinical:drugName "Metformin 500mg" ;
+    cascade:dataProvenance cascade:AIExtracted ;
+    cascade:schemaVersion "1.9" ;
+    prov:wasGeneratedBy <urn:cascade:ai-activity:batch-1> .
+`;
+    const ttlPath = path.join(tempDir, 'ai-extraction.ttl');
+    await fs.writeFile(ttlPath, ttl, 'utf-8');
+
+    runCli(`pod import ${podDir} ${ttlPath} --source-system workbench-ai`);
+
+    // The activity lands in its own file...
+    const activityFile = path.join(podDir, 'clinical', 'ai-extraction-activities.ttl');
+    expect(existsSync(activityFile)).toBe(true);
+    const activityContent = await fs.readFile(activityFile, 'utf-8');
+    expect(activityContent).toContain('AIExtractionActivity');
+    expect(activityContent).toContain('qwen3.5-4b-q4_k_m');
+
+    // ...and NOT in fhir-passthrough.
+    const passthroughFile = path.join(podDir, 'clinical', 'fhir-passthrough.ttl');
+    expect(existsSync(passthroughFile)).toBe(false);
+
+    // The medication record routes to medications.ttl, carrying AIExtracted.
+    const medFile = path.join(podDir, 'clinical', 'medications.ttl');
+    expect(existsSync(medFile)).toBe(true);
+    const medContent = await fs.readFile(medFile, 'utf-8');
+    expect(medContent).toContain('AIExtracted');
+    expect(medContent).toContain('wasGeneratedBy');
+
+    // The publicTypeIndex stays parseable (no undeclared `fhir:` prefix).
+    const publicIndex = await fs.readFile(
+      path.join(podDir, 'settings', 'publicTypeIndex.ttl'),
+      'utf-8',
+    );
+    expect(publicIndex).not.toContain('solid:forClass fhir:');
+    expect(publicIndex).toContain('ai-extraction-activities.ttl');
+  });
+
+  // ─── Test 6c: SocialHistoryRecord routes to its own file, not passthrough ───
+
+  it('should route clinical:SocialHistoryRecord to clinical/social-history.ttl', async () => {
+    const ttl = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+
+<urn:cascade:ai:socialHistory-1> a clinical:SocialHistoryRecord ;
+    clinical:socialHistoryCategory "smokingStatus" ;
+    cascade:dataProvenance cascade:AIExtracted ;
+    cascade:schemaVersion "1.9" .
+`;
+    const ttlPath = path.join(tempDir, 'social.ttl');
+    await fs.writeFile(ttlPath, ttl, 'utf-8');
+
+    runCli(`pod import ${podDir} ${ttlPath} --source-system workbench-ai`);
+
+    const socialFile = path.join(podDir, 'clinical', 'social-history.ttl');
+    expect(existsSync(socialFile)).toBe(true);
+    const content = await fs.readFile(socialFile, 'utf-8');
+    expect(content).toContain('SocialHistoryRecord');
+    expect(content).toContain('smokingStatus');
+
+    // Not misfiled as a FHIR passthrough resource.
+    expect(existsSync(path.join(podDir, 'clinical', 'fhir-passthrough.ttl'))).toBe(false);
+  });
+
   // ─── Test 7: index.ttl gets ldp:contains entries for new files ─────────────
 
   it('should append ldp:contains references to index.ttl', async () => {


### PR DESCRIPTION
## What

`cascade pod import` routes each imported subject to a canonical pod file by its
rdf:type (the `DATA_TYPES` registry). Two record classes had no route and fell
through to the `fhir-passthrough` bucket:

- `cascade:AIExtractionActivity`, the provenance activity an AI-extracted record
  links to via `prov:wasGeneratedBy` (the Cascade Workbench document-extraction
  write path emits one per extraction batch).
- `clinical:SocialHistoryRecord`, EHR-extracted social history.

Mis-filing them as FHIR resources also wrote a `solid:forClass fhir:` type
registration into `settings/publicTypeIndex.ttl` using a `fhir:` prefix that file
never declares, leaving the type index unparseable.

This adds a `DATA_TYPES` entry for each, mapping them to their own clinical files
(`ai-extraction-activities.ttl`, `social-history.ttl`). They now register cleanly
(`cascade:` and `clinical:` prefixes are already declared in `publicTypeIndex`),
validate, and are queryable via `pod query --all`.

## Evidence

Before this change, importing an AI-extraction Turtle batch left the type index
broken:

```
$ cascade validate <pod>
FAIL  <pod>/settings/publicTypeIndex.ttl
  FAIL Parse error: Undefined prefix "fhir:" on line 29.
```

After (verified):

```
$ cascade --json pod query <pod> --all
medications -> 1 | clinical:Medication
conditions  -> 1 | health:ConditionRecord
ai-extraction-activities -> 1 | core:AIExtractionActivity
$ cascade validate <pod>/settings/publicTypeIndex.ttl
PASS
```

## Validation

- New integration tests (`tests/pod-import.test.ts`) assert both classes route
  to their own files, stay out of `fhir-passthrough`, and keep `publicTypeIndex`
  parseable.
- Full suite green: 60 files, 861 passed, 21 skipped.

## Notes

- Bumps `0.5.10` to `0.5.11` (new import routing behavior).
- Stacked on `sync-clinical-v1.9` (PR #2): that PR adds the clinical v1.9 shapes
  that permit `cascade:AIExtracted`; this PR makes the activity and social-history
  records land in the right place. Both are needed by the Workbench
  document-extraction write path.

Co-authored with the Cascade Workbench INGEST-02 Turtle-provenance change.