### PR TITLE
fix(cli): pod init emitted an invalid profile/extended.ttl

### DIFF
--- a/src/commands/pod/init.ts
+++ b/src/commands/pod/init.ts
@@ -147,7 +147,8 @@ const EXTENDED_PROFILE_TTL = `@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 # settings/preferences via rdfs:seeAlso.
 # =============================================================================
 
-<#me>
+# Uncomment <#me> and fill in to record your private profile:
+# <#me>
     # ── Demographics ──
     # cascade:dateOfBirth "1990-01-01"^^xsd:date ;
     # cascade:biologicalSex "M" ;
@@ -164,7 +165,7 @@ const EXTENDED_PROFILE_TTL = `@prefix foaf: <http://xmlns.com/foaf/0.1/> .
     #     cascade:addressPostalCode "98101" ;
     #     cascade:addressCountry "US" ;
     # ] ;
-    .
+#     .
 `;
 
 function indexTtl(dirName: string): string {


### PR DESCRIPTION
## Bug
Every freshly initialized Pod shipped a `profile/extended.ttl` that fails to parse — "Unexpected . on line 32". The template wrote a `<#me>` subject with every predicate commented out, then a bare `.`. A subject with no predicate-object list is not valid Turtle. So `cascade validate <pod>` always reported one violation on a clean pod, and anything reading the extended profile broke.

Pre-existing (reproduced identically on published 0.5.10 and the local build); surfaced while validating Cascade Workbench pods.

## Fix
Comment the `<#me>` skeleton and its trailing `.` so the template is a valid empty graph: prefix declarations plus commented examples the owner uncomments and fills in. The private profile starts genuinely empty until the owner adds PHI.

## Verification
A fresh `cascade pod init` now produces an `extended.ttl` that parses (0 triples, PASS).

Independent of the v1.9 / AIExtraction chain (base `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)