### PR TITLE
Encryption at rest: AES-256-GCM Pod resources (envelope + Argon2id passphrase)

### DIFF
--- a/docs/pod-encryption.md
+++ b/docs/pod-encryption.md
@@ -1,0 +1,159 @@
+# Encrypted resources (encryption at rest)
+
+> **Status:** Implemented in `@the-cascade-protocol/cli`. This document is the
+> working spec for the on-disk encryption format. **Promote this into
+> `spec/pod-structure.md`** (the authoritative pod-structure spec) once the
+> format is ratified, so the Swift SDK, TypeScript/Python SDKs, and the CLI all
+> reference one source of truth.
+
+A Cascade Pod may be encrypted at rest. When enabled, every pod **resource**
+(the `.ttl` files plus the non-`.ttl` resources `.well-known/solid` and
+`settings/preferences`) is stored as ciphertext on disk, while the CLI
+transparently decrypts on read and encrypts on write. `README.md` is left as
+plaintext documentation and is not a pod resource.
+
+A pod is encrypted **iff** it contains an encryption manifest at
+`settings/encryption.json`. Plaintext pods (no manifest) are unaffected: all
+read/write paths fall through to plaintext.
+
+## Envelope encryption
+
+Encryption uses an envelope (two-key) scheme:
+
+- A random per-pod **Data Encryption Key (DEK)** — 256-bit — encrypts each
+  resource.
+- The DEK is **wrapped** (encrypted) by a **Key Encryption Key (KEK)** derived
+  from a passphrase. The wrapped DEK is stored in the manifest.
+
+This lets the passphrase be changed (re-wrap the same DEK) without re-encrypting
+every resource, and lets multiple key holders unlock the same pod by storing
+multiple wraps of the same DEK (see [Multi-wrap design](#multi-wrap-design)).
+
+## Resource layout (`.combined`, CryptoKit-interoperable)
+
+Each encrypted resource blob is exactly:
+
+```
+nonce(12) || ciphertext || tag(16)
+```
+
+- **Cipher:** AES-256-GCM (256-bit DEK).
+- **nonce:** 12 random bytes, fresh per write.
+- **tag:** 16-byte GCM authentication tag.
+- **No magic header** precedes the blob.
+
+This is byte-for-byte identical to Apple CryptoKit's
+`AES.GCM.SealedBox(...).combined` representation, so blobs written by this CLI
+are directly openable by the Swift SDK's `PodEncryption` (and vice versa).
+
+The CLI builds/parses the combined layout manually over Node's `node:crypto`:
+
+```ts
+// encrypt
+const nonce = randomBytes(12);
+const cipher = createCipheriv('aes-256-gcm', dek /* 32 bytes */, nonce);
+const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+const tag = cipher.getAuthTag();          // 16 bytes
+const blob = Buffer.concat([nonce, ct, tag]);
+
+// decrypt
+const nonce = blob.subarray(0, 12);
+const tag = blob.subarray(blob.length - 16);
+const ct = blob.subarray(12, blob.length - 16);
+const decipher = createDecipheriv('aes-256-gcm', dek, nonce);
+decipher.setAuthTag(tag);
+const plaintext = Buffer.concat([decipher.update(ct), decipher.final()]);
+```
+
+Any GCM authentication failure (wrong key or tampered bytes) surfaces as a
+single clean error: **`incorrect passphrase or corrupt key`**.
+
+## Key derivation (Argon2id)
+
+The passphrase KEK is derived with **Argon2id** (memory-hard, side-channel
+resistant) via `@noble/hashes` — a pure-JS implementation, so there is no native
+build step. Default parameters (recorded in the manifest):
+
+| Param | Value | Meaning |
+|-------|-------|---------|
+| `t`   | 3     | time cost (iterations) |
+| `m`   | 65536 | memory cost in **KiB** (= 64 MiB) |
+| `p`   | 1     | parallelism |
+| —     | salt  | 16 random bytes (base64 in manifest) |
+| —     | dkLen | 32 bytes (256-bit KEK) |
+
+The parameters are stored in the manifest so a future reader can reproduce the
+KEK even if the defaults change.
+
+## Manifest schema — `settings/encryption.json`
+
+```jsonc
+{
+  "version": "1.0",
+  "algorithm": "aes-256-gcm",
+  "kdf": "argon2id",
+  "kdfParams": {
+    "salt": "<base64>",   // Argon2id salt
+    "t": 3,               // time cost
+    "m": 65536,           // memory cost (KiB)
+    "p": 1                // parallelism
+  },
+  // Multiple wraps of the SAME DEK may coexist.
+  // v1 implements only the "passphrase" wrap.
+  "wraps": [
+    {
+      "by": "passphrase",
+      "wrappedDek": "<base64 combined nonce||ct||tag>"
+    }
+  ]
+}
+```
+
+The `wrappedDek` is itself a combined AES-256-GCM blob (the DEK encrypted under
+the KEK), base64-encoded.
+
+### Multi-wrap design
+
+`wraps` is an **array** so the same DEK can be unlocked by different key holders.
+Each entry is identified by its `by` discriminator:
+
+- **`passphrase`** — implemented. DEK wrapped under an Argon2id passphrase KEK.
+- **`device-keychain`** — **RESERVED, not implemented in v1.** The slot is
+  documented so a future writer can add a wrap of the form
+  `{ "by": "device-keychain", ... }` (DEK wrapped under a device keychain /
+  secure-enclave key) **without a schema bump**. Readers should ignore wrap
+  kinds they do not understand and fall back to one they can use.
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `cascade pod init <dir> --encrypt` | Generate a DEK, derive the KEK from the passphrase, write the manifest, then write all template resources **encrypted**. |
+| `cascade pod encrypt <dir>` | Migrate an existing **plaintext** pod to encrypted in place. Guards if already encrypted. |
+| `cascade pod decrypt <dir>` | Reverse: decrypt every resource back to plaintext and remove the manifest. |
+| `cascade pod import` / `pod query` / `validate` | Encryption-aware: if the pod is encrypted, resolve the DEK and route every resource read/write through the decrypt/encrypt helpers. Plaintext pods are unchanged. |
+
+### Passphrase handling
+
+The passphrase is **never** taken as a command-line argument (that would leak it
+into `ps` and shell history). It is resolved in this order:
+
+1. The **`CASCADE_POD_PASSPHRASE`** environment variable (for CI / scripting).
+2. A **hidden interactive prompt** on a TTY (input echo suppressed). `init` and
+   `encrypt` additionally prompt for confirmation.
+
+If a pod is encrypted and no passphrase is available (no env var,
+non-interactive), encryption-aware commands fail with a clean error instructing
+the caller to set `CASCADE_POD_PASSPHRASE` or run interactively.
+
+## Known limitations (v1)
+
+- `cascade pod conflicts` / `cascade pod resolve` read and write
+  `settings/pending-conflicts.ttl` and `settings/user-resolutions.ttl` as
+  plaintext. They are **not yet encryption-aware**. `cascade pod encrypt` will
+  encrypt those files if they already exist (they are `settings/*.ttl`), after
+  which the conflicts/resolve commands cannot read them until they are wired the
+  same way as import/query/validate. A freshly initialized + imported pod only
+  creates these files when reconciliation conflicts occur.
+- Key rotation (change passphrase / add a wrap) is not yet exposed as a command,
+  though the manifest format already supports it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.5.9",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-cascade-protocol/cli",
-      "version": "0.5.9",
+      "version": "0.5.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmod/vcf": "^7.0.2",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@the-cascade-protocol/agent": "^1.1.3",
         "adm-zip": "^0.5.16",
         "commander": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@gmod/vcf": "^7.0.2",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "@the-cascade-protocol/agent": "^1.1.3",
     "adm-zip": "^0.5.16",
     "commander": "^13.0.0",

--- a/src/commands/pod/encrypt.ts
+++ b/src/commands/pod/encrypt.ts
@@ -1,0 +1,210 @@
+/**
+ * cascade pod encrypt <dir>
+ * cascade pod decrypt <dir>
+ *
+ * Migrate an existing PLAINTEXT pod to encrypted-at-rest (and back).
+ *
+ * `encrypt`:
+ *   - Guards if the pod is already encrypted.
+ *   - Obtains a passphrase (CASCADE_POD_PASSPHRASE or hidden prompt).
+ *   - Generates a fresh DEK + manifest, then re-writes every pod resource
+ *     (read plaintext -> writeResource with DEK) in place.
+ *
+ * `decrypt`:
+ *   - Guards if the pod is not encrypted.
+ *   - Resolves the DEK, re-writes every resource as plaintext, then removes the
+ *     encryption manifest.
+ */
+
+import type { Command } from 'commander';
+import * as path from 'node:path';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { resolvePodDir, fileExists } from './helpers.js';
+import {
+  generateDek,
+  buildPassphraseManifest,
+  writeEncryptionManifest,
+  isPodEncrypted,
+  resolveDek,
+  readResource,
+  writeResource,
+  PodDecryptError,
+  MANIFEST_RELATIVE_PATH,
+} from '../../lib/pod-encryption.js';
+import { obtainNewPassphrase, obtainPassphrase } from '../../lib/passphrase.js';
+import * as fs from 'node:fs/promises';
+
+/**
+ * Enumerate the absolute paths of every encryptable pod resource.
+ *
+ * Covers: index.ttl, every `.ttl` under clinical/ wellness/ profile/ settings/,
+ * plus the non-`.ttl` resources the initializer writes (`.well-known/solid`,
+ * `settings/preferences`). README.md and the encryption manifest itself are
+ * deliberately excluded.
+ */
+async function enumerateResources(podDir: string): Promise<string[]> {
+  const out: string[] = [];
+
+  // index.ttl at the root
+  const indexPath = path.join(podDir, 'index.ttl');
+  if (await fileExists(indexPath)) out.push(indexPath);
+
+  // All .ttl files under data + profile + settings directories (recursive).
+  const dataDirs = ['clinical', 'wellness', 'profile', 'settings'];
+  for (const dir of dataDirs) {
+    const dirPath = path.join(podDir, dir);
+    await walkTtl(dirPath, out);
+  }
+
+  // Non-.ttl resources written by `pod init`.
+  for (const rel of [
+    path.join('.well-known', 'solid'),
+    path.join('settings', 'preferences'),
+  ]) {
+    const p = path.join(podDir, rel);
+    if (await fileExists(p)) out.push(p);
+  }
+
+  // Stable order, de-duplicated.
+  return Array.from(new Set(out)).sort();
+}
+
+async function walkTtl(dir: string, out: string[]): Promise<void> {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // directory doesn't exist
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory() && !entry.name.startsWith('.')) {
+      await walkTtl(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.ttl')) {
+      out.push(full);
+    }
+  }
+}
+
+export function registerEncryptSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('encrypt')
+    .description('Encrypt an existing plaintext pod at rest (AES-256-GCM)')
+    .argument('<dir>', 'Path to the Cascade Pod directory')
+    .action(async (dirArg: string) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(dirArg);
+
+      try {
+        if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+          printError(`Pod not found at ${podDir} (no index.ttl).`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
+
+        if (isPodEncrypted(podDir)) {
+          printError(`Pod is already encrypted: ${podDir}`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
+
+        const passphrase = await obtainNewPassphrase();
+
+        // Read every resource as plaintext FIRST, before writing the manifest,
+        // so a mid-migration failure leaves a recoverable (still-plaintext) pod.
+        const resources = await enumerateResources(podDir);
+        const contents: Array<{ path: string; text: string }> = [];
+        for (const p of resources) {
+          contents.push({ path: p, text: readResource(p) });
+        }
+
+        const dek = generateDek();
+        const manifest = buildPassphraseManifest(dek, passphrase);
+        writeEncryptionManifest(podDir, manifest);
+
+        for (const { path: p, text } of contents) {
+          writeResource(p, text, dek);
+          printVerbose(`  Encrypted ${path.relative(podDir, p)}`, globalOpts);
+        }
+
+        const result = {
+          status: 'encrypted',
+          directory: podDir,
+          manifest: MANIFEST_RELATIVE_PATH.split(path.sep).join('/'),
+          resourcesEncrypted: contents.length,
+        };
+        if (globalOpts.json) {
+          printResult(result, globalOpts);
+        } else {
+          console.log(`Pod encrypted: ${podDir}`);
+          console.log(`  Resources encrypted: ${contents.length}`);
+          console.log(`  Manifest: ${result.manifest}`);
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        printError(`Failed to encrypt pod: ${message}`, globalOpts);
+        process.exitCode = 1;
+      }
+    });
+
+  pod
+    .command('decrypt')
+    .description('Decrypt an encrypted pod back to plaintext at rest')
+    .argument('<dir>', 'Path to the Cascade Pod directory')
+    .action(async (dirArg: string) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(dirArg);
+
+      try {
+        if (!isPodEncrypted(podDir)) {
+          printError(`Pod is not encrypted: ${podDir}`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
+
+        const passphrase = await obtainPassphrase();
+        let dek: Buffer;
+        try {
+          dek = resolveDek(podDir, passphrase);
+        } catch (e) {
+          if (e instanceof PodDecryptError) {
+            printError(`Cannot decrypt pod: ${e.message}`, globalOpts);
+            process.exitCode = 1;
+            return;
+          }
+          throw e;
+        }
+
+        // Decrypt everything into memory first, then write plaintext + drop the
+        // manifest only after all reads succeed.
+        const resources = await enumerateResources(podDir);
+        const contents: Array<{ path: string; text: string }> = [];
+        for (const p of resources) {
+          contents.push({ path: p, text: readResource(p, dek) });
+        }
+
+        for (const { path: p, text } of contents) {
+          writeResource(p, text);
+          printVerbose(`  Decrypted ${path.relative(podDir, p)}`, globalOpts);
+        }
+
+        await fs.rm(path.join(podDir, MANIFEST_RELATIVE_PATH), { force: true });
+
+        const result = {
+          status: 'decrypted',
+          directory: podDir,
+          resourcesDecrypted: contents.length,
+        };
+        if (globalOpts.json) {
+          printResult(result, globalOpts);
+        } else {
+          console.log(`Pod decrypted: ${podDir}`);
+          console.log(`  Resources decrypted: ${contents.length}`);
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        printError(`Failed to decrypt pod: ${message}`, globalOpts);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/commands/pod/helpers.ts
+++ b/src/commands/pod/helpers.ts
@@ -9,11 +9,13 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import {
   parseTurtleFile,
+  parseTurtle,
   getProperties,
   shortenIRI,
   extractLabel,
   CASCADE_NAMESPACES,
 } from '../../lib/turtle-parser.js';
+import { readResource } from '../../lib/pod-encryption.js';
 
 // ─── Data Type Registry ──────────────────────────────────────────────────────
 
@@ -248,8 +250,11 @@ export async function discoverTtlFiles(podDir: string): Promise<string[]> {
 
 /**
  * Parse a single TTL file and extract typed records.
+ *
+ * When `dek` is supplied, the on-disk resource is decrypted (combined
+ * AES-256-GCM layout) before parsing; otherwise it is read as plaintext.
  */
-export async function parseDataFile(filePath: string): Promise<{
+export async function parseDataFile(filePath: string, dek?: Buffer): Promise<{
   records: Array<{
     id: string;
     type: string;
@@ -259,7 +264,19 @@ export async function parseDataFile(filePath: string): Promise<{
   totalQuads: number;
   error?: string;
 }> {
-  const result = await parseTurtleFile(filePath);
+  let result;
+  if (dek) {
+    let content: string;
+    try {
+      content = readResource(filePath, dek);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { records: [], totalQuads: 0, error: message };
+    }
+    result = parseTurtle(content, `file://${filePath}`);
+  } else {
+    result = await parseTurtleFile(filePath);
+  }
   if (!result.success) {
     return { records: [], totalQuads: 0, error: result.errors.join('; ') };
   }

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -36,6 +36,14 @@ import {
   type PendingConflict,
 } from '../../lib/user-resolutions.js';
 import { randomUUID } from 'node:crypto';
+import {
+  isPodEncrypted,
+  resolveDek,
+  readResource,
+  writeResource,
+  PodDecryptError,
+} from '../../lib/pod-encryption.js';
+import { obtainPassphrase } from '../../lib/passphrase.js';
 
 // ---------------------------------------------------------------------------
 // Import report type
@@ -62,7 +70,7 @@ interface ImportReport {
 // Load existing pod data as ReconcilerInput records for cross-batch dedup
 // ---------------------------------------------------------------------------
 
-async function loadExistingPodData(podDir: string): Promise<ReconcilerInput[]> {
+async function loadExistingPodData(podDir: string, dek?: Buffer): Promise<ReconcilerInput[]> {
   // Pod data directories that contain reconcilable records
   const DATA_DIRS = ['clinical', 'wellness'];
   const inputs: ReconcilerInput[] = [];
@@ -80,7 +88,7 @@ async function loadExistingPodData(podDir: string): Promise<ReconcilerInput[]> {
       if (!file.endsWith('.ttl')) continue;
       const filePath = path.join(dirPath, file);
       try {
-        const content = await fs.readFile(filePath, 'utf-8');
+        const content = readResource(filePath, dek);
         if (content.trim().length > 0) {
           inputs.push({ content, systemName: 'existing-pod' });
         }
@@ -181,8 +189,9 @@ async function appendTypeRegistration(
   key: string,
   info: typeof DATA_TYPES[string],
   dryRun: boolean,
+  dek?: Buffer,
 ): Promise<boolean> {
-  const content = await fs.readFile(indexPath, 'utf-8');
+  const content = readResource(indexPath, dek);
 
   // Check if already registered (by key name)
   if (content.includes(`<#${key}>`) || content.includes(`/${info.filename}`)) {
@@ -191,7 +200,8 @@ async function appendTypeRegistration(
 
   const block = buildTypeRegistration(key, info);
   if (!dryRun) {
-    await fs.appendFile(indexPath, block, 'utf-8');
+    // Read-modify-write (encrypted resources cannot be appended to in place).
+    writeResource(indexPath, content + block, dek);
   }
   return true;
 }
@@ -204,8 +214,9 @@ async function appendIndexContains(
   indexPath: string,
   relPath: string,
   dryRun: boolean,
+  dek?: Buffer,
 ): Promise<boolean> {
-  const content = await fs.readFile(indexPath, 'utf-8');
+  const content = readResource(indexPath, dek);
 
   if (content.includes(relPath)) {
     return false; // already present
@@ -214,7 +225,8 @@ async function appendIndexContains(
   // Append a simple ldp:contains statement
   const line = `\n<> <http://www.w3.org/ns/ldp#contains> <${relPath}> .\n`;
   if (!dryRun) {
-    await fs.appendFile(indexPath, line, 'utf-8');
+    // Read-modify-write (encrypted resources cannot be appended to in place).
+    writeResource(indexPath, content + line, dek);
   }
   return true;
 }
@@ -261,6 +273,24 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
         process.exitCode = 1;
         return;
+      }
+
+      // If the pod is encrypted, resolve the DEK so every pod-resource read/write
+      // below routes through readResource/writeResource. Input FILES being
+      // imported are always plaintext on disk (they are external inputs).
+      let dek: Buffer | undefined;
+      if (isPodEncrypted(podDir)) {
+        try {
+          const passphrase = await obtainPassphrase();
+          dek = resolveDek(podDir, passphrase);
+          printVerbose('Pod is encrypted; routing resource I/O through DEK.', globalOpts);
+        } catch (e: unknown) {
+          const msg =
+            e instanceof PodDecryptError ? e.message : e instanceof Error ? e.message : String(e);
+          printError(`Cannot write to encrypted pod: ${msg}`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
       }
 
       if (dryRun) {
@@ -355,7 +385,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // Load existing pod data as an implicit source 0 when --reconcile-existing is set
       let existingInputs: ReconcilerInput[] = [];
       if (options.reconcileExisting !== false) {
-        existingInputs = await loadExistingPodData(podDir);
+        existingInputs = await loadExistingPodData(podDir, dek);
         if (existingInputs.length > 0) {
           printVerbose(`Loaded ${existingInputs.length} existing pod file(s) for cross-batch reconciliation.`, globalOpts);
         }
@@ -458,7 +488,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           // Merge: parse existing, combine unique subjects
           let existingQuads: Map<string, Quad[]>;
           try {
-            const existing = await fs.readFile(targetFile, 'utf-8');
+            const existing = readResource(targetFile, dek);
             existingQuads = await parseTurtleToQuads(existing);
           } catch {
             existingQuads = new Map();
@@ -482,7 +512,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
 
         if (!dryRun) {
           await fs.mkdir(path.dirname(targetFile), { recursive: true });
-          await fs.writeFile(targetFile, finalTurtle, 'utf-8');
+          writeResource(targetFile, finalTurtle, dek);
         }
 
         typeCounts[typeKey] = (typeCounts[typeKey] ?? 0) + recordsAdded;
@@ -508,7 +538,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         const indexPath = indexFile === 'publicTypeIndex.ttl' ? publicIndexPath : privateIndexPath;
 
         if (await fileExists(indexPath)) {
-          const appended = await appendTypeRegistration(indexPath, typeKey, info, dryRun);
+          const appended = await appendTypeRegistration(indexPath, typeKey, info, dryRun, dek);
           if (appended) {
             printVerbose(`  ${dryRun ? '[dry-run] ' : ''}Added type registration for ${typeKey} to ${indexFile}`, globalOpts);
           }
@@ -518,7 +548,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // --- Step 9: Update index.ttl for new files ---
       for (const relPath of newFiles) {
         if (await fileExists(indexTtlPath)) {
-          const appended = await appendIndexContains(indexTtlPath, relPath, dryRun);
+          const appended = await appendIndexContains(indexTtlPath, relPath, dryRun, dek);
           if (appended) {
             printVerbose(`  ${dryRun ? '[dry-run] ' : ''}Added ${relPath} to index.ttl`, globalOpts);
           }
@@ -532,7 +562,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         const profileFile = path.join(podDir, 'clinical', 'patient-profile.ttl');
         if (await fileExists(profileFile)) {
           try {
-            const profileTurtle = await fs.readFile(profileFile, 'utf-8');
+            const profileTurtle = readResource(profileFile, dek);
             const profileQuads = await parseTurtleToQuads(profileTurtle);
             // Find the PatientProfile subject
             const NS_CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
@@ -569,7 +599,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
 
               // ── card.ttl: public-safe name fields only ──
               if (fullName || givenName || familyName) {
-                const cardTurtle = await fs.readFile(cardPath, 'utf-8');
+                const cardTurtle = readResource(cardPath, dek);
                 const nameFields: string[] = [];
                 if (fullName) nameFields.push(`    foaf:name "${fullName}" ;`);
                 if (givenName) nameFields.push(`    foaf:givenName "${givenName}" ;`);
@@ -579,7 +609,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
                   /    # ── Identity \(safe to make public\) ──\n(    #[^\n]*\n)*/,
                   `    # ── Identity (safe to make public) ──\n${nameFields.join('\n')}\n`,
                 );
-                await fs.writeFile(cardPath, updated, 'utf-8');
+                writeResource(cardPath, updated, dek);
                 printVerbose('  Populated profile/card.ttl with name from PatientProfile', globalOpts);
               }
 
@@ -600,13 +630,13 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
                   phiFields.push(`    cascade:address [\n${addrLines.join('\n')}\n    ] ;`);
                 }
 
-                const extTurtle = await fs.readFile(extendedPath, 'utf-8');
+                const extTurtle = readResource(extendedPath, dek);
                 // Replace the commented-out PHI block (from # ── Demographics to the trailing dot)
                 const updated = extTurtle.replace(
                   /    # ── Demographics ──\n[\s\S]*?\n    \./,
                   `    # ── Demographics ──\n${phiFields.join('\n')}\n    .`,
                 );
-                await fs.writeFile(extendedPath, updated, 'utf-8');
+                writeResource(extendedPath, updated, dek);
                 printVerbose('  Populated profile/extended.ttl with PHI from PatientProfile', globalOpts);
               }
             }
@@ -669,7 +699,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           try {
             const documentsPath = path.join(podDir, 'clinical', 'documents.ttl');
             if (await fileExists(documentsPath)) {
-              const docContent = await fs.readFile(documentsPath, 'utf-8');
+              const docContent = readResource(documentsPath, dek);
               const narrativeCount = (docContent.match(/cascade:requiresLLMExtraction/g) ?? []).length;
               if (narrativeCount > 0) {
                 console.log('');

--- a/src/commands/pod/index.ts
+++ b/src/commands/pod/index.ts
@@ -25,6 +25,7 @@ import { registerImportSubcommand } from './import.js';
 import { registerConflictsCommand } from './conflicts.js';
 import { registerResolveCommand } from './resolve.js';
 import { registerExtractSubcommand } from './extract.js';
+import { registerEncryptSubcommand } from './encrypt.js';
 
 export function registerPodCommand(program: Command): void {
   const pod = program.command('pod').description('Manage Cascade Pod structures');
@@ -37,4 +38,5 @@ export function registerPodCommand(program: Command): void {
   registerConflictsCommand(pod);
   registerResolveCommand(pod);
   registerExtractSubcommand(pod);
+  registerEncryptSubcommand(pod, program);
 }

--- a/src/commands/pod/init.ts
+++ b/src/commands/pod/init.ts
@@ -10,6 +10,14 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
 import { resolvePodDir, fileExists } from './helpers.js';
+import {
+  generateDek,
+  buildPassphraseManifest,
+  writeEncryptionManifest,
+  writeResource,
+  MANIFEST_RELATIVE_PATH,
+} from '../../lib/pod-encryption.js';
+import { obtainNewPassphrase } from '../../lib/passphrase.js';
 
 // ─── Pod Init Templates ──────────────────────────────────────────────────────
 
@@ -257,7 +265,12 @@ export function registerInitSubcommand(pod: Command, program: Command): void {
     .command('init')
     .description('Initialize a new Cascade Pod')
     .argument('<directory>', 'Directory to initialize as a Cascade Pod')
-    .action(async (directory: string) => {
+    .option(
+      '--encrypt',
+      'Encrypt pod resources at rest (AES-256-GCM, passphrase-wrapped). ' +
+        'Passphrase is read from CASCADE_POD_PASSPHRASE or a hidden prompt.',
+    )
+    .action(async (directory: string, options: { encrypt?: boolean }) => {
       const globalOpts = program.opts() as OutputOptions;
       const absDir = resolvePodDir(directory);
       const dirName = path.basename(absDir);
@@ -285,14 +298,27 @@ export function registerInitSubcommand(pod: Command, program: Command): void {
           await fs.mkdir(dir, { recursive: true });
         }
 
-        // Write template files
-        await fs.writeFile(path.join(absDir, '.well-known', 'solid'), wellKnownSolid(absDir));
-        await fs.writeFile(path.join(absDir, 'profile', 'card.ttl'), PROFILE_CARD_TTL);
-        await fs.writeFile(path.join(absDir, 'profile', 'extended.ttl'), EXTENDED_PROFILE_TTL);
-        await fs.writeFile(path.join(absDir, 'settings', 'preferences'), PREFERENCES_TTL);
-        await fs.writeFile(path.join(absDir, 'settings', 'publicTypeIndex.ttl'), PUBLIC_TYPE_INDEX_TTL);
-        await fs.writeFile(path.join(absDir, 'settings', 'privateTypeIndex.ttl'), PRIVATE_TYPE_INDEX_TTL);
-        await fs.writeFile(path.join(absDir, 'index.ttl'), indexTtl(dirName));
+        // If --encrypt: generate a DEK, wrap it with a passphrase-derived KEK,
+        // and write the encryption manifest BEFORE writing template resources so
+        // every resource lands encrypted.
+        let dek: Buffer | undefined;
+        if (options.encrypt) {
+          const passphrase = await obtainNewPassphrase();
+          dek = generateDek();
+          const manifest = buildPassphraseManifest(dek, passphrase);
+          writeEncryptionManifest(absDir, manifest);
+          printVerbose(`Wrote encryption manifest: ${MANIFEST_RELATIVE_PATH}`, globalOpts);
+        }
+
+        // Write template files. Pod resources route through writeResource so they
+        // are encrypted when a DEK is present; README.md stays plaintext (docs).
+        writeResource(path.join(absDir, '.well-known', 'solid'), wellKnownSolid(absDir), dek);
+        writeResource(path.join(absDir, 'profile', 'card.ttl'), PROFILE_CARD_TTL, dek);
+        writeResource(path.join(absDir, 'profile', 'extended.ttl'), EXTENDED_PROFILE_TTL, dek);
+        writeResource(path.join(absDir, 'settings', 'preferences'), PREFERENCES_TTL, dek);
+        writeResource(path.join(absDir, 'settings', 'publicTypeIndex.ttl'), PUBLIC_TYPE_INDEX_TTL, dek);
+        writeResource(path.join(absDir, 'settings', 'privateTypeIndex.ttl'), PRIVATE_TYPE_INDEX_TTL, dek);
+        writeResource(path.join(absDir, 'index.ttl'), indexTtl(dirName), dek);
         await fs.writeFile(path.join(absDir, 'README.md'), README_MD);
 
         const filesCreated = [
@@ -307,12 +333,16 @@ export function registerInitSubcommand(pod: Command, program: Command): void {
           'index.ttl',
           'README.md',
         ];
+        if (dek) {
+          filesCreated.push(MANIFEST_RELATIVE_PATH.split(path.sep).join('/'));
+        }
 
         if (globalOpts.json) {
           printResult(
             {
               status: 'created',
               directory: absDir,
+              encrypted: Boolean(dek),
               files: filesCreated,
               message: 'Cascade Pod initialized successfully.',
             },
@@ -320,6 +350,9 @@ export function registerInitSubcommand(pod: Command, program: Command): void {
           );
         } else {
           console.log(`Cascade Pod initialized at: ${absDir}\n`);
+          if (dek) {
+            console.log('Encryption: enabled (AES-256-GCM, passphrase-wrapped DEK)\n');
+          }
           console.log('Created:');
           for (const f of filesCreated) {
             console.log(`  ${f}`);

--- a/src/commands/pod/query.ts
+++ b/src/commands/pod/query.ts
@@ -18,6 +18,8 @@ import {
   extractLabelFromProps,
   selectKeyProperties,
 } from './helpers.js';
+import { isPodEncrypted, resolveDek, PodDecryptError } from '../../lib/pod-encryption.js';
+import { obtainPassphrase } from '../../lib/passphrase.js';
 
 export function registerQuerySubcommand(pod: Command, program: Command): void {
   pod
@@ -79,6 +81,22 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
           printError(`Pod directory not found: ${absDir}`, globalOpts);
           process.exitCode = 1;
           return;
+        }
+
+        // If the pod is encrypted, resolve the DEK so reads can decrypt.
+        let dek: Buffer | undefined;
+        if (isPodEncrypted(absDir)) {
+          try {
+            const passphrase = await obtainPassphrase();
+            dek = resolveDek(absDir, passphrase);
+            printVerbose('Pod is encrypted; decrypting resources for query.', globalOpts);
+          } catch (e: unknown) {
+            const msg =
+              e instanceof PodDecryptError ? e.message : e instanceof Error ? e.message : String(e);
+            printError(`Cannot read encrypted pod: ${msg}`, globalOpts);
+            process.exitCode = 1;
+            return;
+          }
         }
 
         try {
@@ -168,7 +186,7 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
               continue;
             }
 
-            const { records, error } = await parseDataFile(filePath);
+            const { records, error } = await parseDataFile(filePath, dek);
 
             queryResults[typeName] = {
               count: records.length,
@@ -187,7 +205,7 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
             const relPath = path.relative(absDir, extraFile);
             const baseName = path.basename(extraFile, '.ttl');
 
-            const { records, error } = await parseDataFile(extraFile);
+            const { records, error } = await parseDataFile(extraFile, dek);
             if (records.length > 0) {
               queryResults[baseName] = {
                 count: records.length,

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -24,6 +24,8 @@ import {
   findTurtleFiles,
   type ValidationResult,
 } from '../lib/shacl-validator.js';
+import { isPodEncrypted, resolveDek, PodDecryptError } from '../lib/pod-encryption.js';
+import { obtainPassphrase } from '../lib/passphrase.js';
 
 /** ANSI color codes for terminal output */
 const colors = {
@@ -198,6 +200,27 @@ export function registerValidateCommand(program: Command): void {
         return;
       }
 
+      // If validating an encrypted pod directory, resolve the DEK up front so
+      // each file can be decrypted before SHACL parsing.
+      let dek: Buffer | undefined;
+      if (fs.statSync(targetPath).isDirectory() && isPodEncrypted(targetPath)) {
+        try {
+          const passphrase = await obtainPassphrase();
+          dek = resolveDek(targetPath, passphrase);
+          printVerbose('Pod is encrypted; decrypting resources for validation.', globalOpts);
+        } catch (e: unknown) {
+          const msg =
+            e instanceof PodDecryptError ? e.message : e instanceof Error ? e.message : String(e);
+          if (globalOpts.json) {
+            console.log(JSON.stringify({ error: `Cannot read encrypted pod: ${msg}` }, null, 2));
+          } else {
+            console.error(`${colors.red}ERROR${colors.reset}: Cannot read encrypted pod: ${msg}`);
+          }
+          process.exitCode = 2;
+          return;
+        }
+      }
+
       // Determine files to validate
       let filesToValidate: string[];
       const stat = fs.statSync(targetPath);
@@ -244,7 +267,7 @@ export function registerValidateCommand(program: Command): void {
         printVerbose(`Validating: ${file}`, globalOpts);
 
         try {
-          const result = validateFile(file, shapesStore, shapeFiles);
+          const result = validateFile(file, shapesStore, shapeFiles, dek);
           results.push(result);
 
           if (!result.valid) {

--- a/src/lib/passphrase.ts
+++ b/src/lib/passphrase.ts
@@ -1,0 +1,115 @@
+/**
+ * Passphrase acquisition for pod encryption.
+ *
+ * Resolution order:
+ *   1. `CASCADE_POD_PASSPHRASE` environment variable (non-interactive / CI).
+ *   2. Hidden interactive prompt on a TTY (input echoing suppressed).
+ *
+ * We deliberately do NOT accept a plaintext `--passphrase` argv value: it would
+ * leak into the process table (`ps`) and shell history.
+ */
+
+const ENV_VAR = 'CASCADE_POD_PASSPHRASE';
+
+/** Read the passphrase from the environment, or `undefined` if unset/empty. */
+export function passphraseFromEnv(): string | undefined {
+  const v = process.env[ENV_VAR];
+  return v && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Prompt for a passphrase on the TTY with input hidden (no echo).
+ * Rejects if stdin is not a TTY.
+ */
+export function promptHidden(prompt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const input = process.stdin;
+    const output = process.stdout;
+
+    if (!input.isTTY) {
+      reject(new Error('Cannot prompt for passphrase: stdin is not a TTY.'));
+      return;
+    }
+
+    output.write(prompt);
+
+    let value = '';
+    const wasRaw = input.isRaw ?? false;
+    input.setRawMode(true);
+    input.resume();
+    input.setEncoding('utf-8');
+
+    const cleanup = (): void => {
+      input.setRawMode(wasRaw);
+      input.pause();
+      input.removeListener('data', onData);
+      output.write('\n');
+    };
+
+    const onData = (chunk: string): void => {
+      for (const ch of chunk) {
+        const code = ch.charCodeAt(0);
+        if (ch === '\n' || ch === '\r' || code === 4 /* Ctrl-D */) {
+          cleanup();
+          resolve(value);
+          return;
+        }
+        if (code === 3 /* Ctrl-C */) {
+          cleanup();
+          reject(new Error('Passphrase entry cancelled.'));
+          return;
+        }
+        if (code === 127 /* DEL */ || code === 8 /* Backspace */) {
+          value = value.slice(0, -1);
+          continue;
+        }
+        // Ignore other control characters; accept printable input.
+        if (ch >= ' ') value += ch;
+      }
+    };
+
+    input.on('data', onData);
+  });
+}
+
+/**
+ * Obtain a passphrase for an existing encrypted pod (read path): env first,
+ * then a hidden prompt if interactive. Throws a clean error when neither is
+ * available (e.g. CI without the env var).
+ */
+export async function obtainPassphrase(prompt = 'Pod passphrase: '): Promise<string> {
+  const fromEnv = passphraseFromEnv();
+  if (fromEnv) return fromEnv;
+  if (process.stdin.isTTY) {
+    return promptHidden(prompt);
+  }
+  throw new Error(
+    `Pod is encrypted. Set ${ENV_VAR} or run interactively to supply the passphrase.`,
+  );
+}
+
+/**
+ * Obtain a passphrase when CREATING encryption (init/encrypt): env first, then
+ * a hidden prompt WITH confirmation if interactive. Throws when non-interactive
+ * and the env var is unset.
+ */
+export async function obtainNewPassphrase(): Promise<string> {
+  const fromEnv = passphraseFromEnv();
+  if (fromEnv) return fromEnv;
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      `Encryption requested but no passphrase available. Set ${ENV_VAR} or run interactively.`,
+    );
+  }
+  const first = await promptHidden('New pod passphrase: ');
+  if (first.length === 0) {
+    throw new Error('Passphrase cannot be empty.');
+  }
+  const second = await promptHidden('Confirm pod passphrase: ');
+  if (first !== second) {
+    throw new Error('Passphrases did not match.');
+  }
+  return first;
+}
+
+export { ENV_VAR as PASSPHRASE_ENV_VAR };

--- a/src/lib/pod-encryption.ts
+++ b/src/lib/pod-encryption.ts
@@ -1,0 +1,284 @@
+/**
+ * Pod encryption at rest.
+ *
+ * Transparent encrypt-on-write / decrypt-on-read for Cascade Pod `.ttl`
+ * resources. Uses envelope encryption:
+ *
+ *   - A random per-pod 256-bit Data Encryption Key (DEK) encrypts each resource.
+ *   - The DEK is wrapped by a passphrase-derived Key Encryption Key (KEK).
+ *   - The wrapped DEK + KDF parameters live in `settings/encryption.json`.
+ *
+ * Resource bytes on disk use the CryptoKit `.combined` layout so the bytes are
+ * byte-for-byte interoperable with the Swift SDK's `PodEncryption`:
+ *
+ *   nonce(12) || ciphertext || tag(16)        (AES-256-GCM, 256-bit key)
+ *
+ * There is NO magic header on the resource blob.
+ *
+ * The passphrase KEK is derived with Argon2id via `@noble/hashes` (pure JS, no
+ * native build). AES-256-GCM is performed with `node:crypto`.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { argon2id } from '@noble/hashes/argon2.js';
+
+// ─── Layout constants ─────────────────────────────────────────────────────────
+
+/** GCM nonce length in bytes (CryptoKit uses 12). */
+export const NONCE_LEN = 12;
+/** GCM authentication tag length in bytes. */
+export const TAG_LEN = 16;
+/** DEK / KEK length in bytes (256-bit). */
+export const KEY_LEN = 32;
+
+// ─── Manifest types ───────────────────────────────────────────────────────────
+
+export interface KdfParams {
+  /** Base64 Argon2id salt. */
+  salt: string;
+  /** Argon2id time cost (iterations). */
+  t: number;
+  /** Argon2id memory cost in KiB. */
+  m: number;
+  /** Argon2id parallelism. */
+  p: number;
+}
+
+/**
+ * A single wrap of the pod DEK. Multiple wraps of the SAME DEK may coexist so
+ * the pod can be unlocked by different key holders.
+ *
+ * v1 implements only `passphrase`. A future `device-keychain` wrap is reserved
+ * (see {@link EncryptionWrap.by}) but intentionally NOT implemented here.
+ */
+export interface EncryptionWrap {
+  /**
+   * The key-holder kind that can unwrap the DEK.
+   *
+   *  - `passphrase`      — DEK wrapped by an Argon2id passphrase KEK (implemented).
+   *  - `device-keychain` — RESERVED. DEK wrapped by a device keychain / secure
+   *                        enclave key. Not implemented in v1; the slot exists so
+   *                        a future writer can add it without a schema bump.
+   */
+  by: 'passphrase' | 'device-keychain';
+  /** Base64 combined (nonce||ct||tag) of the wrapped DEK. */
+  wrappedDek: string;
+}
+
+export interface EncryptionManifest {
+  version: string;
+  algorithm: 'aes-256-gcm';
+  kdf: 'argon2id';
+  kdfParams: KdfParams;
+  wraps: EncryptionWrap[];
+}
+
+/** Default Argon2id parameters (t=3, m=64 MiB, p=1). Recorded in the manifest. */
+export const DEFAULT_KDF = { t: 3, m: 65536, p: 1 } as const;
+
+export const MANIFEST_RELATIVE_PATH = path.join('settings', 'encryption.json');
+
+/** Clean, user-facing error for any GCM authentication failure. */
+export class PodDecryptError extends Error {
+  constructor(message = 'incorrect passphrase or corrupt key') {
+    super(message);
+    this.name = 'PodDecryptError';
+  }
+}
+
+// ─── Primitive crypto ─────────────────────────────────────────────────────────
+
+/** Generate a fresh random 256-bit Data Encryption Key. */
+export function generateDek(): Buffer {
+  return randomBytes(KEY_LEN);
+}
+
+/**
+ * AES-256-GCM encrypt with the supplied 32-byte key, returning the combined
+ * `nonce(12) || ciphertext || tag(16)` blob (CryptoKit `.combined` layout).
+ */
+function sealCombined(plaintext: Buffer, key: Buffer): Buffer {
+  if (key.length !== KEY_LEN) {
+    throw new Error(`Key must be ${KEY_LEN} bytes, got ${key.length}`);
+  }
+  const nonce = randomBytes(NONCE_LEN);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([nonce, ciphertext, tag]);
+}
+
+/**
+ * AES-256-GCM open a combined `nonce(12) || ciphertext || tag(16)` blob with the
+ * supplied 32-byte key. Throws {@link PodDecryptError} on any auth failure.
+ */
+function openCombined(blob: Buffer, key: Buffer): Buffer {
+  if (key.length !== KEY_LEN) {
+    throw new Error(`Key must be ${KEY_LEN} bytes, got ${key.length}`);
+  }
+  if (blob.length < NONCE_LEN + TAG_LEN) {
+    throw new PodDecryptError();
+  }
+  const nonce = blob.subarray(0, NONCE_LEN);
+  const tag = blob.subarray(blob.length - TAG_LEN);
+  const ciphertext = blob.subarray(NONCE_LEN, blob.length - TAG_LEN);
+  const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+  decipher.setAuthTag(tag);
+  try {
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    // GCM auth failure (wrong key or tampered data).
+    throw new PodDecryptError();
+  }
+}
+
+/**
+ * Encrypt a resource's UTF-8 text with the DEK.
+ * @returns combined `nonce(12) || ciphertext || tag(16)` blob.
+ */
+export function encryptResource(plaintext: string, dek: Buffer): Buffer {
+  return sealCombined(Buffer.from(plaintext, 'utf-8'), dek);
+}
+
+/**
+ * Decrypt a combined resource blob with the DEK back to UTF-8 text.
+ * @throws {PodDecryptError} on auth failure.
+ */
+export function decryptResource(blob: Buffer, dek: Buffer): string {
+  return openCombined(blob, dek).toString('utf-8');
+}
+
+// ─── Key derivation & DEK wrapping ────────────────────────────────────────────
+
+/**
+ * Derive a 256-bit KEK from a passphrase using Argon2id.
+ *
+ * @param passphrase user passphrase
+ * @param salt       Argon2id salt
+ * @param params     Argon2id cost params (t, m in KiB, p)
+ */
+export function deriveKek(
+  passphrase: string,
+  salt: Buffer,
+  params: { t: number; m: number; p: number },
+): Buffer {
+  const out = argon2id(
+    new TextEncoder().encode(passphrase),
+    new Uint8Array(salt),
+    { t: params.t, m: params.m, p: params.p, dkLen: KEY_LEN },
+  );
+  return Buffer.from(out);
+}
+
+/** Wrap (encrypt) the DEK with the KEK. Returns base64 combined blob. */
+export function wrapDek(dek: Buffer, kek: Buffer): string {
+  return sealCombined(dek, kek).toString('base64');
+}
+
+/**
+ * Unwrap (decrypt) a base64 combined wrapped-DEK blob with the KEK.
+ * @throws {PodDecryptError} when the KEK is wrong or the blob is corrupt.
+ */
+export function unwrapDek(wrapped: string, kek: Buffer): Buffer {
+  return openCombined(Buffer.from(wrapped, 'base64'), kek);
+}
+
+// ─── Manifest I/O ─────────────────────────────────────────────────────────────
+
+function manifestPath(podDir: string): string {
+  return path.join(podDir, MANIFEST_RELATIVE_PATH);
+}
+
+/** Read `settings/encryption.json`, or `null` if the pod is not encrypted. */
+export function readEncryptionManifest(podDir: string): EncryptionManifest | null {
+  const p = manifestPath(podDir);
+  if (!fs.existsSync(p)) return null;
+  const raw = fs.readFileSync(p, 'utf-8');
+  return JSON.parse(raw) as EncryptionManifest;
+}
+
+/** Write `settings/encryption.json`. */
+export function writeEncryptionManifest(podDir: string, manifest: EncryptionManifest): void {
+  const p = manifestPath(podDir);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+}
+
+/** A pod is encrypted iff it has an encryption manifest. */
+export function isPodEncrypted(podDir: string): boolean {
+  return fs.existsSync(manifestPath(podDir));
+}
+
+// ─── Manifest construction & DEK resolution ───────────────────────────────────
+
+/**
+ * Build a fresh encryption manifest for a new DEK protected by a passphrase.
+ * Generates a random salt and wraps the DEK with a freshly derived KEK.
+ */
+export function buildPassphraseManifest(
+  dek: Buffer,
+  passphrase: string,
+  params: { t: number; m: number; p: number } = DEFAULT_KDF,
+): EncryptionManifest {
+  const salt = randomBytes(16);
+  const kek = deriveKek(passphrase, salt, params);
+  const wrappedDek = wrapDek(dek, kek);
+  return {
+    version: '1.0',
+    algorithm: 'aes-256-gcm',
+    kdf: 'argon2id',
+    kdfParams: { salt: salt.toString('base64'), t: params.t, m: params.m, p: params.p },
+    wraps: [{ by: 'passphrase', wrappedDek }],
+  };
+}
+
+/**
+ * Resolve the pod DEK from its manifest using a passphrase:
+ * read manifest -> deriveKek -> unwrapDek.
+ *
+ * @throws {Error} if the pod is not encrypted.
+ * @throws {PodDecryptError} on an incorrect passphrase / corrupt key.
+ */
+export function resolveDek(podDir: string, passphrase: string): Buffer {
+  const manifest = readEncryptionManifest(podDir);
+  if (!manifest) {
+    throw new Error(`Pod is not encrypted (no ${MANIFEST_RELATIVE_PATH}): ${podDir}`);
+  }
+  const wrap = manifest.wraps.find((w) => w.by === 'passphrase');
+  if (!wrap) {
+    throw new Error('No passphrase wrap found in encryption manifest.');
+  }
+  const salt = Buffer.from(manifest.kdfParams.salt, 'base64');
+  const kek = deriveKek(passphrase, salt, manifest.kdfParams);
+  return unwrapDek(wrap.wrappedDek, kek);
+}
+
+// ─── Transparent resource read/write ──────────────────────────────────────────
+
+/**
+ * Read a resource. If a DEK is supplied, the on-disk bytes are decrypted from
+ * the combined layout; otherwise the file is read as plaintext UTF-8.
+ *
+ * @throws {PodDecryptError} on auth failure when a DEK is supplied.
+ */
+export function readResource(absPath: string, dek?: Buffer): string {
+  if (dek) {
+    const blob = fs.readFileSync(absPath);
+    return decryptResource(blob, dek);
+  }
+  return fs.readFileSync(absPath, 'utf-8');
+}
+
+/**
+ * Write a resource. If a DEK is supplied, the content is encrypted to the
+ * combined layout; otherwise it is written as plaintext UTF-8.
+ */
+export function writeResource(absPath: string, content: string, dek?: Buffer): void {
+  if (dek) {
+    fs.writeFileSync(absPath, encryptResource(content, dek));
+  } else {
+    fs.writeFileSync(absPath, content, 'utf-8');
+  }
+}

--- a/src/lib/shacl-validator.ts
+++ b/src/lib/shacl-validator.ts
@@ -12,6 +12,7 @@ import { Parser, Store } from 'n3';
 import SHACLValidator from 'rdf-validate-shacl';
 import { parseTurtle, detectVocabularies, CASCADE_NAMESPACES } from './turtle-parser.js';
 import type { ParseResult } from './turtle-parser.js';
+import { readResource } from './pod-encryption.js';
 
 export interface ValidationResult {
   valid: boolean;
@@ -262,11 +263,15 @@ export function validateTurtle(
 
 /**
  * Validate a Turtle file against SHACL shapes.
+ *
+ * When `dek` is supplied, the file is decrypted (combined AES-256-GCM layout)
+ * before parsing; otherwise it is read as plaintext UTF-8.
  */
 export function validateFile(
   filePath: string,
   shapesStore: Store,
   shapeFiles: string[],
+  dek?: Buffer,
 ): ValidationResult {
   if (!fs.existsSync(filePath)) {
     return {
@@ -284,7 +289,9 @@ export function validateFile(
     };
   }
 
-  const content = fs.readFileSync(filePath, 'utf-8');
+  const content = dek
+    ? readResource(filePath, dek)
+    : fs.readFileSync(filePath, 'utf-8');
   return validateTurtle(content, shapesStore, shapeFiles, filePath);
 }
 

--- a/tests/pod-encryption-integration.test.ts
+++ b/tests/pod-encryption-integration.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Integration tests for encrypted-pod command wiring.
+ *
+ * Drives the commander actions programmatically (init/import/query/validate)
+ * against temp dirs, with the passphrase supplied via CASCADE_POD_PASSPHRASE.
+ *
+ * Verifies:
+ *   - `pod init --encrypt` writes ciphertext resources (no @prefix on disk).
+ *   - `pod query` decrypts and returns expected records.
+ *   - `pod import` into an encrypted pod, then `pod query` returns them.
+ *   - `validate` succeeds on an encrypted pod (decrypts first).
+ *   - A plaintext pod (no manifest) still imports/queries unchanged.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { registerValidateCommand } from '../src/commands/validate.js';
+
+const PASSPHRASE = 'integration-test-passphrase';
+
+// These tests exercise the REAL Argon2id KDF (t=3, m=64 MiB) on every
+// init/encrypt/decrypt/query/validate, several times per test. The default
+// 64 MiB memory cost is deliberately heavy, so allow a generous timeout.
+const TEST_TIMEOUT_MS = 60_000;
+
+/** Build a fresh CLI program with the pod + validate commands registered. */
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride() // throw instead of process.exit so tests can catch
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  registerValidateCommand(program);
+  return program;
+}
+
+/**
+ * Run a CLI invocation, capturing stdout. Returns captured stdout lines joined.
+ * `process.exitCode` is reset before each run and returned.
+ */
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const program = buildProgram();
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  // printResult() writes via process.stdout.write, not console.log — capture both.
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown): boolean => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+/** Minimal synthetic FHIR bundle: a Patient + two MedicationStatements. */
+function syntheticFhirBundle(): string {
+  return JSON.stringify({
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: 'pat-1',
+          name: [{ given: ['Testy'], family: 'McTestface' }],
+          gender: 'female',
+          birthDate: '1985-04-12',
+        },
+      },
+      {
+        resource: {
+          resourceType: 'MedicationStatement',
+          id: 'med-1',
+          status: 'active',
+          medicationCodeableConcept: {
+            coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '197361', display: 'Lisinopril 10 MG' }],
+            text: 'Lisinopril 10 MG',
+          },
+          subject: { reference: 'Patient/pat-1' },
+        },
+      },
+      {
+        resource: {
+          resourceType: 'MedicationStatement',
+          id: 'med-2',
+          status: 'active',
+          medicationCodeableConcept: {
+            coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '860975', display: 'Metformin 500 MG' }],
+            text: 'Metformin 500 MG',
+          },
+          subject: { reference: 'Patient/pat-1' },
+        },
+      },
+    ],
+  });
+}
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-enc-it-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+beforeEach(() => {
+  process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+});
+
+afterEach(() => {
+  delete process.env.CASCADE_POD_PASSPHRASE;
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  tmpDirs = [];
+});
+
+describe('encrypted pod end-to-end', () => {
+  it('pod init --encrypt writes ciphertext resources and a manifest', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const { exitCode } = await runCli(['pod', 'init', dir, '--encrypt']);
+    expect(exitCode).toBe(0);
+
+    // Manifest present.
+    expect(fs.existsSync(path.join(dir, 'settings', 'encryption.json'))).toBe(true);
+
+    // index.ttl and template TTLs are ciphertext (no readable @prefix).
+    const indexBytes = fs.readFileSync(path.join(dir, 'index.ttl')).toString('utf-8');
+    expect(indexBytes).not.toContain('@prefix');
+    expect(indexBytes).not.toContain('ldp:BasicContainer');
+
+    const cardBytes = fs.readFileSync(path.join(dir, 'profile', 'card.ttl')).toString('utf-8');
+    expect(cardBytes).not.toContain('@prefix');
+
+    // README stays plaintext docs.
+    expect(fs.readFileSync(path.join(dir, 'README.md'), 'utf-8')).toContain('Cascade Protocol Pod');
+  }, TEST_TIMEOUT_MS);
+
+  it('imports FHIR into an encrypted pod, leaves clinical data as ciphertext, and queries it back', async () => {
+    const root = mkTmpDir();
+    const dir = path.join(root, 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt']);
+
+    const fhirPath = path.join(root, 'bundle.json');
+    fs.writeFileSync(fhirPath, syntheticFhirBundle());
+
+    const imp = await runCli(['pod', 'import', dir, fhirPath]);
+    expect(imp.exitCode).toBe(0);
+
+    // The imported medications file must be on disk as ciphertext.
+    const medsPath = path.join(dir, 'clinical', 'medications.ttl');
+    expect(fs.existsSync(medsPath)).toBe(true);
+    const medsBytes = fs.readFileSync(medsPath).toString('utf-8');
+    expect(medsBytes).not.toContain('@prefix');
+    expect(medsBytes).not.toContain('Lisinopril');
+
+    // Query decrypts and returns the medications.
+    const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
+    expect(q.exitCode).toBe(0);
+    const parsed = JSON.parse(q.stdout);
+    expect(parsed.dataTypes.medications.count).toBe(2);
+  }, TEST_TIMEOUT_MS);
+
+  it('query fails cleanly with the wrong passphrase', async () => {
+    const root = mkTmpDir();
+    const dir = path.join(root, 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt']);
+    const fhirPath = path.join(root, 'bundle.json');
+    fs.writeFileSync(fhirPath, syntheticFhirBundle());
+    await runCli(['pod', 'import', dir, fhirPath]);
+
+    process.env.CASCADE_POD_PASSPHRASE = 'definitely-wrong';
+    const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
+    expect(q.exitCode).toBe(1);
+  }, TEST_TIMEOUT_MS);
+
+  it('validate succeeds on an encrypted pod (decrypts first)', async () => {
+    const root = mkTmpDir();
+    const dir = path.join(root, 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt']);
+    const fhirPath = path.join(root, 'bundle.json');
+    fs.writeFileSync(fhirPath, syntheticFhirBundle());
+    await runCli(['pod', 'import', dir, fhirPath]);
+
+    const v = await runCli(['validate', dir]);
+    // Exit code 0 = all pass, 1 = SHACL violations. Either way it must NOT be 2
+    // (which would mean a read/parse error, i.e. decryption failed).
+    expect(v.exitCode).not.toBe(2);
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('pod encrypt migration', () => {
+  it('migrates a plaintext pod to encrypted in place', async () => {
+    const root = mkTmpDir();
+    const dir = path.join(root, 'pod');
+    // Init plaintext (no env passphrase needed for plaintext init).
+    delete process.env.CASCADE_POD_PASSPHRASE;
+    await runCli(['pod', 'init', dir]);
+    expect(fs.readFileSync(path.join(dir, 'index.ttl'), 'utf-8')).toContain('@prefix');
+
+    // Now encrypt.
+    process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+    const enc = await runCli(['pod', 'encrypt', dir]);
+    expect(enc.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(dir, 'settings', 'encryption.json'))).toBe(true);
+    expect(fs.readFileSync(path.join(dir, 'index.ttl')).toString('utf-8')).not.toContain('@prefix');
+
+    // Guard: encrypting again must fail.
+    const again = await runCli(['pod', 'encrypt', dir]);
+    expect(again.exitCode).toBe(1);
+  }, TEST_TIMEOUT_MS);
+
+  it('decrypts an encrypted pod back to plaintext and removes the manifest', async () => {
+    const root = mkTmpDir();
+    const dir = path.join(root, 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt']);
+
+    const dec = await runCli(['pod', 'decrypt', dir]);
+    expect(dec.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(dir, 'settings', 'encryption.json'))).toBe(false);
+    expect(fs.readFileSync(path.join(dir, 'index.ttl'), 'utf-8')).toContain('@prefix');
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('plaintext pod still works (no manifest)', () => {
+  it('imports and queries a plaintext pod unchanged', async () => {
+    delete process.env.CASCADE_POD_PASSPHRASE;
+    const root = mkTmpDir();
+    const dir = path.join(root, 'pod');
+    await runCli(['pod', 'init', dir]);
+
+    const fhirPath = path.join(root, 'bundle.json');
+    fs.writeFileSync(fhirPath, syntheticFhirBundle());
+    const imp = await runCli(['pod', 'import', dir, fhirPath]);
+    expect(imp.exitCode).toBe(0);
+
+    // Plaintext on disk.
+    const medsBytes = fs.readFileSync(path.join(dir, 'clinical', 'medications.ttl'), 'utf-8');
+    expect(medsBytes).toContain('@prefix');
+
+    const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
+    expect(q.exitCode).toBe(0);
+    const parsed = JSON.parse(q.stdout);
+    expect(parsed.dataTypes.medications.count).toBe(2);
+  }, TEST_TIMEOUT_MS);
+});

--- a/tests/pod-encryption.test.ts
+++ b/tests/pod-encryption.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the pod-encryption core module.
+ *
+ * Covers the AES-256-GCM combined-layout round-trip, DEK wrapping with an
+ * Argon2id passphrase KEK, manifest I/O, and the clean error on a wrong
+ * passphrase. No CLI is driven here (see pod-encryption-integration.test.ts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  generateDek,
+  encryptResource,
+  decryptResource,
+  deriveKek,
+  wrapDek,
+  unwrapDek,
+  buildPassphraseManifest,
+  writeEncryptionManifest,
+  readEncryptionManifest,
+  isPodEncrypted,
+  resolveDek,
+  readResource,
+  writeResource,
+  PodDecryptError,
+  NONCE_LEN,
+  TAG_LEN,
+  KEY_LEN,
+  DEFAULT_KDF,
+} from '../src/lib/pod-encryption.js';
+
+// Use cheap Argon2id params in tests to keep them fast. (m is in KiB.)
+const FAST_KDF = { t: 2, m: 256, p: 1 };
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-enc-'));
+}
+
+describe('encryptResource / decryptResource', () => {
+  it('round-trips and produces the combined nonce||ct||tag layout', () => {
+    const dek = generateDek();
+    expect(dek.length).toBe(KEY_LEN);
+
+    const plaintext = '@prefix ex: <http://example.org/> . ex:s ex:p "hello" .';
+    const blob = encryptResource(plaintext, dek);
+
+    const plaintextBytes = Buffer.from(plaintext, 'utf-8').length;
+    expect(blob.length).toBe(NONCE_LEN + plaintextBytes + TAG_LEN);
+
+    expect(decryptResource(blob, dek)).toBe(plaintext);
+  });
+
+  it('uses a fresh random nonce per call', () => {
+    const dek = generateDek();
+    const a = encryptResource('same plaintext', dek);
+    const b = encryptResource('same plaintext', dek);
+    // First NONCE_LEN bytes are the nonce; they must differ.
+    expect(a.subarray(0, NONCE_LEN).equals(b.subarray(0, NONCE_LEN))).toBe(false);
+    // And the whole ciphertext therefore differs.
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('throws PodDecryptError when the DEK is wrong', () => {
+    const blob = encryptResource('secret', generateDek());
+    expect(() => decryptResource(blob, generateDek())).toThrow(PodDecryptError);
+  });
+
+  it('throws PodDecryptError on a truncated/corrupt blob', () => {
+    const dek = generateDek();
+    const blob = encryptResource('secret', dek);
+    const corrupt = blob.subarray(0, 5); // too short
+    expect(() => decryptResource(corrupt, dek)).toThrow(PodDecryptError);
+  });
+});
+
+describe('deriveKek / wrapDek / unwrapDek', () => {
+  it('derives a 32-byte KEK deterministically for the same salt', () => {
+    const salt = Buffer.from('0123456789abcdef');
+    const k1 = deriveKek('correct horse', salt, FAST_KDF);
+    const k2 = deriveKek('correct horse', salt, FAST_KDF);
+    expect(k1.length).toBe(KEY_LEN);
+    expect(k1.equals(k2)).toBe(true);
+  });
+
+  it('round-trips a DEK wrapped with the KEK', () => {
+    const dek = generateDek();
+    const salt = Buffer.from('0123456789abcdef');
+    const kek = deriveKek('passphrase', salt, FAST_KDF);
+
+    const wrapped = wrapDek(dek, kek);
+    expect(typeof wrapped).toBe('string'); // base64
+    const unwrapped = unwrapDek(wrapped, kek);
+    expect(unwrapped.equals(dek)).toBe(true);
+  });
+
+  it('throws the clean error when unwrapping with the wrong KEK', () => {
+    const dek = generateDek();
+    const salt = Buffer.from('0123456789abcdef');
+    const goodKek = deriveKek('right', salt, FAST_KDF);
+    const badKek = deriveKek('wrong', salt, FAST_KDF);
+
+    const wrapped = wrapDek(dek, goodKek);
+    expect(() => unwrapDek(wrapped, badKek)).toThrow(PodDecryptError);
+    expect(() => unwrapDek(wrapped, badKek)).toThrow(/incorrect passphrase or corrupt key/);
+  });
+});
+
+describe('manifest I/O and resolveDek', () => {
+  it('writes and reads a manifest; isPodEncrypted reflects presence', () => {
+    const dir = mkTmpDir();
+    expect(isPodEncrypted(dir)).toBe(false);
+
+    const dek = generateDek();
+    const manifest = buildPassphraseManifest(dek, 'hunter2', FAST_KDF);
+    writeEncryptionManifest(dir, manifest);
+
+    expect(isPodEncrypted(dir)).toBe(true);
+    const read = readEncryptionManifest(dir);
+    expect(read).not.toBeNull();
+    expect(read!.algorithm).toBe('aes-256-gcm');
+    expect(read!.kdf).toBe('argon2id');
+    expect(read!.wraps[0].by).toBe('passphrase');
+    expect(read!.kdfParams.t).toBe(FAST_KDF.t);
+  });
+
+  it('resolveDek recovers the same DEK with the right passphrase', () => {
+    const dir = mkTmpDir();
+    const dek = generateDek();
+    writeEncryptionManifest(dir, buildPassphraseManifest(dek, 'hunter2', FAST_KDF));
+
+    const resolved = resolveDek(dir, 'hunter2');
+    expect(resolved.equals(dek)).toBe(true);
+  });
+
+  it('resolveDek throws the clean error on a wrong passphrase', () => {
+    const dir = mkTmpDir();
+    const dek = generateDek();
+    writeEncryptionManifest(dir, buildPassphraseManifest(dek, 'hunter2', FAST_KDF));
+
+    expect(() => resolveDek(dir, 'wrong-pass')).toThrow(PodDecryptError);
+  });
+
+  it('records the default KDF params in a manifest built without overrides', () => {
+    const dek = generateDek();
+    const m = buildPassphraseManifest(dek, 'pw'); // default DEFAULT_KDF (slow; just inspect params)
+    expect(m.kdfParams.t).toBe(DEFAULT_KDF.t);
+    expect(m.kdfParams.m).toBe(DEFAULT_KDF.m);
+    expect(m.kdfParams.p).toBe(DEFAULT_KDF.p);
+  });
+});
+
+describe('readResource / writeResource passthrough', () => {
+  it('writes ciphertext (not Turtle) with a DEK and reads it back', () => {
+    const dir = mkTmpDir();
+    const file = path.join(dir, 'r.ttl');
+    const dek = generateDek();
+    const ttl = '@prefix ex: <http://example.org/> . ex:s a ex:Thing .';
+
+    writeResource(file, ttl, dek);
+    const onDisk = fs.readFileSync(file);
+    // On-disk bytes must not be readable Turtle.
+    expect(onDisk.toString('utf-8')).not.toContain('@prefix');
+
+    expect(readResource(file, dek)).toBe(ttl);
+  });
+
+  it('writes and reads plaintext when no DEK is supplied', () => {
+    const dir = mkTmpDir();
+    const file = path.join(dir, 'r.ttl');
+    const ttl = '@prefix ex: <http://example.org/> .';
+    writeResource(file, ttl);
+    expect(fs.readFileSync(file, 'utf-8')).toBe(ttl);
+    expect(readResource(file)).toBe(ttl);
+  });
+});


### PR DESCRIPTION
Implements **encryption at rest** for Cascade Pods (the production gate from the Workbench hardening scope). Opening for review; **not for merge/publish yet**.

## What
Transparent encrypt-on-write / decrypt-on-read so Pod `.ttl` resources are AES-256-GCM encrypted on disk, while `init`/`import`/`query`/`validate` keep working.

- **Resource bytes = the Swift `.combined` layout** `nonce(12) || ciphertext || tag(16)` (AES-256-GCM, 256-bit DEK), so they are byte-interoperable with the Swift SDK's `PodEncryption`.
- **Envelope encryption**: a random per-Pod DEK encrypts resources; the DEK is wrapped by a passphrase-derived KEK. **KDF = Argon2id via `@noble/hashes`** (pure JS, no native build; sibling of the already-present `@noble/curves`).
- **Manifest** `settings/encryption.json`: `{ version, algorithm, kdf, kdfParams{salt,t,m,p}, wraps:[{by:"passphrase", wrappedDek}] }`. The `wraps[]` array reserves a `device-keychain` slot (documented, not yet implemented).
- **Key custody**: passphrase via `CASCADE_POD_PASSPHRASE` env or a hidden TTY prompt; **never a plaintext `--passphrase` argv** (no `ps` leak).

## Commands
- `pod init --encrypt` — generate DEK + manifest, write template resources encrypted.
- `pod encrypt <dir>` / `pod decrypt <dir>` — migrate an existing Pod in place (guards if already in the target state).
- `pod import` / `pod query` / `validate` — encryption-aware: resolve the DEK when a manifest is present, else pass through as plaintext.

## Module
`src/lib/pod-encryption.ts` (single chokepoint: `readResource`/`writeResource`, `encryptResource`/`decryptResource`, `deriveKek`, `wrapDek`/`unwrapDek`, `resolveDek` with a clean "incorrect passphrase or corrupt key" error on GCM auth failure) + `src/lib/passphrase.ts`.

## Tests / docs
- 20 new tests (combined-layout length + nonce variance, wrap/unwrap + wrong-passphrase, encrypted init→query with on-disk ciphertext assertion, import→query, validate on an encrypted Pod, encrypt/decrypt round-trip, plaintext parity). **Full suite 881 pass, 0 fail.** Build green.
- `docs/pod-encryption.md` documents the layout/manifest/KDF/commands and flags promotion into `spec/pod-structure.md`.

## Known limitation
`pod conflicts` / `pod resolve` read/write `settings/*.ttl` as plaintext and are not yet encryption-aware (outside the audited call-site scope). Documented in `docs/pod-encryption.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)