### PR TITLE
Append-only record-edit commands (amend/annotate/add-record/retract/erase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.6.0] - 2026-06-22
+
+### Added
+
+- **Append-only record-amendment commands.** Original Pod records are now never modified in place; every edit/delete is a new provenanced overlay resource written to a new `<pod>/annotations/` directory (one `.ttl` per kind) and auto-discovered by `pod query --all`. All writes route through the encryption chokepoint (ciphertext on disk when the pod is encrypted), mint `urn:uuid:` ids, stamp `dct:created`, tag `cascade:dataProvenance cascade:SelfReported`, and are SHACL-validated before they are written (a malformed overlay fails and nothing is persisted). New subcommands:
+  - `cascade pod amend <pod> --record <uri> --property <curie> --value <val> [--reason] [--by]` writes a `workbench:Amendment` (overrides one property value). Result: `{ amended, amendmentUri, recordUri, property, value }`.
+  - `cascade pod annotate <pod> --record <uri> [--text] [--property --value] [--by]` writes a `workbench:Annotation` (adds a note / extra attribute). Result: `{ annotated, annotationUri, recordUri }`.
+  - `cascade pod add-record <pod> --type <curie> --json '<propsJson>' [--by]` writes a NEW self-reported record into its canonical bucket (`clinical/...` or `wellness/...`) via the same type-to-file map `pod import` uses. `propsJson` is read from the argument or the `CASCADE_RECORD_JSON` env var. Result: `{ added, recordUri, type }`.
+  - `cascade pod retract <pod> --record <uri> [--reason] [--superseded-by <keptUri>] [--by]` writes a `workbench:Retraction` (soft-delete / supersede). Result: `{ retracted, retractionUri, recordUri, supersededBy }`.
+  - `cascade pod erase <pod> --record <uri> --confirm [--reason] [--by]` HARD-deletes: removes the subject from its bucket file, computes the sha-256 `contentHash` of its triples, and writes a `workbench:Tombstone` audit marker. Requires `--confirm`. The only records command that mutates a base bucket file. Result: `{ erased, tombstoneUri, recordUri, contentHash }`.
+- `workbench:` is now a recognized Cascade namespace for vocabulary detection, so `cascade validate` applies the workbench shapes to overlay resources.
+
+### Shapes
+
+- Synced `workbench.shapes.ttl` from spec (`workbench@v1-draft.0.2`): SHACL shapes for `workbench:Amendment` / `Annotation` / `Retraction` / `Tombstone`. Per D-PATH, the draft is not registered as a `VOCAB_VERSIONS` row until v1.0 graduation.
+
+---
+
 ## [0.5.11] - 2026-06-17
 
 ### Added

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -16,6 +16,10 @@
 #   (shape relaxations only: geneSymbol Violation→Warning,
 #   variantInterpreted range widened to {Variant, CopyNumberVariant, Haplotype}).
 #   No vocabulary additions; no row change.
+# Updated 2026-06-22: synced workbench.shapes.ttl for workbench@v1-draft.0.2
+#   (append-only record-amendment overlays: Amendment, Annotation, Retraction,
+#   Tombstone, plus their shapes). Per D-PATH, drafts are NOT registered as a
+#   row until v1.0 graduation; no row change.
 core=3.3
 health=2.4
 clinical=1.9

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -20,6 +20,10 @@
 #   (append-only record-amendment overlays: Amendment, Annotation, Retraction,
 #   Tombstone, plus their shapes). Per D-PATH, drafts are NOT registered as a
 #   row until v1.0 graduation; no row change.
+# Updated 2026-06-23: synced workbench.shapes.ttl for workbench@v1-draft.0.3
+#   (content-free Tombstone — contentHash removed, erasureAction added; plus the
+#   verification axis: verificationStatus + VerificationStatusShape via sh:in).
+#   Per D-PATH, still draft; no row change.
 core=3.3
 health=2.4
 clinical=1.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.5.11",
+  "version": "0.6.0",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"

--- a/src/commands/pod/add-record.ts
+++ b/src/commands/pod/add-record.ts
@@ -1,0 +1,211 @@
+/**
+ * cascade pod add-record <pod-dir> --type <curie> --json '<propsJson>' [--by <actorIri>]
+ *
+ * Add a NEW self-reported record (NOT an annotation overlay). The record is
+ * routed to its canonical bucket file (clinical/<type>.ttl or wellness/...) via
+ * the SAME type->file map import.ts uses, tagged cascade:dataProvenance
+ * cascade:SelfReported plus an optional actor and dct:created, with a minted
+ * urn:uuid: id.
+ *
+ * <propsJson> is an object of { "<curie>": "<value>" }. It is read from the
+ * --json arg, or from the CASCADE_RECORD_JSON environment variable when --json
+ * is omitted (useful for large payloads).
+ *
+ * --json result (global --json flag):
+ *   { added: true, recordUri, type }
+ */
+
+import type { Command } from 'commander';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { DATA_TYPES, resolvePodDir, fileExists, type DataTypeInfo } from './helpers.js';
+import {
+  resolvePodDek,
+  mintUri,
+  escapeTurtleString,
+} from '../../lib/annotations.js';
+import { readResource, writeResource } from '../../lib/pod-encryption.js';
+
+// CURIE prefix -> namespace IRI for expanding --type and property CURIEs.
+const PREFIX_NS: Record<string, string> = {
+  cascade: 'https://ns.cascadeprotocol.org/core/v1#',
+  core: 'https://ns.cascadeprotocol.org/core/v1#',
+  health: 'https://ns.cascadeprotocol.org/health/v1#',
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+  coverage: 'https://ns.cascadeprotocol.org/coverage/v1#',
+  checkup: 'https://ns.cascadeprotocol.org/checkup/v1#',
+  pots: 'https://ns.cascadeprotocol.org/pots/v1#',
+  workbench: 'https://ns.cascadeprotocol.org/workbench/v1#',
+  fhir: 'http://hl7.org/fhir/',
+};
+
+const TURTLE_PREFIX_HEADER = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix coverage: <https://ns.cascadeprotocol.org/coverage/v1#> .
+@prefix checkup: <https://ns.cascadeprotocol.org/checkup/v1#> .
+@prefix pots: <https://ns.cascadeprotocol.org/pots/v1#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+`;
+
+/** Expand a CURIE (prefix:local) to a full IRI, or return it unchanged. */
+function expandCurie(curie: string): string | undefined {
+  const idx = curie.indexOf(':');
+  if (idx < 0) return undefined;
+  const prefix = curie.slice(0, idx);
+  const local = curie.slice(idx + 1);
+  const ns = PREFIX_NS[prefix];
+  if (!ns) return undefined;
+  return ns + local;
+}
+
+/** Find the DATA_TYPES bucket key whose rdfTypes contains the type IRI. */
+function findBucketForType(typeIri: string): { key: string; info: DataTypeInfo } | undefined {
+  for (const [key, info] of Object.entries(DATA_TYPES)) {
+    if (info.isFhirPassthroughBucket) continue;
+    if (info.rdfTypes.includes(typeIri)) return { key, info };
+  }
+  return undefined;
+}
+
+export function registerAddRecordSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('add-record')
+    .description('Add a new self-reported record to its canonical bucket file')
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    // propsJson is an optional positional so the documented `--json '<propsJson>'`
+    // surface works: the global boolean `--json` flag absorbs `--json` and the
+    // following `'{...}'` value lands here. CASCADE_RECORD_JSON is the env fallback.
+    .argument('[propsJson]', 'JSON object of { "<curie>": "<value>" } properties')
+    .requiredOption('--type <curie>', 'rdf:type CURIE of the new record, e.g. clinical:Medication')
+    .option('--by <actorIri>', 'Optional actor IRI (prov:wasAttributedTo)')
+    .action(async (
+      podDirArg: string,
+      propsJson: string | undefined,
+      options: { type: string; by?: string },
+    ) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(podDirArg);
+
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Resolve the type CURIE to a full IRI and its destination bucket.
+      const typeIri = expandCurie(options.type);
+      if (!typeIri) {
+        printError(`Unknown type CURIE prefix: ${options.type}`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+      const bucket = findBucketForType(typeIri);
+      if (!bucket) {
+        printError(
+          `No known bucket for type ${options.type}. Supported types are the Cascade record classes registered in the data-type map.`,
+          globalOpts,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      // Read propsJson from the positional arg (e.g. `--json '{...}'`), else from
+      // the CASCADE_RECORD_JSON env var.
+      const rawProps = propsJson ?? process.env.CASCADE_RECORD_JSON;
+      if (!rawProps) {
+        printError('No properties provided. Pass --json \'{...}\' or set CASCADE_RECORD_JSON.', globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+      let props: Record<string, unknown>;
+      try {
+        props = JSON.parse(rawProps) as Record<string, unknown>;
+        if (typeof props !== 'object' || props === null || Array.isArray(props)) {
+          throw new Error('propsJson must be a JSON object');
+        }
+      } catch (e: unknown) {
+        printError(`Invalid --json payload: ${e instanceof Error ? e.message : String(e)}`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      let dek: Buffer | undefined;
+      try {
+        dek = await resolvePodDek(podDir);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const recordUri = mintUri();
+      const createdIso = new Date().toISOString();
+
+      // Build the record's predicate/object lines from propsJson.
+      const lines: string[] = [`    a ${options.type}`];
+      for (const [curie, value] of Object.entries(props)) {
+        // Validate each property CURIE expands to a known namespace.
+        if (!expandCurie(curie)) {
+          printError(`Unknown property CURIE prefix: ${curie}`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
+        lines.push(`    ${curie} "${escapeTurtleString(String(value))}"`);
+      }
+      lines.push('    cascade:dataProvenance cascade:SelfReported');
+      if (options.by) {
+        lines.push(`    prov:wasAttributedTo <${options.by}>`);
+      }
+      lines.push(`    dct:created "${escapeTurtleString(createdIso)}"^^xsd:dateTime`);
+
+      const block = `<${recordUri}>\n${lines.join(' ;\n')} .\n`;
+
+      const targetFile = path.join(podDir, bucket.info.directory, bucket.info.filename);
+
+      // Read-merge-write into the bucket file (preserve a single prefix header).
+      let mergedBody = block;
+      if (await fileExists(targetFile)) {
+        const existing = readResource(targetFile, dek);
+        const existingBody = stripPrefixHeader(existing);
+        mergedBody = existingBody.trim().length > 0
+          ? `${existingBody.trimEnd()}\n\n${block}`
+          : block;
+      }
+      const merged = `${TURTLE_PREFIX_HEADER}\n${mergedBody}`;
+
+      await fs.mkdir(path.dirname(targetFile), { recursive: true });
+      writeResource(targetFile, merged, dek);
+
+      const result = { added: true, recordUri, type: options.type };
+
+      // The documented `--json '<propsJson>'` surface sets the global boolean
+      // `--json` (the value lands in the positional), so JSON output is the norm.
+      if (globalOpts.json) {
+        printResult(result, globalOpts);
+      } else {
+        printVerbose(`Wrote record to ${bucket.info.directory}/${bucket.info.filename}`, globalOpts);
+        console.log(`Record added: ${recordUri}`);
+        console.log(`  Type: ${options.type}`);
+        console.log(`  File: ${bucket.info.directory}/${bucket.info.filename}`);
+      }
+    });
+}
+
+/** Strip leading @prefix / @base header lines, returning the statement body. */
+function stripPrefixHeader(turtle: string): string {
+  const lines = turtle.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '' || trimmed.startsWith('@prefix') || trimmed.startsWith('@base')) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  return lines.slice(i).join('\n');
+}

--- a/src/commands/pod/add-record.ts
+++ b/src/commands/pod/add-record.ts
@@ -3,9 +3,12 @@
  *
  * Add a NEW self-reported record (NOT an annotation overlay). The record is
  * routed to its canonical bucket file (clinical/<type>.ttl or wellness/...) via
- * the SAME type->file map import.ts uses, tagged cascade:dataProvenance
- * cascade:SelfReported plus an optional actor and dct:created, with a minted
- * urn:uuid: id.
+ * the SAME type->file map import.ts uses, tagged on two orthogonal axes:
+ *   - SOURCE: cascade:dataProvenance cascade:SelfReported + a real
+ *     prov:wasAttributedTo actor (the --by IRI, else the Pod patient WebID).
+ *   - VERIFICATION: workbench:verificationStatus workbench:Unverified (self-
+ *     entered data is unverified until corroborated; mirrors FHIR).
+ * Plus dct:created and a minted urn:uuid: id.
  *
  * <propsJson> is an object of { "<curie>": "<value>" }. It is read from the
  * --json arg, or from the CASCADE_RECORD_JSON environment variable when --json
@@ -46,10 +49,17 @@ const TURTLE_PREFIX_HEADER = `@prefix cascade: <https://ns.cascadeprotocol.org/c
 @prefix coverage: <https://ns.cascadeprotocol.org/coverage/v1#> .
 @prefix checkup: <https://ns.cascadeprotocol.org/checkup/v1#> .
 @prefix pots: <https://ns.cascadeprotocol.org/pots/v1#> .
+@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 `;
+
+// The Pod's canonical patient WebID (see `cascade pod init`), used as the
+// default prov:wasAttributedTo actor for a self-entered record when --by is
+// not supplied — so attribution is a real PROV-O triple that survives export,
+// not just a UI affordance.
+const PATIENT_WEBID = '/profile/card.ttl#me';
 
 /** Expand a CURIE (prefix:local) to a full IRI, or return it unchanged. */
 function expandCurie(curie: string): string | undefined {
@@ -156,10 +166,12 @@ export function registerAddRecordSubcommand(pod: Command, program: Command): voi
         }
         lines.push(`    ${curie} "${escapeTurtleString(String(value))}"`);
       }
+      // Source axis: who reported it (self) — and a real attribution triple.
       lines.push('    cascade:dataProvenance cascade:SelfReported');
-      if (options.by) {
-        lines.push(`    prov:wasAttributedTo <${options.by}>`);
-      }
+      lines.push(`    prov:wasAttributedTo <${options.by ?? PATIENT_WEBID}>`);
+      // Verification axis (orthogonal to source): self-entered data is unverified
+      // until corroborated. Mirrors FHIR verificationStatus.
+      lines.push('    workbench:verificationStatus workbench:Unverified');
       lines.push(`    dct:created "${escapeTurtleString(createdIso)}"^^xsd:dateTime`);
 
       const block = `<${recordUri}>\n${lines.join(' ;\n')} .\n`;

--- a/src/commands/pod/amend.ts
+++ b/src/commands/pod/amend.ts
@@ -1,0 +1,105 @@
+/**
+ * cascade pod amend <pod-dir> --record <uri> --property <curie> --value <val>
+ *                             [--reason <r>] [--by <actorIri>]
+ *
+ * Write an append-only workbench:Amendment overlay that overrides one property
+ * value on an existing record. The original record is never modified.
+ *
+ * --json result:
+ *   { amended: true, amendmentUri, recordUri, property, value }
+ */
+
+import type { Command } from 'commander';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { resolvePodDir, fileExists } from './helpers.js';
+import {
+  resolvePodDek,
+  appendOverlay,
+  mintUri,
+  iriRef,
+  strLit,
+  type OverlayLine,
+} from '../../lib/annotations.js';
+import * as path from 'node:path';
+
+export function registerAmendSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('amend')
+    .description('Override one property value on a record via an append-only Amendment overlay')
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    .requiredOption('--record <uri>', 'IRI of the record to amend')
+    .requiredOption('--property <curie>', 'Predicate CURIE being overridden, e.g. clinical:dosage')
+    .requiredOption('--value <val>', 'The new value that supersedes the original')
+    .option('--reason <r>', 'Optional rationale for the amendment')
+    .option('--by <actorIri>', 'Optional actor IRI (prov:wasAttributedTo)')
+    .action(async (
+      podDirArg: string,
+      options: { record: string; property: string; value: string; reason?: string; by?: string },
+    ) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(podDirArg);
+
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      let dek: Buffer | undefined;
+      try {
+        dek = await resolvePodDek(podDir);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const amendmentUri = mintUri();
+      const createdIso = new Date().toISOString();
+
+      const lines: OverlayLine[] = [
+        { predicate: 'workbench:amendsRecord', object: iriRef(options.record) },
+        { predicate: 'workbench:amendsProperty', object: strLit(options.property) },
+        { predicate: 'workbench:amendedValue', object: strLit(options.value) },
+      ];
+      if (options.reason) {
+        lines.push({ predicate: 'workbench:amendmentReason', object: strLit(options.reason) });
+      }
+
+      try {
+        await appendOverlay(
+          podDir,
+          {
+            fileName: 'amendments.ttl',
+            subjectUri: amendmentUri,
+            rdfType: 'workbench:Amendment',
+            lines,
+            actorIri: options.by,
+            createdIso,
+          },
+          dek,
+        );
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = {
+        amended: true,
+        amendmentUri,
+        recordUri: options.record,
+        property: options.property,
+        value: options.value,
+      };
+
+      if (globalOpts.json) {
+        printResult(result, globalOpts);
+      } else {
+        printVerbose(`Wrote Amendment to annotations/amendments.ttl`, globalOpts);
+        console.log(`Amendment written: ${amendmentUri}`);
+        console.log(`  Record:   ${options.record}`);
+        console.log(`  Override: ${options.property} = ${options.value}`);
+      }
+    });
+}

--- a/src/commands/pod/annotate.ts
+++ b/src/commands/pod/annotate.ts
@@ -1,0 +1,114 @@
+/**
+ * cascade pod annotate <pod-dir> --record <uri> [--text <note>]
+ *                                [--property <curie> --value <val>] [--by <actorIri>]
+ *
+ * Write an append-only workbench:Annotation overlay that ADDS a note or extra
+ * attribute to an existing record (does not override). The original record is
+ * never modified.
+ *
+ * --json result:
+ *   { annotated: true, annotationUri, recordUri }
+ */
+
+import type { Command } from 'commander';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { resolvePodDir, fileExists } from './helpers.js';
+import {
+  resolvePodDek,
+  appendOverlay,
+  mintUri,
+  iriRef,
+  strLit,
+  type OverlayLine,
+} from '../../lib/annotations.js';
+import * as path from 'node:path';
+
+export function registerAnnotateSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('annotate')
+    .description('Add a note or extra attribute to a record via an append-only Annotation overlay')
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    .requiredOption('--record <uri>', 'IRI of the record to annotate')
+    .option('--text <note>', 'Free-text note to attach to the record')
+    .option('--property <curie>', 'Predicate CURIE of an extra attribute (paired with --value)')
+    .option('--value <val>', 'Value of the extra attribute named by --property')
+    .option('--by <actorIri>', 'Optional actor IRI (prov:wasAttributedTo)')
+    .action(async (
+      podDirArg: string,
+      options: { record: string; text?: string; property?: string; value?: string; by?: string },
+    ) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(podDirArg);
+
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Require at least one of --text or --value (mirrors the SHACL shape).
+      if (!options.text && !options.value) {
+        printError('Provide at least one of --text or --value (with --property).', globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      let dek: Buffer | undefined;
+      try {
+        dek = await resolvePodDek(podDir);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const annotationUri = mintUri();
+      const createdIso = new Date().toISOString();
+
+      const lines: OverlayLine[] = [
+        { predicate: 'workbench:annotatesRecord', object: iriRef(options.record) },
+      ];
+      if (options.text) {
+        lines.push({ predicate: 'workbench:annotationText', object: strLit(options.text) });
+      }
+      if (options.property) {
+        lines.push({ predicate: 'workbench:annotationProperty', object: strLit(options.property) });
+      }
+      if (options.value) {
+        lines.push({ predicate: 'workbench:annotationValue', object: strLit(options.value) });
+      }
+
+      try {
+        await appendOverlay(
+          podDir,
+          {
+            fileName: 'annotations.ttl',
+            subjectUri: annotationUri,
+            rdfType: 'workbench:Annotation',
+            lines,
+            actorIri: options.by,
+            createdIso,
+          },
+          dek,
+        );
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = {
+        annotated: true,
+        annotationUri,
+        recordUri: options.record,
+      };
+
+      if (globalOpts.json) {
+        printResult(result, globalOpts);
+      } else {
+        printVerbose('Wrote Annotation to annotations/annotations.ttl', globalOpts);
+        console.log(`Annotation written: ${annotationUri}`);
+        console.log(`  Record: ${options.record}`);
+      }
+    });
+}

--- a/src/commands/pod/erase.ts
+++ b/src/commands/pod/erase.ts
@@ -1,0 +1,207 @@
+/**
+ * cascade pod erase <pod-dir> --record <uri> --confirm [--reason <r>] [--by <actorIri>]
+ *
+ * HARD delete: locate the record's subject in its bucket file, compute the
+ * sha-256 of its serialized triples (the contentHash), remove that subject from
+ * the bucket file (read-merge-write minus the subject, re-encrypting), and write
+ * a workbench:Tombstone audit marker to annotations/.
+ *
+ * This is the ONLY records command that mutates a base bucket file (removal);
+ * every other command is purely additive. `--confirm` is REQUIRED.
+ *
+ * --json result:
+ *   { erased: true, tombstoneUri, recordUri, contentHash }
+ */
+
+import type { Command } from 'commander';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+import { Parser, type Quad } from 'n3';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { resolvePodDir, fileExists, discoverTtlFiles } from './helpers.js';
+import {
+  resolvePodDek,
+  appendOverlay,
+  mintUri,
+  iriRef,
+  strLit,
+  type OverlayLine,
+} from '../../lib/annotations.js';
+import { readResource, writeResource } from '../../lib/pod-encryption.js';
+import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/** Parse Turtle into a flat quad array. */
+function parseQuads(turtle: string): Quad[] {
+  const parser = new Parser({ format: 'Turtle' });
+  return parser.parse(turtle);
+}
+
+/**
+ * Canonical hash of a subject's quads: sort the `predicate object` terms and
+ * sha-256 the joined string. Stable regardless of statement order.
+ */
+function hashSubject(quads: Quad[]): string {
+  const lines = quads
+    .map((q) => `${q.predicate.value} ${q.object.value}`)
+    .sort();
+  return createHash('sha256').update(lines.join('\n'), 'utf-8').digest('hex');
+}
+
+/** Shorten a known rdf:type IRI to a CURIE for the Tombstone audit marker. */
+function shortenType(iri: string): string {
+  const map: Record<string, string> = {
+    'https://ns.cascadeprotocol.org/core/v1#': 'cascade:',
+    'https://ns.cascadeprotocol.org/health/v1#': 'health:',
+    'https://ns.cascadeprotocol.org/clinical/v1#': 'clinical:',
+    'https://ns.cascadeprotocol.org/coverage/v1#': 'coverage:',
+    'https://ns.cascadeprotocol.org/checkup/v1#': 'checkup:',
+    'https://ns.cascadeprotocol.org/pots/v1#': 'pots:',
+    'http://hl7.org/fhir/': 'fhir:',
+  };
+  for (const [ns, prefix] of Object.entries(map)) {
+    if (iri.startsWith(ns)) return prefix + iri.slice(ns.length);
+  }
+  return iri;
+}
+
+export function registerEraseSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('erase')
+    .description('Hard-delete a record from its bucket file and write a Tombstone audit marker')
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    .requiredOption('--record <uri>', 'IRI of the record to erase')
+    .option('--confirm', 'Required confirmation for the destructive hard delete')
+    .option('--reason <r>', 'Optional rationale for the erasure')
+    .option('--by <actorIri>', 'Optional actor IRI (prov:wasAttributedTo)')
+    .action(async (
+      podDirArg: string,
+      options: { record: string; confirm?: boolean; reason?: string; by?: string },
+    ) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(podDirArg);
+
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!options.confirm) {
+        printError('Refusing to hard-erase without --confirm (this permanently removes the record bytes).', globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      let dek: Buffer | undefined;
+      try {
+        dek = await resolvePodDek(podDir);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Find the bucket file that contains the subject. Search data + extra
+      // ttl files, excluding overlays, indexes, profile, and settings.
+      const allTtl = await discoverTtlFiles(podDir);
+      const excludeDirs = new Set([
+        path.join(podDir, 'annotations'),
+        path.join(podDir, 'settings'),
+        path.join(podDir, 'profile'),
+      ]);
+      const excludeFiles = new Set([
+        path.join(podDir, 'index.ttl'),
+        path.join(podDir, 'manifest.ttl'),
+      ]);
+
+      let foundFile: string | undefined;
+      let subjectQuads: Quad[] = [];
+      let remainingQuads: Quad[] = [];
+
+      for (const file of allTtl) {
+        if (excludeFiles.has(file)) continue;
+        if ([...excludeDirs].some((d) => file.startsWith(d + path.sep))) continue;
+
+        let quads: Quad[];
+        try {
+          quads = parseQuads(readResource(file, dek));
+        } catch {
+          continue;
+        }
+        const match = quads.filter((q) => q.subject.value === options.record);
+        if (match.length > 0) {
+          foundFile = file;
+          subjectQuads = match;
+          remainingQuads = quads.filter((q) => q.subject.value !== options.record);
+          break;
+        }
+      }
+
+      if (!foundFile) {
+        printError(`Record not found in any bucket file: ${options.record}`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Compute the content hash and capture the erased type (if present).
+      const contentHash = hashSubject(subjectQuads);
+      const typeQuad = subjectQuads.find((q) => q.predicate.value === RDF_TYPE);
+      const erasedType = typeQuad ? shortenType(typeQuad.object.value) : undefined;
+
+      // Re-serialize the bucket WITHOUT the erased subject and write it back.
+      const newBucketTurtle = await quadsToTurtle(remainingQuads);
+      writeResource(foundFile, newBucketTurtle, dek);
+
+      // Write the Tombstone overlay.
+      const tombstoneUri = mintUri();
+      const createdIso = new Date().toISOString();
+
+      const lines: OverlayLine[] = [
+        { predicate: 'workbench:erasedRecord', object: iriRef(options.record) },
+        { predicate: 'workbench:contentHash', object: strLit(contentHash) },
+      ];
+      if (erasedType) {
+        lines.push({ predicate: 'workbench:erasedType', object: strLit(erasedType) });
+      }
+      if (options.reason) {
+        lines.push({ predicate: 'workbench:erasureReason', object: strLit(options.reason) });
+      }
+
+      try {
+        await appendOverlay(
+          podDir,
+          {
+            fileName: 'tombstones.ttl',
+            subjectUri: tombstoneUri,
+            rdfType: 'workbench:Tombstone',
+            lines,
+            actorIri: options.by,
+            createdIso,
+          },
+          dek,
+        );
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = {
+        erased: true,
+        tombstoneUri,
+        recordUri: options.record,
+        contentHash,
+      };
+
+      if (globalOpts.json) {
+        printResult(result, globalOpts);
+      } else {
+        printVerbose(`Removed ${options.record} from ${path.relative(podDir, foundFile)}`, globalOpts);
+        console.log(`Record erased: ${options.record}`);
+        console.log(`  Content hash: ${contentHash}`);
+        console.log(`  Tombstone:    ${tombstoneUri}`);
+      }
+    });
+}

--- a/src/commands/pod/erase.ts
+++ b/src/commands/pod/erase.ts
@@ -1,21 +1,28 @@
 /**
  * cascade pod erase <pod-dir> --record <uri> --confirm [--reason <r>] [--by <actorIri>]
  *
- * HARD delete: locate the record's subject in its bucket file, compute the
- * sha-256 of its serialized triples (the contentHash), remove that subject from
- * the bucket file (read-merge-write minus the subject, re-encrypting), and write
- * a workbench:Tombstone audit marker to annotations/.
+ * HARD delete: locate the record's subject in its bucket file, remove that
+ * subject from the bucket file (read-merge-write minus the subject,
+ * re-encrypting), and write a CONTENT-FREE workbench:Tombstone audit marker to
+ * annotations/.
+ *
+ * The Tombstone records only the EVENT — the erased record's opaque id, the
+ * action, the actor (prov:wasAttributedTo), and the timestamp (dct:created). It
+ * deliberately retains NO content hash: a SHA-256 of an erased record's triples
+ * is still pseudonymised personal data (EDPB Guidelines 01/2025; WP29 WP216),
+ * because health content is low-entropy and enumerable, so a hash is
+ * brute-forceable and would re-create the very erasure obligation this command
+ * discharges. The Tombstone is thus the content-free audit/provenance event.
  *
  * This is the ONLY records command that mutates a base bucket file (removal);
  * every other command is purely additive. `--confirm` is REQUIRED.
  *
  * --json result:
- *   { erased: true, tombstoneUri, recordUri, contentHash }
+ *   { erased: true, tombstoneUri, recordUri, action }
  */
 
 import type { Command } from 'commander';
 import * as path from 'node:path';
-import { createHash } from 'node:crypto';
 import { Parser, type Quad } from 'n3';
 import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
 import { resolvePodDir, fileExists, discoverTtlFiles } from './helpers.js';
@@ -32,21 +39,16 @@ import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
+/** The action this command records on its Tombstone. */
+const ERASE_ACTION = 'hard-erase';
+
+/** Default actor for the erasure audit event (the Pod patient WebID). */
+const PATIENT_WEBID = '/profile/card.ttl#me';
+
 /** Parse Turtle into a flat quad array. */
 function parseQuads(turtle: string): Quad[] {
   const parser = new Parser({ format: 'Turtle' });
   return parser.parse(turtle);
-}
-
-/**
- * Canonical hash of a subject's quads: sort the `predicate object` terms and
- * sha-256 the joined string. Stable regardless of statement order.
- */
-function hashSubject(quads: Quad[]): string {
-  const lines = quads
-    .map((q) => `${q.predicate.value} ${q.object.value}`)
-    .sort();
-  return createHash('sha256').update(lines.join('\n'), 'utf-8').digest('hex');
 }
 
 /** Shorten a known rdf:type IRI to a CURIE for the Tombstone audit marker. */
@@ -145,8 +147,9 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
         return;
       }
 
-      // Compute the content hash and capture the erased type (if present).
-      const contentHash = hashSubject(subjectQuads);
+      // Capture the erased type (category only, if present). We deliberately do
+      // NOT hash the erased content: a hash of low-entropy health triples is
+      // still pseudonymised personal data and would defeat the erasure.
       const typeQuad = subjectQuads.find((q) => q.predicate.value === RDF_TYPE);
       const erasedType = typeQuad ? shortenType(typeQuad.object.value) : undefined;
 
@@ -154,13 +157,13 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
       const newBucketTurtle = await quadsToTurtle(remainingQuads);
       writeResource(foundFile, newBucketTurtle, dek);
 
-      // Write the Tombstone overlay.
+      // Write the content-free Tombstone overlay (the erasure audit event).
       const tombstoneUri = mintUri();
       const createdIso = new Date().toISOString();
 
       const lines: OverlayLine[] = [
         { predicate: 'workbench:erasedRecord', object: iriRef(options.record) },
-        { predicate: 'workbench:contentHash', object: strLit(contentHash) },
+        { predicate: 'workbench:erasureAction', object: strLit(ERASE_ACTION) },
       ];
       if (erasedType) {
         lines.push({ predicate: 'workbench:erasedType', object: strLit(erasedType) });
@@ -177,7 +180,9 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
             subjectUri: tombstoneUri,
             rdfType: 'workbench:Tombstone',
             lines,
-            actorIri: options.by,
+            // Always attribute the erasure so the audit event records WHO; the
+            // tombstone is then id + actor + timestamp + action (content-free).
+            actorIri: options.by ?? PATIENT_WEBID,
             createdIso,
           },
           dek,
@@ -192,7 +197,7 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
         erased: true,
         tombstoneUri,
         recordUri: options.record,
-        contentHash,
+        action: ERASE_ACTION,
       };
 
       if (globalOpts.json) {
@@ -200,8 +205,8 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
       } else {
         printVerbose(`Removed ${options.record} from ${path.relative(podDir, foundFile)}`, globalOpts);
         console.log(`Record erased: ${options.record}`);
-        console.log(`  Content hash: ${contentHash}`);
-        console.log(`  Tombstone:    ${tombstoneUri}`);
+        console.log(`  Action:    ${ERASE_ACTION}`);
+        console.log(`  Tombstone: ${tombstoneUri}`);
       }
     });
 }

--- a/src/commands/pod/index.ts
+++ b/src/commands/pod/index.ts
@@ -26,6 +26,11 @@ import { registerConflictsCommand } from './conflicts.js';
 import { registerResolveCommand } from './resolve.js';
 import { registerExtractSubcommand } from './extract.js';
 import { registerEncryptSubcommand } from './encrypt.js';
+import { registerAmendSubcommand } from './amend.js';
+import { registerAnnotateSubcommand } from './annotate.js';
+import { registerAddRecordSubcommand } from './add-record.js';
+import { registerRetractSubcommand } from './retract.js';
+import { registerEraseSubcommand } from './erase.js';
 
 export function registerPodCommand(program: Command): void {
   const pod = program.command('pod').description('Manage Cascade Pod structures');
@@ -39,4 +44,9 @@ export function registerPodCommand(program: Command): void {
   registerResolveCommand(pod);
   registerExtractSubcommand(pod);
   registerEncryptSubcommand(pod, program);
+  registerAmendSubcommand(pod, program);
+  registerAnnotateSubcommand(pod, program);
+  registerAddRecordSubcommand(pod, program);
+  registerRetractSubcommand(pod, program);
+  registerEraseSubcommand(pod, program);
 }

--- a/src/commands/pod/retract.ts
+++ b/src/commands/pod/retract.ts
@@ -1,0 +1,108 @@
+/**
+ * cascade pod retract <pod-dir> --record <uri> [--reason <r>]
+ *                              [--superseded-by <keptUri>] [--by <actorIri>]
+ *
+ * Write an append-only workbench:Retraction overlay that soft-deletes /
+ * supersedes a record (the entered-in-error pattern). The retracted record's
+ * bytes are retained; this overlay marks it withdrawn and may point at the kept
+ * record when merging duplicates.
+ *
+ * --json result:
+ *   { retracted: true, retractionUri, recordUri, supersededBy }
+ */
+
+import type { Command } from 'commander';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { resolvePodDir, fileExists } from './helpers.js';
+import {
+  resolvePodDek,
+  appendOverlay,
+  mintUri,
+  iriRef,
+  strLit,
+  type OverlayLine,
+} from '../../lib/annotations.js';
+import * as path from 'node:path';
+
+export function registerRetractSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('retract')
+    .description('Soft-delete / supersede a record via an append-only Retraction overlay')
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    .requiredOption('--record <uri>', 'IRI of the record to retract')
+    .option('--reason <r>', 'Optional rationale (e.g. "entered in error")')
+    .option('--superseded-by <keptUri>', 'Optional IRI of the kept record when merging duplicates')
+    .option('--by <actorIri>', 'Optional actor IRI (prov:wasAttributedTo)')
+    .action(async (
+      podDirArg: string,
+      options: { record: string; reason?: string; supersededBy?: string; by?: string },
+    ) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(podDirArg);
+
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      let dek: Buffer | undefined;
+      try {
+        dek = await resolvePodDek(podDir);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const retractionUri = mintUri();
+      const createdIso = new Date().toISOString();
+
+      const lines: OverlayLine[] = [
+        { predicate: 'workbench:retractsRecord', object: iriRef(options.record) },
+      ];
+      if (options.reason) {
+        lines.push({ predicate: 'workbench:retractionReason', object: strLit(options.reason) });
+      }
+      if (options.supersededBy) {
+        lines.push({ predicate: 'workbench:supersededBy', object: iriRef(options.supersededBy) });
+      }
+
+      try {
+        await appendOverlay(
+          podDir,
+          {
+            fileName: 'retractions.ttl',
+            subjectUri: retractionUri,
+            rdfType: 'workbench:Retraction',
+            lines,
+            actorIri: options.by,
+            createdIso,
+          },
+          dek,
+        );
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = {
+        retracted: true,
+        retractionUri,
+        recordUri: options.record,
+        supersededBy: options.supersededBy ?? null,
+      };
+
+      if (globalOpts.json) {
+        printResult(result, globalOpts);
+      } else {
+        printVerbose('Wrote Retraction to annotations/retractions.ttl', globalOpts);
+        console.log(`Retraction written: ${retractionUri}`);
+        console.log(`  Record: ${options.record}`);
+        if (options.supersededBy) {
+          console.log(`  Superseded by: ${options.supersededBy}`);
+        }
+      }
+    });
+}

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -1,0 +1,226 @@
+/**
+ * Append-only record-amendment overlays (workbench: vocabulary).
+ *
+ * Original Pod records are immutable. Every edit/delete is a NEW overlay
+ * resource written to `<pod>/annotations/<kind>.ttl`:
+ *
+ *   - workbench:Amendment   overrides one property value on a record
+ *   - workbench:Annotation  adds a note / extra attribute (no override)
+ *   - workbench:Retraction  soft-deletes / supersedes a record
+ *   - workbench:Tombstone   hard-erase audit marker (bytes gone, fact kept)
+ *
+ * Overlays carry cascade:dataProvenance cascade:SelfReported, an optional
+ * prov:wasAttributedTo actor, and a dct:created timestamp. All resource I/O
+ * routes through the pod-encryption chokepoint so overlays are ciphertext on
+ * disk when the pod is encrypted. A malformed overlay fails before it is
+ * written: the merged annotations file is SHACL-validated first.
+ */
+
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import {
+  isPodEncrypted,
+  resolveDek,
+  readResource,
+  writeResource,
+  PodDecryptError,
+} from './pod-encryption.js';
+import { obtainPassphrase } from './passphrase.js';
+import { loadShapes, validateTurtle } from './shacl-validator.js';
+import { fileExists } from '../commands/pod/helpers.js';
+
+/** The pod-relative directory holding append-only overlay resources. */
+export const ANNOTATIONS_DIR = 'annotations';
+
+/** Shared Turtle prefix header for every overlay resource file. */
+export const OVERLAY_PREFIXES = `@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+`;
+
+/**
+ * Resolve the DEK for an encrypted pod, or `undefined` for a plaintext pod.
+ * Throws a clean Error when the pod is encrypted but the passphrase is wrong
+ * or unavailable.
+ */
+export async function resolvePodDek(podDir: string): Promise<Buffer | undefined> {
+  if (!isPodEncrypted(podDir)) return undefined;
+  try {
+    const passphrase = await obtainPassphrase();
+    return resolveDek(podDir, passphrase);
+  } catch (e: unknown) {
+    const msg =
+      e instanceof PodDecryptError ? e.message : e instanceof Error ? e.message : String(e);
+    throw new Error(`Cannot access encrypted pod: ${msg}`);
+  }
+}
+
+/** Escape a value for use inside a Turtle "..." string literal. */
+export function escapeTurtleString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+/** A single `predicate value` line within an overlay subject block. */
+export interface OverlayLine {
+  /** Predicate in CURIE form, e.g. 'workbench:amendsRecord'. */
+  predicate: string;
+  /** The object term, already serialized (IRI in <...> or "literal"^^type). */
+  object: string;
+}
+
+/** A literal string object: `"escaped"`. */
+export function strLit(value: string): string {
+  return `"${escapeTurtleString(value)}"`;
+}
+
+/** A typed dateTime object: `"..."^^xsd:dateTime`. */
+export function dateTimeLit(iso: string): string {
+  return `"${escapeTurtleString(iso)}"^^xsd:dateTime`;
+}
+
+/** An IRI object: `<iri>`. */
+export function iriRef(iri: string): string {
+  return `<${iri}>`;
+}
+
+/**
+ * Build the Turtle block for one overlay subject.
+ *
+ * @param subjectUri  the minted urn:uuid: of this overlay
+ * @param rdfType     the workbench class CURIE, e.g. 'workbench:Amendment'
+ * @param lines       the class-specific predicate/object lines
+ * @param actorIri    optional prov:wasAttributedTo actor IRI
+ * @param createdIso  dct:created timestamp (ISO 8601)
+ */
+export function buildOverlayBlock(
+  subjectUri: string,
+  rdfType: string,
+  lines: OverlayLine[],
+  actorIri: string | undefined,
+  createdIso: string,
+): string {
+  const allLines: OverlayLine[] = [
+    ...lines,
+    { predicate: 'cascade:dataProvenance', object: 'cascade:SelfReported' },
+  ];
+  if (actorIri) {
+    allLines.push({ predicate: 'prov:wasAttributedTo', object: iriRef(actorIri) });
+  }
+  allLines.push({ predicate: 'dct:created', object: dateTimeLit(createdIso) });
+
+  const body = allLines.map((l) => `    ${l.predicate} ${l.object}`).join(' ;\n');
+  return `<${subjectUri}> a ${rdfType} ;\n${body} .\n`;
+}
+
+/** Description of one overlay to be written. */
+export interface OverlaySpec {
+  /** File name under annotations/, e.g. 'amendments.ttl'. */
+  fileName: string;
+  /** The minted urn:uuid: subject of the overlay. */
+  subjectUri: string;
+  /** rdf:type CURIE, e.g. 'workbench:Amendment'. */
+  rdfType: string;
+  /** Class-specific predicate/object lines. */
+  lines: OverlayLine[];
+  /** Optional actor IRI for prov:wasAttributedTo. */
+  actorIri?: string;
+  /** ISO timestamp for dct:created. */
+  createdIso: string;
+}
+
+/**
+ * Append an overlay resource to `<pod>/annotations/<fileName>` via the
+ * read-merge-write pattern. The MERGED file content is SHACL-validated before
+ * it is written; a malformed overlay throws and nothing is persisted.
+ *
+ * @throws {Error} if the merged overlay fails SHACL validation.
+ */
+export async function appendOverlay(
+  podDir: string,
+  spec: OverlaySpec,
+  dek: Buffer | undefined,
+): Promise<void> {
+  const annotationsDir = path.join(podDir, ANNOTATIONS_DIR);
+  const filePath = path.join(annotationsDir, spec.fileName);
+
+  const block = buildOverlayBlock(
+    spec.subjectUri,
+    spec.rdfType,
+    spec.lines,
+    spec.actorIri,
+    spec.createdIso,
+  );
+
+  // Read existing body (without re-applying the prefix header), if present.
+  let existingBody = '';
+  if (await fileExists(filePath)) {
+    const existing = readResource(filePath, dek);
+    // Strip the leading prefix header lines so we keep a single header.
+    existingBody = stripPrefixHeader(existing);
+  }
+
+  const mergedBody = existingBody.trim().length > 0
+    ? `${existingBody.trimEnd()}\n\n${block}`
+    : block;
+  const merged = `${OVERLAY_PREFIXES}\n${mergedBody}`;
+
+  // Validate the merged graph BEFORE writing. A malformed overlay must fail.
+  validateOverlayGraph(merged, filePath);
+
+  await fs.mkdir(annotationsDir, { recursive: true });
+  writeResource(filePath, merged, dek);
+}
+
+/**
+ * Remove the leading `@prefix` / `@base` header lines from a Turtle document,
+ * returning just the statement body. Lets us re-append a single shared header.
+ */
+function stripPrefixHeader(turtle: string): string {
+  const lines = turtle.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '' || trimmed.startsWith('@prefix') || trimmed.startsWith('@base')) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  return lines.slice(i).join('\n');
+}
+
+let cachedShapes: ReturnType<typeof loadShapes> | undefined;
+
+/**
+ * SHACL-validate an overlay Turtle string against the bundled shapes.
+ * @throws {Error} listing the violations when the overlay does not conform.
+ */
+export function validateOverlayGraph(turtle: string, filePath: string): void {
+  if (!cachedShapes) {
+    cachedShapes = loadShapes();
+  }
+  const { store, shapeFiles } = cachedShapes;
+  const result = validateTurtle(turtle, store, shapeFiles, filePath);
+  if (!result.valid) {
+    const violations = result.results.filter((r) => r.severity === 'violation');
+    if (violations.length > 0) {
+      const detail = violations
+        .map((v) => `${v.property || v.shape}: ${v.message}`)
+        .join('; ');
+      throw new Error(`Overlay failed SHACL validation: ${detail}`);
+    }
+  }
+}
+
+/** Mint a fresh urn:uuid: resource URI. */
+export function mintUri(): string {
+  return `urn:uuid:${randomUUID()}`;
+}

--- a/src/lib/turtle-parser.ts
+++ b/src/lib/turtle-parser.ts
@@ -23,6 +23,7 @@ export const CASCADE_NAMESPACES: Record<string, string> = {
   pots: 'https://ns.cascadeprotocol.org/pots/v1#',
   checkup: 'https://ns.cascadeprotocol.org/checkup/v1#',
   coverage: 'https://ns.cascadeprotocol.org/coverage/v1#',
+  workbench: 'https://ns.cascadeprotocol.org/workbench/v1#',
 } as const;
 
 /** Well-known non-Cascade namespaces for IRI shortening */

--- a/src/shapes/workbench.shapes.ttl
+++ b/src/shapes/workbench.shapes.ttl
@@ -20,3 +20,37 @@ workbench:ImportedConversationShape a sh:NodeShape ;
     sh:targetClass workbench:ImportedConversation ;
     sh:property [ sh:path workbench:conversationSource ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:rawContentLocation ; sh:minCount 1 ; sh:datatype xsd:string ] .
+
+# ── Append-only record amendment overlays (v1-draft.0.2) ────────────────────
+
+workbench:AmendmentShape a sh:NodeShape ;
+    sh:targetClass workbench:Amendment ;
+    sh:property [ sh:path workbench:amendsRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:amendsProperty ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:amendedValue ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:amendmentReason ; sh:datatype xsd:string ] .
+
+workbench:AnnotationShape a sh:NodeShape ;
+    sh:targetClass workbench:Annotation ;
+    sh:property [ sh:path workbench:annotatesRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:annotationText ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:annotationProperty ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:annotationValue ; sh:datatype xsd:string ] ;
+    # Require at least one of annotationText / annotationValue.
+    sh:or (
+        [ sh:path workbench:annotationText ; sh:minCount 1 ]
+        [ sh:path workbench:annotationValue ; sh:minCount 1 ]
+    ) .
+
+workbench:RetractionShape a sh:NodeShape ;
+    sh:targetClass workbench:Retraction ;
+    sh:property [ sh:path workbench:retractsRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:retractionReason ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:supersededBy ; sh:nodeKind sh:IRI ] .
+
+workbench:TombstoneShape a sh:NodeShape ;
+    sh:targetClass workbench:Tombstone ;
+    sh:property [ sh:path workbench:erasedRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:erasedType ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:contentHash ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:erasureReason ; sh:datatype xsd:string ] .

--- a/src/shapes/workbench.shapes.ttl
+++ b/src/shapes/workbench.shapes.ttl
@@ -48,9 +48,18 @@ workbench:RetractionShape a sh:NodeShape ;
     sh:property [ sh:path workbench:retractionReason ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:supersededBy ; sh:nodeKind sh:IRI ] .
 
+# Content-free audit event (v1-draft.0.3): records the erasure EVENT only —
+# erased record id, action, optional category/reason — never a content hash.
 workbench:TombstoneShape a sh:NodeShape ;
     sh:targetClass workbench:Tombstone ;
     sh:property [ sh:path workbench:erasedRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:erasureAction ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:erasedType ; sh:datatype xsd:string ] ;
-    sh:property [ sh:path workbench:contentHash ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:erasureReason ; sh:datatype xsd:string ] .
+
+# Verification axis (v1-draft.0.3): orthogonal to cascade:dataProvenance.
+# Uses sh:in (not sh:class) so the constraint is self-contained in the shapes
+# graph — validating a bucket record needs no ontology individual-typing.
+workbench:VerificationStatusShape a sh:NodeShape ;
+    sh:targetObjectsOf workbench:verificationStatus ;
+    sh:in ( workbench:Unverified workbench:Confirmed workbench:Refuted ) .

--- a/tests/pod-records-edit.test.ts
+++ b/tests/pod-records-edit.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Integration tests for the append-only record-amendment commands:
+ *   pod amend / annotate / add-record / retract / erase
+ *
+ * Originals are immutable; every edit/delete is a new overlay resource in
+ * <pod>/annotations/, discovered by `pod query --all`. All writes route through
+ * the encryption chokepoint. Overlays must pass `cascade validate`; malformed
+ * ones must fail. The same flows are exercised on an ENCRYPTED pod.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { registerValidateCommand } from '../src/commands/validate.js';
+import { validateOverlayGraph } from '../src/lib/annotations.js';
+
+// Argon2id at 64 MiB makes encrypted runs heavy; allow a generous timeout.
+const TEST_TIMEOUT_MS = 60_000;
+const PASSPHRASE = 'records-edit-test-passphrase';
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  registerValidateCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const program = buildProgram();
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown): boolean => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws on errors; exitCode reflects the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+/** Pull the last complete JSON object out of captured stdout. */
+function lastJson(stdout: string): any {
+  const start = stdout.indexOf('{');
+  // Find the JSON block: results are pretty-printed objects.
+  const candidates: string[] = [];
+  let depth = 0;
+  let buf = '';
+  for (let i = start; i < stdout.length; i++) {
+    const ch = stdout[i];
+    if (ch === '{') {
+      if (depth === 0) buf = '';
+      depth++;
+    }
+    if (depth > 0) buf += ch;
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) candidates.push(buf);
+    }
+  }
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    try {
+      return JSON.parse(candidates[i]);
+    } catch {
+      /* keep looking */
+    }
+  }
+  throw new Error(`No JSON object found in stdout:\n${stdout}`);
+}
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-rec-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  delete process.env.CASCADE_POD_PASSPHRASE;
+  delete process.env.CASCADE_RECORD_JSON;
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  tmpDirs = [];
+});
+
+/** Init a plaintext pod and add one well-formed Medication; return its URI. */
+async function initPodWithMedication(dir: string): Promise<string> {
+  await runCli(['pod', 'init', dir]);
+  const add = await runCli([
+    'pod', 'add-record', dir,
+    '--type', 'clinical:Medication',
+    '--json', '{"clinical:drugName":"Lisinopril","cascade:schemaVersion":"1.3","clinical:dosage":"10mg"}',
+  ]);
+  expect(add.exitCode).toBe(0);
+  return lastJson(add.stdout).recordUri as string;
+}
+
+describe('SHACL overlay gate (unit)', () => {
+  it('accepts a well-formed Amendment overlay', () => {
+    const ttl = `@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:uuid:a> a workbench:Amendment ;
+  workbench:amendsRecord <urn:uuid:r> ;
+  workbench:amendsProperty "clinical:dosage" ;
+  workbench:amendedValue "20mg" ;
+  cascade:dataProvenance cascade:SelfReported ;
+  dct:created "2026-06-22T00:00:00Z"^^xsd:dateTime .`;
+    expect(() => validateOverlayGraph(ttl, 'a.ttl')).not.toThrow();
+  });
+
+  it('rejects an Amendment missing the required amendedValue', () => {
+    const ttl = `@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+<urn:uuid:b> a workbench:Amendment ;
+  workbench:amendsRecord <urn:uuid:r> ;
+  workbench:amendsProperty "clinical:dosage" ;
+  cascade:dataProvenance cascade:SelfReported .`;
+    expect(() => validateOverlayGraph(ttl, 'b.ttl')).toThrow(/SHACL/);
+  });
+
+  it('rejects an Annotation with neither text nor value', () => {
+    const ttl = `@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+<urn:uuid:c> a workbench:Annotation ;
+  workbench:annotatesRecord <urn:uuid:r> ;
+  cascade:dataProvenance cascade:SelfReported .`;
+    expect(() => validateOverlayGraph(ttl, 'c.ttl')).toThrow(/SHACL/);
+  });
+});
+
+describe('plaintext pod: append-only record amendments', () => {
+  it('add-record lands a SelfReported record in the right bucket; query returns it', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+
+    // Lands in clinical/medications.ttl, tagged SelfReported.
+    const medsPath = path.join(dir, 'clinical', 'medications.ttl');
+    expect(fs.existsSync(medsPath)).toBe(true);
+    const medsText = fs.readFileSync(medsPath, 'utf-8');
+    expect(medsText).toContain('cascade:SelfReported');
+    expect(medsText).toContain('Lisinopril');
+
+    const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
+    expect(q.exitCode).toBe(0);
+    const parsed = lastJson(q.stdout);
+    expect(parsed.dataTypes.medications.count).toBe(1);
+    expect(parsed.dataTypes.medications.records[0].id).toBe(recordUri);
+  }, TEST_TIMEOUT_MS);
+
+  it('amend writes a valid Amendment that query --all surfaces with the right fields', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+
+    const a = await runCli([
+      '--json', 'pod', 'amend', dir,
+      '--record', recordUri,
+      '--property', 'clinical:dosage',
+      '--value', '20mg',
+      '--reason', 'titrated up',
+    ]);
+    expect(a.exitCode).toBe(0);
+    const ares = lastJson(a.stdout);
+    expect(ares.amended).toBe(true);
+    expect(ares.recordUri).toBe(recordUri);
+    expect(ares.property).toBe('clinical:dosage');
+    expect(ares.value).toBe('20mg');
+    expect(ares.amendmentUri).toMatch(/^urn:uuid:/);
+
+    // Overlay file exists and passes validation.
+    const overlayPath = path.join(dir, 'annotations', 'amendments.ttl');
+    expect(fs.existsSync(overlayPath)).toBe(true);
+    const v = await runCli(['validate', overlayPath]);
+    expect(v.exitCode).toBe(0);
+
+    // query --all surfaces the Amendment with the right triples.
+    const q = await runCli(['--json', 'pod', 'query', dir, '--all']);
+    const dt = lastJson(q.stdout).dataTypes;
+    const amendments = (Object.values(dt) as any[]).flatMap((b) => b.records)
+      .filter((r: any) => r.type === 'workbench:Amendment');
+    expect(amendments.length).toBe(1);
+    const props = amendments[0].properties;
+    expect(props['workbench:amendsRecord']).toBe(recordUri);
+    expect(props['workbench:amendsProperty']).toBe('clinical:dosage');
+    expect(props['workbench:amendedValue']).toBe('20mg');
+  }, TEST_TIMEOUT_MS);
+
+  it('annotate writes a valid Annotation overlay', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+
+    const r = await runCli([
+      '--json', 'pod', 'annotate', dir,
+      '--record', recordUri,
+      '--text', 'patient reports nausea',
+    ]);
+    expect(r.exitCode).toBe(0);
+    const res = lastJson(r.stdout);
+    expect(res.annotated).toBe(true);
+    expect(res.recordUri).toBe(recordUri);
+    expect(res.annotationUri).toMatch(/^urn:uuid:/);
+
+    const v = await runCli(['validate', path.join(dir, 'annotations', 'annotations.ttl')]);
+    expect(v.exitCode).toBe(0);
+  }, TEST_TIMEOUT_MS);
+
+  it('annotate with neither --text nor --value errors', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+    const r = await runCli(['--json', 'pod', 'annotate', dir, '--record', recordUri]);
+    expect(r.exitCode).toBe(1);
+  }, TEST_TIMEOUT_MS);
+
+  it('retract writes a Retraction; --superseded-by records the link', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+
+    const r = await runCli([
+      '--json', 'pod', 'retract', dir,
+      '--record', recordUri,
+      '--reason', 'duplicate',
+      '--superseded-by', 'urn:uuid:kept-123',
+    ]);
+    expect(r.exitCode).toBe(0);
+    const res = lastJson(r.stdout);
+    expect(res.retracted).toBe(true);
+    expect(res.recordUri).toBe(recordUri);
+    expect(res.supersededBy).toBe('urn:uuid:kept-123');
+
+    const overlayPath = path.join(dir, 'annotations', 'retractions.ttl');
+    expect(fs.readFileSync(overlayPath, 'utf-8')).toContain('workbench:supersededBy');
+    const v = await runCli(['validate', overlayPath]);
+    expect(v.exitCode).toBe(0);
+  }, TEST_TIMEOUT_MS);
+
+  it('erase --confirm removes the subject from its bucket and writes a Tombstone with a contentHash', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+
+    const e = await runCli([
+      '--json', 'pod', 'erase', dir,
+      '--record', recordUri,
+      '--confirm',
+      '--reason', 'merged duplicate',
+    ]);
+    expect(e.exitCode).toBe(0);
+    const res = lastJson(e.stdout);
+    expect(res.erased).toBe(true);
+    expect(res.recordUri).toBe(recordUri);
+    expect(res.tombstoneUri).toMatch(/^urn:uuid:/);
+    expect(res.contentHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // The subject is gone from the bucket: query no longer returns it.
+    const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
+    const meds = lastJson(q.stdout).dataTypes.medications;
+    expect((meds?.records ?? []).some((r: any) => r.id === recordUri)).toBe(false);
+
+    // A Tombstone overlay exists, carries the hash, and validates.
+    const tombPath = path.join(dir, 'annotations', 'tombstones.ttl');
+    const tomb = fs.readFileSync(tombPath, 'utf-8');
+    expect(tomb).toContain('workbench:Tombstone');
+    expect(tomb).toContain(res.contentHash);
+    const v = await runCli(['validate', tombPath]);
+    expect(v.exitCode).toBe(0);
+  }, TEST_TIMEOUT_MS);
+
+  it('erase without --confirm errors and does not mutate the bucket', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const recordUri = await initPodWithMedication(dir);
+    const before = fs.readFileSync(path.join(dir, 'clinical', 'medications.ttl'), 'utf-8');
+
+    const e = await runCli(['--json', 'pod', 'erase', dir, '--record', recordUri]);
+    expect(e.exitCode).toBe(1);
+
+    const after = fs.readFileSync(path.join(dir, 'clinical', 'medications.ttl'), 'utf-8');
+    expect(after).toBe(before);
+    expect(fs.existsSync(path.join(dir, 'annotations', 'tombstones.ttl'))).toBe(false);
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('encrypted pod: overlays are ciphertext on disk and still work', () => {
+  beforeEach(() => {
+    process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+  });
+
+  it('amend/annotate/retract/erase on an encrypted pod write ciphertext overlays', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt']);
+
+    const add = await runCli([
+      'pod', 'add-record', dir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Metformin","cascade:schemaVersion":"1.3"}',
+    ]);
+    expect(add.exitCode).toBe(0);
+    const recordUri = lastJson(add.stdout).recordUri as string;
+
+    // amend
+    const a = await runCli([
+      '--json', 'pod', 'amend', dir,
+      '--record', recordUri, '--property', 'clinical:dosage', '--value', '500mg',
+    ]);
+    expect(a.exitCode).toBe(0);
+
+    // annotate
+    const an = await runCli([
+      '--json', 'pod', 'annotate', dir, '--record', recordUri, '--text', 'with meals',
+    ]);
+    expect(an.exitCode).toBe(0);
+
+    // The amendments overlay is CIPHERTEXT on disk (no readable @prefix / URNs).
+    const amendBytes = fs.readFileSync(path.join(dir, 'annotations', 'amendments.ttl')).toString('utf-8');
+    expect(amendBytes).not.toContain('@prefix');
+    expect(amendBytes).not.toContain('workbench:Amendment');
+    const annBytes = fs.readFileSync(path.join(dir, 'annotations', 'annotations.ttl')).toString('utf-8');
+    expect(annBytes).not.toContain('@prefix');
+
+    // query --all decrypts and surfaces the overlays.
+    const q = await runCli(['--json', 'pod', 'query', dir, '--all']);
+    expect(q.exitCode).toBe(0);
+    const dt = lastJson(q.stdout).dataTypes;
+    const types = new Set(
+      (Object.values(dt) as any[]).flatMap((b) => b.records).map((r: any) => r.type),
+    );
+    expect(types.has('workbench:Amendment')).toBe(true);
+    expect(types.has('workbench:Annotation')).toBe(true);
+
+    // erase on encrypted pod removes the record and writes a ciphertext Tombstone.
+    const e = await runCli(['--json', 'pod', 'erase', dir, '--record', recordUri, '--confirm']);
+    expect(e.exitCode).toBe(0);
+    const tombBytes = fs.readFileSync(path.join(dir, 'annotations', 'tombstones.ttl')).toString('utf-8');
+    expect(tombBytes).not.toContain('@prefix');
+
+    const q2 = await runCli(['--json', 'pod', 'query', dir, '--medications']);
+    const meds = lastJson(q2.stdout).dataTypes.medications;
+    expect((meds?.records ?? []).some((r: any) => r.id === recordUri)).toBe(false);
+
+    // validate decrypts and the overlays pass.
+    const v = await runCli(['validate', dir]);
+    expect(v.exitCode).not.toBe(2); // not a read/decrypt error
+  }, TEST_TIMEOUT_MS);
+});

--- a/tests/pod-records-edit.test.ts
+++ b/tests/pod-records-edit.test.ts
@@ -166,6 +166,10 @@ describe('plaintext pod: append-only record amendments', () => {
     const medsText = fs.readFileSync(medsPath, 'utf-8');
     expect(medsText).toContain('cascade:SelfReported');
     expect(medsText).toContain('Lisinopril');
+    // Source axis: a real attribution triple to the Pod patient WebID.
+    expect(medsText).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+    // Verification axis: self-entered data defaults to Unverified.
+    expect(medsText).toContain('workbench:verificationStatus workbench:Unverified');
 
     const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
     expect(q.exitCode).toBe(0);
@@ -259,7 +263,7 @@ describe('plaintext pod: append-only record amendments', () => {
     expect(v.exitCode).toBe(0);
   }, TEST_TIMEOUT_MS);
 
-  it('erase --confirm removes the subject from its bucket and writes a Tombstone with a contentHash', async () => {
+  it('erase --confirm removes the subject and writes a CONTENT-FREE Tombstone (no content hash)', async () => {
     const dir = path.join(mkTmpDir(), 'pod');
     const recordUri = await initPodWithMedication(dir);
 
@@ -274,18 +278,24 @@ describe('plaintext pod: append-only record amendments', () => {
     expect(res.erased).toBe(true);
     expect(res.recordUri).toBe(recordUri);
     expect(res.tombstoneUri).toMatch(/^urn:uuid:/);
-    expect(res.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    // The result records the action, not a content hash.
+    expect(res.action).toBe('hard-erase');
+    expect(res.contentHash).toBeUndefined();
 
     // The subject is gone from the bucket: query no longer returns it.
     const q = await runCli(['--json', 'pod', 'query', dir, '--medications']);
     const meds = lastJson(q.stdout).dataTypes.medications;
     expect((meds?.records ?? []).some((r: any) => r.id === recordUri)).toBe(false);
 
-    // A Tombstone overlay exists, carries the hash, and validates.
+    // The Tombstone is a content-free audit event: it names the erased id and
+    // the action, but carries NO sha-256 content hash of the erased record.
     const tombPath = path.join(dir, 'annotations', 'tombstones.ttl');
     const tomb = fs.readFileSync(tombPath, 'utf-8');
     expect(tomb).toContain('workbench:Tombstone');
-    expect(tomb).toContain(res.contentHash);
+    expect(tomb).toContain('workbench:erasureAction');
+    expect(tomb).toContain('hard-erase');
+    expect(tomb).not.toMatch(/[0-9a-f]{64}/); // no content hash residue
+    expect(tomb).not.toContain('contentHash');
     const v = await runCli(['validate', tombPath]);
     expect(v.exitCode).toBe(0);
   }, TEST_TIMEOUT_MS);


### PR DESCRIPTION
Stacked on #7 (encryption). Adds append-only record editing: originals are never modified; every edit/delete is a new provenanced overlay resource in a new `<pod>/annotations/` dir, auto-discovered by `pod query --all`, written through the encryption chokepoint (encrypted + SHACL-valid).

New `pod` verbs (all `--json`):
- `pod amend <pod> --record --property --value [--reason] [--by]` -> `workbench:Amendment` -> `{ amended, amendmentUri, recordUri, property, value }`
- `pod annotate <pod> --record [--text] [--property --value] [--by]` -> `workbench:Annotation` -> `{ annotated, annotationUri, recordUri }`
- `pod add-record <pod> --type <curie> --json '<props>' [--by]` -> a new `cascade:SelfReported` record in its canonical bucket -> `{ added, recordUri, type }`
- `pod retract <pod> --record [--reason] [--superseded-by] [--by]` -> `workbench:Retraction` (archive / merge) -> `{ retracted, retractionUri, recordUri }`
- `pod erase <pod> --record --confirm [--reason]` -> hard delete (removes the subject from its bucket) + a `workbench:Tombstone` with a sha-256 contentHash -> `{ erased, tombstoneUri, recordUri, contentHash }`. Requires `--confirm`.

Consumes the `workbench:` draft overlay vocab (spec PR `feat/workbench-amendments`); shapes synced via `sync-shapes-from-spec.sh`; `workbench` added to `CASCADE_NAMESPACES` so overlays validate.

Tests: 11 new (valid overlays pass `cascade validate` / malformed fail; amend/add/retract/erase round-trips incl. on an encrypted pod with ciphertext overlays; `--confirm` guard). Full suite **892 pass**. Package 0.5.11 -> 0.6.0 (branch only).

Note: `add-record` takes propsJson as a positional (the global boolean `--json` shadows a subcommand `--json <value>` in commander); `--json '<props>'` still works as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)