### PR TITLE
Humanize query --all buckets (R1: stop leaking filenames)

### DIFF
--- a/src/commands/pod/query.ts
+++ b/src/commands/pod/query.ts
@@ -21,6 +21,24 @@ import {
 import { isPodEncrypted, resolveDek, PodDecryptError } from '../../lib/pod-encryption.js';
 import { obtainPassphrase } from '../../lib/passphrase.js';
 
+/**
+ * Classify an unregistered ("extra") TTL file discovered by `--all` into a
+ * stable, humanized bucket key, so the query never leaks raw filenames
+ * (`ai-extraction-<epoch>`, UUID-named bundles, conversation artifacts) as if
+ * they were record types. Files under `analysis/` and any `ai-extraction-*`
+ * output collapse into one `ai-extracted` bucket; every other unrecognized TTL
+ * collapses into `other`. Several files can map to the same bucket — their
+ * records are aggregated by the caller. The app-side display map turns these
+ * keys into labels/badges.
+ */
+function classifyExtraBucket(relPath: string, baseName: string): string {
+  const topDir = relPath.split(/[\\/]/)[0];
+  if (topDir === 'analysis' || baseName.startsWith('ai-extraction')) {
+    return 'ai-extracted';
+  }
+  return 'other';
+}
+
 export function registerQuerySubcommand(pod: Command, program: Command): void {
   pod
     .command('query')
@@ -200,21 +218,33 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
             };
           }
 
-          // Process extra files found in --all mode
+          // Process extra files found in --all mode. Instead of leaking each
+          // file's raw basename as a record type, classify it into a stable,
+          // humanized bucket (ai-extracted / other) and AGGREGATE records, so
+          // the UI never shows `ai-extraction-<epoch>` or a UUID as a "type".
           for (const extraFile of extraFiles) {
             const relPath = path.relative(absDir, extraFile);
             const baseName = path.basename(extraFile, '.ttl');
 
             const { records, error } = await parseDataFile(extraFile, dek);
-            if (records.length > 0) {
-              queryResults[baseName] = {
+            if (records.length === 0) continue;
+
+            const bucketKey = classifyExtraBucket(relPath, baseName);
+            const mapped = records.map((r) => ({
+              id: r.id,
+              type: r.type,
+              properties: r.properties,
+            }));
+            const existing = queryResults[bucketKey];
+            if (existing) {
+              existing.count += records.length;
+              existing.records.push(...mapped);
+              if (error && !existing.error) existing.error = error;
+            } else {
+              queryResults[bucketKey] = {
                 count: records.length,
-                file: relPath,
-                records: records.map((r) => ({
-                  id: r.id,
-                  type: r.type,
-                  properties: r.properties,
-                })),
+                file: relPath, // representative source; bucket may aggregate many
+                records: mapped,
                 error,
               };
             }

--- a/tests/pod.test.ts
+++ b/tests/pod.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
@@ -397,5 +398,52 @@ describe.skipIf(skipIfNoPod)('pod export', () => {
   it('should error for unknown export format', () => {
     const output = runCli(`pod export ${REFERENCE_POD} --format csv`);
     expect(output).toContain('Unknown export format');
+  });
+});
+
+describe('pod query --all: extra-file bucket humanization (R1 de-leak)', () => {
+  let podDir: string;
+
+  beforeEach(async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'cascade-deleak-'));
+    podDir = path.join(base, 'pod');
+    runCli(`pod init ${podDir}`);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(path.dirname(podDir), { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('aggregates analysis/ + ai-extraction-* into ai-extracted, collapses other artifacts, and never leaks raw filenames', async () => {
+    await fs.mkdir(path.join(podDir, 'analysis'), { recursive: true });
+    await fs.writeFile(
+      path.join(podDir, 'analysis', 'ai-extraction-1782163693.ttl'),
+      '@prefix evidence: <https://ns.cascadeprotocol.org/evidence/v1#> .\n<urn:uuid:a1> a evidence:Assertion ; evidence:assertionText "x" .\n',
+    );
+    await fs.writeFile(
+      path.join(podDir, 'analysis', '2c9e05cb-06d6-4a21-a339-0d689bff3545.ttl'),
+      '@prefix evidence: <https://ns.cascadeprotocol.org/evidence/v1#> .\n<urn:uuid:b1> a evidence:Assertion ; evidence:assertionText "y" .\n',
+    );
+    await fs.writeFile(
+      path.join(podDir, 'gemini-1782163693.ttl'),
+      '@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .\n<urn:uuid:c1> a workbench:ImportedConversation ; workbench:conversationSource "gemini" .\n',
+    );
+
+    const out = runCli(`--json pod query ${podDir} --all`);
+    const j = JSON.parse(out);
+    const keys = Object.keys(j.dataTypes);
+
+    // The two analysis files collapse into ONE ai-extracted bucket (2 records).
+    expect(j.dataTypes['ai-extracted']?.count).toBe(2);
+    // The conversation artifact collapses into `other`.
+    expect(j.dataTypes['other']?.count).toBe(1);
+    // No raw filename ever surfaces as a bucket key.
+    expect(keys.some((k) => k.includes('ai-extraction-'))).toBe(false);
+    expect(keys.some((k) => /[0-9a-f]{8}-[0-9a-f]{4}/.test(k))).toBe(false);
+    expect(keys.some((k) => k.startsWith('gemini'))).toBe(false);
   });
 });


### PR DESCRIPTION
**Explore-UX Wave 1, R1 (de-leak buckets).** First cascade-cli change after the encryption/record-edit stack merged.

## Problem
`pod query --all` keyed any TTL file not in the `DATA_TYPES` registry by its raw basename, so analysis artifacts (`analysis/ai-extraction-<epoch>.ttl`), UUID-named bundles, and conversation files (`gemini-<epoch>.ttl`) showed up in the Workbench rail as if they were clinical record types.

## Fix
Classify each extra file into a stable, humanized bucket and **aggregate** records:
- under `analysis/` or named `ai-extraction-*` → one `ai-extracted` bucket
- every other unrecognized TTL → `other`

No raw filename ever appears as a bucket key. Output shape is unchanged (keys improved, records aggregated), so existing consumers are unaffected; the app-side display map turns `ai-extracted`/`other` into labels + a provenance badge.

## Tests
New `pod query --all` de-leak test in `tests/pod.test.ts` (two `analysis/` files collapse to `ai-extracted: 2`, a conversation collapses to `other: 1`, asserts no `ai-extraction-`/UUID/`gemini` keys). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)