### PR TITLE
Folder + Apple Health import: source-adapter layer (streaming-ingestion slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.7.0] - 2026-06-26
+
+### Added
+
+- **Folder and vendor-export import (source-adapter layer).** `cascade pod import` now accepts a directory, not just files. A new source-adapter registry detects the container shape and expands it into importable files: an **Apple Health export** folder imports its `clinical-records/` FHIR and skips the multi-GB device exports (`export.xml`, `export_cda.xml`) and ECG/workout-route folders with a clear reason; any other folder is walked recursively for supported files (FHIR JSON, Turtle, C-CDA XML/zip). This is the first slice of the streaming-ingestion architecture: the container layer above the per-file FormatImporters. Verified on a real Apple Health export (1,267 files in, 1,160 records imported, both device exports skipped).
+
+### Fixed
+
+- **Import is resilient to a single bad file.** A file the converter cannot handle is now skipped with a reason in the import report, instead of aborting the whole import. Essential for folder imports of hundreds of files.
+- **`contentHashedUri` coerces non-string content fields.** Real-world FHIR (an Apple Health Patient) could carry a non-string field where the URI derivation expected a string, throwing `v.trim is not a function`. Values are coerced with `String(v)`; the derived URI is unchanged for valid string inputs, so existing URIs are stable.
+- **Whole-file read guard.** A file over ~2 GiB (Node's `fs.readFile` cap) is skipped with a clear reason rather than failing with an opaque "Cannot read file." Streaming import will lift this.
+
+---
+
 ## [0.6.1] - 2026-06-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"

--- a/spikes/streaming-ingest/README.md
+++ b/spikes/streaming-ingest/README.md
@@ -1,0 +1,35 @@
+# Streaming-ingestion spike
+
+A throwaway harness that proves streaming, not Rust, is the fix for multi-GB
+health artifacts. It streams a large XML through a real SAX parser (`saxes`),
+projects/downsamples as it parses, and reports peak RSS, time, and throughput.
+
+Companion design doc: `cascade-assets/Cascade-documents/Cascade-Workbench/2026-06-26-ingestion-architecture-and-streaming-spike.md`.
+
+## Run
+
+```sh
+npm i saxes        # standalone dep, intentionally not added to cascade-cli
+node spike.mjs /path/to/large.xml
+```
+
+NDJSON projection samples go to stdout; the stats line goes to stderr.
+
+## Results (2026-06-26, Node 22, Apple Health export, default heap)
+
+| File | Size | Time | Throughput | Peak RSS |
+|------|------|------|-----------|----------|
+| `export_cda.xml` | 2.31 GB | 11.4 s | 202 MB/s | 159 MB |
+| `export.xml` | 4.55 GB | 21.9 s | 207 MB/s | 150 MB |
+
+The 4.5 GB file used *less* RAM than the 2.3 GB file: memory is independent of
+file size, which is the signature of true streaming (we never hold the
+document). 10.2M heart-rate samples downsampled to 3,061 daily summaries with no
+memory growth.
+
+## Conclusion
+
+The decision gate passed decisively for streaming in TypeScript. Node is not the
+bottleneck for multi-GB XML/JSON/FHIR/CCDA. Rust is deferred to the binary +
+compute + extreme-scale tail (PDF/OCR, DICOM, genomics at tens-plus of GB),
+measured against this ~205 MB/s baseline when such a file is actually in hand.

--- a/spikes/streaming-ingest/spike.mjs
+++ b/spikes/streaming-ingest/spike.mjs
@@ -1,0 +1,114 @@
+// Streaming-ingestion spike. Streams a multi-GB health XML through a real SAX
+// parser, projects/extracts as it goes, and reports peak RSS, time, throughput.
+// The whole point: prove memory stays FLAT regardless of file size (no whole-file
+// read, no whole-document tree). Run with default heap (no --max-old-space-size)
+// so a passing run proves we never accumulate.
+import { createReadStream, statSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
+import { SaxesParser } from "saxes";
+
+const file = process.argv[2];
+const size = statSync(file).size;
+const t0 = Date.now();
+
+let peakRss = 0;
+const sampleRss = () => {
+  const r = process.memoryUsage().rss;
+  if (r > peakRss) peakRss = r;
+};
+const rssTimer = setInterval(sampleRss, 200);
+
+const parser = new SaxesParser({ fileName: file });
+let elements = 0,
+  records = 0,
+  observations = 0,
+  entries = 0,
+  saxErrors = 0;
+const hrDaily = new Map(); // Apple Health: heart-rate downsampled to per-day.
+let emitted = 0;
+const emit = (obj) => {
+  if (emitted < 4) {
+    process.stdout.write(JSON.stringify(obj) + "\n");
+    emitted++;
+  }
+};
+
+parser.on("opentagstart", () => {
+  elements++;
+});
+parser.on("opentag", (node) => {
+  const n = node.name;
+  if (n === "Record") {
+    records++;
+    const a = node.attributes;
+    if (a.type === "HKQuantityTypeIdentifierHeartRate") {
+      const day = (a.startDate || a.creationDate || "").slice(0, 10);
+      const v = parseFloat(a.value);
+      if (day && !Number.isNaN(v)) {
+        let d = hrDaily.get(day);
+        if (!d) {
+          d = { min: v, max: v, sum: 0, n: 0 };
+          hrDaily.set(day, d);
+        }
+        d.min = Math.min(d.min, v);
+        d.max = Math.max(d.max, v);
+        d.sum += v;
+        d.n++;
+      }
+    }
+  } else if (n === "observation") {
+    observations++;
+  } else if (n === "entry") {
+    entries++;
+  }
+});
+parser.on("error", () => {
+  saxErrors++;
+});
+
+const decoder = new StringDecoder("utf8");
+const stream = createReadStream(file, { highWaterMark: 1 << 20 });
+stream.on("data", (chunk) => parser.write(decoder.write(chunk)));
+stream.on("end", () => {
+  parser.write(decoder.end());
+  parser.close();
+  clearInterval(rssTimer);
+  sampleRss();
+  const secs = (Date.now() - t0) / 1000;
+  // Demonstrate the projection output: a few downsampled HR days as NDJSON.
+  let i = 0;
+  for (const [day, d] of hrDaily) {
+    if (i++ >= 4) break;
+    emit({
+      kind: "hr-daily-summary",
+      day,
+      min: d.min,
+      max: d.max,
+      avg: +(d.sum / d.n).toFixed(1),
+      samples: d.n,
+    });
+  }
+  console.error(
+    JSON.stringify(
+      {
+        file: file.split("/").pop(),
+        sizeGB: +(size / 1e9).toFixed(2),
+        elements,
+        records,
+        observations,
+        entries,
+        hrDays: hrDaily.size,
+        saxErrors,
+        seconds: +secs.toFixed(1),
+        throughputMBs: +(size / 1e6 / secs).toFixed(1),
+        peakRssMB: +(peakRss / 1e6).toFixed(0),
+      },
+      null,
+      2,
+    ),
+  );
+});
+stream.on("error", (e) => {
+  clearInterval(rssTimer);
+  console.error("STREAM ERROR:", e.code, e.message);
+});

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -25,6 +25,7 @@ import { printResult, printError, printVerbose, type OutputOptions } from '../..
 import { convert } from '../../lib/fhir-converter/index.js';
 import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
 import { runReconciliation, type ReconcilerInput } from '../../lib/reconciler.js';
+import { detectSource } from '../../lib/source-adapters/registry.js';
 import {
   DATA_TYPES,
   resolvePodDir,
@@ -240,7 +241,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
     .command('import')
     .description('Import FHIR JSON or Cascade Turtle files into a pod')
     .argument('<pod-dir>', 'Path to the Cascade Pod directory')
-    .argument('<files...>', 'FHIR JSON or Cascade Turtle files to import')
+    .argument('<files...>', 'Files or folders to import (FHIR JSON, Cascade Turtle, C-CDA XML/zip, or a folder / Apple Health export)')
     .option('--source-system <name>', 'Tag all imported records with this system name')
     .option('--no-reconcile', 'Skip reconciliation even when importing multiple files')
     .option('--reconcile-existing', 'Include existing pod records in reconciliation pass (cross-batch dedup, on by default; disable with --no-reconcile-existing)', true)
@@ -306,13 +307,76 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         }
       }
 
+      // --- Step 1.5: Expand container inputs (folders, vendor exports) ---
+      // A directory argument is run through the source-adapter registry, which
+      // expands it into concrete importable files and records what it skipped
+      // (e.g. an Apple Health export -> its clinical-records FHIR, skipping the
+      // multi-GB device XMLs). Plain file arguments pass through unchanged.
+      const expandedFiles: string[] = [];
+      const sourceSkips: string[] = [];
+      for (const arg of files) {
+        const absArg = path.resolve(process.cwd(), arg);
+        let isDirectory = false;
+        try {
+          isDirectory = (await fs.stat(absArg)).isDirectory();
+        } catch {
+          // Not stat-able; leave it for the per-file read below to report.
+          expandedFiles.push(arg);
+          continue;
+        }
+        if (!isDirectory) {
+          expandedFiles.push(arg);
+          continue;
+        }
+        const adapter = detectSource(absArg);
+        if (!adapter) {
+          printError(`Don't know how to import the folder: ${arg}`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
+        const expanded = adapter.expand(absArg);
+        for (const s of expanded.skipped) {
+          sourceSkips.push(`Skipped ${path.basename(s.path)}: ${s.reason}`);
+        }
+        if (expanded.files.length === 0) {
+          printError(
+            `No importable files found in ${arg} (${expanded.sourceLabel}).` +
+              (expanded.skipped.length ? ` ${expanded.skipped.length} artifact(s) skipped.` : ''),
+            globalOpts,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        printVerbose(
+          `${expanded.sourceLabel}: importing ${expanded.files.length} file(s)` +
+            (expanded.skipped.length ? `, skipping ${expanded.skipped.length}` : ''),
+          globalOpts,
+        );
+        expandedFiles.push(...expanded.files);
+      }
+
       // --- Step 2: Convert / collect inputs ---
       const reconcilerInputs: ReconcilerInput[] = [];
       const sourceReport: ImportReport['sources'] = [];
-      const allWarnings: string[] = [];
+      const allWarnings: string[] = [...sourceSkips];
 
-      for (const filePath of files) {
+      for (const filePath of expandedFiles) {
+        try {
         const absPath = path.resolve(process.cwd(), filePath);
+        // Guard the whole-file read limit: a file over ~2 GiB cannot be read
+        // whole (Node's fs.readFile cap). Skip it with a clear reason instead of
+        // aborting the entire import. Streaming import will lift this.
+        try {
+          const sizeBytes = (await fs.stat(absPath)).size;
+          if (sizeBytes > 2_000_000_000) {
+            allWarnings.push(
+              `Skipped ${path.basename(filePath)}: ${(sizeBytes / 1e9).toFixed(1)} GB exceeds the whole-file import limit (streaming import not yet supported)`,
+            );
+            continue;
+          }
+        } catch {
+          // stat failed; let the read below produce the precise error.
+        }
         const isZip = absPath.toLowerCase().endsWith('.zip') || absPath.toLowerCase().endsWith('.xml');
         let rawContent: string | Buffer;
         try {
@@ -376,6 +440,15 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
 
         reconcilerInputs.push({ content: turtleContent, systemName });
         sourceReport.push({ file: filePath, system: systemName, resourceCount, warnings });
+        } catch (e) {
+          // Resilience: a single malformed file becomes a skip-with-reason, not a
+          // crashed import. Essential when a folder yields hundreds of files and
+          // one carries a shape the converter cannot handle.
+          allWarnings.push(
+            `Skipped ${path.basename(filePath)}: conversion error (${e instanceof Error ? e.message : String(e)})`,
+          );
+          continue;
+        }
       }
 
       // --- Step 3: Reconcile or concatenate ---

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -342,11 +342,14 @@ export function contentHashedUri(
   contentFields: Record<string, string | undefined>,
   fallbackId?: string,
 ): string {
-  // Filter out undefined/empty values and sort keys for stability
+  // Filter out undefined/empty values and sort keys for stability. Values are
+  // coerced to string before trimming: the type says string, but real-world
+  // FHIR (e.g. an Apple Health Patient) can slip a non-string field through, and
+  // String(s) === s for valid string inputs, so the derived URI is unchanged.
   const content = Object.entries(contentFields)
-    .filter(([, v]) => v != null && v.trim().length > 0)
+    .filter(([, v]) => v != null && String(v).trim().length > 0)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}=${v}`)
+    .map(([k, v]) => `${k}=${String(v)}`)
     .join('|');
 
   if (content.length > 0) {

--- a/src/lib/source-adapters/apple-health.ts
+++ b/src/lib/source-adapters/apple-health.ts
@@ -1,0 +1,90 @@
+/**
+ * Apple Health export source adapter.
+ *
+ * An unzipped Apple Health export is a folder containing:
+ *   - export.xml        (the device firehose: years of heart-rate/step samples)
+ *   - export_cda.xml    (a CDA rendering of the same, also multi-GB)
+ *   - clinical-records/ (the GOLD: per-resource FHIR JSON synced from the user's
+ *                        providers — conditions, meds, labs, immunizations, ...)
+ *   - electrocardiograms/, workout-routes/ (device data)
+ *
+ * The clinical-records FHIR files are small and the existing FHIR importer
+ * already converts them. The two giant XMLs are device time-series, over Node's
+ * whole-file read limit, and not the clinical data a user is usually after. So
+ * this adapter imports clinical-records and SKIPS the device exports with a clear
+ * reason (rather than failing on a 2.3 GB read). Streaming import of the device
+ * series is a later slice; when it lands, this adapter starts yielding it too.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ExpandedSource, SkippedArtifact, SourceAdapter } from './types.js';
+
+const CLINICAL_DIR = 'clinical-records';
+/** The multi-GB device exports Apple writes at the export root. */
+const DEVICE_EXPORTS = ['export.xml', 'export_cda.xml'];
+/** Other non-clinical device-data folders. */
+const DEVICE_DIRS = ['electrocardiograms', 'workout-routes'];
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function sizeGB(p: string): string {
+  try {
+    return (fs.statSync(p).size / 1e9).toFixed(1);
+  } catch {
+    return '?';
+  }
+}
+
+export const appleHealthAdapter: SourceAdapter = {
+  id: 'apple-health',
+  description:
+    'Apple Health export folder (imports clinical-records FHIR; device exports skipped pending streaming import)',
+
+  detect(targetPath: string): boolean {
+    if (!isDir(targetPath)) return false;
+    // Signature: the device export XML(s) and/or the clinical-records folder.
+    const hasDeviceExport = DEVICE_EXPORTS.some((f) =>
+      fs.existsSync(path.join(targetPath, f)),
+    );
+    return hasDeviceExport || isDir(path.join(targetPath, CLINICAL_DIR));
+  },
+
+  expand(targetPath: string): ExpandedSource {
+    const files: string[] = [];
+    const skipped: SkippedArtifact[] = [];
+
+    const clinicalDir = path.join(targetPath, CLINICAL_DIR);
+    if (isDir(clinicalDir)) {
+      for (const name of fs.readdirSync(clinicalDir)) {
+        if (name.toLowerCase().endsWith('.json')) {
+          files.push(path.join(clinicalDir, name));
+        }
+      }
+    }
+
+    for (const f of DEVICE_EXPORTS) {
+      const p = path.join(targetPath, f);
+      if (fs.existsSync(p)) {
+        skipped.push({
+          path: p,
+          reason: `Apple Health device export (${sizeGB(p)} GB of time-series); streaming import not yet supported`,
+        });
+      }
+    }
+    for (const d of DEVICE_DIRS) {
+      const p = path.join(targetPath, d);
+      if (isDir(p)) {
+        skipped.push({ path: p, reason: 'device data (ECG / workout routes), not clinical records' });
+      }
+    }
+
+    return { files, skipped, sourceLabel: 'Apple Health export' };
+  },
+};

--- a/src/lib/source-adapters/directory.ts
+++ b/src/lib/source-adapters/directory.ts
@@ -1,0 +1,88 @@
+/**
+ * Generic directory source adapter: the catch-all for "a folder of files."
+ *
+ * Recursively collects every supported file (FHIR JSON, Turtle, C-CDA XML, IHE
+ * XDM zip) under a directory and hands them to the per-file import path. This is
+ * what makes "import this folder of records" work for any layout that is not a
+ * recognized vendor export.
+ *
+ * It also guards the whole-file read limit: a file larger than ~2 GiB cannot be
+ * read whole by the current importer (Node's fs.readFile cap), so rather than
+ * letting it blow up mid-import, the adapter SKIPS it with a clear reason. When
+ * streaming converters land, this guard is where they take over.
+ *
+ * Registered AFTER more specific adapters (e.g. Apple Health), so a recognized
+ * export is handled by its own adapter and only an unrecognized folder falls
+ * through to here.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ExpandedSource, SkippedArtifact, SourceAdapter } from './types.js';
+
+/** Extensions the per-file import path understands. */
+const SUPPORTED_EXT = new Set(['.json', '.ttl', '.xml', '.zip']);
+
+/**
+ * Whole-file read ceiling. Node's fs.readFile throws above 2 GiB
+ * (2,147,483,647 bytes); we stay just under to skip gracefully instead of
+ * failing. Streaming import will lift this.
+ */
+const MAX_WHOLE_FILE_BYTES = 2_000_000_000;
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export const directoryAdapter: SourceAdapter = {
+  id: 'directory',
+  description: 'A folder of supported files (FHIR JSON, Turtle, C-CDA XML or IHE XDM zip)',
+
+  detect(targetPath: string): boolean {
+    return isDir(targetPath);
+  },
+
+  expand(targetPath: string): ExpandedSource {
+    const files: string[] = [];
+    const skipped: SkippedArtifact[] = [];
+
+    const walk = (dir: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const ent of entries) {
+        if (ent.name.startsWith('.')) continue; // skip dotfiles / .DS_Store
+        const full = path.join(dir, ent.name);
+        if (ent.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!SUPPORTED_EXT.has(path.extname(ent.name).toLowerCase())) continue;
+        let size = 0;
+        try {
+          size = fs.statSync(full).size;
+        } catch {
+          continue;
+        }
+        if (size > MAX_WHOLE_FILE_BYTES) {
+          skipped.push({
+            path: full,
+            reason: `${(size / 1e9).toFixed(1)} GB exceeds the whole-file import limit; streaming import not yet supported`,
+          });
+          continue;
+        }
+        files.push(full);
+      }
+    };
+    walk(targetPath);
+
+    return { files, skipped, sourceLabel: 'folder' };
+  },
+};

--- a/src/lib/source-adapters/registry.ts
+++ b/src/lib/source-adapters/registry.ts
@@ -1,0 +1,35 @@
+/**
+ * Source-adapter registry: the container layer's dispatch.
+ *
+ * `pod import` runs each directory input through `detectSource` to find the
+ * adapter that expands it into importable files. Order is significant: more
+ * specific adapters (a recognized vendor export) come before the generic
+ * directory catch-all, and the first match wins.
+ *
+ * Adding a new container shape (a new vendor export, a tarball, a portal
+ * download bundle) is a one-line edit here plus an adapter file, mirroring the
+ * FormatImporter registry pattern.
+ */
+
+import { appleHealthAdapter } from './apple-health.js';
+import { directoryAdapter } from './directory.js';
+import type { SourceAdapter } from './types.js';
+
+/** Registered source adapters, most specific first. */
+export const sourceAdapters: ReadonlyArray<SourceAdapter> = [
+  appleHealthAdapter,
+  directoryAdapter, // catch-all: any other folder
+];
+
+/** The first adapter that handles `targetPath`, or undefined. Never throws. */
+export function detectSource(targetPath: string): SourceAdapter | undefined {
+  return sourceAdapters.find((a) => {
+    try {
+      return a.detect(targetPath);
+    } catch {
+      return false;
+    }
+  });
+}
+
+export type { SourceAdapter, ExpandedSource, SkippedArtifact } from './types.js';

--- a/src/lib/source-adapters/types.ts
+++ b/src/lib/source-adapters/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Source adapters: the CONTAINER layer above the per-file FormatImporters.
+ *
+ * A FormatImporter (import-registry.ts) knows one file FORMAT (FHIR JSON, C-CDA
+ * XML, ...). It does not know that a real-world health artifact is often a
+ * CONTAINER: a folder, a zip, a vendor export with many files plus a few giant
+ * ones. A SourceAdapter fills that gap. It detects a container shape and expands
+ * it into the concrete files worth importing, recording what it deliberately
+ * skipped (and why), so the importer never silently drops data and never chokes
+ * on a multi-GB payload it should not have read whole.
+ *
+ * This is the first slice of the streaming-ingestion architecture
+ * (cascade-assets .../2026-06-26-ingestion-architecture-and-streaming-spike.md).
+ * It reuses the existing FormatImporters unchanged: an adapter yields file
+ * paths, the proven per-file import path converts them. Streaming converters for
+ * the skipped multi-GB artifacts (device time-series) come in a later slice.
+ */
+
+/** One artifact an adapter chose not to import, with a human-readable reason. */
+export interface SkippedArtifact {
+  /** Absolute path of the skipped file or directory. */
+  path: string;
+  /** Why it was skipped (e.g. "device export, streaming import not yet supported"). */
+  reason: string;
+}
+
+/** The result of expanding a container into importable inputs. */
+export interface ExpandedSource {
+  /** Absolute paths of the concrete files to feed the per-file import path. */
+  files: string[];
+  /** Artifacts intentionally not imported (surfaced to the user, never silent). */
+  skipped: SkippedArtifact[];
+  /** What the adapter recognized, for the import report / verbose log. */
+  sourceLabel: string;
+}
+
+/**
+ * Recognizes a container shape and expands it to importable files. Detection and
+ * expansion are synchronous filesystem reads (inputs are local, run once per
+ * import). `detect` must never throw.
+ */
+export interface SourceAdapter {
+  /** Stable id (e.g. "apple-health"). */
+  id: string;
+  /** Human description for help/verbose output. */
+  description: string;
+  /** True iff this adapter handles `targetPath` (a directory or file). */
+  detect(targetPath: string): boolean;
+  /** Expand the container into concrete importable files plus skip notes. */
+  expand(targetPath: string): ExpandedSource;
+}

--- a/tests/source-adapters.test.ts
+++ b/tests/source-adapters.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Source-adapter layer: the container abstraction above per-file importers.
+ * Detection + expansion are pure filesystem reads, so these tests build small
+ * temp fixtures (an Apple Health-shaped export, a plain folder) and assert what
+ * each adapter yields and skips, plus the registry's specific-first dispatch.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { appleHealthAdapter } from '../src/lib/source-adapters/apple-health.js';
+import { directoryAdapter } from '../src/lib/source-adapters/directory.js';
+import { detectSource } from '../src/lib/source-adapters/registry.js';
+
+let root: string;
+let appleDir: string;
+let plainDir: string;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-source-adapters-'));
+
+  // An Apple Health-shaped export: clinical-records FHIR + two device exports.
+  appleDir = path.join(root, 'apple_health_export');
+  fs.mkdirSync(path.join(appleDir, 'clinical-records'), { recursive: true });
+  fs.writeFileSync(path.join(appleDir, 'clinical-records', 'Condition-1.json'), '{"resourceType":"Condition"}');
+  fs.writeFileSync(path.join(appleDir, 'clinical-records', 'Observation-2.json'), '{"resourceType":"Observation"}');
+  fs.writeFileSync(path.join(appleDir, 'export.xml'), '<HealthData/>');
+  fs.writeFileSync(path.join(appleDir, 'export_cda.xml'), '<ClinicalDocument/>');
+  fs.mkdirSync(path.join(appleDir, 'workout-routes'));
+
+  // A plain folder of mixed files, including a nested dir, an unsupported file,
+  // and a dotfile.
+  plainDir = path.join(root, 'records');
+  fs.mkdirSync(path.join(plainDir, 'sub'), { recursive: true });
+  fs.writeFileSync(path.join(plainDir, 'a.json'), '{}');
+  fs.writeFileSync(path.join(plainDir, 'b.ttl'), '');
+  fs.writeFileSync(path.join(plainDir, 'sub', 'c.xml'), '<x/>');
+  fs.writeFileSync(path.join(plainDir, 'notes.txt'), 'not importable');
+  fs.writeFileSync(path.join(plainDir, '.DS_Store'), '');
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('appleHealthAdapter', () => {
+  it('detects an export folder by clinical-records / device exports', () => {
+    expect(appleHealthAdapter.detect(appleDir)).toBe(true);
+    expect(appleHealthAdapter.detect(plainDir)).toBe(false);
+    expect(appleHealthAdapter.detect(path.join(appleDir, 'export.xml'))).toBe(false); // a file, not a dir
+  });
+
+  it('expands to clinical-records FHIR and skips the device exports', () => {
+    const out = appleHealthAdapter.expand(appleDir);
+    expect(out.sourceLabel).toBe('Apple Health export');
+    expect(out.files.map((f) => path.basename(f)).sort()).toEqual([
+      'Condition-1.json',
+      'Observation-2.json',
+    ]);
+    // Every imported file lives under clinical-records.
+    expect(out.files.every((f) => f.includes(`${path.sep}clinical-records${path.sep}`))).toBe(true);
+    // Both device exports and the workout-routes dir are skipped with reasons.
+    const skippedNames = out.skipped.map((s) => path.basename(s.path)).sort();
+    expect(skippedNames).toEqual(['export.xml', 'export_cda.xml', 'workout-routes']);
+    expect(out.skipped.every((s) => s.reason.length > 0)).toBe(true);
+  });
+});
+
+describe('directoryAdapter', () => {
+  it('detects any directory', () => {
+    expect(directoryAdapter.detect(plainDir)).toBe(true);
+    expect(directoryAdapter.detect(path.join(plainDir, 'a.json'))).toBe(false);
+  });
+
+  it('recursively collects supported files; skips unsupported + dotfiles', () => {
+    const out = directoryAdapter.expand(plainDir);
+    const names = out.files.map((f) => path.basename(f)).sort();
+    expect(names).toEqual(['a.json', 'b.ttl', 'c.xml']); // recursed into sub/, dropped notes.txt + .DS_Store
+  });
+});
+
+describe('detectSource (registry dispatch)', () => {
+  it('routes an Apple Health export to its adapter, a plain folder to directory', () => {
+    expect(detectSource(appleDir)?.id).toBe('apple-health'); // specific wins
+    expect(detectSource(plainDir)?.id).toBe('directory');
+  });
+
+  it('returns undefined for a non-directory path', () => {
+    expect(detectSource(path.join(plainDir, 'a.json'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

The first slice of the [streaming-ingestion architecture](https://github.com/jedr-cal): a **container layer** above the per-file `FormatImporter`s. `cascade pod import` now accepts a **directory**, detects its shape via a source-adapter registry, and expands it into importable files. This makes "import my Apple Health export" work end to end, and "import this folder of records" work generally.

It also carries the streaming-spike that justified the approach (`spikes/streaming-ingest/`): Node SAX streamed 4.5 GB in 21.9 s at 207 MB/s with 150 MB flat RSS, which is why this foundation is TypeScript streaming, not Rust. Full reasoning in the architecture doc (cascade-assets).

## The new layer

- **`SourceAdapter` contract** (`src/lib/source-adapters/types.ts`): `detect(path)` + `expand(path) -> { files, skipped[], sourceLabel }`. Skips are first-class and carry a human reason, so nothing is dropped silently.
- **Apple Health adapter**: detects an export folder, imports `clinical-records/` FHIR, and **skips the multi-GB `export.xml` / `export_cda.xml` and ECG/workout-route dirs** with a clear reason (device time-series; streaming import is a later slice).
- **Generic directory adapter**: recursively collects supported files (FHIR JSON, Turtle, C-CDA XML/zip); a file over ~2 GiB is skipped (Node's whole-file read cap) rather than crashing.
- **Registry**: specific-first dispatch (Apple Health before the directory catch-all).

The existing per-file `FormatImporter`s are untouched; an adapter yields paths, the proven import path converts them.

## Robustness fixes (surfaced by real data)

- **Import is resilient to a single bad file** — the per-file body is wrapped, so a file the converter can't handle becomes a skip-with-reason in the report, not a crashed 1,267-file import.
- **`contentHashedUri` coerces non-string fields** — a real Apple Health Patient threw `v.trim is not a function`; `String(v)` fixes it with the URI unchanged for valid strings (algorithm untouched).
- **Whole-file >2 GiB guard** — clear skip reason instead of the opaque "Cannot read file."

## Verified on the real export

```
1,267 files in -> 1,160 records imported
  648 lab-results   64 immunizations    8 conditions
  255 vital-signs   55 documents        3 allergies
   84 lab-reports   33 medications      2 procedures + 1 patient-profile
skipped: export.xml (4.6 GB), export_cda.xml (2.3 GB), electrocardiograms/, workout-routes/
conversion crashes: 0
```

Full suite **899 pass / 21 skip / 0 fail**; +6 source-adapter tests. Minor bump **0.6.1 -> 0.7.0**.

## Not in this PR (next slices)

- Streaming converter for the skipped device exports (the spike's proven approach; emits downsampled vitals).
- Workbench wiring: a folder-picker so this is reachable from the app UI (small follow-up).
- Indexed reconcile (the O(n) whole-Pod load is the next scale cliff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)