### PR TITLE
Importer hardening: provenance capture, source attribution, folder/XDM import, SHACL-clean C-CDA

### DIFF
--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -25,7 +25,7 @@ import { printResult, printError, printVerbose, type OutputOptions } from '../..
 import { convert } from '../../lib/fhir-converter/index.js';
 import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
 import { runReconciliation, type ReconcilerInput } from '../../lib/reconciler.js';
-import { detectSource } from '../../lib/source-adapters/registry.js';
+import { detectSource, type FileSourceMeta } from '../../lib/source-adapters/registry.js';
 import {
   DATA_TYPES,
   resolvePodDir,
@@ -327,7 +327,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // records from one export share one honest source-batch name instead of
       // each file's basename ("MedicationRequest-<id>"), which was the Source
       // facet wall. A plain file argument has no label (falls back to basename).
-      const expandedFiles: { path: string; label?: string }[] = [];
+      const expandedFiles: { path: string; label?: string; source?: FileSourceMeta }[] = [];
       const sourceSkips: string[] = [];
       for (const arg of files) {
         const absArg = path.resolve(process.cwd(), arg);
@@ -368,7 +368,11 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           globalOpts,
         );
         expandedFiles.push(
-          ...expanded.files.map((f) => ({ path: f, label: expanded.sourceLabel })),
+          ...expanded.files.map((f) => ({
+            path: f,
+            label: expanded.sourceLabel,
+            source: expanded.fileSources?.[f],
+          })),
         );
       }
 
@@ -433,7 +437,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
           // FHIR JSON
           printVerbose(`Converting FHIR JSON: ${filePath}`, globalOpts);
-          const result = await convert(content, 'fhir', 'cascade', 'turtle', systemName, passthroughMinimal);
+          const result = await convert(content, 'fhir', 'cascade', 'turtle', systemName, passthroughMinimal, entry.source?.sourceEhr);
           if (!result.success) {
             printError(`Failed to convert ${filePath}: ${result.errors.join(', ')}`, globalOpts);
             process.exitCode = 1;

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -25,7 +25,7 @@ import { printResult, printError, printVerbose, type OutputOptions } from '../..
 import { convert } from '../../lib/fhir-converter/index.js';
 import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
 import { runReconciliation, type ReconcilerInput } from '../../lib/reconciler.js';
-import { detectSource, type FileSourceMeta } from '../../lib/source-adapters/registry.js';
+import { detectSource, type FileSourceMeta, type CompletenessCheck } from '../../lib/source-adapters/registry.js';
 import {
   DATA_TYPES,
   resolvePodDir,
@@ -62,6 +62,10 @@ interface ImportReport {
   };
   filesWritten: Array<{ path: string; recordsAdded: number; type: string }>;
   typeCounts: Record<string, number>;
+  /** Record counts grouped by EHR of origin (clinical:sourceEHR), for the plan. */
+  sourceBreakdown: Record<string, number>;
+  /** "Do we have everything?" checks from container adapters (e.g. source labels). */
+  completeness: CompletenessCheck[];
   totalRecordsImported: number;
   warnings: string[];
   dryRun: boolean;
@@ -329,6 +333,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // facet wall. A plain file argument has no label (falls back to basename).
       const expandedFiles: { path: string; label?: string; source?: FileSourceMeta }[] = [];
       const sourceSkips: string[] = [];
+      const completeness: CompletenessCheck[] = [];
       for (const arg of files) {
         const absArg = path.resolve(process.cwd(), arg);
         let isDirectory = false;
@@ -353,10 +358,13 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         for (const s of expanded.skipped) {
           sourceSkips.push(`Skipped ${path.basename(s.path)}: ${s.reason}`);
         }
+        if (expanded.completeness) completeness.push(...expanded.completeness);
         if (expanded.files.length === 0) {
+          const why = expanded.skipped.length
+            ? ` ${expanded.skipped.map((s) => s.reason).join('; ')}`
+            : '';
           printError(
-            `No importable files found in ${arg} (${expanded.sourceLabel}).` +
-              (expanded.skipped.length ? ` ${expanded.skipped.length} artifact(s) skipped.` : ''),
+            `No importable records found in ${arg} (${expanded.sourceLabel}).${why}`,
             globalOpts,
           );
           process.exitCode = 1;
@@ -422,9 +430,13 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           printVerbose(`Converting C-CDA: ${filePath}`, globalOpts);
           const result = await convert(rawContent, 'c-cda', 'cascade', 'turtle', systemName, passthroughMinimal);
           if (!result.success) {
-            printError(`Failed to convert ${filePath}: ${result.errors.join(', ')}`, globalOpts);
-            process.exitCode = 1;
-            return;
+            // Skip an unconvertible file with a reason rather than aborting the
+            // whole batch: in a folder import (e.g. an IHE XDM export's manifest,
+            // or one malformed document among many) the other files must still
+            // import. The outer catch turns this into a skip-with-reason warning.
+            throw new Error(
+              result.errors.join(', ') || 'conversion produced no output',
+            );
           }
           turtleContent = result.output;
           resourceCount = result.resourceCount;
@@ -439,9 +451,13 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           printVerbose(`Converting FHIR JSON: ${filePath}`, globalOpts);
           const result = await convert(content, 'fhir', 'cascade', 'turtle', systemName, passthroughMinimal, entry.source?.sourceEhr);
           if (!result.success) {
-            printError(`Failed to convert ${filePath}: ${result.errors.join(', ')}`, globalOpts);
-            process.exitCode = 1;
-            return;
+            // Skip an unconvertible file with a reason rather than aborting the
+            // whole batch: in a folder import (e.g. an IHE XDM export's manifest,
+            // or one malformed document among many) the other files must still
+            // import. The outer catch turns this into a skip-with-reason warning.
+            throw new Error(
+              result.errors.join(', ') || 'conversion produced no output',
+            );
           }
           turtleContent = result.output;
           resourceCount = result.resourceCount;
@@ -538,6 +554,18 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         printError(`Failed to parse merged Turtle: ${msg}`, globalOpts);
         process.exitCode = 1;
         return;
+      }
+
+      // Source breakdown by EHR of origin (clinical:sourceEHR), for the pre-import
+      // plan: exactly what the source-organized Records view will show, computed
+      // from the merged/deduped quads so a --dry-run preview matches the real run.
+      const sourceBreakdown: Record<string, number> = {};
+      const SRC_EHR_IRI = 'https://ns.cascadeprotocol.org/clinical/v1#sourceEHR';
+      for (const [, quads] of subjectQuads) {
+        const ehr = quads.find((q) => q.predicate.value === SRC_EHR_IRI);
+        if (ehr) {
+          sourceBreakdown[ehr.object.value] = (sourceBreakdown[ehr.object.value] ?? 0) + 1;
+        }
       }
 
       // --- Step 5: Route subjects to DATA_TYPES buckets ---
@@ -759,6 +787,8 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           : { enabled: false },
         filesWritten,
         typeCounts,
+        sourceBreakdown,
+        completeness,
         totalRecordsImported,
         warnings: allWarnings,
         dryRun,
@@ -780,6 +810,19 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         console.log(`  Sources:          ${sourceReport.length} file(s)`);
         console.log(`  Records imported: ${totalRecordsImported}`);
         console.log(`  Files written:    ${filesWritten.length}`);
+        const bySource = Object.entries(sourceBreakdown).sort((a, b) => b[1] - a[1]);
+        if (bySource.length > 0) {
+          console.log(`  By source (EHR of origin):`);
+          for (const [src, count] of bySource) console.log(`    - ${src}: ${count}`);
+        }
+        if (completeness.length > 0) {
+          console.log(`  Completeness:`);
+          for (const c of completeness) {
+            const ok = c.recovered >= c.total ? 'OK' : 'partial';
+            console.log(`    - ${c.label}: ${c.recovered}/${c.total} (${ok})`);
+            if (c.note) console.log(`        ${c.note}`);
+          }
+        }
         if (allWarnings.length > 0) {
           console.log(`  Warnings:         ${allWarnings.length}`);
           for (const w of allWarnings) {

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -200,9 +200,19 @@ async function appendTypeRegistration(
   }
 
   const block = buildTypeRegistration(key, info);
+
+  // The block may reference the `fhir:` prefix (fhir-passthrough catch-all).
+  // Pods initialized before that prefix was added to the index header would
+  // otherwise fail to parse with "Undefined prefix fhir:". Self-heal by
+  // declaring the prefix once if the block needs it and the file lacks it.
+  let header = '';
+  if (block.includes('fhir:') && !/@prefix\s+fhir:/.test(content)) {
+    header = '@prefix fhir: <http://hl7.org/fhir/> .\n';
+  }
+
   if (!dryRun) {
     // Read-modify-write (encrypted resources cannot be appended to in place).
-    writeResource(indexPath, content + block, dek);
+    writeResource(indexPath, header + content + block, dek);
   }
   return true;
 }

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -312,7 +312,12 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // expands it into concrete importable files and records what it skipped
       // (e.g. an Apple Health export -> its clinical-records FHIR, skipping the
       // multi-GB device XMLs). Plain file arguments pass through unchanged.
-      const expandedFiles: string[] = [];
+      // Each entry carries an optional `label`: a source adapter's `sourceLabel`
+      // (e.g. "Apple Health export") becomes the per-file source-system, so all
+      // records from one export share one honest source-batch name instead of
+      // each file's basename ("MedicationRequest-<id>"), which was the Source
+      // facet wall. A plain file argument has no label (falls back to basename).
+      const expandedFiles: { path: string; label?: string }[] = [];
       const sourceSkips: string[] = [];
       for (const arg of files) {
         const absArg = path.resolve(process.cwd(), arg);
@@ -321,11 +326,11 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           isDirectory = (await fs.stat(absArg)).isDirectory();
         } catch {
           // Not stat-able; leave it for the per-file read below to report.
-          expandedFiles.push(arg);
+          expandedFiles.push({ path: arg });
           continue;
         }
         if (!isDirectory) {
-          expandedFiles.push(arg);
+          expandedFiles.push({ path: arg });
           continue;
         }
         const adapter = detectSource(absArg);
@@ -352,7 +357,9 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
             (expanded.skipped.length ? `, skipping ${expanded.skipped.length}` : ''),
           globalOpts,
         );
-        expandedFiles.push(...expanded.files);
+        expandedFiles.push(
+          ...expanded.files.map((f) => ({ path: f, label: expanded.sourceLabel })),
+        );
       }
 
       // --- Step 2: Convert / collect inputs ---
@@ -360,7 +367,8 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       const sourceReport: ImportReport['sources'] = [];
       const allWarnings: string[] = [...sourceSkips];
 
-      for (const filePath of expandedFiles) {
+      for (const entry of expandedFiles) {
+        const filePath = entry.path;
         try {
         const absPath = path.resolve(process.cwd(), filePath);
         // Guard the whole-file read limit: a file over ~2 GiB cannot be read
@@ -387,7 +395,8 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           return;
         }
 
-        const systemName = options.sourceSystem ?? path.basename(filePath, path.extname(filePath));
+        const systemName =
+          options.sourceSystem ?? entry.label ?? path.basename(filePath, path.extname(filePath));
         const warnings: string[] = [];
 
         let turtleContent: string;

--- a/src/commands/pod/init.ts
+++ b/src/commands/pod/init.ts
@@ -75,6 +75,7 @@ const PUBLIC_TYPE_INDEX_TTL = `@prefix solid: <http://www.w3.org/ns/solid/terms#
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
 @prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 @prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix fhir: <http://hl7.org/fhir/> .
 
 # =============================================================================
 # Public Type Index

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -38,11 +38,12 @@ import { extractFamilyHistoryQuads, FAMILY_HISTORY_TEMPLATE_ID } from './section
 import { extractDeviceQuads, DEVICES_TEMPLATE_ID } from './sections/devices.js';
 import { extractSocialHistoryQuads, SOCIAL_HISTORY_TEMPLATE_ID } from './sections/social-history.js';
 import { extractNarrativeQuads } from './narrative.js';
+import { deriveSourceEhr, ensureProvenanceQuads, ensureSourceEhrQuads } from './provenance.js';
 
 // Map templateId → extractor function and LOINC code
 const SECTION_HANDLERS: Record<string, {
   loinc: string;
-  extract: (entries: any[], patientUri: string, sourceSystem: string) => any[];
+  extract: (entries: any[], patientUri: string, sourceSystem: string, sectionText?: any) => any[];
 }> = {
   [IMMUNIZATIONS_TEMPLATE_ID]:  { loinc: '11369-6', extract: extractImmunizationQuads },
   [LABS_TEMPLATE_ID]:           { loinc: '30954-2', extract: extractLabQuads },
@@ -163,6 +164,9 @@ function convertSingleCcda(
   const ccdaDoc = normalizedDoc?.ClinicalDocument ?? normalizedDoc;
   const sourceSystem = options.sourceSystem ?? getSourceSystemName(normalizedDoc);
   const documentType = detectDocumentType(normalizedDoc);
+  // The EHR of origin is the document's custodian organization (ratified CDA
+  // signal), independent of the import-batch label that drives `sourceSystem`.
+  const sourceEhr = deriveSourceEhr(ccdaDoc);
 
   // Document ID for narrative linking
   const docIdEl = Array.isArray(ccdaDoc?.id) ? ccdaDoc.id[0] : ccdaDoc?.id;
@@ -240,7 +244,7 @@ function convertSingleCcda(
         sectionCode || (matchedTemplateId ? (SECTION_HANDLERS[matchedTemplateId]?.loinc ?? '') : '');
       const narrativeQuads = extractNarrativeQuads(
         sectionText, effectiveLoinc, documentType, documentId, sourceSystem, importedAt,
-        requiresLLMExtraction,
+        requiresLLMExtraction, sourceEhr,
       );
       allQuads.push(...narrativeQuads);
     }
@@ -248,7 +252,7 @@ function convertSingleCcda(
     // Extract structured entries
     if (matchedTemplateId && SECTION_HANDLERS[matchedTemplateId]) {
       const handler = SECTION_HANDLERS[matchedTemplateId];
-      const quads = handler.extract(entries, patientUri, sourceSystem);
+      const quads = handler.extract(entries, patientUri, sourceSystem, sectionText);
 
       // Tag each structured record from a summarization document so the
       // reconciler can apply a lower confidence threshold for deduplication.
@@ -281,6 +285,15 @@ function convertSingleCcda(
       }
     }
   }
+
+  // Shared post-passes over every record subject (every subject with an rdf:type):
+  //  - stamp cascade:dataProvenance + cascade:schemaVersion if absent (mirrors the
+  //    FHIR converter's commonTriples), and
+  //  - stamp clinical:sourceEHR (the custodian organization) so structured records
+  //    are attributed to their EHR of origin in the source-organized Records view.
+  // Both are additive + idempotent: they never overwrite a value a handler set.
+  ensureProvenanceQuads(allQuads);
+  ensureSourceEhrQuads(allQuads, sourceEhr);
 
   return { quads: allQuads, count };
 }

--- a/src/lib/ccda-converter/narrative.ts
+++ b/src/lib/ccda-converter/narrative.ts
@@ -22,6 +22,7 @@ export function extractNarrativeQuads(
   sourceSystem: string,
   importedAt: string,
   requiresLLMExtraction: boolean = false,
+  sourceEhr: string = '',
 ): Quad[] {
   if (!sectionText && !requiresLLMExtraction) return [];
 
@@ -44,7 +45,19 @@ export function extractNarrativeQuads(
     makeQuad(subj, namedNode(NS.cascade + 'sectionCode'), literal(sectionLoincCode)),
     makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)),
     makeQuad(subj, namedNode(NS.prov + 'generatedAtTime'), literal(importedAt, namedNode(NS.xsd + 'dateTime'))),
+    // ClinicalDocumentShape required fields. A CDA section document is the CDA
+    // analog of a FHIR DocumentReference.
+    makeQuad(subj, namedNode(NS.clinical + 'importedAt'), literal(importedAt, namedNode(NS.xsd + 'dateTime'))),
+    makeQuad(subj, namedNode(NS.clinical + 'fhirResourceId'), literal(uri.replace(/^urn:uuid:/, ''))),
+    makeQuad(subj, namedNode(NS.clinical + 'fhirResourceType'), literal('DocumentReference')),
   ];
+
+  // Required: sourceEHR (custodian organization). Bounded to the shape's 100-char
+  // maxLength; falls back to the source-system label only if no EHR was derived.
+  const ehr = (sourceEhr || sourceSystem || '').slice(0, 100);
+  if (ehr) {
+    quads.push(makeQuad(subj, namedNode(NS.clinical + 'sourceEHR'), literal(ehr, namedNode(NS.xsd + 'string'))));
+  }
 
   // P5.1-A: emit cascade:narrativeText as plain text (LLM-ready)
   if (narrativeStr.trim()) {

--- a/src/lib/ccda-converter/provenance.ts
+++ b/src/lib/ccda-converter/provenance.ts
@@ -1,0 +1,127 @@
+/**
+ * C-CDA provenance: the source EHR / organization of origin, and a shared
+ * post-pass that stamps every converted record with cascade:dataProvenance +
+ * cascade:schemaVersion.
+ *
+ * The EHR of origin for a C-CDA is its *custodian* organization (the system that
+ * holds the legal record), per HL7 CDA R2 §4.2.2.4. That is a ratified, document-
+ * level signal — preferable to the import-batch label (which is how the data got
+ * in, not where it came from). We derive it once per document and stamp it onto
+ * the ClinicalDocument records (required by SHACL) and every structured record so
+ * the source-organized Records view attributes them correctly.
+ *
+ * When neither custodian nor author organization names the source, we fall back
+ * to the ratified FHIR/HL7 Data Absent Reason token "unknown" (SOURCE_EHR_UNKNOWN
+ * from the FHIR converter) rather than fabricating a value.
+ */
+
+import type { Quad } from 'n3';
+import { DataFactory } from 'n3';
+
+import {
+  NS,
+  SCHEMA_VERSION,
+  commonTriples,
+} from '../fhir-converter/types.js';
+import { SOURCE_EHR_UNKNOWN } from '../fhir-converter/provenance.js';
+
+const { namedNode } = DataFactory;
+
+/** Unwrap a CDA <name> element (string, array, or { '#text' } shapes). */
+function nameText(name: any): string {
+  if (name == null) return '';
+  if (Array.isArray(name)) return nameText(name[0]);
+  if (typeof name === 'string') return name.trim();
+  if (typeof name === 'object') return (name['#text'] ?? '').toString().trim();
+  return String(name).trim();
+}
+
+/**
+ * Derive the source EHR for a parsed ClinicalDocument node.
+ *
+ * Priority (ratified-standards principle):
+ *   1. custodian/assignedCustodian/representedCustodianOrganization/name
+ *   2. author/assignedAuthor/representedOrganization/name
+ *   3. SOURCE_EHR_UNKNOWN ("unknown", HL7 Data Absent Reason)
+ *
+ * @param ccdaDoc  the parsed ClinicalDocument node (not the document root)
+ */
+export function deriveSourceEhr(ccdaDoc: any): string {
+  const custodianName = nameText(
+    ccdaDoc?.custodian?.assignedCustodian?.representedCustodianOrganization?.name,
+  );
+  if (custodianName) return custodianName.slice(0, 100);
+
+  // author may be an array (multiple authors / authoring devices)
+  const authorRaw = ccdaDoc?.author;
+  const authors = Array.isArray(authorRaw) ? authorRaw : authorRaw ? [authorRaw] : [];
+  for (const author of authors) {
+    const orgName = nameText(author?.assignedAuthor?.representedOrganization?.name);
+    if (orgName) return orgName.slice(0, 100);
+  }
+
+  return SOURCE_EHR_UNKNOWN;
+}
+
+/**
+ * Post-pass over a document's converted quads: for every record subject (every
+ * subject carrying an rdf:type), ensure cascade:dataProvenance and
+ * cascade:schemaVersion are present, adding them only when absent. Idempotent —
+ * never duplicates a triple a section handler already emitted.
+ */
+export function ensureProvenanceQuads(quads: Quad[]): void {
+  const subjects = new Set<string>();
+  const hasProvenance = new Set<string>();
+  const hasSchemaVersion = new Set<string>();
+
+  for (const q of quads) {
+    const p = q.predicate.value;
+    if (p === NS.rdf + 'type') subjects.add(q.subject.value);
+    else if (p === NS.cascade + 'dataProvenance') hasProvenance.add(q.subject.value);
+    else if (p === NS.cascade + 'schemaVersion') hasSchemaVersion.add(q.subject.value);
+  }
+
+  for (const subject of subjects) {
+    if (!hasProvenance.has(subject) && !hasSchemaVersion.has(subject)) {
+      quads.push(...commonTriples(subject));
+      continue;
+    }
+    // Partial coverage: add just the missing half (commonTriples emits both).
+    for (const t of commonTriples(subject)) {
+      const p = t.predicate.value;
+      if (p === NS.cascade + 'dataProvenance' && hasProvenance.has(subject)) continue;
+      if (p === NS.cascade + 'schemaVersion' && hasSchemaVersion.has(subject)) continue;
+      quads.push(t);
+    }
+  }
+}
+
+/**
+ * Stamp clinical:sourceEHR onto every record subject (every subject carrying an
+ * rdf:type) that does not already have it. Document-level value derived once via
+ * deriveSourceEhr(); applied uniformly so the source-organized Records view
+ * attributes every structured record to its EHR of origin.
+ */
+export function ensureSourceEhrQuads(quads: Quad[], sourceEhr: string): void {
+  if (!sourceEhr) return;
+  const subjects = new Set<string>();
+  const hasSourceEhr = new Set<string>();
+  for (const q of quads) {
+    const p = q.predicate.value;
+    if (p === NS.rdf + 'type') subjects.add(q.subject.value);
+    else if (p === NS.clinical + 'sourceEHR') hasSourceEhr.add(q.subject.value);
+  }
+  for (const subject of subjects) {
+    if (!hasSourceEhr.has(subject)) {
+      quads.push(
+        DataFactory.quad(
+          namedNode(subject),
+          namedNode(NS.clinical + 'sourceEHR'),
+          DataFactory.literal(sourceEhr, namedNode(NS.xsd + 'string')),
+        ),
+      );
+    }
+  }
+}
+
+export { SCHEMA_VERSION };

--- a/src/lib/ccda-converter/sections/medications.ts
+++ b/src/lib/ccda-converter/sections/medications.ts
@@ -13,13 +13,78 @@ const { namedNode, literal, quad: makeQuad } = DataFactory;
 export const MEDICATIONS_TEMPLATE_ID = '2.16.840.1.113883.10.20.22.2.1.1';
 export const MEDICATIONS_LOINC = '10160-0';
 
+/**
+ * Build a map of narrative element ID -> plain text from a section's <text>
+ * block. Epic medication entries put the human-readable drug name in the
+ * narrative (e.g. <paragraph ID="med12">cholecalciferol (VITAMIN D-3) ...) and
+ * reference it from the entry's
+ * consumable/manufacturedMaterial/code/originalText/reference/@value="#med12".
+ * Resolving the reference recovers the drug name the structured code omits.
+ */
+function buildNarrativeIdMap(sectionText: any): Record<string, string> {
+  const map: Record<string, string> = {};
+  const walk = (node: any): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    const id = node['@_ID'];
+    if (typeof id === 'string' && id) {
+      const text = collapseText(node);
+      if (text) map[id] = text;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('@_')) continue;
+      if (value && typeof value === 'object') walk(value);
+    }
+  };
+  walk(sectionText);
+  return map;
+}
+
+/** Collect all #text descendants of a parsed node into a single trimmed string. */
+function collapseText(node: any): string {
+  if (node == null) return '';
+  if (typeof node === 'string') return node.trim();
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collapseText).filter(Boolean).join(' ').trim();
+  if (typeof node === 'object') {
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('@_')) continue;
+      const t = collapseText(value);
+      if (t) parts.push(t);
+    }
+    return parts.join(' ').replace(/\s+/g, ' ').trim();
+  }
+  return '';
+}
+
+/** Resolve a manufacturedMaterial code's originalText/reference/@value (#medNN). */
+function resolveNarrativeName(codeEl: any, narrativeIdMap: Record<string, string>): string {
+  const ref =
+    codeEl?.originalText?.reference?.['@_value'] ??
+    codeEl?.originalText?.reference?.value ?? '';
+  if (typeof ref === 'string' && ref.startsWith('#')) {
+    const name = narrativeIdMap[ref.slice(1)];
+    if (name) return name;
+  }
+  // originalText may carry the text inline rather than a reference.
+  const inline = codeEl?.originalText?.['#text'] ??
+    (typeof codeEl?.originalText === 'string' ? codeEl.originalText : '');
+  return typeof inline === 'string' ? inline.trim() : '';
+}
+
 export function extractMedicationQuads(
   entries: any[],
   patientUri: string,
   sourceSystem: string,
+  sectionText?: any,
 ): Quad[] {
   const quads: Quad[] = [];
   const rxNormOid = '2.16.840.1.113883.6.88';
+  const narrativeIdMap = buildNarrativeIdMap(sectionText);
 
   for (const entry of entries) {
     // entry.substanceAdministration is always an array from fast-xml-parser's isArray config — unwrap first element
@@ -35,8 +100,16 @@ export function extractMedicationQuads(
       codeEl?.['@_displayName'] ?? codeEl?.displayName ??
       (typeof material?.name === 'string' ? material.name : material?.name?.['#text'] ?? '');
     const isRxNorm = codeSystem.includes('6.88') || codeSystem === rxNormOid;
-    // Fall back to RxNorm lookup when the C-CDA entry omits displayName (common in Epic exports)
-    const displayName = rawDisplayName || (isRxNorm && code ? lookupRxNormName(code) ?? '' : '');
+    // Drug name resolution order:
+    //   1. structured code @displayName (rare in Epic exports)
+    //   2. the narrative paragraph the code's originalText references (#medNN)
+    //      — this is where Epic puts the human-readable name
+    //   3. RxNorm ingredient lookup by RXCUI (only resolves ingredient-level codes)
+    const narrativeName = resolveNarrativeName(codeEl, narrativeIdMap);
+    const displayName =
+      (typeof rawDisplayName === 'string' ? rawDisplayName.trim() : '') ||
+      narrativeName ||
+      (isRxNorm && code ? lookupRxNormName(code) ?? '' : '');
 
     // Extract dates
     const effectiveTimeRaw = sa?.effectiveTime;

--- a/src/lib/ccda-converter/sections/patient.ts
+++ b/src/lib/ccda-converter/sections/patient.ts
@@ -8,6 +8,28 @@ import type { Quad } from 'n3';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
+/**
+ * Map an HL7 AdministrativeGender code (CDA administrativeGenderCode/@code) to the
+ * cascade:biologicalSex enum the PatientProfileShape accepts ("male", "female",
+ * "intersex"). Returns undefined for unknown / data-absent codes (UN, nullFlavor)
+ * so we omit the property rather than emit an out-of-enum value.
+ * @see http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender
+ */
+function mapBiologicalSex(code: string): string | undefined {
+  switch ((code ?? '').trim().toUpperCase()) {
+    case 'M':
+      return 'male';
+    case 'F':
+      return 'female';
+    // HL7 v3 has no "intersex"; map common intersex/indeterminate codes through.
+    case 'I':       // Intersex (some EHR local extensions)
+    case 'IN':
+      return 'intersex';
+    default:
+      return undefined; // UN (Undifferentiated) / unknown -> omit
+  }
+}
+
 export function extractPatientQuads(
   recordTarget: any,
   sourceSystem: string,
@@ -77,11 +99,15 @@ export function extractPatientQuads(
 
   if (givenStr) quads.push(makeQuad(subj, namedNode(NS.cascade + 'givenName'), literal(givenStr)));
   if (familyStr) quads.push(makeQuad(subj, namedNode(NS.cascade + 'familyName'), literal(familyStr)));
-  if (dob) {
-    const dobFormatted = dob.length >= 8 ? `${dob.slice(0, 4)}-${dob.slice(4, 6)}-${dob.slice(6, 8)}` : dob;
-    quads.push(makeQuad(subj, namedNode(NS.cascade + 'dateOfBirth'), literal(dobFormatted)));
+  if (dob && dob.length >= 8) {
+    // PatientProfileShape requires cascade:dateOfBirth as xsd:date (YYYY-MM-DD).
+    const dobFormatted = `${dob.slice(0, 4)}-${dob.slice(4, 6)}-${dob.slice(6, 8)}`;
+    quads.push(makeQuad(subj, namedNode(NS.cascade + 'dateOfBirth'), literal(dobFormatted, namedNode(NS.xsd + 'date'))));
   }
-  if (sex) quads.push(makeQuad(subj, namedNode(NS.cascade + 'biologicalSex'), literal(sex)));
+  // PatientProfileShape requires cascade:biologicalSex in ("male" "female"
+  // "intersex"). Map the HL7 AdministrativeGender code (M/F/...) to the enum.
+  const mappedSex = mapBiologicalSex(sex);
+  if (mappedSex) quads.push(makeQuad(subj, namedNode(NS.cascade + 'biologicalSex'), literal(mappedSex, namedNode(NS.xsd + 'string'))));
   // Flat address predicates (blank node structure is built when writing profile/extended.ttl)
   if (street) quads.push(makeQuad(subj, namedNode(NS.cascade + 'addressLine'), literal(street)));
   if (city) quads.push(makeQuad(subj, namedNode(NS.cascade + 'addressCity'), literal(city)));

--- a/src/lib/ccda-converter/sections/vitals.ts
+++ b/src/lib/ccda-converter/sections/vitals.ts
@@ -1,8 +1,16 @@
 /**
  * Extract vital signs from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.4.1)
+ *
+ * The VitalSignShape requires clinical:vitalType from a narrow sh:in enum and
+ * keeps the reading under clinical:value. C-CDA vital observations carry a LOINC
+ * code; we map that LOINC to the enum. Anything whose LOINC is not in the enum
+ * (e.g. mean BP, head circumference, percentiles) is NOT a VitalSign per the
+ * shape: rather than drop it, we re-route it to a health:LabResultRecord so the
+ * value is preserved ("Cascade does not drop data"). This mirrors the FHIR
+ * converter's convertObservationVital -> convertObservationLab fallback.
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS, contentHashedUri, VITAL_LOINC_CODES } from '../../fhir-converter/types.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -11,6 +19,27 @@ const { namedNode, literal, quad: makeQuad } = DataFactory;
 
 export const VITALS_TEMPLATE_ID = '2.16.840.1.113883.10.20.22.2.4.1';
 export const VITALS_LOINC = '8716-3';
+
+/**
+ * Maps a VITAL_LOINC_CODES `type` to a clinical:vitalType the VitalSignShape's
+ * sh:in enum accepts. A LOINC vital whose type is not listed here (mean BP,
+ * percentiles, head circumference, intraocular pressure, body surface area, etc.)
+ * is not a VitalSign per the shape and is routed to a lab result instead.
+ * Kept in lockstep with VITAL_TYPE_TO_SHACL in the FHIR converter.
+ */
+const VITAL_TYPE_TO_SHACL: Record<string, string> = {
+  heartRate: 'heartRate',
+  bloodPressurePanel: 'bloodPressure',
+  bloodPressureSystolic: 'bloodPressureSystolic',
+  bloodPressureDiastolic: 'bloodPressureDiastolic',
+  respiratoryRate: 'respiratoryRate',
+  bodyTemperature: 'temperature',
+  bodyTemperatureOral: 'temperature',
+  oxygenSaturation: 'oxygenSaturation',
+  bodyWeight: 'bodyWeight',
+  bodyHeight: 'bodyHeight',
+  bmi: 'bodyMassIndex',
+};
 
 export function extractVitalQuads(
   entries: any[],
@@ -44,7 +73,12 @@ export function extractVitalQuads(
       const codeEl = obs?.code ?? {};
       const loincCode = codeEl?.['@_code'] ?? codeEl?.code ?? '';
       const codeSystem = codeEl?.['@_codeSystem'] ?? codeEl?.codeSystem ?? '';
-      const displayName = codeEl?.['@_displayName'] ?? codeEl?.displayName ?? '';
+      // Some C-CDA vitals carry the display in <originalText> rather than @displayName.
+      const displayName =
+        codeEl?.['@_displayName'] ?? codeEl?.displayName ??
+        (typeof codeEl?.originalText === 'string'
+          ? codeEl.originalText
+          : codeEl?.originalText?.['#text'] ?? '');
       const isLoinc = codeSystem.includes('6.1') || codeSystem === loincOid;
 
       const effTime = obs?.effectiveTime;
@@ -56,13 +90,27 @@ export function extractVitalQuads(
         : dateVal;
 
       const valueEl = obs?.value ?? {};
-      const value = valueEl?.['@_value'] ?? valueEl?.value ?? '';
+      const value = valueEl?.['@_value'] ?? valueEl?.value ?? valueEl?.['#text'] ?? '';
       const unit = valueEl?.['@_unit'] ?? valueEl?.unit ?? '';
 
       const sourceId = (() => {
         const idEl = Array.isArray(obs?.id) ? obs.id[0] : obs?.id;
         return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
       })();
+
+      // Resolve a clinical:vitalType the VitalSignShape enum accepts.
+      const vitalInfo = isLoinc && loincCode ? VITAL_LOINC_CODES[loincCode] : undefined;
+      const shaclVitalType = vitalInfo ? VITAL_TYPE_TO_SHACL[vitalInfo.type] : undefined;
+
+      if (!shaclVitalType) {
+        // Not a VitalSign per the shape (no LOINC match, or a LOINC outside the
+        // canonical enum). Preserve the value as a lab result rather than drop it.
+        quads.push(...buildLabFallback({
+          patientUri, sourceSystem, loincCode, isLoinc, loincOid,
+          displayName, dateStr, value, unit, sourceId,
+        }));
+        continue;
+      }
 
       const uri = contentHashedUri('VitalSign', {
         patient: patientUri,
@@ -76,14 +124,57 @@ export function extractVitalQuads(
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'VitalSign')));
       quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
 
-      if (isLoinc && loincCode) quads.push(makeQuad(subj, namedNode(NS.health + 'testCode'), namedNode(resolveCodeUri(loincOid, loincCode))));
+      // Required: vitalType (enum-valid).
+      quads.push(makeQuad(subj, namedNode(NS.clinical + 'vitalType'), literal(shaclVitalType, namedNode(NS.xsd + 'string'))));
+      // Value lives under clinical:value (untyped in the shape; string is fine).
+      if (value) quads.push(makeQuad(subj, namedNode(NS.clinical + 'value'), literal(String(value))));
+      if (unit) quads.push(makeQuad(subj, namedNode(NS.clinical + 'unit'), literal(String(unit), namedNode(NS.xsd + 'string'))));
+      if (isLoinc && loincCode) quads.push(makeQuad(subj, namedNode(NS.clinical + 'loincCode'), namedNode(resolveCodeUri(loincOid, loincCode))));
       if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'vitalName'), literal(displayName)));
-      if (dateStr) quads.push(makeQuad(subj, namedNode(NS.health + 'effectiveDate'), literal(dateStr)));
-      if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'value'), literal(value)));
-      if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'unit'), literal(unit)));
+      if (dateStr) quads.push(makeQuad(subj, namedNode(NS.clinical + 'effectiveDate'), literal(dateStr)));
       if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
     }
   }
 
+  return quads;
+}
+
+/**
+ * Build a health:LabResultRecord for a vital observation whose type is not in the
+ * VitalSignShape enum, preserving its value. health:LabResultRecord has no
+ * SHACL target shape, so this validates cleanly while keeping the data.
+ */
+function buildLabFallback(args: {
+  patientUri: string;
+  sourceSystem: string;
+  loincCode: string;
+  isLoinc: boolean;
+  loincOid: string;
+  displayName: string;
+  dateStr: string;
+  value: string;
+  unit: string;
+  sourceId: string;
+}): Quad[] {
+  const { patientUri, sourceSystem, loincCode, isLoinc, loincOid, displayName, dateStr, value, unit, sourceId } = args;
+  const quads: Quad[] = [];
+
+  const uri = contentHashedUri('LabResult', {
+    patient: patientUri,
+    loincCode: isLoinc ? loincCode : undefined,
+    testName: displayName || undefined,
+    date: dateStr || undefined,
+    value: value || undefined,
+  }, sourceId || undefined);
+
+  const subj = namedNode(uri);
+  quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'LabResultRecord')));
+  quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
+  if (isLoinc && loincCode) quads.push(makeQuad(subj, namedNode(NS.health + 'testCode'), namedNode(resolveCodeUri(loincOid, loincCode))));
+  if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'testName'), literal(displayName)));
+  if (dateStr) quads.push(makeQuad(subj, namedNode(NS.health + 'performedDate'), literal(dateStr)));
+  if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'resultValue'), literal(String(value))));
+  if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'resultUnit'), literal(String(unit))));
+  if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
   return quads;
 }

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -440,35 +440,64 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
 // Observation (vital sign) converter
 // ---------------------------------------------------------------------------
 
+/**
+ * Maps the converter's internal vital `type` (from VITAL_LOINC_CODES) to a
+ * clinical:vitalType value the VitalSignShape's sh:in enum actually accepts.
+ * The enum is intentionally narrow (the canonical clinical vital signs), so any
+ * VITAL_LOINC_CODES type not listed here (e.g. body surface area, mean blood
+ * pressure, head circumference, percentiles, intraocular pressure) is NOT a
+ * VitalSign per the shape and is routed to the lab/observation converter so its
+ * value is still preserved ("Cascade does not drop data").
+ */
+const VITAL_TYPE_TO_SHACL: Record<string, string> = {
+  heartRate: 'heartRate',
+  bloodPressurePanel: 'bloodPressure',
+  bloodPressureSystolic: 'bloodPressureSystolic',
+  bloodPressureDiastolic: 'bloodPressureDiastolic',
+  respiratoryRate: 'respiratoryRate',
+  bodyTemperature: 'temperature',
+  bodyTemperatureOral: 'temperature',
+  oxygenSaturation: 'oxygenSaturation',
+  bodyWeight: 'bodyWeight',
+  bodyHeight: 'bodyHeight',
+  bmi: 'bodyMassIndex',
+};
+
 export function convertObservationVital(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const subjectUri = mintSubjectUri(resource);
   const quads: Quad[] = [];
 
-  quads.push(tripleType(subjectUri, NS.clinical + 'VitalSign'));
-  quads.push(...commonTriples(subjectUri));
-
   const codings = extractCodings(resource.code);
   let vitalInfo: { type: string; name: string; unit: string; snomedCode: string } | undefined;
+  let loincCode: string | undefined;
   for (const c of codings) {
     if (isLoincSystem(c.system) && VITAL_LOINC_CODES[c.code]) {
       vitalInfo = VITAL_LOINC_CODES[c.code];
-      quads.push(tripleRef(subjectUri, NS.clinical + 'loincCode', NS.loinc + c.code));
+      loincCode = c.code;
       break;
     }
   }
 
-  if (vitalInfo) {
-    quads.push(tripleStr(subjectUri, NS.clinical + 'vitalType', vitalInfo.type));
-    quads.push(tripleStr(subjectUri, NS.clinical + 'vitalTypeName', vitalInfo.name));
-    quads.push(tripleRef(subjectUri, NS.clinical + 'snomedCode', NS.sct + vitalInfo.snomedCode));
-  } else {
-    // No LOINC match in the map — fall back to a slug derived from the display name.
-    // Data is fully preserved (value + unit + name); we just lack a canonical vitalType enum.
-    const name = codeableConceptText(resource.code) ?? 'Unknown Vital';
-    quads.push(tripleStr(subjectUri, NS.clinical + 'vitalType', name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')));
-    quads.push(tripleStr(subjectUri, NS.clinical + 'vitalTypeName', name));
+  // Resolve a clinical:vitalType the VitalSignShape enum accepts. If we cannot
+  // (no LOINC match, or a LOINC vital type outside the shape's canonical enum
+  // such as body surface area / mean BP / percentiles), this is not a VitalSign
+  // per the shape: route it to the lab/observation converter, which preserves
+  // every value form (valueQuantity, valueString, valueCodeableConcept,
+  // components) without dropping data.
+  const shaclVitalType = vitalInfo ? VITAL_TYPE_TO_SHACL[vitalInfo.type] : undefined;
+  if (!shaclVitalType) {
+    return convertObservationLab(resource);
   }
+
+  quads.push(tripleType(subjectUri, NS.clinical + 'VitalSign'));
+  quads.push(...commonTriples(subjectUri));
+  if (loincCode) {
+    quads.push(tripleRef(subjectUri, NS.clinical + 'loincCode', NS.loinc + loincCode));
+  }
+  quads.push(tripleStr(subjectUri, NS.clinical + 'vitalType', shaclVitalType));
+  quads.push(tripleStr(subjectUri, NS.clinical + 'vitalTypeName', vitalInfo!.name));
+  quads.push(tripleRef(subjectUri, NS.clinical + 'snomedCode', NS.sct + vitalInfo!.snomedCode));
 
   if (resource.valueQuantity) {
     quads.push(tripleDouble(subjectUri, NS.clinical + 'value', resource.valueQuantity.value));
@@ -497,8 +526,21 @@ export function convertObservationVital(resource: any): ConversionResult & { _qu
     if (emittedCount === 0) {
       warnings.push('No valueQuantity found in vital sign Observation');
     }
+  } else if (typeof resource.valueString === 'string') {
+    // Some vitals carry a non-quantity value (e.g. a textual reading). Capture it
+    // rather than drop it. clinical:value is untyped in the shape, so a string is fine.
+    quads.push(tripleStr(subjectUri, NS.clinical + 'value', resource.valueString));
+  } else if (resource.valueCodeableConcept) {
+    const valText = codeableConceptText(resource.valueCodeableConcept);
+    if (valText) {
+      quads.push(tripleStr(subjectUri, NS.clinical + 'value', valText));
+    } else {
+      warnings.push('No value found in vital sign Observation');
+    }
+  } else if (typeof resource.valueInteger === 'number') {
+    quads.push(tripleDouble(subjectUri, NS.clinical + 'value', resource.valueInteger));
   } else {
-    warnings.push('No valueQuantity found in vital sign Observation');
+    warnings.push('No value found in vital sign Observation');
   }
 
   const effectiveDate = resource.effectiveDateTime ?? resource.effectivePeriod?.start;
@@ -631,9 +673,16 @@ export function convertClinicalDocument(resource: any): ConversionResult & { _qu
     }
   }
 
+  // The ClinicalDocumentShape requires clinical:fhirResourceId and
+  // clinical:fhirResourceType (not clinical:sourceRecordId). Emit the exact
+  // predicates the shape requires from the FHIR resource. Keep sourceRecordId
+  // too (used by reconciliation / other consumers); it is additive, not a
+  // substitute.
   if (resource.id) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'fhirResourceId', resource.id));
     quads.push(tripleStr(subjectUri, NS.clinical + 'sourceRecordId', resource.id));
   }
+  quads.push(tripleStr(subjectUri, NS.clinical + 'fhirResourceType', resource.resourceType ?? 'DocumentReference'));
 
   quads.push(tripleRef(subjectUri, NS.cascade + 'layerPromotionStatus', NS.cascade + 'FullyMapped'));
 

--- a/src/lib/fhir-converter/fhir-to-cascade.ts
+++ b/src/lib/fhir-converter/fhir-to-cascade.ts
@@ -49,11 +49,22 @@ import {
   EXCLUDED_TYPES,
 } from './converters-passthrough.js';
 
+import { appendProvenanceQuads } from './provenance.js';
+
 // ---------------------------------------------------------------------------
 // Main dispatcher: single FHIR resource -> Cascade
 // ---------------------------------------------------------------------------
 
 export function convertFhirResourceToQuads(fhirResource: any, passthroughMinimal = false): (ConversionResult & { _quads: Quad[] }) | null {
+  const result = dispatchFhirResource(fhirResource, passthroughMinimal);
+  // Recover the performing clinician + source EHR/organization that the per-type
+  // converters historically dropped for most types ("Cascade does not drop
+  // data"). Additive + idempotent; see provenance.ts.
+  if (result) appendProvenanceQuads(fhirResource, result._quads);
+  return result;
+}
+
+function dispatchFhirResource(fhirResource: any, passthroughMinimal: boolean): (ConversionResult & { _quads: Quad[] }) | null {
   const resourceType = fhirResource?.resourceType as string | undefined;
   if (!resourceType) return null;
 

--- a/src/lib/fhir-converter/index.ts
+++ b/src/lib/fhir-converter/index.ts
@@ -57,6 +57,7 @@ const { namedNode, literal, quad: makeQuad } = DataFactory;
 import { convertFhirResourceToQuads } from './fhir-to-cascade.js';
 import { convertCascadeToFhir } from './cascade-to-fhir.js';
 import { EXCLUDED_TYPES } from './converters-passthrough.js';
+import { SOURCE_EHR_UNKNOWN } from './provenance.js';
 
 // Re-export public types
 export type { InputFormat, OutputFormat, ConversionResult, BatchConversionResult };
@@ -177,9 +178,12 @@ export async function convert(
     }
     // Document subtypes require clinical:sourceEHR (SHACL). The per-resource
     // provenance pass may already have captured the REAL source org/EHR from the
-    // resource; only fall back to the import label for subjects that still lack
-    // one, so a real "swedish.org" / "Kaiser Permanente Washington" is never
-    // overwritten by the import-batch name.
+    // resource; only fill the gap for subjects that still lack one. The gap is
+    // filled with the ratified data-absent-reason token "unknown", NEVER the
+    // import-batch label: that label (cascade:sourceSystem, e.g. "Apple Health
+    // export") is how the data entered the Pod, not the EHR it came from, so
+    // writing it into sourceEHR misattributes provenance. An honest "unknown" lets
+    // the user re-file the record under the right EHR later.
     const subjectsWithSourceEhr = new Set(
       allQuads
         .filter((q) => q.predicate.value === NS.clinical + 'sourceEHR')
@@ -190,9 +194,9 @@ export async function convert(
         makeQuad(namedNode(subjectUri), namedNode(NS.clinical + 'importedAt'),
           literal(conversionTimestamp, namedNode(NS.xsd + 'dateTime'))),
       );
-      if (sourceSystem && !subjectsWithSourceEhr.has(subjectUri)) {
+      if (!subjectsWithSourceEhr.has(subjectUri)) {
         allQuads.push(
-          makeQuad(namedNode(subjectUri), namedNode(NS.clinical + 'sourceEHR'), literal(sourceSystem)),
+          makeQuad(namedNode(subjectUri), namedNode(NS.clinical + 'sourceEHR'), literal(SOURCE_EHR_UNKNOWN)),
         );
       }
     }

--- a/src/lib/fhir-converter/index.ts
+++ b/src/lib/fhir-converter/index.ts
@@ -175,12 +175,22 @@ export async function convert(
         );
       }
     }
+    // Document subtypes require clinical:sourceEHR (SHACL). The per-resource
+    // provenance pass may already have captured the REAL source org/EHR from the
+    // resource; only fall back to the import label for subjects that still lack
+    // one, so a real "swedish.org" / "Kaiser Permanente Washington" is never
+    // overwritten by the import-batch name.
+    const subjectsWithSourceEhr = new Set(
+      allQuads
+        .filter((q) => q.predicate.value === NS.clinical + 'sourceEHR')
+        .map((q) => q.subject.value),
+    );
     for (const subjectUri of clinicalDocSubjects) {
       allQuads.push(
         makeQuad(namedNode(subjectUri), namedNode(NS.clinical + 'importedAt'),
           literal(conversionTimestamp, namedNode(NS.xsd + 'dateTime'))),
       );
-      if (sourceSystem) {
+      if (sourceSystem && !subjectsWithSourceEhr.has(subjectUri)) {
         allQuads.push(
           makeQuad(namedNode(subjectUri), namedNode(NS.clinical + 'sourceEHR'), literal(sourceSystem)),
         );

--- a/src/lib/fhir-converter/index.ts
+++ b/src/lib/fhir-converter/index.ts
@@ -76,6 +76,13 @@ export { convertCascadeToFhir } from './cascade-to-fhir.js';
  * @param passthroughMinimal  If true, omits cascade:fhirJson from passthrough records.
  *                            Round-trip export is not supported in minimal mode.
  *                            Produces smaller output for display-only scenarios.
+ * @param sourceEhrOverride   Authoritative EHR/account of origin for EVERY record
+ *                            in this input, supplied by a container adapter that
+ *                            knows the source the FHIR payload omits (e.g. Apple
+ *                            Health's export.xml `<ClinicalRecord sourceName>`).
+ *                            When set it REPLACES any host-derived clinical:sourceEHR
+ *                            and pre-empts the data-absent "unknown" fallback, so
+ *                            all records from one account share one honest source.
  */
 export async function convert(
   input: string | Buffer,
@@ -84,6 +91,7 @@ export async function convert(
   outputSerialization: 'turtle' | 'jsonld' = 'turtle',
   sourceSystem?: string,
   passthroughMinimal = false,
+  sourceEhrOverride?: string,
 ): Promise<BatchConversionResult> {
   const warnings: string[] = [];
   const errors: string[] = [];
@@ -172,6 +180,35 @@ export async function convert(
             namedNode(subjectUri),
             namedNode(NS.cascade + 'sourceSystem'),
             literal(sourceSystem),
+          ),
+        );
+      }
+    }
+    // Authoritative per-record source override (e.g. the Apple Health export.xml
+    // <ClinicalRecord sourceName> the container adapter recovered). The container
+    // knows the EHR/account of origin even when the FHIR payload does not (Epic
+    // records carry only relative references + OID identifiers, no absolute org
+    // host), so this label is authoritative for EVERY record from the input: it is
+    // what the user sees in the Health app and it is consistent across the account.
+    // It REPLACES any host-derived sourceEHR (so one account groups under one name
+    // instead of splitting "Swedish" vs "swedish.org") and pre-empts the "unknown"
+    // fallback below. The import-batch tag stays separately on cascade:sourceSystem.
+    if (sourceEhrOverride) {
+      for (let i = allQuads.length - 1; i >= 0; i--) {
+        const q = allQuads[i];
+        if (
+          q.predicate.value === NS.clinical + 'sourceEHR' &&
+          recordSubjects.has(q.subject.value)
+        ) {
+          allQuads.splice(i, 1);
+        }
+      }
+      for (const subjectUri of recordSubjects) {
+        allQuads.push(
+          makeQuad(
+            namedNode(subjectUri),
+            namedNode(NS.clinical + 'sourceEHR'),
+            literal(sourceEhrOverride),
           ),
         );
       }

--- a/src/lib/fhir-converter/provenance.ts
+++ b/src/lib/fhir-converter/provenance.ts
@@ -1,0 +1,191 @@
+/**
+ * Per-resource provenance capture: the performing/ordering clinician and the
+ * source EHR / organization.
+ *
+ * Apple Health (and most FHIR) carry these inline on `performer` / `requester` /
+ * `recorder` / `asserter` and in the endpoint host of provider reference URLs,
+ * but the per-type converters historically read them for only three types
+ * (DiagnosticReport, Encounter, Immunization). Everything else dropped the
+ * provider that the source actually provided, which violates the "Cascade does
+ * not drop data" tenet and is why an Apple Health pod ends up with no usable
+ * source axis. This shared pass recovers both signals uniformly:
+ *
+ *   - clinical:providerName  the clinician/performer display. Reuses the
+ *     predicate the converters already emit on LaboratoryReport/Encounter rather
+ *     than minting new vocabulary (which would need a spec cycle).
+ *   - clinical:sourceEHR     the source system / organization: an org-looking
+ *     provider display when present (e.g. "Kaiser Permanente Washington"), else
+ *     the registrable host of a provider reference endpoint
+ *     (e.g. https://haiku.swedish.org/... -> "swedish.org"). This is the axis the
+ *     source-organized Records view needs. `sourceEHR` is intentionally broad in
+ *     the ontology ("LabResult and other EHR-sourced records").
+ *
+ * Additive + idempotent: it never overwrites a value a converter already set,
+ * and it emits nothing when the resource carries no provenance signal (so a
+ * record with only a relative-reference provider keeps an honest, empty source
+ * rather than a fabricated one). Shapes are not `sh:closed`, so the extra
+ * predicates validate cleanly on every record type.
+ */
+
+import type { Quad } from 'n3';
+
+import { NS, tripleStr } from './types.js';
+
+/** Resource fields, in priority order, that name the performing/ordering agent. */
+const PROVIDER_FIELDS = [
+  'performer',
+  'requester',
+  'recorder',
+  'asserter',
+  'serviceProvider',
+] as const;
+
+/** FHIR resource types that represent a clinical record with a performing agent. */
+const CLINICAL_RECORD_TYPES = new Set([
+  'MedicationStatement',
+  'MedicationRequest',
+  'Condition',
+  'AllergyIntolerance',
+  'Observation',
+  'Procedure',
+  'DocumentReference',
+  'Encounter',
+  'DiagnosticReport',
+  'MedicationAdministration',
+  'Device',
+  'ImagingStudy',
+  'Immunization',
+]);
+
+/**
+ * Institution-level words for the org-display FALLBACK (used only when no
+ * reference host is available). Deliberately multi-word / proper-noun terms, not
+ * role words like "medical" or "radiology" that also appear in a clinician's
+ * title ("Medical Assistant", "Radiologist").
+ */
+const INSTITUTION_KEYWORDS =
+  /\b(permanente|hospital|health system|healthcare|health services|health center|medical center|medical centre|medical group|clinic|laboratory|laboratories|imaging center|pathology associates|kaiser|sutter|providence|swedish|cerner|mayo)\b/i;
+
+/** Clinician role / credential markers: if a display has one, it is a PERSON. */
+const PERSON_ROLE =
+  /(\b(MD|DO|RN|NP|PA|PA-C|CMA|CNA|MA|CM|PhD|DDS|DMD|Dr|Nurse|Technician|Tech|Phlebotomist|Radiologist)\b|Medical Assistant|, [A-Z]{1,4}$)/;
+
+/** The first `.display` among a node, its `.actor`, or its `.individual` (array-tolerant). */
+function displayOf(node: unknown): string | undefined {
+  if (!node) return undefined;
+  const arr = Array.isArray(node) ? node : [node];
+  for (const n of arr) {
+    const r = n as { display?: unknown; actor?: { display?: unknown }; individual?: { display?: unknown } };
+    const d = r?.display ?? r?.actor?.display ?? r?.individual?.display;
+    if (typeof d === 'string' && d.trim()) return d.trim();
+  }
+  return undefined;
+}
+
+/** The clinician/performer display from the first populated provider field. */
+export function extractProviderName(resource: any): string | undefined {
+  for (const field of PROVIDER_FIELDS) {
+    const d = displayOf(resource?.[field]);
+    if (d) return d;
+  }
+  return undefined;
+}
+
+/** The registrable domain of a host ("haiku.swedish.org" -> "swedish.org"). */
+function registrableDomain(host: string): string {
+  const labels = host.split('.').filter(Boolean);
+  // Last two labels is the registrable domain for the common (US health) case.
+  return labels.length > 2 ? labels.slice(-2).join('.') : host;
+}
+
+/**
+ * The host of the FIRST absolute (http/https) `reference` anywhere in the
+ * resource. Every reference in an Apple Health record points at the SAME source
+ * FHIR server (e.g. haiku.swedish.org), so any one identifies the source system,
+ * including on records (lab Observations) whose own performer is absent and whose
+ * only absolute reference is the subject/encounter.
+ */
+function sourceHost(resource: unknown): string | undefined {
+  const seen = new Set<unknown>();
+  const walk = (node: unknown): string | undefined => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return undefined;
+    seen.add(node);
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const h = walk(item);
+        if (h) return h;
+      }
+      return undefined;
+    }
+    const obj = node as Record<string, unknown>;
+    const ref = obj.reference;
+    if (typeof ref === 'string' && /^https?:\/\//i.test(ref)) {
+      try {
+        return registrableDomain(new URL(ref).hostname);
+      } catch {
+        /* not parseable: keep walking */
+      }
+    }
+    for (const v of Object.values(obj)) {
+      if (v && typeof v === 'object') {
+        const h = walk(v);
+        if (h) return h;
+      }
+    }
+    return undefined;
+  };
+  return walk(resource);
+}
+
+/**
+ * The source EHR/organization. Prefer the source FHIR server host (unambiguous,
+ * clean, low-cardinality, present even when the performer is not); fall back to
+ * an institution-looking provider display only when no host is available, never
+ * a clinician's name.
+ */
+export function extractSourceEhr(resource: any): string | undefined {
+  const host = sourceHost(resource);
+  if (host) return host;
+  const display = extractProviderName(resource);
+  if (display && INSTITUTION_KEYWORDS.test(display) && !PERSON_ROLE.test(display)) {
+    return display;
+  }
+  return undefined;
+}
+
+/**
+ * Append clinical:providerName + clinical:sourceEHR to a converted resource's
+ * record subjects (those carrying an rdf:type), without overwriting any value a
+ * converter already set. No-op when the resource is not a clinical record or
+ * carries no provenance signal.
+ */
+export function appendProvenanceQuads(resource: any, quads: Quad[]): void {
+  if (!resource || !CLINICAL_RECORD_TYPES.has(resource.resourceType)) return;
+
+  const provider = extractProviderName(resource);
+  const sourceEhr = extractSourceEhr(resource);
+  if (!provider && !sourceEhr) return;
+
+  const subjects = new Set<string>();
+  const hasProvider = new Set<string>();
+  const hasSourceEhr = new Set<string>();
+  for (const q of quads) {
+    const p = q.predicate.value;
+    if (p === NS.rdf + 'type') subjects.add(q.subject.value);
+    // A converter may already carry the provider under either predicate.
+    else if (p === NS.clinical + 'providerName' || p === NS.health + 'administeringProvider') {
+      hasProvider.add(q.subject.value);
+    } else if (p === NS.clinical + 'sourceEHR') {
+      hasSourceEhr.add(q.subject.value);
+    }
+  }
+
+  for (const subject of subjects) {
+    if (provider && !hasProvider.has(subject)) {
+      quads.push(tripleStr(subject, NS.clinical + 'providerName', provider));
+    }
+    if (sourceEhr && !hasSourceEhr.has(subject)) {
+      quads.push(tripleStr(subject, NS.clinical + 'sourceEHR', sourceEhr));
+    }
+  }
+}

--- a/src/lib/fhir-converter/provenance.ts
+++ b/src/lib/fhir-converter/provenance.ts
@@ -31,6 +31,17 @@ import type { Quad } from 'n3';
 
 import { NS, tripleStr } from './types.js';
 
+/**
+ * The ratified "value is expected but not known" token, from the FHIR/HL7
+ * Data Absent Reason code system. Written into `clinical:sourceEHR` when the
+ * record's EHR of origin cannot be determined, instead of fabricating a value
+ * (e.g. copying the import-batch label, which is how the data got in, not where
+ * it came from). Deferring to the ratified vocabulary keeps "unknown" honest and
+ * machine-detectable downstream.
+ * @see http://terminology.hl7.org/CodeSystem/data-absent-reason (code "unknown")
+ */
+export const SOURCE_EHR_UNKNOWN = 'unknown';
+
 /** Resource fields, in priority order, that name the performing/ordering agent. */
 const PROVIDER_FIELDS = [
   'performer',

--- a/src/lib/source-adapters/apple-health.ts
+++ b/src/lib/source-adapters/apple-health.ts
@@ -18,7 +18,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ExpandedSource, FileSourceMeta, SkippedArtifact, SourceAdapter } from './types.js';
+import type { CompletenessCheck, ExpandedSource, FileSourceMeta, SkippedArtifact, SourceAdapter } from './types.js';
 
 const CLINICAL_DIR = 'clinical-records';
 /** The primary device export Apple writes at the export root (the firehose). */
@@ -161,6 +161,7 @@ export const appleHealthAdapter: SourceAdapter = {
     // Recover the authoritative per-record source (the Apple account) from
     // export.xml's <ClinicalRecord> wrappers and attach it by absolute path. The
     // device firehose itself is still skipped below; we only read its tail block.
+    let labeled = 0;
     const exportXmlPath = path.join(targetPath, PRIMARY_EXPORT);
     if (clinicalNames.length > 0 && fs.existsSync(exportXmlPath)) {
       const byFilename = readClinicalRecordSources(exportXmlPath, clinicalNames.length);
@@ -168,8 +169,25 @@ export const appleHealthAdapter: SourceAdapter = {
         const meta = byFilename.get(name);
         if (meta && (meta.sourceEhr || meta.sourceUrl || meta.receivedDate)) {
           fileSources[path.join(clinicalDir, name)] = meta;
+          if (meta.sourceEhr) labeled += 1;
         }
       }
+    }
+
+    // Completeness: did every clinical record get a source account label? A
+    // shortfall means some records will import with no EHR of origin (e.g. a
+    // record with no <ClinicalRecord> wrapper, or export.xml absent entirely).
+    const completeness: CompletenessCheck[] = [];
+    if (clinicalNames.length > 0) {
+      completeness.push({
+        label: 'Source account labels',
+        recovered: labeled,
+        total: clinicalNames.length,
+        note:
+          labeled < clinicalNames.length
+            ? `${clinicalNames.length - labeled} record(s) had no source label in export.xml and will import without an EHR of origin`
+            : undefined,
+      });
     }
 
     for (const f of DEVICE_EXPORTS) {
@@ -188,6 +206,6 @@ export const appleHealthAdapter: SourceAdapter = {
       }
     }
 
-    return { files, skipped, sourceLabel: 'Apple Health export', fileSources };
+    return { files, skipped, sourceLabel: 'Apple Health export', fileSources, completeness };
   },
 };

--- a/src/lib/source-adapters/apple-health.ts
+++ b/src/lib/source-adapters/apple-health.ts
@@ -18,9 +18,11 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ExpandedSource, SkippedArtifact, SourceAdapter } from './types.js';
+import type { ExpandedSource, FileSourceMeta, SkippedArtifact, SourceAdapter } from './types.js';
 
 const CLINICAL_DIR = 'clinical-records';
+/** The primary device export Apple writes at the export root (the firehose). */
+const PRIMARY_EXPORT = 'export.xml';
 /** The multi-GB device exports Apple writes at the export root. */
 const DEVICE_EXPORTS = ['export.xml', 'export_cda.xml'];
 /** Other non-clinical device-data folders. */
@@ -42,6 +44,90 @@ function sizeGB(p: string): string {
   }
 }
 
+/** Minimal XML entity decode for attribute values (sourceName carries `&amp;`). */
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'");
+}
+
+/** Read a single attribute value out of one element's opening tag. */
+function readAttr(element: string, name: string): string | undefined {
+  const m = new RegExp(`${name}="([^"]*)"`).exec(element);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Recover Apple's per-record source labels from export.xml's `<ClinicalRecord>`
+ * wrappers, keyed by the clinical-records JSON filename (basename of
+ * resourceFilePath).
+ *
+ * export.xml is the device firehose (multi-GB) and is otherwise skipped, but the
+ * `<ClinicalRecord ... />` elements are a small block at the very END of the file
+ * (after the millions of `<Record>` HealthKit samples). So we never read the
+ * whole file: we read a bounded window off the TAIL, growing it only if the
+ * expected number of wrappers is not yet present. Each wrapper carries the
+ * authoritative `sourceName` (e.g. "Providence Health & Services") that the FHIR
+ * payloads themselves often lack. A partial element at the window's leading edge
+ * simply fails the full-element regex and is recovered when the window grows.
+ */
+function readClinicalRecordSources(
+  exportXmlPath: string,
+  expectedCount: number,
+): Map<string, FileSourceMeta> {
+  const byFilename = new Map<string, FileSourceMeta>();
+  let fd: number;
+  try {
+    fd = fs.openSync(exportXmlPath, 'r');
+  } catch {
+    return byFilename;
+  }
+  try {
+    const fileSize = fs.fstatSync(fd).size;
+    if (fileSize === 0) return byFilename;
+    const MAX_WINDOW = 64 * 1024 * 1024; // cap the tail read; the block is ~1 byte/record
+    let window = Math.min(fileSize, 2 * 1024 * 1024);
+    let text = '';
+    for (;;) {
+      const start = Math.max(0, fileSize - window);
+      const length = fileSize - start;
+      const buf = Buffer.allocUnsafe(length);
+      fs.readSync(fd, buf, 0, length, start);
+      text = buf.toString('utf-8');
+      const seen = (text.match(/<ClinicalRecord\b/g) ?? []).length;
+      if (seen >= expectedCount || start === 0 || window >= MAX_WINDOW) break;
+      window = Math.min(window * 2, MAX_WINDOW, fileSize);
+    }
+    const elementRe = /<ClinicalRecord\b[^>]*?\/>/g;
+    let m: RegExpExecArray | null;
+    while ((m = elementRe.exec(text)) !== null) {
+      const el = m[0];
+      const rfp = readAttr(el, 'resourceFilePath');
+      if (!rfp) continue;
+      const filename = rfp.split('/').pop();
+      if (!filename) continue;
+      const sourceName = readAttr(el, 'sourceName');
+      const sourceUrl = readAttr(el, 'sourceURL');
+      const receivedDate = readAttr(el, 'receivedDate');
+      byFilename.set(filename, {
+        sourceEhr: sourceName ? decodeXmlEntities(sourceName) : undefined,
+        sourceUrl: sourceUrl ? decodeXmlEntities(sourceUrl) : undefined,
+        receivedDate,
+      });
+    }
+  } catch {
+    // Best-effort: a parse/read failure just means no per-record source labels;
+    // conversion falls back to per-resource derivation. Never fatal to import.
+  } finally {
+    fs.closeSync(fd);
+  }
+  return byFilename;
+}
+
 export const appleHealthAdapter: SourceAdapter = {
   id: 'apple-health',
   description:
@@ -59,12 +145,29 @@ export const appleHealthAdapter: SourceAdapter = {
   expand(targetPath: string): ExpandedSource {
     const files: string[] = [];
     const skipped: SkippedArtifact[] = [];
+    const fileSources: Record<string, FileSourceMeta> = {};
 
     const clinicalDir = path.join(targetPath, CLINICAL_DIR);
+    const clinicalNames: string[] = [];
     if (isDir(clinicalDir)) {
       for (const name of fs.readdirSync(clinicalDir)) {
         if (name.toLowerCase().endsWith('.json')) {
           files.push(path.join(clinicalDir, name));
+          clinicalNames.push(name);
+        }
+      }
+    }
+
+    // Recover the authoritative per-record source (the Apple account) from
+    // export.xml's <ClinicalRecord> wrappers and attach it by absolute path. The
+    // device firehose itself is still skipped below; we only read its tail block.
+    const exportXmlPath = path.join(targetPath, PRIMARY_EXPORT);
+    if (clinicalNames.length > 0 && fs.existsSync(exportXmlPath)) {
+      const byFilename = readClinicalRecordSources(exportXmlPath, clinicalNames.length);
+      for (const name of clinicalNames) {
+        const meta = byFilename.get(name);
+        if (meta && (meta.sourceEhr || meta.sourceUrl || meta.receivedDate)) {
+          fileSources[path.join(clinicalDir, name)] = meta;
         }
       }
     }
@@ -85,6 +188,6 @@ export const appleHealthAdapter: SourceAdapter = {
       }
     }
 
-    return { files, skipped, sourceLabel: 'Apple Health export' };
+    return { files, skipped, sourceLabel: 'Apple Health export', fileSources };
   },
 };

--- a/src/lib/source-adapters/directory.ts
+++ b/src/lib/source-adapters/directory.ts
@@ -24,11 +24,38 @@ import type { ExpandedSource, SkippedArtifact, SourceAdapter } from './types.js'
 const SUPPORTED_EXT = new Set(['.json', '.ttl', '.xml', '.zip']);
 
 /**
+ * Directory names that never hold clinical records but commonly hold thousands
+ * of JSON/XML files (build output, package caches, IDE metadata). Descending into
+ * them when a user accidentally picks a project or home folder turns a quick
+ * import into a long grind, so the walk skips them. Dotfile dirs (.git, .cache,
+ * .venv, ...) are already skipped by the leading-dot rule below.
+ */
+const IGNORED_DIRS = new Set([
+  'node_modules', 'bower_components', 'vendor', 'Pods', 'DerivedData',
+  'dist', 'build', 'out', 'target', 'bin', 'obj',
+  'venv', '__pycache__', 'site-packages',
+  'Library', 'AppData',
+]);
+
+/**
  * Whole-file read ceiling. Node's fs.readFile throws above 2 GiB
  * (2,147,483,647 bytes); we stay just under to skip gracefully instead of
  * failing. Streaming import will lift this.
  */
 const MAX_WHOLE_FILE_BYTES = 2_000_000_000;
+
+/**
+ * Aggregate guards for the whole folder. The importer reads every collected file
+ * into memory and holds all converted quads at once (no streaming yet), so an
+ * accidentally-picked parent/home folder used to walk thousands of files and
+ * gigabytes until Node's heap OOM-ed. Past these limits a folder is almost
+ * certainly NOT a deliberate record export, so the adapter refuses it (returns no
+ * files) with guidance, instead of grinding into an out-of-memory crash. A real
+ * Apple Health clinical-records export (~1.3k small JSON) or a MyChart download
+ * (a few MB) is far under both.
+ */
+const MAX_TOTAL_FILES = 20_000;
+const MAX_TOTAL_BYTES = 1_000_000_000; // ~1 GB of source across the folder
 
 function isDir(p: string): boolean {
   try {
@@ -49,8 +76,11 @@ export const directoryAdapter: SourceAdapter = {
   expand(targetPath: string): ExpandedSource {
     const files: string[] = [];
     const skipped: SkippedArtifact[] = [];
+    let totalBytes = 0;
+    let overLimit = false;
 
     const walk = (dir: string): void => {
+      if (overLimit) return;
       let entries: fs.Dirent[];
       try {
         entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -58,9 +88,11 @@ export const directoryAdapter: SourceAdapter = {
         return;
       }
       for (const ent of entries) {
+        if (overLimit) return;
         if (ent.name.startsWith('.')) continue; // skip dotfiles / .DS_Store
         const full = path.join(dir, ent.name);
         if (ent.isDirectory()) {
+          if (IGNORED_DIRS.has(ent.name)) continue; // build/cache/IDE junk, never records
           walk(full);
           continue;
         }
@@ -79,9 +111,34 @@ export const directoryAdapter: SourceAdapter = {
           continue;
         }
         files.push(full);
+        totalBytes += size;
+        if (files.length > MAX_TOTAL_FILES || totalBytes > MAX_TOTAL_BYTES) {
+          overLimit = true;
+          return;
+        }
       }
     };
     walk(targetPath);
+
+    if (overLimit) {
+      // Too big to be a deliberate record export — refuse rather than read
+      // gigabytes into memory and OOM. Return no files so the import reports the
+      // reason and stops fast.
+      return {
+        files: [],
+        skipped: [
+          {
+            path: targetPath,
+            reason:
+              `this folder is larger than a record export (over ${MAX_TOTAL_FILES.toLocaleString()} files or ` +
+              `${(MAX_TOTAL_BYTES / 1e9).toFixed(0)} GB) — choose the specific export folder ` +
+              `(the Apple Health export, or the MyChart download), not a parent like Downloads or your home folder`,
+          },
+          ...skipped,
+        ],
+        sourceLabel: 'folder',
+      };
+    }
 
     return { files, skipped, sourceLabel: 'folder' };
   },

--- a/src/lib/source-adapters/ihe-xdm.ts
+++ b/src/lib/source-adapters/ihe-xdm.ts
@@ -1,0 +1,128 @@
+/**
+ * IHE XDM source adapter: an UNZIPPED "Download My Record" export (Epic MyChart,
+ * Cerner, etc.). The media layout is a folder containing an `IHE_XDM/` directory
+ * with one submission-set subfolder per export, each holding:
+ *   - METADATA.XML    the ebXML SubmitObjectsRequest manifest (NOT a clinical doc)
+ *   - DOC0001.XML ...  the actual C-CDA ClinicalDocument(s)
+ *   - STYLE.XSL        a rendering stylesheet
+ * plus, at the package root, a rendered HTML view, a PDF, INDEX.HTM, and a README.
+ *
+ * The per-file importer converts C-CDA, but feeding it METADATA.XML (ebXML, not
+ * CDA) produces no output and used to abort the whole import. This adapter
+ * recognizes the XDM layout and yields ONLY the C-CDA documents, skipping the
+ * manifest and the non-clinical rendering files with clear reasons; the existing
+ * C-CDA converter (with its Epic/Cerner vendor normalization) does the rest.
+ *
+ * Classification is by CONTENT, not filename, so it is robust to vendor naming:
+ * an XML whose root is <ClinicalDocument> is a document; one whose root is
+ * <SubmitObjectsRequest> / <ProvideAndRegister...> is the manifest.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ExpandedSource, SkippedArtifact, SourceAdapter } from './types.js';
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Read the first ~2 KB of a file as text (enough to see the XML root element). */
+function peekHead(p: string): string {
+  let fd: number;
+  try {
+    fd = fs.openSync(p, 'r');
+  } catch {
+    return '';
+  }
+  try {
+    const buf = Buffer.allocUnsafe(2048);
+    const n = fs.readSync(fd, buf, 0, 2048, 0);
+    return buf.toString('utf-8', 0, n);
+  } catch {
+    return '';
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+const CDA_ROOT = /<ClinicalDocument[\s>]/i;
+const XDM_MANIFEST = /<(?:[a-z0-9]+:)?(?:SubmitObjectsRequest|ProvideAndRegisterDocumentSetRequest)[\s>]/i;
+
+/** True iff this folder looks like an unzipped IHE XDM media export. */
+function looksLikeXdm(targetPath: string): boolean {
+  if (!isDir(targetPath)) return false;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(targetPath, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const e of entries) {
+    // An IHE_XDM/ container folder, or a submission-set folder holding METADATA.XML.
+    if (e.isDirectory() && e.name.toUpperCase() === 'IHE_XDM') return true;
+    if (e.isFile() && e.name.toUpperCase() === 'METADATA.XML') return true;
+  }
+  return false;
+}
+
+export const iheXdmAdapter: SourceAdapter = {
+  id: 'ihe-xdm',
+  description:
+    'Unzipped IHE XDM export folder (Epic MyChart / Cerner "Download My Record")',
+
+  detect(targetPath: string): boolean {
+    return looksLikeXdm(targetPath);
+  },
+
+  expand(targetPath: string): ExpandedSource {
+    const files: string[] = [];
+    const skipped: SkippedArtifact[] = [];
+    let nonClinical = 0;
+
+    const walk = (dir: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const ent of entries) {
+        if (ent.name.startsWith('.')) continue;
+        const full = path.join(dir, ent.name);
+        if (ent.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (path.extname(ent.name).toLowerCase() !== '.xml') {
+          nonClinical += 1; // PDF, INDEX.HTM, STYLE.XSL, README.TXT, png, css...
+          continue;
+        }
+        const head = peekHead(full);
+        if (CDA_ROOT.test(head)) {
+          files.push(full);
+        } else if (XDM_MANIFEST.test(head)) {
+          skipped.push({
+            path: full,
+            reason: 'IHE XDM submission manifest (not a clinical document)',
+          });
+        } else {
+          skipped.push({ path: full, reason: 'XML is not a C-CDA ClinicalDocument' });
+        }
+      }
+    };
+    walk(targetPath);
+
+    if (nonClinical > 0) {
+      skipped.push({
+        path: targetPath,
+        reason: `${nonClinical} non-clinical file(s) (rendered HTML, PDF, stylesheet, images)`,
+      });
+    }
+
+    return { files, skipped, sourceLabel: 'Clinical document export (IHE XDM)' };
+  },
+};

--- a/src/lib/source-adapters/registry.ts
+++ b/src/lib/source-adapters/registry.ts
@@ -32,4 +32,4 @@ export function detectSource(targetPath: string): SourceAdapter | undefined {
   });
 }
 
-export type { SourceAdapter, ExpandedSource, SkippedArtifact } from './types.js';
+export type { SourceAdapter, ExpandedSource, SkippedArtifact, FileSourceMeta } from './types.js';

--- a/src/lib/source-adapters/registry.ts
+++ b/src/lib/source-adapters/registry.ts
@@ -12,12 +12,14 @@
  */
 
 import { appleHealthAdapter } from './apple-health.js';
+import { iheXdmAdapter } from './ihe-xdm.js';
 import { directoryAdapter } from './directory.js';
 import type { SourceAdapter } from './types.js';
 
 /** Registered source adapters, most specific first. */
 export const sourceAdapters: ReadonlyArray<SourceAdapter> = [
   appleHealthAdapter,
+  iheXdmAdapter, // unzipped MyChart/Cerner "Download My Record" XDM folder
   directoryAdapter, // catch-all: any other folder
 ];
 
@@ -32,4 +34,4 @@ export function detectSource(targetPath: string): SourceAdapter | undefined {
   });
 }
 
-export type { SourceAdapter, ExpandedSource, SkippedArtifact, FileSourceMeta } from './types.js';
+export type { SourceAdapter, ExpandedSource, SkippedArtifact, FileSourceMeta, CompletenessCheck } from './types.js';

--- a/src/lib/source-adapters/types.ts
+++ b/src/lib/source-adapters/types.ts
@@ -47,6 +47,24 @@ export interface FileSourceMeta {
   receivedDate?: string;
 }
 
+/**
+ * A "did we recover everything this container offers?" check, surfaced in the
+ * pre-import plan so a successful-but-incomplete import is visible BEFORE writing.
+ * Example: an Apple Health export where source account labels were recovered for
+ * `recovered` of `total` clinical records (a shortfall means some records will
+ * import without an EHR-of-origin).
+ */
+export interface CompletenessCheck {
+  /** What was being recovered, e.g. "Source account labels". */
+  label: string;
+  /** How many of `total` were recovered. */
+  recovered: number;
+  /** The denominator (e.g. clinical records found). */
+  total: number;
+  /** Optional human note shown when `recovered < total`. */
+  note?: string;
+}
+
 /** The result of expanding a container into importable inputs. */
 export interface ExpandedSource {
   /** Absolute paths of the concrete files to feed the per-file import path. */
@@ -63,6 +81,11 @@ export interface ExpandedSource {
    * the whole map being undefined) simply fall back to per-resource derivation.
    */
   fileSources?: Record<string, FileSourceMeta>;
+  /**
+   * Optional "do we have everything we need?" checks for the pre-import plan.
+   * The Apple Health adapter reports how many records got a source account label.
+   */
+  completeness?: CompletenessCheck[];
 }
 
 /**

--- a/src/lib/source-adapters/types.ts
+++ b/src/lib/source-adapters/types.ts
@@ -24,6 +24,29 @@ export interface SkippedArtifact {
   reason: string;
 }
 
+/**
+ * Per-file source provenance an adapter recovered from a container's manifest,
+ * keyed (in ExpandedSource.fileSources) by the absolute path of the file it
+ * describes.
+ *
+ * The motivating case: an Apple Health export wraps every clinical record in an
+ * `<ClinicalRecord sourceName="..." sourceURL="..." receivedDate="...">` element
+ * in export.xml. `sourceName` is the EHR/account of origin exactly as the Health
+ * app shows it ("Providence Health & Services", "Swedish", "Kaiser Permanente"),
+ * and it is AUTHORITATIVE — present even for records whose FHIR payload omits an
+ * absolute organization host (Epic relative references), which is precisely the
+ * data the per-resource derivation cannot recover. The container knew the source
+ * all along; this carries it through to conversion instead of discarding it.
+ */
+export interface FileSourceMeta {
+  /** The EHR / account of origin as the container labels it (authoritative). */
+  sourceEhr?: string;
+  /** The source FHIR endpoint URL this record was synced from. */
+  sourceUrl?: string;
+  /** When the container received this record from the source (as written). */
+  receivedDate?: string;
+}
+
 /** The result of expanding a container into importable inputs. */
 export interface ExpandedSource {
   /** Absolute paths of the concrete files to feed the per-file import path. */
@@ -32,6 +55,14 @@ export interface ExpandedSource {
   skipped: SkippedArtifact[];
   /** What the adapter recognized, for the import report / verbose log. */
   sourceLabel: string;
+  /**
+   * Optional per-file source provenance recovered from the container manifest,
+   * keyed by the absolute file path (matching entries in `files`). The Apple
+   * Health adapter populates this from export.xml's `<ClinicalRecord>` wrappers;
+   * a plain directory import leaves it undefined. Files absent from the map (or
+   * the whole map being undefined) simply fall back to per-resource derivation.
+   */
+  fileSources?: Record<string, FileSourceMeta>;
 }
 
 /**

--- a/tests/ccda-converter.test.ts
+++ b/tests/ccda-converter.test.ts
@@ -181,38 +181,22 @@ describe('C-CDA converter — full summarization (P4-A)', () => {
     expect(result.output).toContain('"TestSystem"');
   });
 
-  it('output passes SHACL validation (no violations on health: record types)', async () => {
+  it('output passes SHACL validation with zero violations on every record type', async () => {
     const xml = readFixture('full-summarization.xml');
     const result = await convertCcda(xml, { sourceSystem: 'TestSystem' });
 
     const { store: shapesStore, shapeFiles } = loadShapes();
     const validation = validateTurtle(result.output, shapesStore, shapeFiles, 'full-summarization.xml');
 
-    // C-CDA conversion produces health: records (allergy, immunization, lab, medication, condition).
-    // Filter to only violations on health: record shapes — the PatientProfile and ClinicalDocument
-    // shapes require additional provenance/FHIR fields that the C-CDA converter does not emit
-    // (importedAt, fhir:id, prov:wasGeneratedBy, schemaVersion, dataProvenance), which is an
-    // acceptable limitation for a raw C-CDA import that feeds into a reconciliation pipeline.
-    const healthRecordViolations = validation.results.filter(
-      (r) =>
-        r.severity === 'violation' &&
-        !r.message.includes('importedAt') &&
-        !r.message.includes('source EHR') &&
-        !r.message.includes('FHIR resource') &&
-        !r.message.includes('provenance') &&
-        !r.message.includes('Schema version') &&
-        !r.message.includes('Schema Version') &&
-        !r.message.includes('date of birth') &&
-        !r.message.includes('biological sex') &&
-        !r.message.includes('provenance classification') &&
-        // Generic minCount violations on cascade:schemaVersion / cascade:dataProvenance
-        // don't always have custom messages — filter by property path
-        !r.property?.includes('schemaVersion') &&
-        !r.property?.includes('dataProvenance'),
-    );
+    // After the C-CDA provenance/required-field fixes, the converter emits the
+    // ClinicalDocument (importedAt, sourceEHR, fhirResourceId, fhirResourceType),
+    // PatientProfile (typed dateOfBirth, enum biologicalSex), and the shared
+    // cascade:dataProvenance + cascade:schemaVersion on every record. Nothing is
+    // filtered out: the full document must validate clean.
+    const violations = validation.results.filter((r) => r.severity === 'violation');
     expect(
-      healthRecordViolations,
-      `Health record SHACL violations:\n${healthRecordViolations.map((v) => `  ${v.shape}: ${v.message}`).join('\n')}`,
+      violations,
+      `SHACL violations:\n${violations.map((v) => `  ${v.shape}: ${v.message} (${v.property})`).join('\n')}`,
     ).toHaveLength(0);
   });
 });

--- a/tests/ccda-p51-integration.test.ts
+++ b/tests/ccda-p51-integration.test.ts
@@ -518,15 +518,16 @@ describe('P5.7-A-5: detectVendor — epic-summarization.xml behaviour', () => {
 // =============================================================================
 
 // ---------------------------------------------------------------------------
-// Helper: strip prov:generatedAtTime lines before comparing outputs.
-// The converter stamps each ClinicalDocument section with the wall-clock time
-// at conversion, so two calls to convertCcda will differ by milliseconds.
-// Structural idempotency is tested by comparing everything except those lines.
+// Helper: strip wall-clock timestamp lines before comparing outputs.
+// The converter stamps each ClinicalDocument section with the conversion time
+// under both prov:generatedAtTime and clinical:importedAt, so two calls to
+// convertCcda will differ by milliseconds. Structural idempotency is tested by
+// comparing everything except those lines.
 // ---------------------------------------------------------------------------
 function stripTimestamps(ttl: string): string {
   return ttl
     .split('\n')
-    .filter((line) => !line.includes('generatedAtTime'))
+    .filter((line) => !line.includes('generatedAtTime') && !line.includes('importedAt'))
     .join('\n');
 }
 

--- a/tests/ccda-provenance-required-fields.test.ts
+++ b/tests/ccda-provenance-required-fields.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the native C-CDA importer's provenance + required-field fixes that
+ * make Epic MyChart exports pass SHACL validation:
+ *
+ *  - cascade:dataProvenance + cascade:schemaVersion on every record (shared pass)
+ *  - clinical:ClinicalDocument required fields (importedAt, sourceEHR,
+ *    fhirResourceId, fhirResourceType)
+ *  - clinical:drugName resolved from the medication narrative reference
+ *  - cascade:dateOfBirth (xsd:date) + cascade:biologicalSex (enum) on the patient
+ *  - clinical:sourceEHR derived from the custodian organization
+ *  - clinical:vitalType enum mapping, with non-enum vitals re-routed to lab
+ *    results rather than dropped
+ */
+
+import { describe, it, expect } from 'vitest';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+
+// A minimal but realistic Epic-style C-CDA: custodian org, patient demographics,
+// a medication whose drug name lives in the narrative (originalText reference),
+// an enum vital (heart rate), and a non-enum vital (mean blood pressure, LOINC
+// 8478-0, which is NOT in the VitalSignShape enum and must re-route to a lab).
+const CCDA = `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of Episode Note"/>
+  <id root="9.8.7.6.5" extension="DOC-TEST-1"/>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="1.2.3.4"/>
+        <name>Providence Health and Services Washington and Montana</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <recordTarget>
+    <patientRole>
+      <id root="1.2.3" extension="MRN-1"/>
+      <patient>
+        <name><given>Jane</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1" displayName="Female"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+          <code code="10160-0" codeSystem="2.16.840.1.113883.6.1" displayName="Medications"/>
+          <title>Medications</title>
+          <text>
+            <table><tbody>
+              <tr><td><paragraph ID="med1">cholecalciferol (VITAMIN D-3) 25 mcg tablet</paragraph></td></tr>
+            </tbody></table>
+          </text>
+          <entry>
+            <substanceAdministration classCode="SBADM" moodCode="EVN">
+              <id root="1.2.3.4.5" extension="MED-1"/>
+              <effectiveTime xsi:type="IVL_TS"><low value="20240101"/></effectiveTime>
+              <consumable>
+                <manufacturedProduct>
+                  <manufacturedMaterial>
+                    <code code="199362" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm">
+                      <originalText><reference value="#med1"/></originalText>
+                    </code>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+          <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" displayName="Vital signs"/>
+          <title>Vital Signs</title>
+          <text><table><tbody><tr><td>Heart Rate</td><td>67</td></tr></tbody></table></text>
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <id root="1.2.3.4.6" extension="VIT-1"/>
+                  <code code="8867-4" codeSystem="2.16.840.1.113883.6.1"><originalText>Heart rate</originalText></code>
+                  <effectiveTime value="20240101120000+0000"/>
+                  <value xsi:type="PQ" unit="/min" value="67"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <id root="1.2.3.4.6" extension="VIT-2"/>
+                  <code code="8478-0" codeSystem="2.16.840.1.113883.6.1"><originalText>Mean blood pressure</originalText></code>
+                  <effectiveTime value="20240101120000+0000"/>
+                  <value xsi:type="PQ" unit="mm[Hg]" value="94"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>`;
+
+const IMPORTED_AT = '2026-06-28T12:00:00Z';
+
+async function convert() {
+  return convertCcda(CCDA, { sourceSystem: 'ImportBatchLabel', importedAt: IMPORTED_AT });
+}
+
+describe('C-CDA shared provenance pass', () => {
+  it('emits cascade:dataProvenance + cascade:schemaVersion on every typed record', async () => {
+    const { output } = await convert();
+    // Count rdf:type subjects vs provenance/schemaVersion occurrences.
+    const typeCount = (output.match(/\ba (clinical:|health:|cascade:)/g) ?? []).length;
+    const provCount = (output.match(/cascade:dataProvenance cascade:ClinicalGenerated/g) ?? []).length;
+    const verCount = (output.match(/cascade:schemaVersion "1\.\d+"/g) ?? []).length;
+    expect(typeCount).toBeGreaterThan(0);
+    expect(provCount).toBe(typeCount);
+    expect(verCount).toBe(typeCount);
+  });
+
+  it('does not duplicate provenance on records that already have it', async () => {
+    const { output } = await convert();
+    // No subject should carry two dataProvenance triples — the n3 writer would
+    // render that as a comma list. A simple proxy: provenance count == type count
+    // (asserted above) and the medication block keeps exactly one each.
+    const medProv = (output.match(/clinical:Medication[\s\S]*?\./g) ?? [])
+      .join('')
+      .match(/cascade:dataProvenance/g);
+    expect((medProv ?? []).length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('C-CDA ClinicalDocument required fields', () => {
+  it('emits importedAt, fhirResourceId, fhirResourceType, sourceEHR', async () => {
+    const { output } = await convert();
+    expect(output).toContain('clinical:importedAt');
+    expect(output).toContain('"2026-06-28T12:00:00Z"');
+    expect(output).toContain('clinical:fhirResourceType "DocumentReference"');
+    expect(output).toMatch(/clinical:fhirResourceId "[^"]+"/);
+    expect(output).toContain('clinical:sourceEHR "Providence Health and Services Washington and Montana"');
+  });
+});
+
+describe('C-CDA medication drug name from narrative', () => {
+  it('resolves clinical:drugName from the originalText reference', async () => {
+    const { output } = await convert();
+    expect(output).toContain('clinical:drugName "cholecalciferol (VITAMIN D-3) 25 mcg tablet"');
+  });
+});
+
+describe('C-CDA patient demographics', () => {
+  it('emits typed dateOfBirth and enum biologicalSex', async () => {
+    const { output } = await convert();
+    expect(output).toContain('cascade:dateOfBirth "1965-01-01"^^xsd:date');
+    expect(output).toContain('cascade:biologicalSex "female"');
+  });
+});
+
+describe('C-CDA sourceEHR derivation from custodian', () => {
+  it('uses the custodian org name, not the import-batch label', async () => {
+    const { output } = await convert();
+    expect(output).toContain('clinical:sourceEHR "Providence Health and Services Washington and Montana"');
+    // The import-batch label must NOT leak into sourceEHR.
+    expect(output).not.toContain('clinical:sourceEHR "ImportBatchLabel"');
+  });
+
+  it('falls back to "unknown" when no custodian or author org is present', async () => {
+    const noCustodian = CCDA.replace(/<custodian>[\s\S]*?<\/custodian>/, '');
+    const { output } = await convertCcda(noCustodian, { sourceSystem: 'Batch', importedAt: IMPORTED_AT });
+    expect(output).toContain('clinical:sourceEHR "unknown"');
+  });
+});
+
+describe('C-CDA vital signs', () => {
+  it('maps an enum vital (heart rate) to clinical:vitalType + clinical:value', async () => {
+    const { output } = await convert();
+    expect(output).toContain('clinical:vitalType "heartRate"');
+    expect(output).toContain('clinical:value "67"');
+  });
+
+  it('re-routes a non-enum vital (mean BP) to a lab result, preserving its value', async () => {
+    const { output } = await convert();
+    // Mean blood pressure (LOINC 8478-0) is not in the VitalSignShape enum.
+    // It must NOT appear as a VitalSign with vitalType "meanBloodPressure".
+    expect(output).not.toContain('"meanBloodPressure"');
+    // Its value (94) must survive on a LabResultRecord.
+    expect(output).toContain('health:LabResultRecord');
+    expect(output).toContain('health:resultValue "94"');
+  });
+});
+
+describe('C-CDA full SHACL validation', () => {
+  it('produces zero SHACL violations across all record types', async () => {
+    const { output } = await convert();
+    const { store, shapeFiles } = loadShapes();
+    const validation = validateTurtle(output, store, shapeFiles, 'ccda-provenance-test');
+    const violations = validation.results.filter((r) => r.severity === 'violation');
+    expect(
+      violations,
+      `SHACL violations:\n${violations.map((v) => `  ${v.shape}: ${v.message} (${v.property})`).join('\n')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/tests/fhir-converter.test.ts
+++ b/tests/fhir-converter.test.ts
@@ -551,7 +551,10 @@ describe('FHIR -> Cascade converters', () => {
       expect(findQuadValue(quads, NS.clinical + 'bloodPressureDiastolicUnit')).toBe('mm[Hg]');
     });
 
-    it('should still warn when component children have no known LOINC codes', () => {
+    it('should route an unmapped LOINC vital with components to a lab record (data preserved, valid type)', () => {
+      // LOINC 99999-9 is not in VITAL_LOINC_CODES, so no SHACL-valid clinical:vitalType
+      // can be assigned. Rather than emit an invalid VitalSign, route to the lab
+      // converter, which preserves the component answers without dropping data.
       const obs = {
         resourceType: 'Observation',
         id: 'panel-unknown-1',
@@ -559,16 +562,20 @@ describe('FHIR -> Cascade converters', () => {
         category: [{ coding: [{ code: 'vital-signs' }] }],
         component: [
           {
-            code: { coding: [{ system: 'http://loinc.org', code: '99998-8' }] },
+            code: { coding: [{ system: 'http://loinc.org', code: '99998-8' }], text: 'Some sub-measure' },
             valueQuantity: { value: 5, unit: 'unit' },
           },
         ],
       };
       const result = convertObservationVital(obs);
-      expect(result.warnings).toContain('No valueQuantity found in vital sign Observation');
+      // It is no longer a VitalSign; it is a lab/observation record.
+      expect(result.cascadeType).toBe('health:LabResultRecord');
+      expect(findQuadValue(result._quads, NS.health + 'resultValue')).toContain('5');
+      // No SHACL-invalid clinical:vitalType is emitted.
+      expect(findQuadValue(result._quads, NS.clinical + 'vitalType')).toBeUndefined();
     });
 
-    it('should fall back to display name slug silently for unmapped vital LOINC codes', () => {
+    it('should route an unmapped LOINC vital to a lab record with its value preserved', () => {
       const obs = {
         resourceType: 'Observation',
         id: 'novel-vital-1',
@@ -581,37 +588,118 @@ describe('FHIR -> Cascade converters', () => {
         effectiveDateTime: '2024-01-15T10:30:00Z',
       };
       const result = convertObservationVital(obs);
-      // Data preserved, no warning emitted
+      // No canonical clinical:vitalType exists, so this is captured as a lab record.
       expect(result.warnings).toHaveLength(0);
-      expect(findQuadValue(result._quads, NS.clinical + 'vitalType')).toBe('novel_vital_sign');
-      expect(findQuadValue(result._quads, NS.clinical + 'vitalTypeName')).toBe('Novel Vital Sign');
-      expect(findQuadValue(result._quads, NS.clinical + 'value')).toBe('42');
+      expect(result.cascadeType).toBe('health:LabResultRecord');
+      expect(findQuadValue(result._quads, NS.health + 'testName')).toBe('Novel Vital Sign');
+      expect(findQuadValue(result._quads, NS.health + 'resultValue')).toBe('42');
+      // No SHACL-invalid clinical:vitalType slug is emitted.
+      expect(findQuadValue(result._quads, NS.clinical + 'vitalType')).toBeUndefined();
     });
 
-    it('should map newly added vital LOINC codes (pain, IOP, pediatric)', () => {
+    it('should route non-canonical LOINC vitals (pain, IOP) to lab records with value preserved', () => {
+      // painSeverity and intraocularPressure* are in VITAL_LOINC_CODES but are NOT
+      // in the VitalSignShape sh:in enum, so they must not be emitted as VitalSign.
       const painObs = {
         resourceType: 'Observation',
         id: 'pain-1',
-        code: { coding: [{ system: 'http://loinc.org', code: '72514-3' }] },
+        code: { coding: [{ system: 'http://loinc.org', code: '72514-3' }], text: 'Pain Severity' },
         category: [{ coding: [{ code: 'vital-signs' }] }],
         valueQuantity: { value: 4, unit: '{score}' },
         effectiveDateTime: '2024-01-15T10:30:00Z',
       };
       const painResult = convertObservationVital(painObs);
-      expect(painResult.warnings).toHaveLength(0);
-      expect(findQuadValue(painResult._quads, NS.clinical + 'vitalType')).toBe('painSeverity');
+      expect(painResult.cascadeType).toBe('health:LabResultRecord');
+      expect(findQuadValue(painResult._quads, NS.health + 'resultValue')).toBe('4');
+      expect(findQuadValue(painResult._quads, NS.clinical + 'vitalType')).toBeUndefined();
 
       const iopObs = {
         resourceType: 'Observation',
         id: 'iop-1',
-        code: { coding: [{ system: 'http://loinc.org', code: '79893-4' }] },
+        code: { coding: [{ system: 'http://loinc.org', code: '79893-4' }], text: 'Intraocular Pressure (Right Eye)' },
         category: [{ coding: [{ code: 'vital-signs' }] }],
         valueQuantity: { value: 16, unit: 'mm[Hg]' },
         effectiveDateTime: '2024-01-15T10:30:00Z',
       };
       const iopResult = convertObservationVital(iopObs);
-      expect(iopResult.warnings).toHaveLength(0);
-      expect(findQuadValue(iopResult._quads, NS.clinical + 'vitalType')).toBe('intraocularPressureRightEye');
+      expect(iopResult.cascadeType).toBe('health:LabResultRecord');
+      expect(findQuadValue(iopResult._quads, NS.health + 'resultValue')).toBe('16');
+      expect(findQuadValue(iopResult._quads, NS.clinical + 'vitalType')).toBeUndefined();
+    });
+
+    it('should map canonical vital types to the SHACL-valid clinical:vitalType enum', () => {
+      // Regression for the importer bug where VITAL_LOINC_CODES types (e.g.
+      // bloodPressurePanel, bodyTemperature) were emitted verbatim and rejected by
+      // the VitalSignShape sh:in enum. The converter must emit the enum value.
+      const bpPanel = {
+        resourceType: 'Observation',
+        id: 'bp-panel-shacl',
+        code: { coding: [{ system: 'http://loinc.org', code: '55284-4' }], text: 'Blood Pressure' },
+        category: [{ coding: [{ code: 'vital-signs' }] }],
+        component: [
+          { code: { coding: [{ system: 'http://loinc.org', code: '8480-6' }] }, valueQuantity: { value: 120, unit: 'mm[Hg]' } },
+          { code: { coding: [{ system: 'http://loinc.org', code: '8462-4' }] }, valueQuantity: { value: 80, unit: 'mm[Hg]' } },
+        ],
+      };
+      const bpResult = convertObservationVital(bpPanel);
+      expect(bpResult.cascadeType).toBe('clinical:VitalSign');
+      // bloodPressurePanel is not a valid enum value; bloodPressure is.
+      expect(findQuadValue(bpResult._quads, NS.clinical + 'vitalType')).toBe('bloodPressure');
+
+      const tempObs = {
+        resourceType: 'Observation',
+        id: 'temp-shacl',
+        code: { coding: [{ system: 'http://loinc.org', code: '8310-5' }], text: 'Body Temperature' },
+        category: [{ coding: [{ code: 'vital-signs' }] }],
+        valueQuantity: { value: 37.0, unit: 'Cel' },
+      };
+      const tempResult = convertObservationVital(tempObs);
+      expect(tempResult.cascadeType).toBe('clinical:VitalSign');
+      // bodyTemperature is not a valid enum value; temperature is.
+      expect(findQuadValue(tempResult._quads, NS.clinical + 'vitalType')).toBe('temperature');
+    });
+
+    it('should capture a vital sign carrying valueCodeableConcept rather than dropping it', () => {
+      // A heart-rate-coded observation whose value is a coded concept: the value
+      // must be preserved under clinical:value, not silently dropped.
+      const obs = {
+        resourceType: 'Observation',
+        id: 'hr-coded',
+        code: { coding: [{ system: 'http://loinc.org', code: '8867-4' }], text: 'Heart Rate' },
+        category: [{ coding: [{ code: 'vital-signs' }] }],
+        valueCodeableConcept: { text: 'Regular' },
+      };
+      const result = convertObservationVital(obs);
+      expect(result.cascadeType).toBe('clinical:VitalSign');
+      expect(findQuadValue(result._quads, NS.clinical + 'value')).toBe('Regular');
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  describe('DocumentReference -> ClinicalDocument', () => {
+    const sampleDocRef = {
+      resourceType: 'DocumentReference',
+      id: 'doc-ref-1',
+      type: { text: 'Progress Note' },
+      date: '2024-02-01T09:00:00Z',
+      content: [{ attachment: { contentType: 'text/plain', url: 'Binary/abc', title: 'Note' } }],
+    };
+
+    it('should emit the FHIR resource id and type the ClinicalDocumentShape requires', () => {
+      // Regression: the shape requires clinical:fhirResourceId + clinical:fhirResourceType.
+      // The converter previously emitted only clinical:sourceRecordId and no type.
+      const result = convertClinicalDocument(sampleDocRef);
+      expect(result.cascadeType).toBe('clinical:ClinicalDocument');
+      expect(findQuadValue(result._quads, NS.clinical + 'fhirResourceId')).toBe('doc-ref-1');
+      expect(findQuadValue(result._quads, NS.clinical + 'fhirResourceType')).toBe('DocumentReference');
+      // sourceRecordId is kept additively for other consumers.
+      expect(findQuadValue(result._quads, NS.clinical + 'sourceRecordId')).toBe('doc-ref-1');
+    });
+
+    it('should still emit fhirResourceType when the resource id is absent', () => {
+      const noId = { ...sampleDocRef, id: undefined };
+      const result = convertClinicalDocument(noId);
+      expect(findQuadValue(result._quads, NS.clinical + 'fhirResourceType')).toBe('DocumentReference');
     });
   });
 

--- a/tests/fhir-provenance.test.ts
+++ b/tests/fhir-provenance.test.ts
@@ -15,10 +15,54 @@ import {
   extractProviderName,
   extractSourceEhr,
   appendProvenanceQuads,
+  SOURCE_EHR_UNKNOWN,
 } from '../src/lib/fhir-converter/provenance.js';
 import { NS, tripleType, tripleStr } from '../src/lib/fhir-converter/types.js';
+import { convert } from '../src/lib/fhir-converter/index.js';
 
 const { namedNode } = DataFactory;
+
+describe('source EHR fallback (D1: never the import-batch label)', () => {
+  it('a document-subtype record with no derivable EHR gets the unknown token, not the import label', async () => {
+    // A DiagnosticReport (-> clinical:LaboratoryReport, a ClinicalDocument subtype
+    // the SHACL shape requires sourceEHR on) with only relative refs and a
+    // placeholder org performer: nothing to derive a real EHR from.
+    const report = {
+      resourceType: 'DiagnosticReport',
+      id: 'r1',
+      status: 'final',
+      code: { text: 'Basic Metabolic Panel' },
+      subject: { reference: 'Patient/abc' },
+      performer: [{ type: 'Organization', display: 'EXTERNAL LAB' }],
+    };
+    const res = await convert(
+      JSON.stringify(report), 'fhir', 'cascade', 'turtle', 'Apple Health export',
+    );
+    expect(res.success).toBe(true);
+    // SHACL is satisfied by the ratified "unknown" token...
+    expect(res.output).toContain(`clinical:sourceEHR "${SOURCE_EHR_UNKNOWN}"`);
+    // ...NOT by the import-batch label (the user's reported bug).
+    expect(res.output).not.toContain('clinical:sourceEHR "Apple Health export"');
+    // ...which stays on the separate ingestion axis.
+    expect(res.output).toContain('cascade:sourceSystem "Apple Health export"');
+  });
+
+  it('keeps a real derived EHR (endpoint host) over the unknown token', async () => {
+    const report = {
+      resourceType: 'DiagnosticReport',
+      id: 'r2',
+      status: 'final',
+      code: { text: 'CBC' },
+      subject: { reference: 'https://haiku.swedish.org/fhir/Patient/x' },
+      performer: [{ display: 'Dr X', reference: 'https://haiku.swedish.org/fhir/Practitioner/y' }],
+    };
+    const res = await convert(
+      JSON.stringify(report), 'fhir', 'cascade', 'turtle', 'Apple Health export',
+    );
+    expect(res.output).toContain('clinical:sourceEHR "swedish.org"');
+    expect(res.output).not.toContain(`clinical:sourceEHR "${SOURCE_EHR_UNKNOWN}"`);
+  });
+});
 
 describe('extractProviderName', () => {
   it('reads requester.display (MedicationRequest)', () => {

--- a/tests/fhir-provenance.test.ts
+++ b/tests/fhir-provenance.test.ts
@@ -64,6 +64,52 @@ describe('source EHR fallback (D1: never the import-batch label)', () => {
   });
 });
 
+describe('authoritative sourceEHR override (Apple Health export.xml sourceName)', () => {
+  it('writes the container-supplied account, not the import-batch label or unknown', async () => {
+    // An Epic record with only relative refs + a placeholder org: the per-resource
+    // derivation cannot find an EHR (would be "unknown"), but the Apple wrapper
+    // knew the account. The override carries it through.
+    const report = {
+      resourceType: 'DiagnosticReport',
+      id: 'r3',
+      status: 'final',
+      code: { text: 'BMP' },
+      subject: { reference: 'Patient/abc' },
+      performer: [{ type: 'Organization', display: 'EXTERNAL LAB' }],
+    };
+    const res = await convert(
+      JSON.stringify(report), 'fhir', 'cascade', 'turtle', 'Apple Health export', false,
+      'Providence Health & Services',
+    );
+    expect(res.success).toBe(true);
+    expect(res.output).toContain('clinical:sourceEHR "Providence Health & Services"');
+    expect(res.output).not.toContain(`clinical:sourceEHR "${SOURCE_EHR_UNKNOWN}"`);
+    expect(res.output).not.toContain('clinical:sourceEHR "Apple Health export"');
+    // The import batch stays on the separate ingestion axis.
+    expect(res.output).toContain('cascade:sourceSystem "Apple Health export"');
+  });
+
+  it('REPLACES a host-derived sourceEHR so one account groups under one name', async () => {
+    // This record WOULD derive "swedish.org" from its host, but Apple labels the
+    // account "Swedish". The authoritative label wins and there is exactly one
+    // sourceEHR value (no split between "Swedish" and "swedish.org").
+    const report = {
+      resourceType: 'DiagnosticReport',
+      id: 'r4',
+      status: 'final',
+      code: { text: 'CBC' },
+      subject: { reference: 'https://haiku.swedish.org/fhir/Patient/x' },
+      performer: [{ display: 'Dr X', reference: 'https://haiku.swedish.org/fhir/Practitioner/y' }],
+    };
+    const res = await convert(
+      JSON.stringify(report), 'fhir', 'cascade', 'turtle', 'Apple Health export', false, 'Swedish',
+    );
+    expect(res.output).toContain('clinical:sourceEHR "Swedish"');
+    expect(res.output).not.toContain('clinical:sourceEHR "swedish.org"');
+    expect((res.output.match(/clinical:sourceEHR/g) ?? []).length).toBe(1);
+  });
+});
+
 describe('extractProviderName', () => {
   it('reads requester.display (MedicationRequest)', () => {
     expect(

--- a/tests/fhir-provenance.test.ts
+++ b/tests/fhir-provenance.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the per-resource provenance pass: recovering the performing
+ * clinician (clinical:providerName) and the source EHR/organization
+ * (clinical:sourceEHR) that the per-type converters historically dropped.
+ *
+ * Anchored on the real Apple Health shapes observed in a live export:
+ *   - MedicationRequest.requester = { reference: "Practitioner/..", display: "Pathmaja Paramsothy, MD" }
+ *   - Observation.performer        = { display: "Shahrzad K A", reference: "https://haiku.swedish.org/fhirproxy/.../Practitioner/.." }
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DataFactory } from 'n3';
+
+import {
+  extractProviderName,
+  extractSourceEhr,
+  appendProvenanceQuads,
+} from '../src/lib/fhir-converter/provenance.js';
+import { NS, tripleType, tripleStr } from '../src/lib/fhir-converter/types.js';
+
+const { namedNode } = DataFactory;
+
+describe('extractProviderName', () => {
+  it('reads requester.display (MedicationRequest)', () => {
+    expect(
+      extractProviderName({
+        resourceType: 'MedicationRequest',
+        requester: { reference: 'Practitioner/abc', display: 'Pathmaja Paramsothy, MD' },
+      }),
+    ).toBe('Pathmaja Paramsothy, MD');
+  });
+
+  it('reads performer[0].display (Observation, array form)', () => {
+    expect(
+      extractProviderName({
+        resourceType: 'Observation',
+        performer: [{ display: 'Shahrzad K A', reference: 'https://haiku.swedish.org/x' }],
+      }),
+    ).toBe('Shahrzad K A');
+  });
+
+  it('reads nested actor.display (Immunization performer)', () => {
+    expect(
+      extractProviderName({
+        resourceType: 'Immunization',
+        performer: [{ actor: { display: 'Nurse Mark H, RN' } }],
+      }),
+    ).toBe('Nurse Mark H, RN');
+  });
+
+  it('returns undefined when no provider field is present', () => {
+    expect(extractProviderName({ resourceType: 'Condition' })).toBeUndefined();
+  });
+});
+
+describe('extractSourceEhr', () => {
+  it('derives the registrable host from an absolute performer reference', () => {
+    expect(
+      extractSourceEhr({
+        resourceType: 'Observation',
+        performer: [{ display: 'Shahrzad K A', reference: 'https://haiku.swedish.org/fhirproxy/api/FHIR/DSTU2/Practitioner/TT' }],
+      }),
+    ).toBe('swedish.org');
+  });
+
+  it('finds the host from ANY absolute reference (a lab whose only ref is subject/encounter)', () => {
+    expect(
+      extractSourceEhr({
+        resourceType: 'Observation',
+        subject: { reference: 'https://haiku.swedish.org/fhirproxy/api/FHIR/DSTU2/Patient/PT' },
+      }),
+    ).toBe('swedish.org');
+  });
+
+  it('NEVER treats a clinician role as the source org (host wins; no host -> none)', () => {
+    // A vital with a person performer and no absolute reference: no fabricated org.
+    expect(
+      extractSourceEhr({
+        resourceType: 'Observation',
+        performer: [{ display: 'MA Vaidehi J, Medical Assistant' }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('falls back to an institution display only when there is no host', () => {
+    expect(
+      extractSourceEhr({
+        resourceType: 'DiagnosticReport',
+        performer: [{ display: 'Kaiser Permanente Washington' }],
+      }),
+    ).toBe('Kaiser Permanente Washington');
+  });
+
+  it('ignores relative references (no host to derive)', () => {
+    expect(
+      extractSourceEhr({
+        resourceType: 'MedicationRequest',
+        requester: { reference: 'Practitioner/abc', display: 'Pathmaja Paramsothy, MD' },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('appendProvenanceQuads', () => {
+  const SUBJ = 'urn:uuid:rec-1';
+  function recordQuads() {
+    return [tripleType(SUBJ, NS.clinical + 'Medication')];
+  }
+
+  it('adds providerName + sourceEHR to the record subject', () => {
+    const quads = recordQuads();
+    appendProvenanceQuads(
+      {
+        resourceType: 'Observation',
+        performer: [{ display: 'Shahrzad K A', reference: 'https://haiku.swedish.org/x/Practitioner/p' }],
+      },
+      quads,
+    );
+    const preds = quads.map((q) => q.predicate.value);
+    expect(preds).toContain(NS.clinical + 'providerName');
+    expect(preds).toContain(NS.clinical + 'sourceEHR');
+    const ehr = quads.find((q) => q.predicate.value === NS.clinical + 'sourceEHR');
+    expect(ehr?.object.value).toBe('swedish.org');
+  });
+
+  it('does not overwrite a providerName a converter already set', () => {
+    const quads = [
+      tripleType(SUBJ, NS.clinical + 'LaboratoryReport'),
+      tripleStr(SUBJ, NS.clinical + 'providerName', 'Kaiser Permanente Washington'),
+    ];
+    appendProvenanceQuads(
+      { resourceType: 'DiagnosticReport', performer: [{ display: 'Someone Else, MD' }] },
+      quads,
+    );
+    const providerNames = quads
+      .filter((q) => q.predicate.value === NS.clinical + 'providerName')
+      .map((q) => q.object.value);
+    expect(providerNames).toEqual(['Kaiser Permanente Washington']);
+  });
+
+  it('treats health:administeringProvider as an existing provider (no duplicate)', () => {
+    const quads = [
+      tripleType(SUBJ, NS.health + 'ImmunizationRecord'),
+      tripleStr(SUBJ, NS.health + 'administeringProvider', 'Nurse Mark H, RN'),
+    ];
+    appendProvenanceQuads(
+      { resourceType: 'Immunization', performer: [{ actor: { display: 'Nurse Mark H, RN' } }] },
+      quads,
+    );
+    expect(quads.some((q) => q.predicate.value === NS.clinical + 'providerName')).toBe(false);
+  });
+
+  it('is a no-op for non-clinical resource types', () => {
+    const quads = [tripleType(SUBJ, NS.cascade + 'PatientProfile')];
+    appendProvenanceQuads(
+      { resourceType: 'Patient', performer: [{ display: 'Whoever' }] },
+      quads,
+    );
+    expect(quads).toHaveLength(1);
+  });
+
+  it('is a no-op when the resource carries no provenance signal', () => {
+    const quads = recordQuads();
+    appendProvenanceQuads({ resourceType: 'Condition' }, quads);
+    expect(quads).toHaveLength(1);
+  });
+
+  it('only attaches to record subjects (those with rdf:type)', () => {
+    const quads = recordQuads();
+    // a stray non-typed subject must not receive provenance
+    quads.push(tripleStr('urn:uuid:nested', NS.clinical + 'someField', 'x'));
+    appendProvenanceQuads(
+      { resourceType: 'Procedure', performer: [{ display: 'Dr X', reference: 'https://x.swedish.org/p' }] },
+      quads,
+    );
+    const onNested = quads.filter(
+      (q) => q.subject.value === 'urn:uuid:nested' && q.predicate.value === NS.clinical + 'sourceEHR',
+    );
+    expect(onNested).toHaveLength(0);
+    expect(namedNode(SUBJ).value).toBe(SUBJ); // sanity
+  });
+});

--- a/tests/pod-import.test.ts
+++ b/tests/pod-import.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
+import { Parser } from 'n3';
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
 
@@ -314,6 +315,19 @@ describe('pod import', () => {
 
     const content = await fs.readFile(passthroughFile, 'utf-8');
     expect(content).toContain('@prefix');
+
+    // Regression: the fhir-passthrough registration uses the `fhir:` CURIE, which
+    // previously was emitted into publicTypeIndex.ttl without the prefix being
+    // declared, producing an "Undefined prefix fhir:" parse error. The index must
+    // declare the prefix and parse cleanly.
+    const publicIndex = await fs.readFile(
+      path.join(podDir, 'settings', 'publicTypeIndex.ttl'),
+      'utf-8',
+    );
+    expect(publicIndex).toContain('solid:forClass fhir:');
+    expect(publicIndex).toMatch(/@prefix\s+fhir:\s+<http:\/\/hl7\.org\/fhir\/>\s*\./);
+    // The whole file must parse without throwing (no undefined-prefix error).
+    expect(() => new Parser().parse(publicIndex)).not.toThrow();
   });
 
   // ─── Test 6b: AI extraction activity routes to its own file, not passthrough ─

--- a/tests/source-adapters.test.ts
+++ b/tests/source-adapters.test.ts
@@ -16,6 +16,7 @@ import { detectSource } from '../src/lib/source-adapters/registry.js';
 
 let root: string;
 let appleDir: string;
+let appleSrcDir: string;
 let plainDir: string;
 
 beforeAll(() => {
@@ -29,6 +30,30 @@ beforeAll(() => {
   fs.writeFileSync(path.join(appleDir, 'export.xml'), '<HealthData/>');
   fs.writeFileSync(path.join(appleDir, 'export_cda.xml'), '<ClinicalDocument/>');
   fs.mkdirSync(path.join(appleDir, 'workout-routes'));
+
+  // A second Apple-shaped export whose export.xml carries <ClinicalRecord>
+  // wrappers (the authoritative per-record source labels) at the END of the
+  // file, after the device <Record> firehose — exactly Apple's real layout. One
+  // clinical file has no wrapper (to prove partial coverage degrades gracefully),
+  // and one sourceName carries an XML entity (to prove it is decoded).
+  appleSrcDir = path.join(root, 'apple_health_export_sourced');
+  fs.mkdirSync(path.join(appleSrcDir, 'clinical-records'), { recursive: true });
+  for (const f of ['AllergyIntolerance-1.json', 'Condition-2.json', 'Observation-3.json']) {
+    fs.writeFileSync(path.join(appleSrcDir, 'clinical-records', f), '{"resourceType":"Condition"}');
+  }
+  const filler = '  <Record type="HKQuantityTypeIdentifierHeartRate" value="72"/>\n'.repeat(50);
+  const exportXml =
+    '<?xml version="1.0" encoding="UTF-8"?>\n<HealthData locale="en_US">\n' +
+    '  <ExportDate value="2026-06-22 16:15:00 -0700"/>\n' +
+    filler +
+    '  <ClinicalRecord type="AllergyIntolerance" identifier="a1" sourceName="Swedish" ' +
+    'sourceURL="https://haiku.swedish.org/fhir/AllergyIntolerance/a1" fhirVersion="1.0.2" ' +
+    'receivedDate="2019-11-18 22:16:15 -0700" resourceFilePath="/clinical-records/AllergyIntolerance-1.json"/>\n' +
+    '  <ClinicalRecord type="Condition" identifier="c2" sourceName="Providence Health &amp; Services" ' +
+    'sourceURL="https://api.providence.org/fhir/Condition/c2" fhirVersion="4.0.1" ' +
+    'receivedDate="2025-11-14 00:11:20 -0700" resourceFilePath="/clinical-records/Condition-2.json"/>\n' +
+    '</HealthData>\n';
+  fs.writeFileSync(path.join(appleSrcDir, 'export.xml'), exportXml);
 
   // A plain folder of mixed files, including a nested dir, an unsupported file,
   // and a dotfile.
@@ -65,6 +90,35 @@ describe('appleHealthAdapter', () => {
     const skippedNames = out.skipped.map((s) => path.basename(s.path)).sort();
     expect(skippedNames).toEqual(['export.xml', 'export_cda.xml', 'workout-routes']);
     expect(out.skipped.every((s) => s.reason.length > 0)).toBe(true);
+  });
+
+  it('recovers per-record source (sourceName) from export.xml <ClinicalRecord> wrappers', () => {
+    const out = appleHealthAdapter.expand(appleSrcDir);
+    expect(out.fileSources).toBeDefined();
+    const fs2 = out.fileSources!;
+
+    const allergyPath = path.join(appleSrcDir, 'clinical-records', 'AllergyIntolerance-1.json');
+    const conditionPath = path.join(appleSrcDir, 'clinical-records', 'Condition-2.json');
+    const observationPath = path.join(appleSrcDir, 'clinical-records', 'Observation-3.json');
+
+    // sourceName becomes the authoritative EHR/account label, keyed by abs path.
+    expect(fs2[allergyPath]?.sourceEhr).toBe('Swedish');
+    expect(fs2[allergyPath]?.sourceUrl).toBe('https://haiku.swedish.org/fhir/AllergyIntolerance/a1');
+    expect(fs2[allergyPath]?.receivedDate).toBe('2019-11-18 22:16:15 -0700');
+
+    // XML entities in sourceName are decoded (&amp; -> &).
+    expect(fs2[conditionPath]?.sourceEhr).toBe('Providence Health & Services');
+
+    // A clinical file with no wrapper is simply absent (falls back to derivation).
+    expect(fs2[observationPath]).toBeUndefined();
+
+    // The device export is still skipped despite being read for its tail block.
+    expect(out.skipped.map((s) => path.basename(s.path))).toContain('export.xml');
+  });
+
+  it('yields no fileSources when export.xml has no clinical wrappers', () => {
+    const out = appleHealthAdapter.expand(appleDir);
+    expect(out.fileSources && Object.keys(out.fileSources).length).toBeFalsy();
   });
 });
 

--- a/tests/source-adapters.test.ts
+++ b/tests/source-adapters.test.ts
@@ -11,12 +11,14 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { appleHealthAdapter } from '../src/lib/source-adapters/apple-health.js';
+import { iheXdmAdapter } from '../src/lib/source-adapters/ihe-xdm.js';
 import { directoryAdapter } from '../src/lib/source-adapters/directory.js';
 import { detectSource } from '../src/lib/source-adapters/registry.js';
 
 let root: string;
 let appleDir: string;
 let appleSrcDir: string;
+let xdmDir: string;
 let plainDir: string;
 
 beforeAll(() => {
@@ -55,15 +57,38 @@ beforeAll(() => {
     '</HealthData>\n';
   fs.writeFileSync(path.join(appleSrcDir, 'export.xml'), exportXml);
 
+  // An unzipped IHE XDM "Download My Record" export (MyChart shape): an IHE_XDM/
+  // submission set with the ebXML manifest + a C-CDA document + a stylesheet,
+  // plus root-level rendered HTML / PDF that are not clinical data.
+  xdmDir = path.join(root, 'mychart_export');
+  const sub = path.join(xdmDir, 'IHE_XDM', 'Jed1');
+  fs.mkdirSync(sub, { recursive: true });
+  fs.writeFileSync(
+    path.join(sub, 'METADATA.XML'),
+    '<?xml version="1.0"?>\n<SubmitObjectsRequest xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0"><RegistryObjectList/></SubmitObjectsRequest>',
+  );
+  fs.writeFileSync(
+    path.join(sub, 'DOC0001.XML'),
+    "<?xml version=\"1.0\"?><?xml-stylesheet type='text/xsl' href='STYLE.XSL'?><ClinicalDocument xmlns=\"urn:hl7-org:v3\"><title>CCD</title></ClinicalDocument>",
+  );
+  fs.writeFileSync(path.join(sub, 'STYLE.XSL'), '<xsl:stylesheet/>');
+  fs.writeFileSync(path.join(xdmDir, 'INDEX.HTM'), '<html></html>');
+  fs.writeFileSync(path.join(xdmDir, 'README.TXT'), 'Open for instructions');
+  fs.writeFileSync(path.join(xdmDir, '1 of 1 - Summary.PDF'), '%PDF-1.4');
+
   // A plain folder of mixed files, including a nested dir, an unsupported file,
   // and a dotfile.
   plainDir = path.join(root, 'records');
   fs.mkdirSync(path.join(plainDir, 'sub'), { recursive: true });
+  fs.mkdirSync(path.join(plainDir, 'node_modules', 'pkg'), { recursive: true });
   fs.writeFileSync(path.join(plainDir, 'a.json'), '{}');
   fs.writeFileSync(path.join(plainDir, 'b.ttl'), '');
   fs.writeFileSync(path.join(plainDir, 'sub', 'c.xml'), '<x/>');
   fs.writeFileSync(path.join(plainDir, 'notes.txt'), 'not importable');
   fs.writeFileSync(path.join(plainDir, '.DS_Store'), '');
+  // Build/cache junk that must NOT be walked (prevents the OOM on an accidentally
+  // huge folder pick): a JSON inside node_modules.
+  fs.writeFileSync(path.join(plainDir, 'node_modules', 'pkg', 'package.json'), '{"x":1}');
 });
 
 afterAll(() => {
@@ -116,9 +141,48 @@ describe('appleHealthAdapter', () => {
     expect(out.skipped.map((s) => path.basename(s.path))).toContain('export.xml');
   });
 
+  it('reports source-label completeness (recovered vs total) for the pre-import plan', () => {
+    // appleSrcDir: 3 clinical files, 2 with <ClinicalRecord> wrappers.
+    const partial = appleHealthAdapter.expand(appleSrcDir).completeness ?? [];
+    const labels = partial.find((c) => c.label === 'Source account labels');
+    expect(labels).toEqual(
+      expect.objectContaining({ recovered: 2, total: 3 }),
+    );
+    expect(labels?.note).toMatch(/1 record/); // the unwrapped Observation-3
+
+    // appleDir: export.xml is bare (<HealthData/>), so 0 of 2 get labels.
+    const none = appleHealthAdapter.expand(appleDir).completeness ?? [];
+    expect(none.find((c) => c.label === 'Source account labels')).toEqual(
+      expect.objectContaining({ recovered: 0, total: 2 }),
+    );
+  });
+
   it('yields no fileSources when export.xml has no clinical wrappers', () => {
     const out = appleHealthAdapter.expand(appleDir);
     expect(out.fileSources && Object.keys(out.fileSources).length).toBeFalsy();
+  });
+});
+
+describe('iheXdmAdapter', () => {
+  it('detects an unzipped IHE XDM export (IHE_XDM folder, or a submission set with METADATA.XML)', () => {
+    expect(iheXdmAdapter.detect(xdmDir)).toBe(true); // top folder has IHE_XDM/
+    expect(iheXdmAdapter.detect(path.join(xdmDir, 'IHE_XDM', 'Jed1'))).toBe(true); // has METADATA.XML
+    expect(iheXdmAdapter.detect(plainDir)).toBe(false);
+  });
+
+  it('yields the C-CDA document(s) and skips the manifest + non-clinical files', () => {
+    const out = iheXdmAdapter.expand(xdmDir);
+    expect(out.files.map((f) => path.basename(f))).toEqual(['DOC0001.XML']);
+    // The ebXML manifest is skipped by CONTENT, with a clear reason.
+    const manifestSkip = out.skipped.find((s) => s.path.endsWith('METADATA.XML'));
+    expect(manifestSkip?.reason).toMatch(/manifest/i);
+    // The rendered HTML / PDF / stylesheet are reported as non-clinical, not imported.
+    expect(out.skipped.some((s) => /non-clinical/i.test(s.reason))).toBe(true);
+    expect(out.files.some((f) => /METADATA|\.PDF|\.HTM|STYLE/i.test(f))).toBe(false);
+  });
+
+  it('the registry routes an XDM folder to ihe-xdm, ahead of the generic directory adapter', () => {
+    expect(detectSource(xdmDir)?.id).toBe('ihe-xdm');
   });
 });
 
@@ -128,10 +192,13 @@ describe('directoryAdapter', () => {
     expect(directoryAdapter.detect(path.join(plainDir, 'a.json'))).toBe(false);
   });
 
-  it('recursively collects supported files; skips unsupported + dotfiles', () => {
+  it('recursively collects supported files; skips unsupported + dotfiles + build/cache dirs', () => {
     const out = directoryAdapter.expand(plainDir);
     const names = out.files.map((f) => path.basename(f)).sort();
-    expect(names).toEqual(['a.json', 'b.ttl', 'c.xml']); // recursed into sub/, dropped notes.txt + .DS_Store
+    // recursed into sub/, dropped notes.txt + .DS_Store, and did NOT descend into
+    // node_modules (so the package.json there is absent).
+    expect(names).toEqual(['a.json', 'b.ttl', 'c.xml']);
+    expect(out.files.some((f) => f.includes('node_modules'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Hardens the EHR import pipeline end-to-end: capture provenance that was being dropped, attribute records to their true source, support real-world export containers, and make both the FHIR and C-CDA paths produce SHACL-clean records.

## What's in this branch
- **Provenance capture (`4474732`)** — read the performing/ordering clinician and source EHR across *all* clinical resource types on FHIR import (previously only 3), so an Apple Health pod stops losing provider/source.
- **Three FHIR validation bugs (`5272111`)** — ClinicalDocument `fhirResourceId`/type, vital `vitalType` enum (non-vitals re-routed to labs, no data dropped), and an undeclared `fhir:` prefix in the type index.
- **Honest unknown source EHR (`55c07d8`)** — emit the ratified FHIR/HL7 data-absent-reason token `"unknown"` instead of the import-batch label when no EHR is derivable.
- **Apple Health source attribution (`0d4260b`)** — recover the authoritative per-record account (`<ClinicalRecord sourceName>`) from the export.xml wrapper via a bounded tail read; records now carry their real account (Providence / Swedish / Kaiser / …) instead of "Unknown".
- **Pre-import plan + IHE XDM + robustness (`d991679`)** — the import report gains a per-source breakdown + per-adapter completeness checks (for a confirm-before-write preview); a new adapter imports unzipped MyChart/Cerner IHE XDM folders (skipping the ebXML manifest by content); a per-file convert failure skips-with-reason instead of aborting the batch; the generic folder adapter skips build/cache dirs and refuses a folder too large to be a record export (no OOM).
- **C-CDA bulletproofing (`66feb19`)** — the native C-CDA path now emits `dataProvenance`/`schemaVersion` + ClinicalDocument provenance + drugName/DOB/biologicalSex/vitalType, and derives `sourceEHR` from the custodian organization. No invented vocabulary.

## Verification
- A real Apple Health export → all records attributed to their account, 11/11 clinical files PASS SHACL.
- A real Epic MyChart IHE XDM folder → 540 records, **8/8 clinical files PASS SHACL (0 violations, was 219)**, custodian-derived `sourceEHR`.
- Full suite **938 pass** / 21 skipped.

Note: the branch name (`fix/importer-validation-bugs`) predates the broader scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
