### PR TITLE
fix(cli): pod extract tolerates cascade-agent's lazy model load

### DIFF
--- a/src/commands/pod/extract.ts
+++ b/src/commands/pod/extract.ts
@@ -283,8 +283,12 @@ async function waitForAgent(agentUrl: string, timeoutMs: number): Promise<boolea
     try {
       const res = await fetch(`${agentUrl}/health`, { signal: AbortSignal.timeout(2000) });
       if (!res.ok) continue;
-      const body = await res.json() as { modelAvailable?: boolean };
-      if (body.modelAvailable) return true;
+      const body = await res.json() as { modelAvailable?: boolean; modelPresent?: boolean };
+      // Ready to extract when a model is loaded OR resolvable on disk / behind an
+      // attached llama-server: cascade-agent loads the model lazily on the first
+      // /extract (2026-07-03 consolidation), so a present-but-not-yet-loaded model
+      // is still serviceable — the first request warms it within its own timeout.
+      if (body.modelAvailable || body.modelPresent) return true;
     } catch { /* not ready yet */ }
   }
   return false;
@@ -378,9 +382,14 @@ export function registerExtractSubcommand(pod: Command): void {
         try {
           const res = await fetch(`${agentUrl}/health`, { signal: AbortSignal.timeout(3000) });
           if (!res.ok) return 'unreachable';
-          const body = await res.json() as { modelAvailable?: boolean; modelId?: string };
+          const body = await res.json() as { modelAvailable?: boolean; modelPresent?: boolean; modelId?: string };
           if (globalOpts.verbose) console.error(`[extract] Agent: ${agentUrl}  model: ${body.modelId}`);
-          return body.modelAvailable ? 'ready' : 'no-model';
+          // cascade-agent loads the model lazily on the first /extract, so a model
+          // that is present-on-disk / behind an attached llama-server is ready to
+          // serve even before it reports modelAvailable. 'no-model' is reserved for
+          // when there is genuinely nothing to load.
+          if (body.modelAvailable || body.modelPresent) return 'ready';
+          return 'no-model';
         } catch {
           return 'unreachable';
         }
@@ -389,8 +398,9 @@ export function registerExtractSubcommand(pod: Command): void {
       let agentStatus = await checkAgent();
 
       if (agentStatus === 'no-model') {
-        console.error('cascade-agent is running but no extraction model is loaded.');
-        console.error('  Restart with: cascade agent serve   (will prompt to download the model)');
+        console.error('cascade-agent is running but no extraction model is available.');
+        console.error('  Download one with: cascade agent login --provider local');
+        console.error('  Or set CASCADE_LLAMA_URL to attach to a running llama-server.');
         process.exitCode = 1;
         return;
       }


### PR DESCRIPTION
## Companion to cascade-agent Slice A (the-cascade-protocol/cascade-agent#6)

cascade-agent loads its extraction model **lazily** on the first `POST /extract` (2026-07-03 local-inference consolidation; also cascade-agent PR #4). `pod extract`'s pre-flight readiness gated on `/health` `modelAvailable`, which stays `false` until a model is actually loaded — so:

- **already-running agent:** `checkAgent` saw `modelAvailable:false` → returned `no-model` → hard error, never calling `/extract`.
- **auto-spawn path:** `waitForAgent` polled `modelAvailable` forever → 120 s timeout.

### Fix
Gate readiness on `modelAvailable` **OR** `modelPresent`. A model that is present on disk (or behind an attached `CASCADE_LLAMA_URL` server) is serviceable; the first `/extract` warms it within its own generous per-request timeout. `no-model` is now reserved for when there is genuinely nothing to load, with an accurate "download or attach" hint.

The `/extract` and `/health` contracts are unchanged.

### Verification
End to end against a real local llama-server: `cascade pod extract` on an imported C-CDA fixture auto-spawned `cascade agent serve`, which managed-spawned llama-server and wrote 5 auto-accepted entities to `clinical/ai-extracted.ttl`. Full cascade-cli suite green (977 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)