### PR TITLE
fix(cli): pod-init profile Turtle + lab-to-Condition mapping

### DIFF
--- a/src/commands/pod/extract.ts
+++ b/src/commands/pod/extract.ts
@@ -53,16 +53,20 @@ const LOINC_TO_SECTION: Record<string, string> = {
 // clinical:Condition (the most semantically neutral clinical class) for
 // unknown types so the triple is always valid against the ontology.
 
-const ENTITY_TYPE_MAP: Record<string, string> = {
+export const ENTITY_TYPE_MAP: Record<string, string> = {
   medication:    'clinical:Medication',
   condition:     'clinical:Condition',
   allergy:       'clinical:Allergy',
-  // The /extract entity type for a lab result is 'lab' (see the agent's
-  // ExtractedEntity.type union); 'labresult' is kept as a defensive alias.
+  // The agent's /extract ExtractedEntity.type union emits 'lab', 'vital' and
+  // 'socialHistory' (not 'labresult'/'vitalsign'). Map each to its real
+  // clinical class so none falls through to the clinical:Condition default;
+  // the '*result'/'*sign' spellings are kept as defensive aliases.
   lab:           'clinical:LabResult',
   labresult:     'clinical:LabResult',
-  immunization:  'clinical:Immunization',
+  vital:         'clinical:VitalSign',
   vitalsign:     'clinical:VitalSign',
+  socialhistory: 'clinical:SocialHistoryRecord',
+  immunization:  'clinical:Immunization',
   procedure:     'clinical:Procedure',
   encounter:     'clinical:Encounter',
   device:        'clinical:ImplantedDevice',

--- a/src/commands/pod/extract.ts
+++ b/src/commands/pod/extract.ts
@@ -57,6 +57,9 @@ const ENTITY_TYPE_MAP: Record<string, string> = {
   medication:    'clinical:Medication',
   condition:     'clinical:Condition',
   allergy:       'clinical:Allergy',
+  // The /extract entity type for a lab result is 'lab' (see the agent's
+  // ExtractedEntity.type union); 'labresult' is kept as a defensive alias.
+  lab:           'clinical:LabResult',
   labresult:     'clinical:LabResult',
   immunization:  'clinical:Immunization',
   vitalsign:     'clinical:VitalSign',
@@ -67,7 +70,7 @@ const ENTITY_TYPE_MAP: Record<string, string> = {
   supplement:    'clinical:Supplement',
 };
 
-function entityRdfType(typeString: string): string {
+export function entityRdfType(typeString: string): string {
   return ENTITY_TYPE_MAP[typeString.toLowerCase()] ?? 'clinical:Condition';
 }
 

--- a/tests/extract-entity-type-map.test.ts
+++ b/tests/extract-entity-type-map.test.ts
@@ -1,35 +1,88 @@
 /**
- * Regression test for the `pod extract` entity-type -> Cascade RDF class map.
+ * Regression tests for the `pod extract` entity-type -> Cascade RDF class map.
  *
- * The cascade-agent /extract service emits `type: 'lab'` for lab results
- * (see @the-cascade-protocol/agent `ExtractedEntity.type`). ENTITY_TYPE_MAP
- * only had a `labresult` key, so `'lab'` fell through to the clinical:Condition
- * default -- a lab result is not a condition. This proves `'lab'` now maps to
- * clinical:LabResult and no longer to clinical:Condition.
+ * The cascade-agent /extract service (`@the-cascade-protocol/agent`,
+ * services/document-intelligence.d.ts) emits an `ExtractedEntity.type` from
+ * this union:
+ *
+ *   'medication' | 'condition' | 'lab' | 'socialHistory' | 'vital'
+ *     | 'allergy' | 'immunization' | 'procedure'
+ *
+ * ENTITY_TYPE_MAP originally keyed on 'labresult'/'vitalsign' and had no
+ * 'socialhistory' key, so 'lab', 'vital' and 'socialHistory' all missed the
+ * table and fell through to the `?? 'clinical:Condition'` default -- three
+ * different clinical entities silently typed as conditions. These tests pin
+ * every union member to a real, explicitly-mapped clinical class so the whole
+ * fall-through bug class cannot recur.
  */
 
 import { describe, it, expect } from 'vitest';
-import { entityRdfType } from '../src/commands/pod/extract.js';
+import { entityRdfType, ENTITY_TYPE_MAP } from '../src/commands/pod/extract.js';
+
+// The exact ExtractedEntity.type union the agent emits, with the correct
+// clinical class for each (verified against src/shapes/clinical.ttl and
+// clinical.shapes.ttl):
+//   clinical:LabResult          (clinical.ttl:107, LabResultShape)
+//   clinical:VitalSign          (clinical.ttl:131, VitalSignShape)
+//   clinical:SocialHistoryRecord(clinical.ttl:1592, EHR-extracted C-CDA social history)
+const AGENT_TYPE_TO_CLASS: Record<string, string> = {
+  medication: 'clinical:Medication',
+  condition: 'clinical:Condition',
+  lab: 'clinical:LabResult',
+  socialHistory: 'clinical:SocialHistoryRecord',
+  vital: 'clinical:VitalSign',
+  allergy: 'clinical:Allergy',
+  immunization: 'clinical:Immunization',
+  procedure: 'clinical:Procedure',
+};
+
+const DEFAULT_FALLBACK = 'clinical:Condition';
 
 describe('entityRdfType (pod extract entity-type mapping)', () => {
+  describe('every agent ExtractedEntity.type member maps to a real, explicit class', () => {
+    for (const [agentType, expectedClass] of Object.entries(AGENT_TYPE_TO_CLASS)) {
+      it(`'${agentType}' -> ${expectedClass}`, () => {
+        // Resolves to the expected clinical class...
+        expect(entityRdfType(agentType)).toBe(expectedClass);
+        // ...and via an EXPLICIT map key, never the clinical:Condition fallback.
+        // (condition legitimately maps to clinical:Condition, but as an explicit
+        // key, so the key-presence check still holds.)
+        expect(
+          Object.prototype.hasOwnProperty.call(ENTITY_TYPE_MAP, agentType.toLowerCase()),
+          `'${agentType}' must have an explicit ENTITY_TYPE_MAP key, not rely on the fallback`,
+        ).toBe(true);
+        // Every mapped class is a clinical: domain class.
+        expect(entityRdfType(agentType).startsWith('clinical:')).toBe(true);
+      });
+    }
+  });
+
+  it("no non-condition agent type resolves to the clinical:Condition fallback", () => {
+    for (const agentType of Object.keys(AGENT_TYPE_TO_CLASS)) {
+      if (agentType === 'condition') continue;
+      expect(entityRdfType(agentType)).not.toBe(DEFAULT_FALLBACK);
+    }
+  });
+
   it("maps the agent's 'lab' entity type to clinical:LabResult, not clinical:Condition", () => {
     expect(entityRdfType('lab')).toBe('clinical:LabResult');
     expect(entityRdfType('lab')).not.toBe('clinical:Condition');
   });
 
-  it('is case-insensitive for lab results', () => {
-    expect(entityRdfType('Lab')).toBe('clinical:LabResult');
+  it("maps 'vital' to clinical:VitalSign and 'socialHistory' to clinical:SocialHistoryRecord", () => {
+    expect(entityRdfType('vital')).toBe('clinical:VitalSign');
+    expect(entityRdfType('socialHistory')).toBe('clinical:SocialHistoryRecord');
+    expect(entityRdfType('vital')).not.toBe('clinical:Condition');
+    expect(entityRdfType('socialHistory')).not.toBe('clinical:Condition');
+  });
+
+  it('is case-insensitive', () => {
     expect(entityRdfType('LAB')).toBe('clinical:LabResult');
+    expect(entityRdfType('SocialHISTORY')).toBe('clinical:SocialHistoryRecord');
+    expect(entityRdfType('Vital')).toBe('clinical:VitalSign');
   });
 
-  it('still maps a real condition to clinical:Condition (unchanged)', () => {
-    expect(entityRdfType('condition')).toBe('clinical:Condition');
-  });
-
-  it('leaves the other explicit mappings intact', () => {
-    expect(entityRdfType('medication')).toBe('clinical:Medication');
-    expect(entityRdfType('allergy')).toBe('clinical:Allergy');
-    expect(entityRdfType('immunization')).toBe('clinical:Immunization');
-    expect(entityRdfType('procedure')).toBe('clinical:Procedure');
+  it('still falls back to clinical:Condition for a genuinely unknown type', () => {
+    expect(entityRdfType('not-a-real-type')).toBe('clinical:Condition');
   });
 });

--- a/tests/extract-entity-type-map.test.ts
+++ b/tests/extract-entity-type-map.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for the `pod extract` entity-type -> Cascade RDF class map.
+ *
+ * The cascade-agent /extract service emits `type: 'lab'` for lab results
+ * (see @the-cascade-protocol/agent `ExtractedEntity.type`). ENTITY_TYPE_MAP
+ * only had a `labresult` key, so `'lab'` fell through to the clinical:Condition
+ * default -- a lab result is not a condition. This proves `'lab'` now maps to
+ * clinical:LabResult and no longer to clinical:Condition.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { entityRdfType } from '../src/commands/pod/extract.js';
+
+describe('entityRdfType (pod extract entity-type mapping)', () => {
+  it("maps the agent's 'lab' entity type to clinical:LabResult, not clinical:Condition", () => {
+    expect(entityRdfType('lab')).toBe('clinical:LabResult');
+    expect(entityRdfType('lab')).not.toBe('clinical:Condition');
+  });
+
+  it('is case-insensitive for lab results', () => {
+    expect(entityRdfType('Lab')).toBe('clinical:LabResult');
+    expect(entityRdfType('LAB')).toBe('clinical:LabResult');
+  });
+
+  it('still maps a real condition to clinical:Condition (unchanged)', () => {
+    expect(entityRdfType('condition')).toBe('clinical:Condition');
+  });
+
+  it('leaves the other explicit mappings intact', () => {
+    expect(entityRdfType('medication')).toBe('clinical:Medication');
+    expect(entityRdfType('allergy')).toBe('clinical:Allergy');
+    expect(entityRdfType('immunization')).toBe('clinical:Immunization');
+    expect(entityRdfType('procedure')).toBe('clinical:Procedure');
+  });
+});

--- a/tests/pod-init-turtle.test.ts
+++ b/tests/pod-init-turtle.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression test: `cascade pod init` must emit only well-formed Turtle.
+ *
+ * A previous template wrote profile/extended.ttl as a `<#me>` subject with
+ * every predicate commented out followed by a bare `.`, which is invalid
+ * Turtle ("Unexpected . on line 32"). Every freshly initialized pod then
+ * shipped one unparseable file, and `cascade validate` reported a violation
+ * on a clean pod. The template fix landed earlier; this test is the missing
+ * guard: init a pod and assert every emitted .ttl parses cleanly through the
+ * repo's own Turtle parser.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { resolve } from 'path';
+import { parseTurtleFile } from '../src/lib/turtle-parser.js';
+
+const CLI_PATH = resolve(__dirname, '../dist/index.js');
+
+async function ttlFilesIn(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await ttlFilesIn(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.ttl')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('pod init emits valid Turtle', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      tempDir = undefined;
+    }
+  });
+
+  it('every emitted .ttl file parses without errors', async () => {
+    tempDir = path.join('/tmp', `cascade-test-init-ttl-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const podDir = path.join(tempDir, 'pod');
+    execSync(`node ${CLI_PATH} pod init ${podDir}`, { encoding: 'utf-8', timeout: 30000 });
+
+    const ttlFiles = await ttlFilesIn(podDir);
+    // Sanity: the standard template ships several .ttl files.
+    expect(ttlFiles.length).toBeGreaterThanOrEqual(4);
+
+    for (const file of ttlFiles) {
+      const result = await parseTurtleFile(file);
+      const rel = path.relative(podDir, file);
+      expect(result.errors, `${rel} should parse without errors, got: ${JSON.stringify(result.errors)}`).toEqual([]);
+      expect(result.success, `${rel} should parse successfully`).toBe(true);
+    }
+  });
+
+  it('profile/extended.ttl specifically parses clean (regression for the bare-dot bug)', async () => {
+    tempDir = path.join('/tmp', `cascade-test-init-ext-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const podDir = path.join(tempDir, 'pod');
+    execSync(`node ${CLI_PATH} pod init ${podDir}`, { encoding: 'utf-8', timeout: 30000 });
+
+    const result = await parseTurtleFile(path.join(podDir, 'profile', 'extended.ttl'));
+    expect(result.errors).toEqual([]);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Two data-correctness items in the import/extract path. Both are small and touch the same `pod extract` type-adapter surface, so they ship together.

## (b) `pod extract` mapped three agent entity types to the wrong class

The cascade-agent `/extract` service (`@the-cascade-protocol/agent`, `services/document-intelligence.d.ts`) emits `ExtractedEntity.type` from this union:

```ts
'medication' | 'condition' | 'lab' | 'socialHistory' | 'vital' | 'allergy' | 'immunization' | 'procedure'
```

But `ENTITY_TYPE_MAP` in `src/commands/pod/extract.ts` keyed on `labresult` / `vitalsign` and had **no** `socialhistory` key, so `lab`, `vital`, and `socialHistory` all missed the table and fell through to the default:

```ts
return ENTITY_TYPE_MAP[typeString.toLowerCase()] ?? 'clinical:Condition';
```

Result: every AI-extracted lab result, vital sign, and social-history observation was typed `clinical:Condition`. None of those is a condition.

**Fix** (`src/commands/pod/extract.ts`): add explicit keys for the union members that were missing, each mapped to the class the repo's own vocab/shapes already define:

| agent type | mapped class | source |
| --- | --- | --- |
| `lab` | `clinical:LabResult` | `clinical.ttl:107`, `clinical:LabResultShape` (`clinical.shapes.ttl:601`) |
| `vital` | `clinical:VitalSign` | `clinical.ttl:131`, `clinical:VitalSignShape` (`clinical.shapes.ttl:934`) |
| `socialHistory` | `clinical:SocialHistoryRecord` | `clinical.ttl:1592`, the EHR-extracted C-CDA social-history class (distinct from the consumer-reported `health:SocialHistoryRecord`) |

`clinical:SocialHistoryRecord` is the correct target because `/extract` runs over EHR-sourced C-CDA documents; its vocab comment is literally "An EHR-extracted social or behavioral history observation from a C-CDA Social History section." The `labresult` / `vitalsign` spellings are kept as defensive aliases. `encounter` / `device` / `familyhistory` / `supplement` are not emitted by `/extract` and are left untouched. `entityRdfType` and `ENTITY_TYPE_MAP` are exported so the mapping is unit-testable without launching a model.

New test `tests/extract-entity-type-map.test.ts` iterates **every** member of the agent's `ExtractedEntity.type` union and asserts each resolves to a real `clinical:` class via an **explicit** map key (never the `clinical:Condition` fallback), plus targeted checks for `lab` / `vital` / `socialHistory`, case-insensitivity, and that a genuinely unknown type still falls back to `clinical:Condition`. This guards the whole fall-through bug class against recurrence.

## (a) `pod init` Turtle regression guard

The template bug where `profile/extended.ttl` shipped a `<#me>` subject with every predicate commented out plus a bare `.` (invalid Turtle, "Unexpected . on line 32") was already corrected in the template. What was missing was a test to keep it fixed. New test `tests/pod-init-turtle.test.ts` inits a real pod and asserts **every** emitted `.ttl` parses cleanly through the repo's own `parseTurtleFile`, with a targeted check on `profile/extended.ttl`.

## Verification

```
npm ci && npm run build && npm test
```

Green: **992 passed, 21 skipped** (77 files), +15 tests over the 977-test baseline. No existing tests changed. Both new test files were also confirmed to pass in a clean checkout with no sibling `conformance` repo, so they add no external dependency.

> Merge order: this PR is behavior-only and carries no workflow. It should merge after (or rebase onto) the CI PR so its own run is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
