### PR TITLE
docs(schema): sync draft shapes from spec (evidence facets + workbench note annotations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Draft shapes synced from spec** (`sync-shapes-from-spec.sh`; batched per `spec/PENDING_DOWNSTREAM_SYNC.md`): `evidence.shapes.ttl` now carries the verdict-taxonomy v2 facet model (spec evidence v1-draft.0.2 — facet-consistency constraints + the generalized SHACL-Core grounding invariant), and `workbench.shapes.ttl` gains the Web Annotation note shapes (spec workbench v1-draft.0.5 — `WebAnnotationShape` / `CommentingBodyShape` / `FollowUpShape`, so `cascade validate` enforces target + motivation + PROV attribution on `oa:Annotation` notes, a body on commenting notes, and the RFC 5545 `ical:status` enum on follow-ups by default). Verified: full suite green (992 passed); positive/negative note fixtures pass/fail as intended against the embedded shapes.
+
+---
+
 ## [0.7.0] - 2026-06-26
 
 ### Added

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -24,6 +24,12 @@
 #   (content-free Tombstone — contentHash removed, erasureAction added; plus the
 #   verification axis: verificationStatus + VerificationStatusShape via sh:in).
 #   Per D-PATH, still draft; no row change.
+# Updated 2026-07-15: batched draft sync (spec PENDING_DOWNSTREAM_SYNC rows 2+3):
+#   evidence.shapes.ttl for evidence@v1-draft.0.2 (verdict facet model +
+#   generalized SHACL-Core grounding invariant) and workbench.shapes.ttl for
+#   workbench@v1-draft.0.5 (Web Annotation note shapes: WebAnnotationShape /
+#   CommentingBodyShape / FollowUpShape). Per D-PATH, drafts stay unrowed
+#   until v1.0 graduation; no row change.
 core=3.3
 health=2.4
 clinical=1.9

--- a/src/shapes/evidence.shapes.ttl
+++ b/src/shapes/evidence.shapes.ttl
@@ -4,6 +4,22 @@
 # NOT SHACL-SPARQL. This is deliberate: `cascade validate` uses
 # rdf-validate-shacl, which does not support SHACL-SPARQL constraints. A
 # sh:sparql formulation would parse but silently never fire. Keep this Core.
+#
+# CHANGELOG
+# v1-draft.0.2 (2026-07-01) — Verdict taxonomy v2: AssertionShape moves to the
+#   facet model. The generalized grounding invariant: a grounded result
+#   (settled Settled, direction Supports/Contradicts/Mixed, basis not None) of
+#   EITHER basis requires >= 1 evidence link. Facet-consistency constraints:
+#   NeedsEvidence must not carry a grounded direction; a grounded direction
+#   must not carry basis None. The legacy evidence:verdict branch is retained
+#   (deprecated) so draft-period data still validates; every assertion must
+#   carry settled OR the legacy verdict. Removal of the legacy branch at v1.0.
+#
+# SHACL Core subtlety this file leans on: a property shape with sh:in
+# constrains only EXISTING values, so it is vacuously satisfied when the
+# property is absent. Each sh:or branch below reads as "the property is absent
+# or has only the listed values"; absence therefore never triggers the
+# grounded-direction constraints, which keeps legacy (facet-less) data valid.
 
 @prefix evidence: <https://ns.cascadeprotocol.org/evidence/v1#> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
@@ -19,18 +35,72 @@ evidence:AssertionShape a sh:NodeShape ;
     sh:targetClass evidence:Assertion ;
     sh:property [ sh:path evidence:assertionText ; sh:minCount 1 ; sh:datatype xsd:string ;
                   sh:message "Every Assertion must carry assertionText." ] ;
-    sh:property [ sh:path evidence:verdict ; sh:minCount 1 ; sh:maxCount 1 ;
+
+    # ── Facet enumerations (canonical form, v1-draft.0.2) ────────────────────
+    sh:property [ sh:path evidence:direction ; sh:maxCount 1 ;
+                  sh:in ( evidence:Supports evidence:Contradicts evidence:Mixed evidence:None ) ;
+                  sh:message "direction must be one of the DirectionValue individuals (Supports | Contradicts | Mixed | None)." ] ;
+    sh:property [ sh:path evidence:basis ; sh:maxCount 1 ;
+                  sh:in ( evidence:Record evidence:Literature evidence:RecordAndLiterature evidence:None ) ;
+                  sh:message "basis must be one of the BasisValue individuals (Record | Literature | RecordAndLiterature | None)." ] ;
+    sh:property [ sh:path evidence:strength ; sh:maxCount 1 ;
+                  sh:in ( evidence:Strong evidence:Moderate evidence:Weak ) ;
+                  sh:message "strength must be one of the StrengthValue individuals (Strong | Moderate | Weak)." ] ;
+    sh:property [ sh:path evidence:settled ; sh:maxCount 1 ;
+                  sh:in ( evidence:Settled evidence:NeedsEvidence ) ;
+                  sh:message "settled must be one of the SettledValue individuals (Settled | NeedsEvidence)." ] ;
+    sh:property [ sh:path evidence:reason ; sh:maxCount 1 ;
+                  sh:in ( evidence:NoRecord evidence:NeedsLiterature evidence:NotCheckableByNature ) ;
+                  sh:message "reason must be one of the NeedsEvidenceReasonValue individuals (NoRecord | NeedsLiterature | NotCheckableByNature)." ] ;
+    sh:property [ sh:path evidence:confidence ; sh:maxCount 1 ; sh:datatype xsd:decimal ;
+                  sh:minInclusive 0.0 ; sh:maxInclusive 1.0 ;
+                  sh:message "confidence must be an xsd:decimal in [0.0, 1.0]." ] ;
+
+    # ── Legacy verdict (deprecated; one-release transition) ──────────────────
+    sh:property [ sh:path evidence:verdict ; sh:maxCount 1 ;
                   sh:in ( evidence:Supported evidence:Contradicted evidence:Unverifiable evidence:NeedsLiterature ) ;
-                  sh:message "Every Assertion must carry exactly one verdict (one of the four VerdictValue individuals)." ] ;
-    # Grounding invariant (SHACL Core). Reads: the verdict is NOT a grounded
-    # one (i.e. it is Unverifiable or NeedsLiterature) OR there is at least one
-    # evidence link. Equivalent to: Supported/Contradicted => >= 1 evidence link.
+                  sh:message "verdict (deprecated) must be one of the four VerdictValue individuals when present." ] ;
+
+    # Every assertion is graded: it carries the facet form (settled) or, for
+    # draft-period data, the deprecated flat verdict.
+    sh:or (
+        [ sh:property [ sh:path evidence:settled ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path evidence:verdict ; sh:minCount 1 ] ]
+    ) ;
+
+    # ── Grounding invariant, generalized (SHACL Core) ────────────────────────
+    # A grounded result — settled Settled AND direction Supports/Contradicts/
+    # Mixed AND basis not None — of EITHER basis requires >= 1 evidence link.
+    # Reads: not settled, or direction None, or basis None, or >= 1 link.
+    sh:or (
+        [ sh:property [ sh:path evidence:settled ; sh:in ( evidence:NeedsEvidence ) ] ]
+        [ sh:property [ sh:path evidence:direction ; sh:in ( evidence:None ) ] ]
+        [ sh:property [ sh:path evidence:basis ; sh:in ( evidence:None ) ] ]
+        [ sh:property [ sh:path evidence:hasEvidenceLink ; sh:minCount 1 ] ]
+    ) ;
+
+    # ── Facet consistency: NeedsEvidence must not carry a grounded direction.
+    # Reads: settled is Settled (or absent), or direction is None (or absent).
+    sh:or (
+        [ sh:property [ sh:path evidence:settled ; sh:in ( evidence:Settled ) ] ]
+        [ sh:property [ sh:path evidence:direction ; sh:in ( evidence:None ) ] ]
+    ) ;
+
+    # ── Facet consistency: a grounded direction requires a real basis.
+    # Reads: direction is None (or absent), or basis is not None.
+    sh:or (
+        [ sh:property [ sh:path evidence:direction ; sh:in ( evidence:None ) ] ]
+        [ sh:property [ sh:path evidence:basis ; sh:not [ sh:in ( evidence:None ) ] ] ]
+    ) ;
+
+    # ── Legacy grounding invariant (deprecated branch; removal at v1.0):
+    # Supported/Contradicted => >= 1 evidence link.
     sh:or (
         [ sh:property [ sh:path evidence:verdict ;
                         sh:not [ sh:in ( evidence:Supported evidence:Contradicted ) ] ] ]
         [ sh:property [ sh:path evidence:hasEvidenceLink ; sh:minCount 1 ] ]
     ) ;
-    sh:message "Grounding invariant: an Assertion with verdict Supported or Contradicted must carry at least one evidence link (evidence:hasEvidenceLink)." .
+    sh:message "Grounding invariant: a grounded Assertion (settled Settled with direction Supports/Contradicts/Mixed and basis not None, or legacy verdict Supported/Contradicted) must carry at least one evidence link (evidence:hasEvidenceLink), and its facets must be mutually consistent." .
 
 evidence:EvidenceLinkShape a sh:NodeShape ;
     sh:targetClass evidence:EvidenceLink ;

--- a/src/shapes/workbench.shapes.ttl
+++ b/src/shapes/workbench.shapes.ttl
@@ -5,6 +5,9 @@
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix oa:   <http://www.w3.org/ns/oa#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix ical: <http://www.w3.org/2002/12/cal/ical#> .
 
 <https://ns.cascadeprotocol.org/workbench/v1/shapes> a owl:Ontology ;
     owl:imports <https://ns.cascadeprotocol.org/workbench/v1#> ;
@@ -63,3 +66,40 @@ workbench:TombstoneShape a sh:NodeShape ;
 workbench:VerificationStatusShape a sh:NodeShape ;
     sh:targetObjectsOf workbench:verificationStatus ;
     sh:in ( workbench:Unverified workbench:Confirmed workbench:Refuted ) .
+
+# ── Notes / flags / follow-ups — the Web Annotation substrate (v1-draft.0.5) ─
+# Targets every oa:Annotation in the Pod (they live under notes/). SHACL Core
+# only, like the evidence grounding invariant, so `cascade validate` actually
+# enforces it. The conditional constraints use the sh:or( sh:not(...) ... )
+# pattern: "NOT motivated-by-X, OR carries the fields X requires".
+
+workbench:WebAnnotationShape a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    # At least one target: a note floats on nothing.
+    sh:property [ sh:path oa:hasTarget ; sh:minCount 1 ;
+                  sh:nodeKind sh:BlankNodeOrIRI ] ;
+    # Exactly which kind of note this is.
+    sh:property [ sh:path oa:motivatedBy ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    # Attribution is load-bearing (caregiver vs patient vs agent): required.
+    sh:property [ sh:path prov:wasAttributedTo ; sh:minCount 1 ] ;
+    sh:property [ sh:path prov:generatedAtTime ; sh:minCount 1 ; sh:maxCount 1 ;
+                  sh:datatype xsd:dateTime ] .
+
+# A commenting note must actually say something: motivatedBy oa:commenting
+# requires a body.
+workbench:CommentingBodyShape a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    sh:or (
+        [ sh:not [ sh:property [ sh:path oa:motivatedBy ; sh:hasValue oa:commenting ] ] ]
+        [ sh:property [ sh:path oa:hasBody ; sh:minCount 1 ] ]
+    ) .
+
+# A follow-up is a to-do: motivatedBy workbench:followUp requires the RFC 5545
+# VTODO status (reused ical:status, closed enum); ical:due stays optional.
+workbench:FollowUpShape a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    sh:or (
+        [ sh:not [ sh:property [ sh:path oa:motivatedBy ; sh:hasValue workbench:followUp ] ] ]
+        [ sh:property [ sh:path ical:status ; sh:minCount 1 ; sh:maxCount 1 ;
+                        sh:in ( "NEEDS-ACTION" "IN-PROCESS" "COMPLETED" "CANCELLED" ) ] ]
+    ) .


### PR DESCRIPTION
Batched draft-shape sync per `spec/PENDING_DOWNSTREAM_SYNC.md` (rows 2 + 3, run together at the ledger's release boundary):

- `evidence.shapes.ttl` <- spec evidence **v1-draft.0.2**: the verdict-taxonomy v2 facet model (facet-consistency constraints + the generalized SHACL-Core grounding invariant). The Workbench has been passing its own synced copy via `--shapes` since 2026-07-01; this makes the embedded default current.
- `workbench.shapes.ttl` <- spec workbench **v1-draft.0.5** (tag `vocab/workbench-v1-draft.0.5`): the Web Annotation note shapes (`WebAnnotationShape` / `CommentingBodyShape` / `FollowUpShape`), so `cascade validate` enforces the notes/flags/follow-ups profile by default.

Verification: full suite green (77 files, 992 passed / 21 skipped); the spec PR's positive fixture PASSES and the negative fixture FAILS with all intended violation classes against the **embedded** shapes (no `--shapes` flag).

Released vocabs untouched (`VOCAB_VERSIONS` rows unchanged per D-PATH — drafts stay out until v1.0 graduation; dated comment added). No npm publish needed for the Workbench (it bundles a local build); say the word if you want a version bump + publish.

Also removed three untracked iCloud conflict-copy phantoms (`tests 2.yml`, `extract-entity-type-map.test 2.ts`/`test 3.ts`) — verified byte-identical or stale-older copies of their originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)