### PR TITLE
fix(cli): type-index prefix self-heal for coverage registrations (root 1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Type index is valid Turtle after a claims import** (root backlog 1.6). When `cascade pod import` appended a `solid:TypeRegistration` block, it self-healed only the `fhir:` prefix, so registering a coverage class (Claim / ExplanationOfBenefit) wrote `coverage:...` into a file with no `@prefix coverage:` declaration. The result was an unparseable `settings/publicTypeIndex.ttl` (`Undefined prefix "coverage:"`) on every fresh pod that touched claims data, which broke any strict-Turtle consumer (validators, other Cascade apps, the coming graph-query surface). The self-heal now declares any Cascade prefix the appended block uses and the file lacks, and `pod init` seeds the index templates with `coverage:` (public) and `fhir:` (private) so new pods start complete. Verified: fresh Synthea import's `publicTypeIndex.ttl` parses under n3 strict mode (it failed on line 46 before).
+
 ### Changed
 
 - **Draft shapes synced from spec** (`sync-shapes-from-spec.sh`; batched per `spec/PENDING_DOWNSTREAM_SYNC.md`): `evidence.shapes.ttl` now carries the verdict-taxonomy v2 facet model (spec evidence v1-draft.0.2 — facet-consistency constraints + the generalized SHACL-Core grounding invariant), and `workbench.shapes.ttl` gains the Web Annotation note shapes (spec workbench v1-draft.0.5 — `WebAnnotationShape` / `CommentingBodyShape` / `FollowUpShape`, so `cascade validate` enforces target + motivation + PROV attribution on `oa:Annotation` notes, a body on commenting notes, and the RFC 5545 `ical:status` enum on follow-ups by default). Verified: full suite green (992 passed); positive/negative note fixtures pass/fail as intended against the embedded shapes.

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -168,6 +168,27 @@ function shortenForTurtle(iri: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Self-heal: declare any PREFIX_MAP prefix the appended block uses but the file
+// lacks. A type registration's `solid:forClass` CURIE can name any PREFIX_MAP
+// prefix (clinical:, health:, coverage:, cascade:, fhir:). Pods initialized
+// before a given prefix was added to the index header would otherwise produce an
+// unparseable index (e.g. "Undefined prefix coverage:" after a Claim import).
+// Returns the "@prefix ..." lines to prepend (empty string when none needed).
+// ---------------------------------------------------------------------------
+
+export function missingPrefixHeader(block: string, existingContent: string): string {
+  const lines: string[] = [];
+  for (const [ns, prefix] of Object.entries(PREFIX_MAP)) {
+    const usedInBlock = block.includes(`${prefix}:`);
+    const alreadyDeclared = new RegExp(`@prefix\\s+${prefix}:`).test(existingContent);
+    if (usedInBlock && !alreadyDeclared) {
+      lines.push(`@prefix ${prefix}: <${ns}> .`);
+    }
+  }
+  return lines.length > 0 ? lines.join('\n') + '\n' : '';
+}
+
+// ---------------------------------------------------------------------------
 // Build a TypeRegistration block
 // ---------------------------------------------------------------------------
 
@@ -189,7 +210,7 @@ function typeIndexForInfo(info: typeof DATA_TYPES[string]): 'publicTypeIndex.ttl
 // Append to type index file (string manipulation to preserve comments)
 // ---------------------------------------------------------------------------
 
-async function appendTypeRegistration(
+export async function appendTypeRegistration(
   indexPath: string,
   key: string,
   info: typeof DATA_TYPES[string],
@@ -205,14 +226,11 @@ async function appendTypeRegistration(
 
   const block = buildTypeRegistration(key, info);
 
-  // The block may reference the `fhir:` prefix (fhir-passthrough catch-all).
-  // Pods initialized before that prefix was added to the index header would
-  // otherwise fail to parse with "Undefined prefix fhir:". Self-heal by
-  // declaring the prefix once if the block needs it and the file lacks it.
-  let header = '';
-  if (block.includes('fhir:') && !/@prefix\s+fhir:/.test(content)) {
-    header = '@prefix fhir: <http://hl7.org/fhir/> .\n';
-  }
+  // Declare any prefix the appended block uses that the file does not yet
+  // declare (e.g. coverage: for a Claim/ExplanationOfBenefit registration, or
+  // fhir: for the passthrough catch-all). Without this, a strict-Turtle consumer
+  // of the type index breaks with "Undefined prefix ...".
+  const header = missingPrefixHeader(block, content);
 
   if (!dryRun) {
     // Read-modify-write (encrypted resources cannot be appended to in place).

--- a/src/commands/pod/init.ts
+++ b/src/commands/pod/init.ts
@@ -71,10 +71,11 @@ const PROFILE_CARD_TTL = `@prefix foaf: <http://xmlns.com/foaf/0.1/> .
     cascade:schemaVersion "1.3" .
 `;
 
-const PUBLIC_TYPE_INDEX_TTL = `@prefix solid: <http://www.w3.org/ns/solid/terms#> .
+export const PUBLIC_TYPE_INDEX_TTL = `@prefix solid: <http://www.w3.org/ns/solid/terms#> .
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
 @prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 @prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix coverage: <https://ns.cascadeprotocol.org/coverage/v1#> .
 @prefix fhir: <http://hl7.org/fhir/> .
 
 # =============================================================================
@@ -100,9 +101,10 @@ const PUBLIC_TYPE_INDEX_TTL = `@prefix solid: <http://www.w3.org/ns/solid/terms#
 #     solid:instance </clinical/conditions.ttl> .
 `;
 
-const PRIVATE_TYPE_INDEX_TTL = `@prefix solid: <http://www.w3.org/ns/solid/terms#> .
+export const PRIVATE_TYPE_INDEX_TTL = `@prefix solid: <http://www.w3.org/ns/solid/terms#> .
 @prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 @prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix fhir: <http://hl7.org/fhir/> .
 
 # =============================================================================
 # Private Type Index

--- a/tests/pod-typeindex-prefix.test.ts
+++ b/tests/pod-typeindex-prefix.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression tests for the type-index prefix self-heal (root backlog 1.6, slice R0).
+ *
+ * When `cascade pod import` appends a `solid:TypeRegistration` block to a type
+ * index, the block's `solid:forClass` CURIE may use any Cascade prefix
+ * (clinical:, health:, coverage:, cascade:, fhir:). If the index header does not
+ * declare that prefix, the resulting file is unparseable Turtle
+ * (`Undefined prefix "coverage:"`), which the 2026-07-16 graph-edge audit found
+ * on every fresh pod that imports claims data.
+ *
+ * These tests lock in that (a) a fresh `pod init` public index already declares
+ * `coverage:`, and (b) appending a coverage registration to a *legacy* index that
+ * lacks it self-heals so the file still parses under n3's strict parser.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+import { mkdtempSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  missingPrefixHeader,
+  appendTypeRegistration,
+} from '../src/commands/pod/import.js';
+import { DATA_TYPES } from '../src/commands/pod/helpers.js';
+import { PUBLIC_TYPE_INDEX_TTL } from '../src/commands/pod/init.js';
+
+/** Parse Turtle with n3's strict parser; return the parse error (or null). */
+function parseError(turtle: string): Error | null {
+  const parser = new Parser({ format: 'Turtle' });
+  try {
+    parser.parse(turtle); // synchronous parse throws on undefined prefix
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+// A pod's public type index as `pod init` produced it BEFORE coverage: was added
+// to the header — the exact shape the audit found unparseable after a claims import.
+const LEGACY_PUBLIC_INDEX = `@prefix solid: <http://www.w3.org/ns/solid/terms#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+
+<> a solid:TypeIndex, solid:ListedDocument .
+`;
+
+describe('missingPrefixHeader (R0 self-heal)', () => {
+  it('declares coverage: when a block uses it and the file lacks it', () => {
+    const block = '\n<#claims> a solid:TypeRegistration ;\n    solid:forClass coverage:ClaimRecord ;\n    solid:instance </clinical/claims.ttl> .\n';
+    const header = missingPrefixHeader(block, LEGACY_PUBLIC_INDEX);
+    expect(header).toContain('@prefix coverage: <https://ns.cascadeprotocol.org/coverage/v1#> .');
+  });
+
+  it('returns empty when every used prefix is already declared', () => {
+    const block = '\n<#conditions> a solid:TypeRegistration ;\n    solid:forClass health:ConditionRecord ;\n    solid:instance </clinical/conditions.ttl> .\n';
+    expect(missingPrefixHeader(block, LEGACY_PUBLIC_INDEX)).toBe('');
+  });
+
+  it('declares fhir: for a passthrough registration on a header that lacks it', () => {
+    const block = '\n<#fhir-passthrough> a solid:TypeRegistration ;\n    solid:forClass fhir: ;\n    solid:instance </clinical/fhir-passthrough.ttl> .\n';
+    const header = missingPrefixHeader(block, LEGACY_PUBLIC_INDEX);
+    expect(header).toContain('@prefix fhir: <http://hl7.org/fhir/> .');
+  });
+
+  it('declares multiple missing prefixes at once', () => {
+    const minimal = '@prefix solid: <http://www.w3.org/ns/solid/terms#> .\n<> a solid:TypeIndex .\n';
+    const block = '\n<#benefits> a solid:TypeRegistration ;\n    solid:forClass coverage:BenefitStatement ;\n    solid:instance </clinical/benefits.ttl> .\n';
+    const header = missingPrefixHeader(block, minimal);
+    expect(header).toContain('@prefix coverage:');
+  });
+});
+
+describe('appendTypeRegistration round-trip parses under n3 (R0)', () => {
+  it('self-heals a legacy index so a coverage registration still parses', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cascade-r0-'));
+    const indexPath = join(dir, 'publicTypeIndex.ttl');
+    writeFileSync(indexPath, LEGACY_PUBLIC_INDEX, 'utf-8');
+
+    // Before the fix this produced `coverage:ClaimRecord` with no @prefix coverage:.
+    return appendTypeRegistration(indexPath, 'claims', DATA_TYPES.claims, false).then((appended) => {
+      expect(appended).toBe(true);
+      const result = readFileSync(indexPath, 'utf-8');
+      expect(result).toContain('coverage:ClaimRecord');
+      const err = parseError(result);
+      expect(err, err?.message).toBeNull();
+    });
+  });
+
+  it('keeps a fresh `pod init` index parseable after a coverage registration', () => {
+    // The fresh template already declares coverage:; appending must not break it.
+    const dir = mkdtempSync(join(tmpdir(), 'cascade-r0-'));
+    const indexPath = join(dir, 'publicTypeIndex.ttl');
+    writeFileSync(indexPath, PUBLIC_TYPE_INDEX_TTL, 'utf-8');
+
+    return appendTypeRegistration(indexPath, 'benefits', DATA_TYPES.benefits, false).then(() => {
+      const result = readFileSync(indexPath, 'utf-8');
+      expect(result).toContain('coverage:BenefitStatement');
+      const err = parseError(result);
+      expect(err, err?.message).toBeNull();
+    });
+  });
+
+  it('the fresh public type index template declares coverage:', () => {
+    expect(PUBLIC_TYPE_INDEX_TTL).toContain('@prefix coverage: <https://ns.cascadeprotocol.org/coverage/v1#> .');
+    expect(parseError(PUBLIC_TYPE_INDEX_TTL)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Slice **R0** of the graph-retrieval remediation (root backlog 1.6). Smallest, independent slice; ships before R1.

`cascade pod import` self-healed only the `fhir:` prefix when it appended a `solid:TypeRegistration` block to a type index. Registering a coverage class (Claim / ExplanationOfBenefit import) therefore emitted `coverage:...` into a file that never declared `@prefix coverage:`, producing an unparseable `settings/publicTypeIndex.ttl` (`Undefined prefix "coverage:"`) on every fresh pod that imports claims data. Any strict-Turtle consumer (validators, other Cascade apps, the coming graph-query surface) breaks on such a pod.

## Fix

- **Generalize the append-time self-heal.** New pure helper `missingPrefixHeader(block, content)` declares any `PREFIX_MAP` prefix the appended block uses and the file lacks (clinical:, health:, coverage:, cascade:, fhir:), replacing the fhir-only special case. The read-modify-write shape is unchanged, so it keeps working on encrypted pods.
- **Seed `pod init` templates.** The public index template now declares `coverage:`; the private index template declares `fhir:` (blood-pressure registers `fhir:Observation`). New pods start complete; the self-heal covers pods created before this change.

## Tests

New `tests/pod-typeindex-prefix.test.ts`:
- Unit coverage of `missingPrefixHeader` (declares a missing prefix, no-ops when present, handles multiple).
- Append round-trip that parses the result under n3 strict mode, for both a legacy index missing `coverage:` (the audit's failing shape) and a fresh template.

## Verification

- `npm run build` clean; new suite green; `pod-import` / `pod-import-integration` / `pod-init-turtle` / `pod` suites green.
- End to end: fresh `pod init` + `pod import` of the synthetic Synthea specimen. `settings/publicTypeIndex.ttl` now parses (it failed on line 46, `Undefined prefix "coverage:"`, before this change).

Evidence: `cascade-workbench/docs/planning/2026-07-16-graph-edge-audit-findings.md` section 4. Plan slice R0 in `2026-07-16-graph-retrieval-sequenced-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)