### PR TITLE
pod identity surface: init --owner-name, profile set-name

### DIFF
--- a/src/commands/pod/helpers.ts
+++ b/src/commands/pod/helpers.ts
@@ -191,6 +191,79 @@ export const DATA_TYPES: Record<string, DataTypeInfo> = {
 // Re-export CASCADE_NAMESPACES for convenience
 export { CASCADE_NAMESPACES };
 
+// ─── Identity Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Name parts written into a pod's profile/card.ttl identity block.
+ * `fullName` maps to foaf:name; the optional given/family parts map to
+ * foaf:givenName / foaf:familyName.
+ */
+export interface CardIdentityName {
+  fullName?: string;
+  givenName?: string;
+  familyName?: string;
+}
+
+/**
+ * Derive card.ttl identity parts from a single display-name string.
+ *
+ * A given/family split is only recorded when it is trivially derivable: exactly
+ * two whitespace-separated tokens (e.g. "Jane Doe"). A single token, or three or
+ * more tokens (middle names, particles, suffixes), records foaf:name only rather
+ * than guessing which token is the family name. Internal whitespace is collapsed
+ * to single spaces; an empty or whitespace-only string yields no parts.
+ */
+export function deriveCardIdentityName(name: string): CardIdentityName {
+  const fullName = name.trim().replace(/\s+/g, ' ');
+  if (!fullName) return {};
+  const tokens = fullName.split(' ');
+  if (tokens.length === 2) {
+    return { fullName, givenName: tokens[0], familyName: tokens[1] };
+  }
+  return { fullName };
+}
+
+/**
+ * Replace the commented-out identity placeholder block in a profile/card.ttl
+ * document with concrete foaf name triples, returning the updated Turtle. When
+ * no name parts are supplied the document is returned unchanged.
+ *
+ * Shared by `pod init --owner-name`, `pod profile set-name`, and `pod import`'s
+ * profile-population step so all three produce byte-identical card.ttl output.
+ *
+ * The section header rule uses U+2500 (box-drawings light horizontal); it must
+ * match the init.ts card template byte-for-byte for the replacement to apply.
+ */
+export function applyCardIdentityName(cardTurtle: string, name: CardIdentityName): string {
+  const nameFields: string[] = [];
+  if (name.fullName) nameFields.push(`    foaf:name "${name.fullName}" ;`);
+  if (name.givenName) nameFields.push(`    foaf:givenName "${name.givenName}" ;`);
+  if (name.familyName) nameFields.push(`    foaf:familyName "${name.familyName}" ;`);
+  if (nameFields.length === 0) return cardTurtle;
+  return cardTurtle.replace(
+    / {4}# ── Identity \(safe to make public\) ──\n( {4}#[^\n]*\n)*/,
+    `    # ── Identity (safe to make public) ──\n${nameFields.join('\n')}\n`,
+  );
+}
+
+/**
+ * Remove any populated foaf identity triples (name / givenName / familyName)
+ * that directly follow the card.ttl identity header, returning the block to a
+ * pristine state so a replacement name can be applied without duplicating
+ * triples. A card that still carries the commented-out placeholders is left
+ * untouched (those are comments, not populated triples).
+ *
+ * Used by `pod profile set-name` so re-naming an already-named pod is
+ * idempotent. `pod init` and import Step 9b only ever write a fresh card and do
+ * not call this.
+ */
+export function stripCardIdentityName(cardTurtle: string): string {
+  return cardTurtle.replace(
+    /( {4}# ── Identity \(safe to make public\) ──\n)(?: {4}foaf:(?:name|givenName|familyName) [^\n]*\n)+/,
+    '$1',
+  );
+}
+
 // ─── File-System Helpers ─────────────────────────────────────────────────────
 
 /**
@@ -328,8 +401,12 @@ export async function parseDataFile(filePath: string, dek?: Buffer): Promise<{
 
 /**
  * Read the patient profile from a pod to extract name, age, schema version.
+ *
+ * When `dek` is supplied, the profile resources are decrypted (combined
+ * AES-256-GCM layout) before parsing, so the owner name is resolvable on
+ * encrypted pods; otherwise they are read as plaintext.
  */
-export async function readPatientProfile(podDir: string): Promise<{
+export async function readPatientProfile(podDir: string, dek?: Buffer): Promise<{
   name?: string;
   age?: string;
   schemaVersion?: string;
@@ -349,7 +426,16 @@ export async function readPatientProfile(podDir: string): Promise<{
   for (const profilePath of profilePaths) {
     if (!(await fileExists(profilePath))) continue;
 
-    const result = await parseTurtleFile(profilePath);
+    let result;
+    if (dek) {
+      try {
+        result = parseTurtle(readResource(profilePath, dek), `file://${profilePath}`);
+      } catch {
+        continue;
+      }
+    } else {
+      result = await parseTurtleFile(profilePath);
+    }
     if (!result.success) continue;
 
     for (const subject of result.subjects) {

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -30,6 +30,7 @@ import {
   DATA_TYPES,
   resolvePodDir,
   fileExists,
+  applyCardIdentityName,
 } from './helpers.js';
 import {
   writePendingConflicts,
@@ -781,17 +782,11 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
               const fullName = [givenName, familyName].filter(Boolean).join(' ');
 
               // ── card.ttl: public-safe name fields only ──
+              // Shared identity-block writer (also used by pod init --owner-name
+              // and pod profile set-name) so all three stay byte-consistent.
               if (fullName || givenName || familyName) {
                 const cardTurtle = readResource(cardPath, dek);
-                const nameFields: string[] = [];
-                if (fullName) nameFields.push(`    foaf:name "${fullName}" ;`);
-                if (givenName) nameFields.push(`    foaf:givenName "${givenName}" ;`);
-                if (familyName) nameFields.push(`    foaf:familyName "${familyName}" ;`);
-                // Replace the commented-out identity block
-                const updated = cardTurtle.replace(
-                  /    # ── Identity \(safe to make public\) ──\n(    #[^\n]*\n)*/,
-                  `    # ── Identity (safe to make public) ──\n${nameFields.join('\n')}\n`,
-                );
+                const updated = applyCardIdentityName(cardTurtle, { fullName, givenName, familyName });
                 writeResource(cardPath, updated, dek);
                 printVerbose('  Populated profile/card.ttl with name from PatientProfile', globalOpts);
               }

--- a/src/commands/pod/index.ts
+++ b/src/commands/pod/index.ts
@@ -21,6 +21,7 @@ import { registerInitSubcommand } from './init.js';
 import { registerQuerySubcommand } from './query.js';
 import { registerExportSubcommand } from './export.js';
 import { registerInfoSubcommand } from './info.js';
+import { registerProfileSubcommand } from './profile.js';
 import { registerImportSubcommand } from './import.js';
 import { registerConflictsCommand } from './conflicts.js';
 import { registerResolveCommand } from './resolve.js';
@@ -39,6 +40,7 @@ export function registerPodCommand(program: Command): void {
   registerQuerySubcommand(pod, program);
   registerExportSubcommand(pod, program);
   registerInfoSubcommand(pod, program);
+  registerProfileSubcommand(pod, program);
   registerImportSubcommand(pod, program);
   registerConflictsCommand(pod);
   registerResolveCommand(pod, program);

--- a/src/commands/pod/info.ts
+++ b/src/commands/pod/info.ts
@@ -25,6 +25,8 @@ import {
   readPatientProfile,
   normalizeProvenanceLabel,
 } from './helpers.js';
+import { isPodEncrypted, resolveDek } from '../../lib/pod-encryption.js';
+import { passphraseFromEnv } from '../../lib/passphrase.js';
 
 // ── Extraction pipeline status helper ─────────────────────────────────────────
 
@@ -92,8 +94,24 @@ export function registerInfoSubcommand(pod: Command, program: Command): void {
       }
 
       try {
+        // On an encrypted pod, resolve the DEK from CASCADE_POD_PASSPHRASE so the
+        // owner name is decryptable for the display chain. Best-effort and
+        // non-interactive: no env var (or a wrong one) simply omits the name
+        // rather than prompting or failing this read-only command.
+        let profileDek: Buffer | undefined;
+        if (isPodEncrypted(absDir)) {
+          const pass = passphraseFromEnv();
+          if (pass) {
+            try {
+              profileDek = resolveDek(absDir, pass);
+            } catch {
+              /* wrong/absent key: proceed without the name */
+            }
+          }
+        }
+
         // Read patient profile info
-        const profile = await readPatientProfile(absDir);
+        const profile = await readPatientProfile(absDir, profileDek);
 
         // Scan data files
         const clinicalSummary: Array<{ file: string; records: number; provenance: string; label: string }> = [];

--- a/src/commands/pod/init.ts
+++ b/src/commands/pod/init.ts
@@ -9,7 +9,12 @@ import type { Command } from 'commander';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
-import { resolvePodDir, fileExists } from './helpers.js';
+import {
+  resolvePodDir,
+  fileExists,
+  applyCardIdentityName,
+  deriveCardIdentityName,
+} from './helpers.js';
 import {
   generateDek,
   buildPassphraseManifest,
@@ -273,7 +278,11 @@ export function registerInitSubcommand(pod: Command, program: Command): void {
       'Encrypt pod resources at rest (AES-256-GCM, passphrase-wrapped). ' +
         'Passphrase is read from CASCADE_POD_PASSPHRASE or a hidden prompt.',
     )
-    .action(async (directory: string, options: { encrypt?: boolean }) => {
+    .option(
+      '--owner-name <name>',
+      "Set the pod owner's display name (foaf:name) in profile/card.ttl.",
+    )
+    .action(async (directory: string, options: { encrypt?: boolean; ownerName?: string }) => {
       const globalOpts = program.opts() as OutputOptions;
       const absDir = resolvePodDir(directory);
       const dirName = path.basename(absDir);
@@ -313,10 +322,17 @@ export function registerInitSubcommand(pod: Command, program: Command): void {
           printVerbose(`Wrote encryption manifest: ${MANIFEST_RELATIVE_PATH}`, globalOpts);
         }
 
+        // When --owner-name is supplied, populate the card.ttl identity block via
+        // the shared helper so it matches import Step 9b byte-for-byte. Without the
+        // flag the template ships unchanged (commented-out placeholders).
+        const cardTtl = options.ownerName
+          ? applyCardIdentityName(PROFILE_CARD_TTL, deriveCardIdentityName(options.ownerName))
+          : PROFILE_CARD_TTL;
+
         // Write template files. Pod resources route through writeResource so they
         // are encrypted when a DEK is present; README.md stays plaintext (docs).
         writeResource(path.join(absDir, '.well-known', 'solid'), wellKnownSolid(absDir), dek);
-        writeResource(path.join(absDir, 'profile', 'card.ttl'), PROFILE_CARD_TTL, dek);
+        writeResource(path.join(absDir, 'profile', 'card.ttl'), cardTtl, dek);
         writeResource(path.join(absDir, 'profile', 'extended.ttl'), EXTENDED_PROFILE_TTL, dek);
         writeResource(path.join(absDir, 'settings', 'preferences'), PREFERENCES_TTL, dek);
         writeResource(path.join(absDir, 'settings', 'publicTypeIndex.ttl'), PUBLIC_TYPE_INDEX_TTL, dek);

--- a/src/commands/pod/profile.ts
+++ b/src/commands/pod/profile.ts
@@ -1,0 +1,111 @@
+/**
+ * cascade pod profile <action>
+ *
+ * Manage a pod owner's public identity in profile/card.ttl.
+ *
+ * Subcommands:
+ *   set-name <dir> <name>   Set the owner's display name (foaf:name)
+ */
+
+import type { Command } from 'commander';
+import * as path from 'path';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import {
+  resolvePodDir,
+  fileExists,
+  applyCardIdentityName,
+  deriveCardIdentityName,
+  stripCardIdentityName,
+} from './helpers.js';
+import {
+  isPodEncrypted,
+  resolveDek,
+  readResource,
+  writeResource,
+  PodDecryptError,
+} from '../../lib/pod-encryption.js';
+import { obtainPassphrase } from '../../lib/passphrase.js';
+
+export function registerProfileSubcommand(pod: Command, program: Command): void {
+  const profile = pod
+    .command('profile')
+    .description("Manage a pod owner's profile identity");
+
+  profile
+    .command('set-name')
+    .description("Set the pod owner's display name (foaf:name) in profile/card.ttl")
+    .argument('<dir>', 'Path to the Cascade Pod')
+    .argument('<name>', "Owner display name (e.g. \"Jane Doe\")")
+    .action(async (dir: string, name: string) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(dir);
+
+      printVerbose(`Setting owner name for pod: ${podDir}`, globalOpts);
+
+      // --- Validate pod dir + card ---
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl). Run 'cascade pod init' first.`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+      const cardPath = path.join(podDir, 'profile', 'card.ttl');
+      if (!(await fileExists(cardPath))) {
+        printError(`Pod is missing profile/card.ttl: ${podDir}`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // --- Validate the name ---
+      const identity = deriveCardIdentityName(name);
+      if (!identity.fullName) {
+        printError('Owner name cannot be empty.', globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // --- If the pod is encrypted, resolve the DEK so the card read/write
+      // routes through the encryption chokepoint. ---
+      let dek: Buffer | undefined;
+      if (isPodEncrypted(podDir)) {
+        try {
+          const passphrase = await obtainPassphrase();
+          dek = resolveDek(podDir, passphrase);
+          printVerbose('Pod is encrypted; routing card.ttl I/O through DEK.', globalOpts);
+        } catch (e: unknown) {
+          const msg =
+            e instanceof PodDecryptError ? e.message : e instanceof Error ? e.message : String(e);
+          printError(`Cannot update encrypted pod: ${msg}`, globalOpts);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      try {
+        // Strip any existing identity triples first so re-naming an
+        // already-named pod replaces rather than duplicates them.
+        const cardTurtle = stripCardIdentityName(readResource(cardPath, dek));
+        const updated = applyCardIdentityName(cardTurtle, identity);
+        writeResource(cardPath, updated, dek);
+
+        if (globalOpts.json) {
+          printResult(
+            {
+              status: 'updated',
+              directory: podDir,
+              name: identity.fullName,
+              givenName: identity.givenName,
+              familyName: identity.familyName,
+              encrypted: Boolean(dek),
+            },
+            globalOpts,
+          );
+        } else {
+          console.log(`Set pod owner name to "${identity.fullName}" in profile/card.ttl`);
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        printError(`Failed to set owner name: ${message}`, globalOpts);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/tests/pod-identity.test.ts
+++ b/tests/pod-identity.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Pod identity surface: `pod init --owner-name`, `pod profile set-name`,
+ * the shared card.ttl identity-block helper, and the DEK-aware owner-name
+ * resolution in `pod info` (root backlog 2.9).
+ *
+ * Drives the commander actions programmatically against temp dirs. Encrypted
+ * cases supply the passphrase via CASCADE_POD_PASSPHRASE (the sidecar spawn has
+ * no TTY, so env-only resolution is the contract under test).
+ *
+ * All names here are obviously invented (no PHI).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolve } from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import {
+  deriveCardIdentityName,
+  applyCardIdentityName,
+  stripCardIdentityName,
+} from '../src/commands/pod/helpers.js';
+
+// C-CDA fixture whose recordTarget carries the invented name "Jane Doe".
+// The FHIR converter omits the patient name from PatientProfile, so C-CDA is the
+// import path that exercises Step 9b's card.ttl name population.
+const CCDA_FIXTURE = resolve(__dirname, '../test-fixtures/ccda-lab-panel.xml');
+
+const PASSPHRASE = 'identity-test-passphrase';
+
+// Encrypted cases run the real Argon2id KDF (t=3, m=64 MiB) several times.
+const TEST_TIMEOUT_MS = 60_000;
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const program = buildProgram();
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown): boolean => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws on commander errors; captured via exitCode below */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+/** Extract the identity block (header through the blank line before Discovery). */
+function identityBlock(cardTurtle: string): string {
+  const m = cardTurtle.match(
+    /    # ── Identity \(safe to make public\) ──\n[\s\S]*?\n\n {4}# ── Discovery/,
+  );
+  return m ? m[0] : '';
+}
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-identity-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  delete process.env.CASCADE_POD_PASSPHRASE;
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  tmpDirs = [];
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('identity helpers (pure)', () => {
+  it('deriveCardIdentityName splits exactly two tokens into given/family', () => {
+    expect(deriveCardIdentityName('Jane Doe')).toEqual({
+      fullName: 'Jane Doe',
+      givenName: 'Jane',
+      familyName: 'Doe',
+    });
+  });
+
+  it('deriveCardIdentityName records name only for one token', () => {
+    expect(deriveCardIdentityName('Prince')).toEqual({ fullName: 'Prince' });
+  });
+
+  it('deriveCardIdentityName records name only for three or more tokens', () => {
+    expect(deriveCardIdentityName('Mary Jane Watson')).toEqual({ fullName: 'Mary Jane Watson' });
+  });
+
+  it('deriveCardIdentityName collapses internal whitespace and trims', () => {
+    expect(deriveCardIdentityName('  Jane   Doe  ')).toEqual({
+      fullName: 'Jane Doe',
+      givenName: 'Jane',
+      familyName: 'Doe',
+    });
+  });
+
+  it('deriveCardIdentityName yields no parts for empty/whitespace input', () => {
+    expect(deriveCardIdentityName('   ')).toEqual({});
+    expect(deriveCardIdentityName('')).toEqual({});
+  });
+
+  it('applyCardIdentityName is a no-op when no name parts are supplied', () => {
+    const card = '    # ── Identity (safe to make public) ──\n    # foaf:name "First Last" ;\n';
+    expect(applyCardIdentityName(card, {})).toBe(card);
+  });
+
+  it('applyCardIdentityName replaces the commented placeholder block', () => {
+    const card =
+      '<#me> a foaf:Person ;\n' +
+      '    # ── Identity (safe to make public) ──\n' +
+      '    # foaf:name "First Last" ;\n' +
+      '    # foaf:givenName "First" ;\n' +
+      '    # foaf:familyName "Last" ;\n' +
+      '\n' +
+      '    # ── Discovery links (do not remove) ──\n';
+    const out = applyCardIdentityName(card, deriveCardIdentityName('Jane Doe'));
+    expect(out).toContain('    foaf:name "Jane Doe" ;');
+    expect(out).toContain('    foaf:givenName "Jane" ;');
+    expect(out).toContain('    foaf:familyName "Doe" ;');
+    expect(out).not.toContain('# foaf:name "First Last"');
+  });
+
+  it('stripCardIdentityName removes populated identity triples, leaving the header', () => {
+    const named =
+      '    # ── Identity (safe to make public) ──\n' +
+      '    foaf:name "Jane Doe" ;\n' +
+      '    foaf:givenName "Jane" ;\n' +
+      '    foaf:familyName "Doe" ;\n' +
+      '\n' +
+      '    # ── Discovery links (do not remove) ──\n';
+    const stripped = stripCardIdentityName(named);
+    expect(stripped).not.toContain('foaf:name "Jane Doe"');
+    expect(stripped).toContain('    # ── Identity (safe to make public) ──\n');
+    expect(stripped).toContain('    # ── Discovery links (do not remove) ──\n');
+  });
+
+  it('stripCardIdentityName leaves a commented (unnamed) block untouched', () => {
+    const commented =
+      '    # ── Identity (safe to make public) ──\n' +
+      '    # foaf:name "First Last" ;\n' +
+      '\n' +
+      '    # ── Discovery links (do not remove) ──\n';
+    expect(stripCardIdentityName(commented)).toBe(commented);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('pod init --owner-name (plaintext)', () => {
+  it('writes foaf name triples into card.ttl', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const { exitCode } = await runCli(['pod', 'init', dir, '--owner-name', 'Jane Doe']);
+    expect(exitCode).toBe(0);
+    const card = fs.readFileSync(path.join(dir, 'profile', 'card.ttl'), 'utf-8');
+    expect(card).toContain('    foaf:name "Jane Doe" ;');
+    expect(card).toContain('    foaf:givenName "Jane" ;');
+    expect(card).toContain('    foaf:familyName "Doe" ;');
+    expect(card).not.toContain('# foaf:name "First Last"');
+  });
+
+  it('records name only for a single-token owner name', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir, '--owner-name', 'Prince']);
+    const card = fs.readFileSync(path.join(dir, 'profile', 'card.ttl'), 'utf-8');
+    expect(card).toContain('    foaf:name "Prince" ;');
+    expect(card).not.toContain('foaf:givenName');
+    expect(card).not.toContain('foaf:familyName');
+  });
+
+  it('no --owner-name flag => byte-identical card.ttl to today (commented placeholders)', async () => {
+    const a = path.join(mkTmpDir(), 'pod');
+    const b = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', a]);
+    await runCli(['pod', 'init', b]);
+    const cardA = fs.readFileSync(path.join(a, 'profile', 'card.ttl'), 'utf-8');
+    const cardB = fs.readFileSync(path.join(b, 'profile', 'card.ttl'), 'utf-8');
+    // Two nameless inits produce identical card.ttl, and the identity block is
+    // still the commented placeholder (no regression from the shared helper).
+    expect(cardA).toBe(cardB);
+    expect(cardA).toContain('    # foaf:name "First Last" ;');
+    expect(cardA).not.toContain('    foaf:name "');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('pod profile set-name (plaintext)', () => {
+  it('round-trips: sets the name, pod info reads it back', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir]);
+    const set = await runCli(['pod', 'profile', 'set-name', dir, 'Jane Doe']);
+    expect(set.exitCode).toBe(0);
+    const info = await runCli(['--json', 'pod', 'info', dir]);
+    expect(info.exitCode).toBe(0);
+    expect(JSON.parse(info.stdout).patient.name).toBe('Jane Doe');
+  });
+
+  it('re-naming is idempotent (no duplicate foaf:name triples)', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir, '--owner-name', 'Jane Doe']);
+    await runCli(['pod', 'profile', 'set-name', dir, 'Prince']);
+    await runCli(['pod', 'profile', 'set-name', dir, 'Mary Major']);
+    const card = fs.readFileSync(path.join(dir, 'profile', 'card.ttl'), 'utf-8');
+    expect((card.match(/foaf:name /g) ?? []).length).toBe(1);
+    expect(card).toContain('    foaf:name "Mary Major" ;');
+    expect(card).not.toContain('Jane Doe');
+    expect(card).not.toContain('Prince');
+  });
+
+  it('rejects an empty name', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir]);
+    const set = await runCli(['pod', 'profile', 'set-name', dir, '   ']);
+    expect(set.exitCode).toBe(1);
+  });
+
+  it('rejects a directory that is not a pod', async () => {
+    const dir = path.join(mkTmpDir(), 'not-a-pod');
+    fs.mkdirSync(dir, { recursive: true });
+    const set = await runCli(['pod', 'profile', 'set-name', dir, 'Jane Doe']);
+    expect(set.exitCode).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('byte-consistency across writers', () => {
+  it('import Step 9b and pod init --owner-name emit the same identity block', async () => {
+    // Import path: fresh pod, then import the C-CDA fixture (patient "Jane Doe").
+    const importedPod = path.join(mkTmpDir(), 'imported');
+    await runCli(['pod', 'init', importedPod]);
+    const imp = await runCli(['pod', 'import', importedPod, CCDA_FIXTURE]);
+    expect(imp.exitCode).toBe(0);
+
+    // Init path: same name via the CLI flag.
+    const initPod = path.join(mkTmpDir(), 'init');
+    await runCli(['pod', 'init', initPod, '--owner-name', 'Jane Doe']);
+
+    const importedBlock = identityBlock(
+      fs.readFileSync(path.join(importedPod, 'profile', 'card.ttl'), 'utf-8'),
+    );
+    const initBlock = identityBlock(
+      fs.readFileSync(path.join(initPod, 'profile', 'card.ttl'), 'utf-8'),
+    );
+    expect(importedBlock).not.toBe('');
+    expect(importedBlock).toBe(initBlock);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('encrypted pods (V1 + V2)', () => {
+  beforeEach(() => {
+    process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+  });
+
+  it('init --encrypt --owner-name resolves the passphrase from env (no TTY) and encrypts the name', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    const { exitCode } = await runCli(['pod', 'init', dir, '--encrypt', '--owner-name', 'Alex Encrypted']);
+    expect(exitCode).toBe(0);
+    // card.ttl is ciphertext on disk (no readable @prefix or plaintext name).
+    const cardBytes = fs.readFileSync(path.join(dir, 'profile', 'card.ttl')).toString('utf-8');
+    expect(cardBytes).not.toContain('@prefix');
+    expect(cardBytes).not.toContain('Alex Encrypted');
+    // pod info decrypts the name via the env passphrase.
+    const info = await runCli(['--json', 'pod', 'info', dir]);
+    expect(JSON.parse(info.stdout).patient.name).toBe('Alex Encrypted');
+  }, TEST_TIMEOUT_MS);
+
+  it('set-name round-trips on an encrypted pod', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt']);
+    const set = await runCli(['pod', 'profile', 'set-name', dir, 'Blair Encrypted']);
+    expect(set.exitCode).toBe(0);
+    const cardBytes = fs.readFileSync(path.join(dir, 'profile', 'card.ttl')).toString('utf-8');
+    expect(cardBytes).not.toContain('Blair Encrypted'); // still ciphertext
+    const info = await runCli(['--json', 'pod', 'info', dir]);
+    expect(JSON.parse(info.stdout).patient.name).toBe('Blair Encrypted');
+  }, TEST_TIMEOUT_MS);
+
+  it('pod info omits the name (no crash) when the passphrase is unavailable', async () => {
+    const dir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', dir, '--encrypt', '--owner-name', 'Alex Encrypted']);
+    delete process.env.CASCADE_POD_PASSPHRASE;
+    const info = await runCli(['--json', 'pod', 'info', dir]);
+    expect(info.exitCode).toBe(0);
+    expect(JSON.parse(info.stdout).patient.name).toBeUndefined();
+  }, TEST_TIMEOUT_MS);
+});


### PR DESCRIPTION
## Summary

Adds a name-writing surface for pod owner identity in `profile/card.ttl`, so a pod can be given a patient name at creation or on an existing pod without hand-editing Turtle.

- `pod init --owner-name <name>`: writes `foaf:name` (with a given/family split when the name is exactly two tokens, name-only otherwise) at init, routed through `writeResource` so `--encrypt` pods encrypt it. Without the flag, `card.ttl` output is byte-identical to before.
- `pod profile set-name <dir> <name>` (new): sets the name on an existing pod, encryption-aware via `resolveDek` + `readResource`/`writeResource`; idempotent on re-name (no duplicate triples).
- The card identity-block replacement is factored out of `pod import` into a shared helper (`applyCardIdentityName`) used by all three writers, so their `card.ttl` output stays byte-consistent; import behavior is unchanged.
- `pod info` resolves the owner name on encrypted pods from `CASCADE_POD_PASSPHRASE` (env-only, graceful when the passphrase is absent).

## Tests

20 new tests (identity helpers, init name, set-name round-trip on plaintext and encrypted pods, no-flag no-regression, and byte-consistency of the import identity block vs init). `tsc --noEmit` clean.

## Verify notes

- `pod init --encrypt --owner-name` resolves the passphrase from `CASCADE_POD_PASSPHRASE` with no TTY and does not prompt (env wins before the TTY and confirm checks).
- `pod info --json` exposes the owner name at `patient.name`; on an encrypted pod with no passphrase available it returns `patient: {}` and exits 0.

Follow-ups discovered and filed separately: the FHIR converter does not populate the patient name into the profile (so FHIR imports leave `card.ttl` nameless where C-CDA does not); `pod info` record counts are not yet DEK-aware on encrypted pods; owner-name writers do not escape Turtle string literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
