### PR TITLE
fix(pod import): sniff input bytes, and read pod-internal resources with the pod DEK

### DIFF
--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -57,6 +57,7 @@ import {
   PodDecryptError,
 } from '../../lib/pod-encryption.js';
 import { obtainPassphrase } from '../../lib/passphrase.js';
+import { classifyImportInput, isPathInsidePod } from '../../lib/import-input.js';
 
 // ---------------------------------------------------------------------------
 // Import report type
@@ -461,10 +462,35 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         } catch {
           // stat failed; let the read below produce the precise error.
         }
-        const isZip = absPath.toLowerCase().endsWith('.zip') || absPath.toLowerCase().endsWith('.xml');
-        let rawContent: string | Buffer;
+        // Read the input. Almost every input is an EXTERNAL document (a C-CDA
+        // the user picked out of Downloads) and is plaintext on disk. The one
+        // exception is an input that resolves INSIDE the destination pod — an
+        // app writing a bundle to `<pod>/analysis/<id>.ttl` and importing the
+        // file it just wrote. That is a pod resource, so on an encrypted pod it
+        // must be read through the DEK we already resolved above (root 4.23).
+        // Containment is decided by the filesystem, not by a flag, because a
+        // flag would eventually be passed for a genuinely external file.
+        let rawBytes: Buffer;
         try {
-          rawContent = isZip ? await fs.readFile(absPath) : await fs.readFile(absPath, 'utf-8');
+          let decrypted: string | undefined;
+          if (dek && isPathInsidePod(absPath, podDir)) {
+            try {
+              decrypted = readResource(absPath, dek);
+              printVerbose(`Input is a pod resource; decrypted with the pod DEK: ${filePath}`, globalOpts);
+            } catch (e) {
+              if (!(e instanceof PodDecryptError)) throw e;
+              // A pod-internal resource that does not authenticate under the pod
+              // DEK is a plaintext leftover (`pod encrypt` seals only some
+              // containers today — root 4.25). Read it as plaintext rather than
+              // failing an import that would otherwise succeed.
+              printVerbose(
+                `Pod resource ${filePath} did not decrypt under the pod DEK; reading it as plaintext.`,
+                globalOpts,
+              );
+            }
+          }
+          rawBytes =
+            decrypted !== undefined ? Buffer.from(decrypted, 'utf-8') : await fs.readFile(absPath);
         } catch {
           printError(`Cannot read file: ${absPath}`, globalOpts);
           process.exitCode = 1;
@@ -478,11 +504,16 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         let turtleContent: string;
         let resourceCount = 0;
 
-        // Detect C-CDA ZIP/XML vs FHIR JSON vs Turtle
-        if (Buffer.isBuffer(rawContent)) {
+        // Route C-CDA ZIP/XML vs FHIR JSON vs Turtle. A recognized extension is
+        // the fast path; a missing or unrecognized extension is decided by
+        // sniffing the bytes, because real portal downloads arrive
+        // extension-less and an IHE XDM zip that reaches the Turtle parser dies
+        // with `Unexpected "PK..."` (root 2.8).
+        const inputKind = classifyImportInput(absPath, rawBytes);
+        if (inputKind === 'ccda') {
           // C-CDA ZIP or XML — convert natively
           printVerbose(`Converting C-CDA: ${filePath}`, globalOpts);
-          const result = await convert(rawContent, 'c-cda', 'cascade', 'turtle', systemName, passthroughMinimal, undefined, true);
+          const result = await convert(rawBytes, 'c-cda', 'cascade', 'turtle', systemName, passthroughMinimal, undefined, true);
           if (!result.success) {
             // Skip an unconvertible file with a reason rather than aborting the
             // whole batch: in a folder import (e.g. an IHE XDM export's manifest,
@@ -508,10 +539,8 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
             }
           }
         } else {
-          const content = rawContent;
-          const trimmed = content.trim();
-        // Detect FHIR JSON vs Turtle
-        if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+          const content = rawBytes.toString('utf-8');
+        if (inputKind === 'fhir-json') {
           // FHIR JSON
           printVerbose(`Converting FHIR JSON: ${filePath}`, globalOpts);
           // deferLiteralLifting + deferReferenceResolution: the condition a

--- a/src/lib/import-input.ts
+++ b/src/lib/import-input.ts
@@ -1,0 +1,173 @@
+/**
+ * Input routing for `cascade pod import`.
+ *
+ * Two decisions live here, both about the file the user handed us:
+ *
+ *  1. WHAT is it? (`classifyImportInput`) — C-CDA (zip or XML), FHIR JSON, or
+ *     Cascade Turtle. A recognized extension is the fast path; anything with a
+ *     missing or unrecognized extension is decided by SNIFFING THE BYTES, never
+ *     by the name. Real portal downloads arrive extension-less (a URL-derived
+ *     filename with no suffix), and an IHE XDM zip that falls through to the
+ *     Turtle parser dies with `Unexpected "PK..."`.
+ *
+ *  2. WHERE is it? (`isPathInsidePod`) — an input path that resolves INSIDE the
+ *     destination pod is a pod resource, not an external document, so on an
+ *     encrypted pod it must be read through the pod DEK rather than as
+ *     plaintext. Containment is answered by the filesystem (device + inode
+ *     identity on the fully resolved path), not by string prefixes, because
+ *     symlinks, `..` and case-insensitive filesystems all make string
+ *     comparison wrong. Getting this wrong in the permissive direction would
+ *     mean trying to decrypt a genuinely external file, so every uncertain case
+ *     answers "outside".
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── 1. What kind of document is this? ────────────────────────────────────────
+
+/** The three converter paths `pod import` can route an input to. */
+export type ImportInputKind = 'ccda' | 'fhir-json' | 'turtle';
+
+/**
+ * Extensions routed straight to the C-CDA converter (which takes raw bytes and
+ * handles both a bare XML document and an IHE XDM zip).
+ */
+const CCDA_EXTENSIONS = new Set(['.zip', '.xml']);
+
+/**
+ * Extensions whose content is known to be text. These keep the historical
+ * leading-character rule (`{`/`[` means FHIR JSON, anything else is Turtle) so
+ * a `.ttl` document that legitimately opens with an IRI is never re-routed.
+ */
+const TEXT_EXTENSIONS = new Set(['.json', '.jsonld', '.ndjson', '.ttl']);
+
+/** Bytes to decode when sniffing a header; enough for any leading whitespace. */
+const SNIFF_WINDOW = 512;
+
+/**
+ * True when the decoded head of `bytes` opens a JSON object or array.
+ * A UTF-8 BOM and any leading whitespace are skipped first.
+ */
+function looksLikeJson(bytes: Buffer): boolean {
+  const head = decodeHead(bytes);
+  return head.startsWith('{') || head.startsWith('[');
+}
+
+/** Decode the first {@link SNIFF_WINDOW} bytes, skipping a BOM and whitespace. */
+function decodeHead(bytes: Buffer): string {
+  let start = 0;
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    start = 3; // UTF-8 BOM
+  }
+  // A multi-byte character may be cut at the window edge; only the START of the
+  // decoded text is ever inspected, so a trailing replacement char is harmless.
+  return bytes.subarray(start, start + SNIFF_WINDOW).toString('utf-8').trimStart();
+}
+
+/**
+ * True when `bytes` begins with a ZIP signature: a local file header
+ * (`PK\x03\x04`), an empty archive's end-of-central-directory (`PK\x05\x06`),
+ * or a spanned archive marker (`PK\x07\x08`).
+ */
+export function looksLikeZip(bytes: Buffer): boolean {
+  if (bytes.length < 4) return false;
+  if (bytes[0] !== 0x50 || bytes[1] !== 0x4b) return false; // 'P' 'K'
+  const [b2, b3] = [bytes[2], bytes[3]];
+  return (
+    (b2 === 0x03 && b3 === 0x04) ||
+    (b2 === 0x05 && b3 === 0x06) ||
+    (b2 === 0x07 && b3 === 0x08)
+  );
+}
+
+/**
+ * True when `bytes` begins with an XML declaration or a bare C-CDA root
+ * element. Deliberately narrow: Turtle may legitimately start with `<` (an
+ * IRI), so a generic "starts with an angle bracket" test would misroute it.
+ */
+export function looksLikeCcdaXml(bytes: Buffer): boolean {
+  const head = decodeHead(bytes);
+  return head.startsWith('<?xml') || head.startsWith('<ClinicalDocument');
+}
+
+/**
+ * Decide the kind of an import input from its bytes alone. Returns `undefined`
+ * when nothing recognizable is at the head, which the caller reads as "no
+ * evidence" rather than "Turtle".
+ */
+export function sniffImportInput(bytes: Buffer): ImportInputKind | undefined {
+  if (looksLikeZip(bytes)) return 'ccda';
+  if (looksLikeCcdaXml(bytes)) return 'ccda';
+  if (looksLikeJson(bytes)) return 'fhir-json';
+  return undefined;
+}
+
+/**
+ * Route one import input to a converter path.
+ *
+ * Fast path: a recognized extension decides without reading the head. When the
+ * extension is missing or unrecognized the bytes decide, and Turtle remains the
+ * final fallback (unchanged from the extension-only behavior).
+ *
+ * @param filePath the input path (only its extension is consulted)
+ * @param bytes    the file's content, already decrypted if it was a pod resource
+ */
+export function classifyImportInput(filePath: string, bytes: Buffer): ImportInputKind {
+  const ext = path.extname(filePath).toLowerCase();
+  if (CCDA_EXTENSIONS.has(ext)) return 'ccda';
+  if (TEXT_EXTENSIONS.has(ext)) return looksLikeJson(bytes) ? 'fhir-json' : 'turtle';
+  return sniffImportInput(bytes) ?? 'turtle';
+}
+
+// ─── 2. Is this input a resource of the destination pod? ──────────────────────
+
+/**
+ * True when `filePath` resolves to a location inside `podDir`.
+ *
+ * Both paths are fully resolved (`fs.realpathSync`) before comparison, then the
+ * input's ancestor chain is walked comparing device + inode against the pod
+ * directory. Identity by inode is what makes this correct on a case-insensitive
+ * filesystem and through symlinked ancestors (`/tmp` -> `/private/tmp`) without
+ * guessing at case-folding rules.
+ *
+ * Conservative by construction:
+ *  - The input file's OWN symlink is resolved, so a link planted inside the pod
+ *    that points at an external file answers "outside".
+ *  - Any error (missing file, unreadable directory) answers "outside", which
+ *    means "treat it as an external plaintext document" — the pre-existing
+ *    behavior.
+ *  - The pod directory itself is not "inside" itself; only descendants are.
+ */
+export function isPathInsidePod(filePath: string, podDir: string): boolean {
+  let podStat: fs.Stats;
+  try {
+    podStat = fs.statSync(fs.realpathSync(podDir));
+  } catch {
+    return false;
+  }
+  if (!podStat.isDirectory()) return false;
+
+  let current: string;
+  try {
+    // Resolve the input itself, then start the walk at its parent: a file is
+    // "inside" the pod when one of its ANCESTORS is the pod directory.
+    current = path.dirname(fs.realpathSync(filePath));
+  } catch {
+    return false;
+  }
+
+  // Bounded by the filesystem depth of the resolved path.
+  for (;;) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(current);
+    } catch {
+      return false;
+    }
+    if (stat.dev === podStat.dev && stat.ino === podStat.ino) return true;
+    const parent = path.dirname(current);
+    if (parent === current) return false; // reached the filesystem root
+    current = parent;
+  }
+}

--- a/tests/pod-import-input-routing.test.ts
+++ b/tests/pod-import-input-routing.test.ts
@@ -1,0 +1,566 @@
+/**
+ * `pod import` input routing and pod-internal resource reads.
+ *
+ * Covers two defects:
+ *
+ *   root 2.8 — routing was by filename suffix only, so an extension-less IHE
+ *   XDM zip (what a real portal download looks like) fell through to the Turtle
+ *   parser and died with `Unexpected "PK..."`. The bytes now decide when the
+ *   extension is missing or unrecognized.
+ *
+ *   root 4.23 — every input was read as plaintext, so a bundle written to
+ *   `<pod>/analysis/<id>.ttl` on an ENCRYPTED pod could not be imported back.
+ *   An input that resolves inside the destination pod is now read through the
+ *   pod DEK the command already holds.
+ *
+ * All documents here are synthetic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import AdmZip from 'adm-zip';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import {
+  classifyImportInput,
+  sniffImportInput,
+  looksLikeZip,
+  looksLikeCcdaXml,
+  isPathInsidePod,
+} from '../src/lib/import-input.js';
+import { resolveDek, writeResource } from '../src/lib/pod-encryption.js';
+
+const PASSPHRASE = 'input-routing-test-passphrase';
+
+// `pod init --encrypt` + `pod import` run the real Argon2id KDF (t=3, m=64 MiB)
+// several times per test, which is deliberately slow.
+const TEST_TIMEOUT_MS = 60_000;
+
+// ─── CLI harness ──────────────────────────────────────────────────────────────
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const program = buildProgram();
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown): boolean => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+// ─── Synthetic documents ──────────────────────────────────────────────────────
+
+/** A minimal but structurally valid C-CDA with one immunization entry. */
+function syntheticCcdaXml(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.3.88.11.32.1" extension="ROUTING-FIXTURE-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Extension-less Routing Fixture</title>
+  <effectiveTime value="20260101120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.4.1" extension="000-00-0000"/>
+      <patient>
+        <name use="L"><given>Testy</given><family>McTestface</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19850412"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+          <code code="11369-6" displayName="History of Immunization Narrative" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Immunizations</title>
+          <text>Influenza, seasonal (CVX 140) - 2023-10-01</text>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+              <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="ROUTING-IMMUN-001"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20231001"/>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                  <manufacturedMaterial>
+                    <code code="140" displayName="Influenza, seasonal, injectable, preservative free" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX"/>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>
+`;
+}
+
+/**
+ * An IHE-XDM-shaped zip: the C-CDA lives under a subdirectory beside an
+ * INDEX.HTM, exactly like a portal "download my record" bundle.
+ */
+function syntheticXdmZip(): Buffer {
+  const zip = new AdmZip();
+  zip.addFile('INDEX.HTM', Buffer.from('<html><body>Portal export</body></html>', 'utf-8'));
+  zip.addFile('IHE_XDM/SUBSET01/DOCUMENT.XML', Buffer.from(syntheticCcdaXml(), 'utf-8'));
+  return zip.toBuffer();
+}
+
+/** Synthetic FHIR bundle: a Patient plus two MedicationStatements. */
+function syntheticFhirBundle(): string {
+  return JSON.stringify({
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: 'pat-1',
+          name: [{ given: ['Testy'], family: 'McTestface' }],
+          gender: 'female',
+          birthDate: '1985-04-12',
+        },
+      },
+      {
+        resource: {
+          resourceType: 'MedicationStatement',
+          id: 'med-1',
+          status: 'active',
+          medicationCodeableConcept: {
+            coding: [
+              {
+                system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+                code: '197361',
+                display: 'Lisinopril 10 MG',
+              },
+            ],
+            text: 'Lisinopril 10 MG',
+          },
+          subject: { reference: 'Patient/pat-1' },
+        },
+      },
+      {
+        resource: {
+          resourceType: 'MedicationStatement',
+          id: 'med-2',
+          status: 'active',
+          medicationCodeableConcept: {
+            coding: [
+              {
+                system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+                code: '860975',
+                display: 'Metformin 500 MG',
+              },
+            ],
+            text: 'Metformin 500 MG',
+          },
+          subject: { reference: 'Patient/pat-1' },
+        },
+      },
+    ],
+  });
+}
+
+/**
+ * A Cascade Turtle bundle shaped like what an app writes to
+ * `<pod>/analysis/<id>.ttl`: two conditions carrying AI-extracted provenance.
+ */
+function syntheticAnalysisBundle(): string {
+  return `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:uuid:11111111-1111-4111-8111-111111111111>
+    a health:ConditionRecord ;
+    rdfs:label "Seasonal allergic rhinitis" ;
+    cascade:dataProvenance cascade:AIExtracted ;
+    cascade:recordedAt "2026-01-01T00:00:00Z"^^xsd:dateTime .
+
+<urn:uuid:22222222-2222-4222-8222-222222222222>
+    a health:ConditionRecord ;
+    rdfs:label "Vitamin D deficiency" ;
+    cascade:dataProvenance cascade:AIExtracted ;
+    cascade:recordedAt "2026-01-01T00:00:00Z"^^xsd:dateTime .
+`;
+}
+
+// ─── Temp dirs ────────────────────────────────────────────────────────────────
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-import-routing-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+beforeEach(() => {
+  delete process.env.CASCADE_POD_PASSPHRASE;
+});
+
+afterEach(() => {
+  delete process.env.CASCADE_POD_PASSPHRASE;
+  for (const d of tmpDirs) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  tmpDirs = [];
+});
+
+// ─── Unit: byte sniffing (root 2.8) ───────────────────────────────────────────
+
+describe('import input sniffing (root 2.8)', () => {
+  it('recognizes the three ZIP signatures and nothing else', () => {
+    expect(looksLikeZip(Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14]))).toBe(true);
+    expect(looksLikeZip(Buffer.from([0x50, 0x4b, 0x05, 0x06]))).toBe(true); // empty archive
+    expect(looksLikeZip(Buffer.from([0x50, 0x4b, 0x07, 0x08]))).toBe(true); // spanned
+    expect(looksLikeZip(Buffer.from([0x50, 0x4b, 0x01, 0x02]))).toBe(false); // central dir header
+    expect(looksLikeZip(Buffer.from('PK', 'utf-8'))).toBe(false); // too short
+    expect(looksLikeZip(Buffer.from('@prefix clinical: <x> .', 'utf-8'))).toBe(false);
+  });
+
+  it('recognizes an XML declaration and a bare ClinicalDocument root', () => {
+    expect(looksLikeCcdaXml(Buffer.from('<?xml version="1.0"?><ClinicalDocument/>', 'utf-8'))).toBe(true);
+    expect(looksLikeCcdaXml(Buffer.from('<ClinicalDocument xmlns="urn:hl7-org:v3"/>', 'utf-8'))).toBe(true);
+    // Leading whitespace and a UTF-8 BOM must not hide the marker.
+    expect(looksLikeCcdaXml(Buffer.from('\n\n  <?xml version="1.0"?>', 'utf-8'))).toBe(true);
+    expect(
+      looksLikeCcdaXml(
+        Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('<?xml version="1.0"?>', 'utf-8')]),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT treat Turtle that opens with an IRI as XML', () => {
+    const turtle = Buffer.from('<https://example.org/a> <https://example.org/b> "c" .', 'utf-8');
+    expect(looksLikeCcdaXml(turtle)).toBe(false);
+    expect(sniffImportInput(turtle)).toBeUndefined();
+  });
+
+  it('sniffs JSON objects and arrays', () => {
+    expect(sniffImportInput(Buffer.from('  {"resourceType":"Bundle"}', 'utf-8'))).toBe('fhir-json');
+    expect(sniffImportInput(Buffer.from('[{"resourceType":"Patient"}]', 'utf-8'))).toBe('fhir-json');
+  });
+});
+
+describe('import input classification (root 2.8)', () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const xmlBytes = Buffer.from(syntheticCcdaXml(), 'utf-8');
+  const jsonBytes = Buffer.from(syntheticFhirBundle(), 'utf-8');
+  const turtleBytes = Buffer.from(syntheticAnalysisBundle(), 'utf-8');
+
+  it('keeps the extension fast path for recognized names', () => {
+    expect(classifyImportInput('/x/export.zip', zipBytes)).toBe('ccda');
+    expect(classifyImportInput('/x/EXPORT.ZIP', zipBytes)).toBe('ccda'); // case-insensitive
+    expect(classifyImportInput('/x/ccd.xml', xmlBytes)).toBe('ccda');
+    expect(classifyImportInput('/x/bundle.json', jsonBytes)).toBe('fhir-json');
+    expect(classifyImportInput('/x/records.ttl', turtleBytes)).toBe('turtle');
+  });
+
+  it('routes an extension-less file by its bytes, not its name', () => {
+    expect(classifyImportInput('/x/1-Download', zipBytes)).toBe('ccda');
+    expect(classifyImportInput('/x/1-Download', xmlBytes)).toBe('ccda');
+    expect(classifyImportInput('/x/1-Download', jsonBytes)).toBe('fhir-json');
+    expect(classifyImportInput('/x/1-Download', turtleBytes)).toBe('turtle');
+  });
+
+  it('routes an unrecognized extension by its bytes too', () => {
+    expect(classifyImportInput('/x/download.bin', zipBytes)).toBe('ccda');
+    expect(classifyImportInput('/x/download.txt', xmlBytes)).toBe('ccda');
+    expect(classifyImportInput('/x/download.dat', jsonBytes)).toBe('fhir-json');
+  });
+
+  it('still falls back to Turtle when nothing is recognizable', () => {
+    expect(classifyImportInput('/x/mystery', Buffer.from('nothing familiar here', 'utf-8'))).toBe('turtle');
+    expect(classifyImportInput('/x/mystery', Buffer.alloc(0))).toBe('turtle');
+  });
+
+  it('does not re-route a .ttl whose content starts with an IRI', () => {
+    const iriTurtle = Buffer.from('<https://example.org/a> a <https://example.org/B> .', 'utf-8');
+    expect(classifyImportInput('/x/records.ttl', iriTurtle)).toBe('turtle');
+  });
+});
+
+// ─── Unit: pod containment (root 4.23) ────────────────────────────────────────
+
+describe('pod containment detection (root 4.23)', () => {
+  it('says inside for a real descendant and outside for a sibling', () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    fs.mkdirSync(path.join(pod, 'analysis'), { recursive: true });
+    const inside = path.join(pod, 'analysis', 'bundle.ttl');
+    fs.writeFileSync(inside, 'x');
+
+    const outside = path.join(root, 'bundle.ttl');
+    fs.writeFileSync(outside, 'x');
+
+    expect(isPathInsidePod(inside, pod)).toBe(true);
+    expect(isPathInsidePod(outside, pod)).toBe(false);
+  });
+
+  it('resolves `..` rather than trusting the literal path', () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    fs.mkdirSync(path.join(pod, 'analysis'), { recursive: true });
+    const outside = path.join(root, 'bundle.ttl');
+    fs.writeFileSync(outside, 'x');
+
+    // Spelled as if it were inside the pod, but `..` walks back out.
+    const sneaky = path.join(pod, 'analysis', '..', '..', 'bundle.ttl');
+    expect(isPathInsidePod(sneaky, pod)).toBe(false);
+  });
+
+  it('follows a symlink planted inside the pod back out to its real location', () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    fs.mkdirSync(path.join(pod, 'analysis'), { recursive: true });
+    const external = path.join(root, 'external.ttl');
+    fs.writeFileSync(external, 'x');
+
+    const link = path.join(pod, 'analysis', 'link.ttl');
+    fs.symlinkSync(external, link);
+
+    // The link LOOKS pod-internal; its target is not, so it must read as external.
+    expect(isPathInsidePod(link, pod)).toBe(false);
+  });
+
+  it('sees through a symlinked ancestor of the pod itself', () => {
+    const root = mkTmpDir();
+    const realPod = path.join(root, 'real-pod');
+    fs.mkdirSync(path.join(realPod, 'analysis'), { recursive: true });
+    const inside = path.join(realPod, 'analysis', 'bundle.ttl');
+    fs.writeFileSync(inside, 'x');
+
+    const alias = path.join(root, 'alias-pod');
+    fs.symlinkSync(realPod, alias);
+
+    // Pod named through the alias, file named through the real path (and vice
+    // versa): both are the same directory, so both must answer "inside".
+    expect(isPathInsidePod(inside, alias)).toBe(true);
+    expect(isPathInsidePod(path.join(alias, 'analysis', 'bundle.ttl'), realPod)).toBe(true);
+  });
+
+  it('does not call the pod directory itself, or a missing file, inside', () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    fs.mkdirSync(pod, { recursive: true });
+
+    expect(isPathInsidePod(pod, pod)).toBe(false);
+    expect(isPathInsidePod(path.join(pod, 'nope.ttl'), pod)).toBe(false);
+    expect(isPathInsidePod(path.join(pod, 'a.ttl'), path.join(root, 'no-such-pod'))).toBe(false);
+  });
+
+  it('is not fooled by a pod-name prefix on a sibling directory', () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    fs.mkdirSync(pod, { recursive: true });
+    const decoy = path.join(root, 'pod-backup');
+    fs.mkdirSync(decoy, { recursive: true });
+    const file = path.join(decoy, 'bundle.ttl');
+    fs.writeFileSync(file, 'x');
+
+    // A naive string-prefix check would call `/root/pod-backup/...` inside `/root/pod`.
+    expect(isPathInsidePod(file, pod)).toBe(false);
+  });
+});
+
+// ─── Integration: extension-less inputs (root 2.8) ────────────────────────────
+
+describe('pod import: extension-less inputs (root 2.8)', () => {
+  it('imports an extension-less IHE XDM zip instead of failing in the Turtle parser', async () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod]);
+
+    // A portal capture: URL-derived name, no suffix, real zip bytes.
+    const capture = path.join(root, '1-Download');
+    fs.writeFileSync(capture, syntheticXdmZip());
+
+    const imp = await runCli(['--json', 'pod', 'import', pod, capture]);
+    expect(imp.exitCode).toBe(0);
+    expect(imp.stdout).not.toContain('Unexpected "PK');
+
+    const report = JSON.parse(imp.stdout);
+    expect(report.totalRecordsImported).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(pod, 'clinical', 'immunizations.ttl'))).toBe(true);
+  }, TEST_TIMEOUT_MS);
+
+  it('imports an extension-less C-CDA XML document', async () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod]);
+
+    const capture = path.join(root, 'ccda-no-extension');
+    fs.writeFileSync(capture, syntheticCcdaXml(), 'utf-8');
+
+    const imp = await runCli(['--json', 'pod', 'import', pod, capture]);
+    expect(imp.exitCode).toBe(0);
+    const report = JSON.parse(imp.stdout);
+    expect(report.totalRecordsImported).toBeGreaterThan(0);
+  }, TEST_TIMEOUT_MS);
+
+  it('imports an extension-less FHIR bundle (unchanged behavior, guarded)', async () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod]);
+
+    const capture = path.join(root, 'fhir-no-extension');
+    fs.writeFileSync(capture, syntheticFhirBundle(), 'utf-8');
+
+    const imp = await runCli(['--json', 'pod', 'import', pod, capture]);
+    expect(imp.exitCode).toBe(0);
+
+    const q = await runCli(['--json', 'pod', 'query', pod, '--medications']);
+    expect(JSON.parse(q.stdout).dataTypes.medications.count).toBe(2);
+  }, TEST_TIMEOUT_MS);
+
+  it('still imports a .zip by its extension (fast path unchanged)', async () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod]);
+
+    const zipPath = path.join(root, 'export.zip');
+    fs.writeFileSync(zipPath, syntheticXdmZip());
+
+    const imp = await runCli(['--json', 'pod', 'import', pod, zipPath]);
+    expect(imp.exitCode).toBe(0);
+    expect(JSON.parse(imp.stdout).totalRecordsImported).toBeGreaterThan(0);
+  }, TEST_TIMEOUT_MS);
+});
+
+// ─── Integration: pod-internal encrypted input (root 4.23) ────────────────────
+
+describe('pod import: pod-internal resources on an encrypted pod (root 4.23)', () => {
+  it('round-trips an encrypted bundle written into <pod>/analysis and imported back', async () => {
+    process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    const init = await runCli(['pod', 'init', pod, '--encrypt']);
+    expect(init.exitCode).toBe(0);
+
+    // Write the bundle the way an app does: sealed with the pod DEK, inside the pod.
+    const dek = resolveDek(pod, PASSPHRASE);
+    const analysisDir = path.join(pod, 'analysis');
+    fs.mkdirSync(analysisDir, { recursive: true });
+    const bundlePath = path.join(analysisDir, 'run-0001.ttl');
+    writeResource(bundlePath, syntheticAnalysisBundle(), dek);
+
+    // It really is ciphertext on disk.
+    const onDisk = fs.readFileSync(bundlePath).toString('utf-8');
+    expect(onDisk).not.toContain('@prefix');
+    expect(onDisk).not.toContain('Vitamin D deficiency');
+
+    // Import it by its POD-INTERNAL path. Before the fix this read ciphertext as
+    // plaintext and failed to parse.
+    const imp = await runCli(['--json', 'pod', 'import', pod, bundlePath]);
+    expect(imp.exitCode).toBe(0);
+    const report = JSON.parse(imp.stdout);
+    expect(report.totalRecordsImported).toBe(2);
+
+    // The records landed in the pod and query reads them back.
+    const q = await runCli(['--json', 'pod', 'query', pod, '--conditions']);
+    expect(q.exitCode).toBe(0);
+    expect(JSON.parse(q.stdout).dataTypes.conditions.count).toBe(2);
+
+    // And the destination file is still sealed.
+    const conditionsBytes = fs
+      .readFileSync(path.join(pod, 'clinical', 'conditions.ttl'))
+      .toString('utf-8');
+    expect(conditionsBytes).not.toContain('@prefix');
+    expect(conditionsBytes).not.toContain('Vitamin D deficiency');
+  }, TEST_TIMEOUT_MS);
+
+  it('still reads a genuinely EXTERNAL file as plaintext on an encrypted pod', async () => {
+    process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod, '--encrypt']);
+
+    // Sits next to the pod, not inside it.
+    const external = path.join(root, 'bundle.json');
+    fs.writeFileSync(external, syntheticFhirBundle(), 'utf-8');
+
+    const imp = await runCli(['pod', 'import', pod, external]);
+    expect(imp.exitCode).toBe(0);
+
+    const q = await runCli(['--json', 'pod', 'query', pod, '--medications']);
+    expect(JSON.parse(q.stdout).dataTypes.medications.count).toBe(2);
+  }, TEST_TIMEOUT_MS);
+
+  it('imports a pod-internal file that is still PLAINTEXT on an encrypted pod', async () => {
+    // `pod encrypt` seals only some containers today (root 4.25), so a pod can
+    // hold a plaintext analysis bundle. It must not become unimportable.
+    process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod, '--encrypt']);
+
+    const analysisDir = path.join(pod, 'analysis');
+    fs.mkdirSync(analysisDir, { recursive: true });
+    const bundlePath = path.join(analysisDir, 'legacy-plaintext.ttl');
+    fs.writeFileSync(bundlePath, syntheticAnalysisBundle(), 'utf-8');
+
+    const imp = await runCli(['--json', 'pod', 'import', pod, bundlePath]);
+    expect(imp.exitCode).toBe(0);
+    expect(JSON.parse(imp.stdout).totalRecordsImported).toBe(2);
+  }, TEST_TIMEOUT_MS);
+
+  it('imports a pod-internal bundle on a PLAINTEXT pod (no DEK, no change)', async () => {
+    const root = mkTmpDir();
+    const pod = path.join(root, 'pod');
+    await runCli(['pod', 'init', pod]);
+
+    const analysisDir = path.join(pod, 'analysis');
+    fs.mkdirSync(analysisDir, { recursive: true });
+    const bundlePath = path.join(analysisDir, 'run-0001.ttl');
+    fs.writeFileSync(bundlePath, syntheticAnalysisBundle(), 'utf-8');
+
+    const imp = await runCli(['--json', 'pod', 'import', pod, bundlePath]);
+    expect(imp.exitCode).toBe(0);
+    expect(JSON.parse(imp.stdout).totalRecordsImported).toBe(2);
+  }, TEST_TIMEOUT_MS);
+});


### PR DESCRIPTION
Two defects in `cascade pod import`, both at the point where the command decides what an input file is and how to read it. They sit a few lines apart, so they are one change.

## 1. Routing was by file extension only (root 2.8)

`isZip = endsWith('.zip') || endsWith('.xml')` decided the C-CDA path, a leading `{`/`[` decided FHIR JSON, and everything else fell through to the Turtle parser. Real portal downloads arrive with a URL-derived name and no suffix, so a genuine IHE XDM zip reached the Turtle parser and exited 1 with `Failed to parse merged Turtle: Unexpected "PK..."`.

A missing or unrecognized extension is now decided by the bytes:

- ZIP local-file / end-of-central-directory / spanned signature -> C-CDA
- `<?xml` or `<ClinicalDocument` (after a UTF-8 BOM and leading whitespace) -> C-CDA
- leading `{` or `[` -> FHIR JSON
- otherwise Turtle, unchanged

Recognized extensions keep their existing fast path, so nothing that imports today changes route. The XML test is deliberately narrow (`<?xml` / `<ClinicalDocument`, not "starts with `<`") because Turtle may legitimately open with an IRI.

## 2. Pod-internal inputs were read as plaintext (root 4.23)

`pod import` assumed every input is an external document: "Input FILES being imported are always plaintext on disk (they are external inputs)". That holds for a C-CDA a user picked out of Downloads. It does not hold for an app that writes a bundle to `<pod>/analysis/<id>.ttl` or `<pod>/literature/<id>.ttl` and imports the file it just wrote. Once those writes are encrypted, the import cannot parse them.

The command already resolves the destination pod's DEK before it writes anything, so an input that resolves INSIDE that pod is now read through `readResource(path, dek)`.

Containment is detected, not flagged. A flag would eventually be passed for a genuinely external file, and the failure mode of a wrong "inside" verdict is attempting to decrypt someone else's document. So the check is answered by the filesystem rather than by string prefixes: both paths are fully resolved with `realpath`, then the input's ancestor chain is walked comparing device + inode against the pod directory. That is correct through symlinked ancestors and on a case-insensitive filesystem without guessing at case-folding rules, it resolves `..`, it follows a symlink planted inside the pod back out to its real location, and every error case answers "outside" (which is the pre-existing behavior).

A pod-internal file that does not authenticate under the pod DEK falls back to a plaintext read, so a partially-sealed pod stays importable.

Nothing changes for a plaintext pod: with no DEK, the containment check is not even consulted.

New module `src/lib/import-input.ts` holds both decisions and is unit-tested directly.

## Tests

23 new tests in `tests/pod-import-input-routing.test.ts`, all documents synthetic and inline.

- Sniffing: the three ZIP signatures, an XML declaration behind whitespace and a BOM, a bare `<ClinicalDocument>` root, and the negative that matters (Turtle opening with an IRI must not read as XML).
- Classification: extension fast path preserved; extension-less and unrecognized-extension inputs routed by content; Turtle still the final fallback.
- Containment: descendant, sibling, `..` escape spelled as if inside, symlink inside the pod pointing out, symlinked ancestor of the pod in both spellings, the pod directory itself, a missing file, and a `pod-backup` sibling that a string-prefix check would wrongly call inside.
- End to end: an extension-less IHE XDM zip and an extension-less C-CDA both import records; a `.zip` still takes the fast path; a sealed bundle written to `<pod>/analysis/run-0001.ttl` imports by its pod-internal path and both records read back through `pod query` while the destination file stays ciphertext; an external file beside an encrypted pod still reads as plaintext; a plaintext leftover inside an encrypted pod still imports.

Checked against the pre-fix command: the extension-less zip, the extension-less C-CDA, and the encrypted round trip all fail without this change; the other 20 pass either way.

Full suite, with `npm run build` and a sibling `conformance` checkout:

- before: 1107 passed, 2 failed, 21 skipped (1130)
- after: 1130 passed, 2 failed, 21 skipped (1153)

The 2 failures are the pre-existing `vcf-conformance` UUID mismatches (root backlog 4.14), unchanged by this branch.

## Downstream

This is the clean fix for the Workbench's at-rest-encryption staging workaround, which currently writes a short-lived plaintext copy of the bundle into `$TMPDIR` for the CLI to read. That workaround gets deleted rather than hardened once this ships. That is a separate repo and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)