### PR TITLE
fix(identity): mint record IRIs from content, never from randomness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Re-importing a document no longer duplicates the records in it that carry no `id`.**
+  This closes the known limitation named in 0.10.0.
+
+  Every importer minted a subject IRI from the source resource's `id`, and when a resource
+  had none, made one up: a random UUID on the FHIR clinical path, `Math.random()` in the
+  genomics converters, and a per-run import timestamp in the phenopacket and C-CDA
+  converters. Because a fresh IRI is indistinguishable from a new record, importing the same
+  document twice produced a second copy of every id-less record in it, on every import,
+  with no warning. `Resource.id` is optional in FHIR, so this was reachable from real
+  payloads — transaction Bundles, contained resources, exported and hand-authored documents,
+  and C-CDA files whose `ClinicalDocument` carries no `<id>`.
+
+  Identity for these resources now comes from the resource's own content: the same record
+  yields the same IRI across runs, across machines, across working directories, and
+  regardless of its position in a bundle. Different records still yield different IRIs.
+
+  **Nothing that already had an `id` changes.** If a source resource carries an identifier,
+  its IRI is byte-for-byte what previous versions minted, so no IRI in an existing pod moves
+  and no re-import is needed. This is not comparable to the 0.10.0 genomics change, which
+  was deliberately IRI-breaking.
+
+  Server-assigned volatile fields are excluded from the content hash — `meta.lastUpdated`,
+  `meta.versionId`, `meta.source` and generated narrative `text` — so a resource re-fetched
+  from an EHR keeps its identity even though the server stamped it with new metadata.
+
+  One behavior worth stating plainly: two id-less resources that carry no distinguishing
+  content at all now collapse to a single IRI rather than multiplying. Records that nothing
+  can tell apart are treated as one record, which is visible and arguable, where the old
+  behavior silently grew a duplicate set forever.
+
 ---
 
 ## [0.10.0] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   was deliberately IRI-breaking.
 
   Server-assigned volatile fields are excluded from the content hash — `meta.lastUpdated`,
-  `meta.versionId`, `meta.source` and generated narrative `text` — so a resource re-fetched
-  from an EHR keeps its identity even though the server stamped it with new metadata.
+  `meta.versionId` and `meta.source` — so a resource re-fetched from an EHR keeps its
+  identity even though the server stamped it with new metadata. Generated narrative (`text`)
+  is excluded too wherever structured fields exist, since servers re-render it freely.
 
-  One behavior worth stating plainly: two id-less resources that carry no distinguishing
-  content at all now collapse to a single IRI rather than multiplying. Records that nothing
-  can tell apart are treated as one record, which is visible and arguable, where the old
-  behavior silently grew a duplicate set forever.
+  **When identity is uncertain, this errs toward a duplicate rather than a merge.** A
+  duplicate is recoverable: all the data is present and can be reconciled later. A merge is
+  not: the second record's content is gone. So a resource with no structured content still
+  takes its identity from its narrative — two Conditions whose only content is
+  "Type 2 diabetes mellitus" and "Metastatic breast cancer" remain two records. The cost is
+  that a server which re-renders such a narrative can produce a duplicate, which is the
+  failure worth preferring.
+
+  A resource with genuinely nothing — no id, no structured content, no narrative — does
+  collapse onto a shared IRI, because there is no content to lose and splitting would mint a
+  fresh IRI on every sync. That case now emits a warning naming what happened rather than
+  passing silently.
 
 ---
 

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -235,7 +235,7 @@ function convertSingleCcda(
         ? `${docIdEl.root ?? ''}:${docIdEl.extension}`
         : (docIdEl?.['@_root'] ?? docIdEl?.root)
           ? `${docIdEl['@_root'] ?? docIdEl.root}`
-          : `doc:${identityKey(undefined, ccdaDoc)}`;
+          : `doc:${identityKey(undefined, ccdaDoc, warnings, 'C-CDA ClinicalDocument (no <id>)')}`;
 
   const allQuads: any[] = [];
   let count = 0;

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -39,6 +39,7 @@ import { extractDeviceQuads, DEVICES_TEMPLATE_ID } from './sections/devices.js';
 import { extractSocialHistoryQuads, SOCIAL_HISTORY_TEMPLATE_ID } from './sections/social-history.js';
 import { extractNarrativeQuads } from './narrative.js';
 import { deriveSourceEhr, ensureProvenanceQuads, ensureSourceEhrQuads } from './provenance.js';
+import { identityKey } from '../identity.js';
 
 // Map templateId → extractor function and LOINC code
 const SECTION_HANDLERS: Record<string, {
@@ -216,9 +217,17 @@ function convertSingleCcda(
   // Document ID for narrative linking
   const docIdEl = Array.isArray(ccdaDoc?.id) ? ccdaDoc.id[0] : ccdaDoc?.id;
   // HL7 II semantics: root+extension when both present; root alone IS the
-  // globally unique document id when extension is absent. Only fall back to
-  // the import timestamp when the document carries no id at all (that
-  // fallback makes re-imports mint new URIs, i.e. duplicate documents).
+  // globally unique document id when extension is absent. When the document
+  // carries no id at all, identity comes from the document's own parsed,
+  // vendor-normalized content.
+  //
+  // That last tier used to be `doc:${importedAt}`, and the comment here used to
+  // record the consequence without fixing it: "that fallback makes re-imports
+  // mint new URIs, i.e. duplicate documents". It did — documentId feeds the
+  // ClinicalDocument subject through `contentHashedUri`, so every section of an
+  // id-less C-CDA became a new document node on every single import. Hashing the
+  // parsed object rather than the raw XML keeps the identity insensitive to
+  // reformatting and to vendor-specific whitespace.
   const documentId =
     docIdEl?.['@_extension']
       ? `${docIdEl['@_root'] ?? ''}:${docIdEl['@_extension']}`
@@ -226,7 +235,7 @@ function convertSingleCcda(
         ? `${docIdEl.root ?? ''}:${docIdEl.extension}`
         : (docIdEl?.['@_root'] ?? docIdEl?.root)
           ? `${docIdEl['@_root'] ?? docIdEl.root}`
-          : `doc:${importedAt}`;
+          : `doc:${identityKey(undefined, ccdaDoc)}`;
 
   const allQuads: any[] = [];
   let count = 0;

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -250,6 +250,7 @@ function convertSingleCcda(
   const { quads: patientQuads, patientUri } = extractPatientQuads(
     Array.isArray(recordTarget) ? recordTarget : [recordTarget],
     sourceSystem,
+    warnings,
   );
   allQuads.push(...patientQuads);
   count++;

--- a/src/lib/ccda-converter/narrative.ts
+++ b/src/lib/ccda-converter/narrative.ts
@@ -36,7 +36,9 @@ export function extractNarrativeQuads(
     section: sectionLoincCode,
     document: documentId,
     source: sourceSystem,
-  });
+    // The narrative itself is the salvage-tier content for a section document
+    // that somehow carries no section code, document id or source system.
+  }, undefined, sectionText);
 
   const subj = namedNode(uri);
   const quads: Quad[] = [

--- a/src/lib/ccda-converter/sections/allergies.ts
+++ b/src/lib/ccda-converter/sections/allergies.ts
@@ -59,7 +59,7 @@ export function extractAllergyQuads(
       const uri = contentHashedUri('Allergy', {
         patient: patientUri,
         allergenName: allergenName.toLowerCase(),
-      }, sourceId || undefined);
+      }, sourceId || undefined, entry);
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'AllergyRecord')));

--- a/src/lib/ccda-converter/sections/devices.ts
+++ b/src/lib/ccda-converter/sections/devices.ts
@@ -48,7 +48,7 @@ export function extractDeviceQuads(
       patient: patientUri,
       displayName: displayName.toLowerCase(),
       date: dateStr || undefined,
-    }, sourceId || undefined);
+    }, sourceId || undefined, entry);
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'ImplantedDevice')));

--- a/src/lib/ccda-converter/sections/encounters.ts
+++ b/src/lib/ccda-converter/sections/encounters.ts
@@ -95,7 +95,7 @@ export function buildEncounterRecord(
     patient: patientUri,
     displayName: displayName || undefined,
     date: dateStr || undefined,
-  }, sourceId || undefined);
+  }, sourceId || undefined, enc);
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];

--- a/src/lib/ccda-converter/sections/family-history.ts
+++ b/src/lib/ccda-converter/sections/family-history.ts
@@ -54,7 +54,7 @@ export function extractFamilyHistoryQuads(
         relation: relation || undefined,
         condition: displayName || undefined,
         code: code || undefined,
-      }, sourceId || undefined);
+      }, sourceId || undefined, entry);
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'FamilyHistoryRecord')));

--- a/src/lib/ccda-converter/sections/immunizations.ts
+++ b/src/lib/ccda-converter/sections/immunizations.ts
@@ -56,7 +56,7 @@ export function extractImmunizationQuads(
       cvxCode: codeSystem.includes('292') || codeSystem === cvxOid ? code : undefined,
       vaccineName: displayName !== 'Unknown Vaccine' ? displayName.toLowerCase() : undefined,
       date: dateStr,
-    }, sourceId || undefined);
+    }, sourceId || undefined, entry);
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'ImmunizationRecord')));

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -113,7 +113,7 @@ function extractObservationQuads(
     loincCode: isLoinc ? code : undefined,
     testName: displayName || undefined,
     date: dateStr || undefined,
-  }, sourceId || undefined);
+  }, sourceId || undefined, obs);
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];
@@ -187,7 +187,7 @@ function buildPanelQuads(
     panelCode: code || undefined,
     date: clinicalDate || undefined,
     panelId: sourceId || undefined,
-  }, sourceId || undefined);
+  }, sourceId || undefined, organizer);
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];

--- a/src/lib/ccda-converter/sections/patient.ts
+++ b/src/lib/ccda-converter/sections/patient.ts
@@ -33,6 +33,14 @@ function mapBiologicalSex(code: string): string | undefined {
 export function extractPatientQuads(
   recordTarget: any,
   sourceSystem: string,
+  /**
+   * Collects a tier-4 identity-collapse notice. This is the ONE C-CDA site that
+   * can reach tier 4: every other section keys on `patient: patientUri`, which is
+   * always a non-empty `urn:uuid:` string, so their content tier always fires.
+   * Here the key is the demographics themselves, and a recordTarget can carry
+   * none of them.
+   */
+  warnings?: string[],
 ): { quads: Quad[]; patientUri: string } {
   // recordTarget may be an array (Epic wraps it)
   const rt = Array.isArray(recordTarget) ? recordTarget[0] : recordTarget;
@@ -92,7 +100,7 @@ export function extractPatientQuads(
     sex: sex,
     family: familyStr.toLowerCase(),
     given: givenStr.toLowerCase(),
-  }, undefined, patientRole);
+  }, undefined, patientRole, warnings);
 
   const subj = namedNode(patientUri);
   const quads: Quad[] = [

--- a/src/lib/ccda-converter/sections/patient.ts
+++ b/src/lib/ccda-converter/sections/patient.ts
@@ -83,13 +83,16 @@ export function extractPatientQuads(
     return raw.replace(/^mailto:/, '');
   })();
 
-  // Deterministic URI from identity fields
+  // Deterministic URI from identity fields. `patientRole` is passed as the last
+  // tier so that a recordTarget with no name, no birthTime and no gender keys on
+  // whatever else it does carry (ids, address, telecom) instead of on a random
+  // UUID, which is what the un-passed version fell through to.
   const patientUri = contentHashedUri('Patient', {
     dob: dob.slice(0, 8),  // YYYYMMDD
     sex: sex,
     family: familyStr.toLowerCase(),
     given: givenStr.toLowerCase(),
-  });
+  }, undefined, patientRole);
 
   const subj = namedNode(patientUri);
   const quads: Quad[] = [

--- a/src/lib/ccda-converter/sections/problems.ts
+++ b/src/lib/ccda-converter/sections/problems.ts
@@ -77,7 +77,7 @@ export function extractProblemQuads(
         icd10Code: isIcd10 ? code : undefined,
         conditionName: displayName || undefined,
         onsetDate: onsetDate || undefined,
-      }, sourceId || undefined);
+      }, sourceId || undefined, entry);
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'ConditionRecord')));

--- a/src/lib/ccda-converter/sections/procedures.ts
+++ b/src/lib/ccda-converter/sections/procedures.ts
@@ -47,7 +47,7 @@ export function extractProcedureQuads(
       code: code || undefined,
       displayName: displayName || undefined,
       date: dateStr || undefined,
-    }, sourceId || undefined);
+    }, sourceId || undefined, entry);
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Procedure')));

--- a/src/lib/ccda-converter/sections/vitals.ts
+++ b/src/lib/ccda-converter/sections/vitals.ts
@@ -118,7 +118,7 @@ export function extractVitalQuads(
         displayName: displayName || undefined,
         date: dateStr || undefined,
         value: value || undefined,
-      }, sourceId || undefined);
+      }, sourceId || undefined, obs);
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'VitalSign')));

--- a/src/lib/fhir-converter/converters-clinical-admin.ts
+++ b/src/lib/fhir-converter/converters-clinical-admin.ts
@@ -30,7 +30,7 @@ import { referencePlaceholder } from './reference-resolution.js';
 
 export function convertClaim(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.coverage + 'ClaimRecord'));
@@ -108,7 +108,7 @@ export function convertClaim(resource: any): ConversionResult & { _quads: Quad[]
 
 export function convertExplanationOfBenefit(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.coverage + 'BenefitStatement'));

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -64,7 +64,7 @@ export function convertMedicationStatement(resource: any): ConversionResult & { 
     rxNormCode: resource.medicationCodeableConcept?.coding?.find((c: any) => c.system?.includes('rxnorm'))?.code,
     medicationName: medName,
     startDate: (resource.authoredOn ?? resource.effectivePeriod?.start)?.split('T')[0],
-  }, resource.id, resource);
+  }, resource.id, resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'Medication'));
@@ -171,7 +171,7 @@ export function convertCondition(resource: any): ConversionResult & { _quads: Qu
     snomedCode: resource.code?.coding?.find((c: any) => c.system?.includes('snomed'))?.code,
     icd10Code: resource.code?.coding?.find((c: any) => c.system?.includes('icd'))?.code,
     onsetDate: (resource.onsetDateTime ?? resource.onsetPeriod?.start)?.split('T')[0],
-  }, resource.id, resource);
+  }, resource.id, resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'ConditionRecord'));
@@ -252,7 +252,7 @@ export function convertAllergyIntolerance(resource: any): ConversionResult & { _
     patient: patientRef,
     allergenCode: resource.code?.coding?.[0]?.code,
     allergenName: resource.code?.text,
-  }, resource.id, resource);
+  }, resource.id, resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'AllergyRecord'));
@@ -345,7 +345,7 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
     patient: patientRef,
     loincCode: resource.code?.coding?.find((c: any) => c.system?.includes('loinc'))?.code,
     date: (resource.effectiveDateTime ?? resource.effectivePeriod?.start)?.split('T')[0],
-  }, resource.id, resource);
+  }, resource.id, resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'LabResultRecord'));
@@ -490,7 +490,7 @@ const VITAL_TYPE_TO_SHACL: Record<string, string> = {
 
 export function convertObservationVital(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   const codings = extractCodings(resource.code);
@@ -615,7 +615,7 @@ export function convertObservationVital(resource: any): ConversionResult & { _qu
 
 export function convertProcedure(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'Procedure'));
@@ -677,7 +677,7 @@ export function convertProcedure(resource: any): ConversionResult & { _quads: Qu
 
 export function convertClinicalDocument(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'ClinicalDocument'));
@@ -746,7 +746,7 @@ export function convertClinicalDocument(resource: any): ConversionResult & { _qu
 
 export function convertEncounter(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'Encounter'));
@@ -822,7 +822,7 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
 
 export function convertLaboratoryReport(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'LaboratoryReport'));
@@ -911,7 +911,7 @@ export function convertLaboratoryReport(resource: any): ConversionResult & { _qu
 
 export function convertMedicationAdministration(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'MedicationAdministration'));
@@ -975,7 +975,7 @@ export function convertMedicationAdministration(resource: any): ConversionResult
 
 export function convertDevice(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'ImplantedDevice'));
@@ -1028,7 +1028,7 @@ export function convertDevice(resource: any): ConversionResult & { _quads: Quad[
 
 export function convertImagingStudy(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'ImagingStudy'));

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -64,7 +64,7 @@ export function convertMedicationStatement(resource: any): ConversionResult & { 
     rxNormCode: resource.medicationCodeableConcept?.coding?.find((c: any) => c.system?.includes('rxnorm'))?.code,
     medicationName: medName,
     startDate: (resource.authoredOn ?? resource.effectivePeriod?.start)?.split('T')[0],
-  }, resource.id);
+  }, resource.id, resource);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'Medication'));
@@ -171,7 +171,7 @@ export function convertCondition(resource: any): ConversionResult & { _quads: Qu
     snomedCode: resource.code?.coding?.find((c: any) => c.system?.includes('snomed'))?.code,
     icd10Code: resource.code?.coding?.find((c: any) => c.system?.includes('icd'))?.code,
     onsetDate: (resource.onsetDateTime ?? resource.onsetPeriod?.start)?.split('T')[0],
-  }, resource.id);
+  }, resource.id, resource);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'ConditionRecord'));
@@ -252,7 +252,7 @@ export function convertAllergyIntolerance(resource: any): ConversionResult & { _
     patient: patientRef,
     allergenCode: resource.code?.coding?.[0]?.code,
     allergenName: resource.code?.text,
-  }, resource.id);
+  }, resource.id, resource);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'AllergyRecord'));
@@ -345,7 +345,7 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
     patient: patientRef,
     loincCode: resource.code?.coding?.find((c: any) => c.system?.includes('loinc'))?.code,
     date: (resource.effectiveDateTime ?? resource.effectivePeriod?.start)?.split('T')[0],
-  }, resource.id);
+  }, resource.id, resource);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'LabResultRecord'));

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -40,7 +40,7 @@ export function convertPatient(resource: any): ConversionResult & { _quads: Quad
     // A Patient with no name, no birthDate, no gender and no id used to fall
     // through to a random UUID. Passing the resource gives the last tier the
     // rest of the demographics (address, telecom, identifier) to key on.
-  }, resource.id, resource);
+  }, resource.id, resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.cascade + 'PatientProfile'));
@@ -127,7 +127,7 @@ export function convertImmunization(resource: any): ConversionResult & { _quads:
     patient: patientRef,
     cvxCode: resource.vaccineCode?.coding?.[0]?.code,
     date: resource.occurrenceDateTime?.split('T')[0],
-  }, resource.id, resource);
+  }, resource.id, resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'ImmunizationRecord'));
@@ -212,7 +212,7 @@ export function convertImmunization(resource: any): ConversionResult & { _quads:
 
 export function convertCoverage(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.coverage + 'InsurancePlan'));

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -127,7 +127,7 @@ export function convertImmunization(resource: any): ConversionResult & { _quads:
     patient: patientRef,
     cvxCode: resource.vaccineCode?.coding?.[0]?.code,
     date: resource.occurrenceDateTime?.split('T')[0],
-  }, resource.id);
+  }, resource.id, resource);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'ImmunizationRecord'));

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -37,7 +37,10 @@ export function convertPatient(resource: any): ConversionResult & { _quads: Quad
     sex: resource.gender,
     family: resource.name?.[0]?.family,
     given: resource.name?.[0]?.given?.[0],
-  }, resource.id);
+    // A Patient with no name, no birthDate, no gender and no id used to fall
+    // through to a random UUID. Passing the resource gives the last tier the
+    // rest of the demographics (address, telecom, identifier) to key on.
+  }, resource.id, resource);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.cascade + 'PatientProfile'));

--- a/src/lib/fhir-converter/converters-passthrough.ts
+++ b/src/lib/fhir-converter/converters-passthrough.ts
@@ -53,7 +53,7 @@ export const EXCLUDED_REASONS: Record<string, string> = {
 export function convertFhirPassthrough(resource: any, minimal = false): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const resourceType = resource.resourceType as string ?? 'Unknown';
-  const subjectUri = mintSubjectUri(resource);
+  const subjectUri = mintSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.fhir + resourceType));

--- a/src/lib/fhir-converter/fhir-to-cascade.ts
+++ b/src/lib/fhir-converter/fhir-to-cascade.ts
@@ -51,7 +51,6 @@ import {
 } from './converters-passthrough.js';
 
 import { appendProvenanceQuads } from './provenance.js';
-import { identitySeed, identityCollapseWarning } from '../identity.js';
 
 // ---------------------------------------------------------------------------
 // Main dispatcher: single FHIR resource -> Cascade
@@ -63,19 +62,15 @@ export function convertFhirResourceToQuads(fhirResource: any, passthroughMinimal
   // converters historically dropped for most types ("Cascade does not drop
   // data"). Additive + idempotent; see provenance.ts.
   if (result) appendProvenanceQuads(fhirResource, result._quads);
-  // One place to catch the identity door's tier-4 collapse for the WHOLE FHIR
-  // clinical path: every per-type converter routes through either mintSubjectUri
-  // or contentHashedUri, and both bottom out in identitySeed on this same
-  // resource. Checking here means a collapse can never be silent regardless of
-  // which of the dozen converters produced it.
-  if (result) {
-    const { source } = identitySeed({ explicitId: fhirResource?.id, content: fhirResource });
-    if (source === 'empty') {
-      result.warnings.push(
-        identityCollapseWarning(`${(fhirResource?.resourceType as string) ?? 'Resource'} (no id)`),
-      );
-    }
-  }
+  // NOTE: the identity door's tier-4 collapse warning is NOT re-derived here.
+  // An earlier revision did exactly that, and it looked right — the dispatcher
+  // is one place covering every converter — but it only reached callers who came
+  // through the dispatcher. `convertCondition(...)` called directly returned an
+  // empty `warnings`, so the "this tier must not be silent" contract was true on
+  // the genomics and C-CDA paths and false on the most reachable one in the repo.
+  // The warning now originates where the identity is actually minted, inside
+  // `mintSubjectUri` / `contentHashedUri`, so it reaches every caller of every
+  // converter. Re-deriving it here as well would duplicate it.
   return result;
 }
 

--- a/src/lib/fhir-converter/fhir-to-cascade.ts
+++ b/src/lib/fhir-converter/fhir-to-cascade.ts
@@ -51,6 +51,7 @@ import {
 } from './converters-passthrough.js';
 
 import { appendProvenanceQuads } from './provenance.js';
+import { identitySeed, identityCollapseWarning } from '../identity.js';
 
 // ---------------------------------------------------------------------------
 // Main dispatcher: single FHIR resource -> Cascade
@@ -62,6 +63,19 @@ export function convertFhirResourceToQuads(fhirResource: any, passthroughMinimal
   // converters historically dropped for most types ("Cascade does not drop
   // data"). Additive + idempotent; see provenance.ts.
   if (result) appendProvenanceQuads(fhirResource, result._quads);
+  // One place to catch the identity door's tier-4 collapse for the WHOLE FHIR
+  // clinical path: every per-type converter routes through either mintSubjectUri
+  // or contentHashedUri, and both bottom out in identitySeed on this same
+  // resource. Checking here means a collapse can never be silent regardless of
+  // which of the dozen converters produced it.
+  if (result) {
+    const { source } = identitySeed({ explicitId: fhirResource?.id, content: fhirResource });
+    if (source === 'empty') {
+      result.warnings.push(
+        identityCollapseWarning(`${(fhirResource?.resourceType as string) ?? 'Resource'} (no id)`),
+      );
+    }
+  }
   return result;
 }
 

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -445,6 +445,8 @@ export function contentHashedUri(
 export function medicationUri(
   fields: { rxNormCode?: string; medicationName?: string; startDate?: string; patient?: string },
   fallbackId?: string,
+  /** Raw source resource, forwarded to `contentHashedUri`'s salvage tier. */
+  source?: unknown,
 ): string {
   return contentHashedUri(
     'MedicationRequest',
@@ -455,6 +457,7 @@ export function medicationUri(
       patient: fields.patient,
     },
     fallbackId,
+    source,
   );
 }
 

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -349,8 +349,18 @@ export function deterministicUuid(input: string): string {
  * content seed can never be mistaken for an id a source assigned, and no IRI
  * that a source id already determines moves.
  */
-export function mintSubjectUri(resource: any): string {
-  const { seed } = identitySeed({ explicitId: resource?.id, content: resource });
+export function mintSubjectUri(resource: any, warnings?: string[]): string {
+  const resourceTypeForLabel = (resource?.resourceType as string) ?? 'Resource';
+  const { seed } = identitySeed({
+    explicitId: resource?.id,
+    content: resource,
+    // Optional so that a caller with nothing to report stays source-compatible.
+    // Every production converter has a warnings array and passes it, because a
+    // tier-4 collapse the user never hears about is the failure this whole
+    // module exists to prevent.
+    warnings,
+    label: `${resourceTypeForLabel} (no id)`,
+  });
   if (UUID_V4_REGEX.test(seed)) return `urn:uuid:${seed}`;
   const resourceType = (resource?.resourceType as string) ?? 'Unknown';
   return `urn:uuid:${deterministicUuid(`${resourceType}:${seed}`)}`;
@@ -405,6 +415,8 @@ export function contentHashedUri(
    * instead of landing on the per-type sentinel.
    */
   source?: unknown,
+  /** Collects a tier-4 collapse notice. See `mintSubjectUri` for why it is optional. */
+  warnings?: string[],
 ): string {
   // Filter out undefined/empty values and sort keys for stability. Values are
   // coerced to string before trimming: the type says string, but real-world
@@ -425,7 +437,11 @@ export function contentHashedUri(
   // Last tier: the identity door. Deterministic whether or not `source` was
   // supplied — with it, a hash of the resource's non-volatile content; without
   // it, the per-type sentinel. Never random.
-  const { seed } = identitySeed({ content: source });
+  const { seed } = identitySeed({
+    content: source,
+    warnings,
+    label: `${resourceType} (no id)`,
+  });
   return `urn:uuid:${deterministicUuid(`${resourceType}::${seed}`)}`;
 }
 
@@ -447,6 +463,8 @@ export function medicationUri(
   fallbackId?: string,
   /** Raw source resource, forwarded to `contentHashedUri`'s salvage tier. */
   source?: unknown,
+  /** Forwarded to `contentHashedUri`; collects a tier-4 collapse notice. */
+  warnings?: string[],
 ): string {
   return contentHashedUri(
     'MedicationRequest',
@@ -458,6 +476,7 @@ export function medicationUri(
     },
     fallbackId,
     source,
+    warnings,
   );
 }
 

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -5,8 +5,9 @@
  */
 
 import { DataFactory, Writer, type Quad } from 'n3';
-import { randomUUID, createHash } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { normalizeMedName } from '../medication-normalize.js';
+import { identitySeed } from '../identity.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
@@ -333,14 +334,26 @@ export function deterministicUuid(input: string): string {
  * Mint a deterministic subject URI from a FHIR resource.
  * - If resource.id is a valid UUID v4: returns urn:uuid:{resource.id}
  * - If resource.id exists but is not a UUID: returns urn:uuid:{deterministicUuid(resourceType:id)}
- * - If no resource.id: falls back to a random UUID (last resort)
+ * - If no resource.id: the seed comes from the resource's own non-volatile
+ *   content, via the identity door. Never from randomness.
+ *
+ * This used to answer the id-less case with `randomUUID()`, so re-importing one
+ * document minted a fresh identity for every id-less record in it and the pod
+ * duplicated instead of reconciling — on every sync, silently. `Resource.id` is
+ * optional in FHIR and real payloads omit it (transaction Bundles, contained
+ * resources, hand-authored and exported documents), so this was reachable, not
+ * theoretical.
+ *
+ * The with-id path is UNCHANGED, deliberately: an anonymous seed is
+ * `anon-` + 64 hex = 69 characters, and FHIR caps `Resource.id` at 64, so a
+ * content seed can never be mistaken for an id a source assigned, and no IRI
+ * that a source id already determines moves.
  */
 export function mintSubjectUri(resource: any): string {
-  const id = resource?.id as string | undefined;
-  if (!id) return `urn:uuid:${randomUUID()}`;
-  if (UUID_V4_REGEX.test(id)) return `urn:uuid:${id}`;
+  const { seed } = identitySeed({ explicitId: resource?.id, content: resource });
+  if (UUID_V4_REGEX.test(seed)) return `urn:uuid:${seed}`;
   const resourceType = (resource?.resourceType as string) ?? 'Unknown';
-  return `urn:uuid:${deterministicUuid(`${resourceType}:${id}`)}`;
+  return `urn:uuid:${deterministicUuid(`${resourceType}:${seed}`)}`;
 }
 
 /**
@@ -358,7 +371,22 @@ export function mintSubjectUri(resource: any): string {
  * URI selection:
  *   If identity string has content: return "urn:uuid:" + deterministicUuid(identity)
  *   Else if fallbackId:             return "urn:uuid:" + deterministicUuid("{resourceType}:{fallbackId}")
- *   Else:                           return "urn:uuid:" + randomUUID()  (non-deterministic fallback)
+ *   Else:                           hash `source` through the identity door
+ *
+ * The final tier used to be `randomUUID()`, labelled "true last resort". It was
+ * more defensible than the other random fallbacks in this codebase — it fires
+ * only after BOTH the content fields and a fallback id come up empty — but it
+ * has the same consequence when it does fire, so it is gone. It is replaced by
+ * a hash of the raw `source` object where a caller can supply one, and by a
+ * deterministic per-type sentinel where it cannot.
+ *
+ * That sentinel COLLAPSES records rather than splitting them: two resources
+ * with no identity-bearing content and no id are indistinguishable to every
+ * part of this system, and merging things nothing can tell apart is a decision
+ * a user can see and argue with, where minting a fresh IRI for each one is a
+ * duplicate set that grows forever and never announces itself. The sentinel key
+ * also cannot collide with the content tier: content entries are always `k=v`
+ * pairs and always contain `=`, and an anonymous seed never does.
  *
  * Example:
  *   contentHashedUri("Patient", { dob:"1985-03-15", sex:"male", family:"Smith", given:"John" })
@@ -370,6 +398,13 @@ export function contentHashedUri(
   resourceType: string,
   contentFields: Record<string, string | undefined>,
   fallbackId?: string,
+  /**
+   * The raw source object, used only when the content fields and the fallback
+   * id are both empty. Optional so that the ~20 existing call sites are
+   * unaffected; supplying it simply gives the last tier something real to hash
+   * instead of landing on the per-type sentinel.
+   */
+  source?: unknown,
 ): string {
   // Filter out undefined/empty values and sort keys for stability. Values are
   // coerced to string before trimming: the type says string, but real-world
@@ -387,7 +422,11 @@ export function contentHashedUri(
   if (fallbackId) {
     return `urn:uuid:${deterministicUuid(`${resourceType}:${fallbackId}`)}`;
   }
-  return `urn:uuid:${randomUUID()}`;  // true last resort
+  // Last tier: the identity door. Deterministic whether or not `source` was
+  // supplied — with it, a hash of the resource's non-volatile content; without
+  // it, the per-type sentinel. Never random.
+  const { seed } = identitySeed({ content: source });
+  return `urn:uuid:${deterministicUuid(`${resourceType}::${seed}`)}`;
 }
 
 /**

--- a/src/lib/fhir-genomics-converter/diagnostic-report.ts
+++ b/src/lib/fhir-genomics-converter/diagnostic-report.ts
@@ -52,11 +52,11 @@ export interface DiagnosticReportParseOutput {
   gaps: VocabularyGap[];
 }
 
-function mintGeneticTestIri(resource: any, ctx: ImportContext): string {
+function mintGeneticTestIri(resource: any, ctx: ImportContext, idWarnings: string[]): string {
   // Identity comes from the source id, or from the resource's own content
   // when it has none. It used to come from Math.random(), so re-importing
   // the same bundle minted a second record every time.
-  const id = identityKey(resource?.id, resource);
+  const id = identityKey(resource?.id, resource, idWarnings, 'GeneticTest');
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:GeneticTest:${sys}:${id}`)}`;
 }
@@ -112,10 +112,14 @@ export function parseDiagnosticReport(
   if (!resource || resource.resourceType !== 'DiagnosticReport') return null;
 
   const sourceId: string = resource.id ?? '<no-id>';
-  const iri = mintGeneticTestIri(resource, ctx);
   const quads: Quad[] = [];
   const warnings: ImportWarning[] = [];
   const gaps: VocabularyGap[] = [];
+  // The identity door reports a tier-4 collapse (no id, no content, no
+  // narrative) as a plain string; surface it as an import warning.
+  const idWarnings: string[] = [];
+  const iri = mintGeneticTestIri(resource, ctx, idWarnings);
+  for (const m of idWarnings) warnings.push({ message: m });
 
   quads.push(tripleType(iri, GENOMICS_NS + 'GeneticTest'));
   quads.push(tripleRef(iri, NS.cascade + 'dataProvenance', NS.cascade + 'ClinicalGenerated'));

--- a/src/lib/fhir-genomics-converter/diagnostic-report.ts
+++ b/src/lib/fhir-genomics-converter/diagnostic-report.ts
@@ -44,6 +44,7 @@ import {
   tripleDate,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 export interface DiagnosticReportParseOutput {
   record: ParsedRecord;
@@ -52,7 +53,10 @@ export interface DiagnosticReportParseOutput {
 }
 
 function mintGeneticTestIri(resource: any, ctx: ImportContext): string {
-  const id = resource?.id ?? Math.random().toString(36);
+  // Identity comes from the source id, or from the resource's own content
+  // when it has none. It used to come from Math.random(), so re-importing
+  // the same bundle minted a second record every time.
+  const id = identityKey(resource?.id, resource);
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:GeneticTest:${sys}:${id}`)}`;
 }

--- a/src/lib/fhir-genomics-converter/observation-diagnostic-implication.ts
+++ b/src/lib/fhir-genomics-converter/observation-diagnostic-implication.ts
@@ -51,6 +51,7 @@ import {
   tripleDate,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 export interface DiagnosticImplicationParseOutput {
   records: ParsedRecord[];
@@ -63,7 +64,10 @@ function mintInterpretationIri(
   conditionCode: string,
   ctx: ImportContext,
 ): string {
-  const id = resource?.id ?? Math.random().toString(36);
+  // Identity comes from the source id, or from the resource's own content
+  // when it has none. It used to come from Math.random(), so re-importing
+  // the same bundle minted a second record every time.
+  const id = identityKey(resource?.id, resource);
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:VariantInterpretation:${sys}:${id}:${conditionCode}`)}`;
 }

--- a/src/lib/fhir-genomics-converter/observation-diagnostic-implication.ts
+++ b/src/lib/fhir-genomics-converter/observation-diagnostic-implication.ts
@@ -63,11 +63,12 @@ function mintInterpretationIri(
   resource: any,
   conditionCode: string,
   ctx: ImportContext,
+  idWarnings: string[],
 ): string {
   // Identity comes from the source id, or from the resource's own content
   // when it has none. It used to come from Math.random(), so re-importing
   // the same bundle minted a second record every time.
-  const id = identityKey(resource?.id, resource);
+  const id = identityKey(resource?.id, resource, idWarnings, 'VariantInterpretation');
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:VariantInterpretation:${sys}:${id}:${conditionCode}`)}`;
 }
@@ -253,7 +254,9 @@ export function parseDiagnosticImplication(
   for (const cc of conditionComps) {
     const condCcc = cc.valueCodeableConcept;
     const key = conditionKey(condCcc);
-    const iri = mintInterpretationIri(resource, key, ctx);
+    const idWarnings: string[] = [];
+    const iri = mintInterpretationIri(resource, key, ctx, idWarnings);
+    for (const m of idWarnings) warnings.push({ message: m });
     const quads: Quad[] = [];
 
     quads.push(tripleType(iri, GENOMICS_NS + 'VariantInterpretation'));

--- a/src/lib/fhir-genomics-converter/observation-genotype.ts
+++ b/src/lib/fhir-genomics-converter/observation-genotype.ts
@@ -41,6 +41,7 @@ import {
   tripleRef,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 import { emitPhasedWithLink } from './observation-variant.js';
 
 export interface GenotypeParseOutput {
@@ -50,7 +51,10 @@ export interface GenotypeParseOutput {
 }
 
 function mintDiplotypeIri(resource: any, ctx: ImportContext): string {
-  const id = resource?.id ?? Math.random().toString(36);
+  // Identity comes from the source id, or from the resource's own content
+  // when it has none. It used to come from Math.random(), so re-importing
+  // the same bundle minted a second record every time.
+  const id = identityKey(resource?.id, resource);
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:Diplotype:${sys}:${id}`)}`;
 }

--- a/src/lib/fhir-genomics-converter/observation-genotype.ts
+++ b/src/lib/fhir-genomics-converter/observation-genotype.ts
@@ -50,11 +50,11 @@ export interface GenotypeParseOutput {
   gaps: VocabularyGap[];
 }
 
-function mintDiplotypeIri(resource: any, ctx: ImportContext): string {
+function mintDiplotypeIri(resource: any, ctx: ImportContext, idWarnings: string[]): string {
   // Identity comes from the source id, or from the resource's own content
   // when it has none. It used to come from Math.random(), so re-importing
   // the same bundle minted a second record every time.
-  const id = identityKey(resource?.id, resource);
+  const id = identityKey(resource?.id, resource, idWarnings, 'Diplotype');
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:Diplotype:${sys}:${id}`)}`;
 }
@@ -101,10 +101,14 @@ export function parseGenotypeObservation(
   if (!resource || resource.resourceType !== 'Observation') return null;
 
   const sourceId: string = resource.id ?? '<no-id>';
-  const iri = mintDiplotypeIri(resource, ctx);
   const quads: Quad[] = [];
   const warnings: ImportWarning[] = [];
   const gaps: VocabularyGap[] = [];
+  // The identity door reports a tier-4 collapse (no id, no content, no
+  // narrative) as a plain string; surface it as an import warning.
+  const idWarnings: string[] = [];
+  const iri = mintDiplotypeIri(resource, ctx, idWarnings);
+  for (const m of idWarnings) warnings.push({ message: m });
 
   quads.push(tripleType(iri, GENOMICS_NS + 'Diplotype'));
   quads.push(tripleRef(iri, NS.cascade + 'dataProvenance', NS.cascade + 'ClinicalGenerated'));

--- a/src/lib/fhir-genomics-converter/observation-haplotype.ts
+++ b/src/lib/fhir-genomics-converter/observation-haplotype.ts
@@ -34,6 +34,7 @@ import {
   tripleRef,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 export interface HaplotypeParseOutput {
   record: ParsedRecord;
@@ -42,7 +43,10 @@ export interface HaplotypeParseOutput {
 }
 
 function mintHaplotypeIri(resource: any, ctx: ImportContext): string {
-  const id = resource?.id ?? Math.random().toString(36);
+  // Identity comes from the source id, or from the resource's own content
+  // when it has none. It used to come from Math.random(), so re-importing
+  // the same bundle minted a second record every time.
+  const id = identityKey(resource?.id, resource);
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:Haplotype:${sys}:${id}`)}`;
 }

--- a/src/lib/fhir-genomics-converter/observation-haplotype.ts
+++ b/src/lib/fhir-genomics-converter/observation-haplotype.ts
@@ -42,11 +42,11 @@ export interface HaplotypeParseOutput {
   gaps: VocabularyGap[];
 }
 
-function mintHaplotypeIri(resource: any, ctx: ImportContext): string {
+function mintHaplotypeIri(resource: any, ctx: ImportContext, idWarnings: string[]): string {
   // Identity comes from the source id, or from the resource's own content
   // when it has none. It used to come from Math.random(), so re-importing
   // the same bundle minted a second record every time.
-  const id = identityKey(resource?.id, resource);
+  const id = identityKey(resource?.id, resource, idWarnings, 'Haplotype');
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:Haplotype:${sys}:${id}`)}`;
 }
@@ -81,10 +81,14 @@ export function parseHaplotypeObservation(
   if (!resource || resource.resourceType !== 'Observation') return null;
 
   const sourceId: string = resource.id ?? '<no-id>';
-  const iri = mintHaplotypeIri(resource, ctx);
   const quads: Quad[] = [];
   const warnings: ImportWarning[] = [];
   const gaps: VocabularyGap[] = [];
+  // The identity door reports a tier-4 collapse (no id, no content, no
+  // narrative) as a plain string; surface it as an import warning.
+  const idWarnings: string[] = [];
+  const iri = mintHaplotypeIri(resource, ctx, idWarnings);
+  for (const m of idWarnings) warnings.push({ message: m });
 
   quads.push(tripleType(iri, GENOMICS_NS + 'Haplotype'));
   quads.push(tripleRef(iri, NS.cascade + 'dataProvenance', NS.cascade + 'ClinicalGenerated'));

--- a/src/lib/fhir-genomics-converter/observation-variant.ts
+++ b/src/lib/fhir-genomics-converter/observation-variant.ts
@@ -85,9 +85,9 @@ export interface VariantParseOutput {
  * extra steps. A genome is the last place a re-import should mint a second
  * identity, so identity now comes from the variant itself.
  */
-function mintVariantIri(resource: any, ctx: ImportContext): string {
+function mintVariantIri(resource: any, ctx: ImportContext, idWarnings: string[]): string {
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
-  const id = identityKey(resource?.id, resource);
+  const id = identityKey(resource?.id, resource, idWarnings, 'Variant');
   return `urn:uuid:${deterministicUuid(`genomics:Variant:${sys}:${id}`)}`;
 }
 
@@ -178,11 +178,14 @@ export function parseVariantObservation(
   if (!resource || resource.resourceType !== 'Observation') return null;
 
   const sourceId: string = resource.id ?? '<no-id>';
-  const iri = mintVariantIri(resource, ctx);
-  const subject = namedNode(iri);
   const quads: Quad[] = [];
   const warnings: ImportWarning[] = [];
   const gaps: VocabularyGap[] = [];
+  // Surface a tier-4 identity collapse as an import warning.
+  const idWarnings: string[] = [];
+  const iri = mintVariantIri(resource, ctx, idWarnings);
+  for (const m of idWarnings) warnings.push({ message: m });
+  const subject = namedNode(iri);
 
   // ---- Type + provenance ----
   quads.push(tripleType(iri, GENOMICS_NS + 'Variant'));

--- a/src/lib/fhir-genomics-converter/observation-variant.ts
+++ b/src/lib/fhir-genomics-converter/observation-variant.ts
@@ -63,6 +63,7 @@ import {
   tripleRef,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
@@ -75,16 +76,19 @@ export interface VariantParseOutput {
 /**
  * Mint a Cascade IRI for a Variant. Inputs:
  *   - sourceSystem (optional ctx tag)
- *   - bundle/resource id (FHIR Observation id)
- * Falls back to bundle-relative deterministic minting if no id.
+ *   - bundle/resource id (FHIR Observation id), or the Observation's own
+ *     non-volatile content when it carries no id.
+ *
+ * The id-less branch used to seed on `${ctx.importedAt}:${Math.random()}`. Both
+ * halves of that were fatal, and removing only the visible one would not have
+ * helped: `importedAt` is a per-run timestamp, so hashing it is randomness with
+ * extra steps. A genome is the last place a re-import should mint a second
+ * identity, so identity now comes from the variant itself.
  */
 function mintVariantIri(resource: any, ctx: ImportContext): string {
-  const id = resource?.id as string | undefined;
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
-  if (id) {
-    return `urn:uuid:${deterministicUuid(`genomics:Variant:${sys}:${id}`)}`;
-  }
-  return `urn:uuid:${deterministicUuid(`genomics:Variant:${sys}:${ctx.importedAt}:${Math.random()}`)}`;
+  const id = identityKey(resource?.id, resource);
+  return `urn:uuid:${deterministicUuid(`genomics:Variant:${sys}:${id}`)}`;
 }
 
 /**

--- a/src/lib/fhir-genomics-converter/service-request.ts
+++ b/src/lib/fhir-genomics-converter/service-request.ts
@@ -44,11 +44,11 @@ export interface ServiceRequestParseOutput {
   gaps: VocabularyGap[];
 }
 
-function mintOrderIri(resource: any, ctx: ImportContext): string {
+function mintOrderIri(resource: any, ctx: ImportContext, idWarnings: string[]): string {
   // Identity comes from the source id, or from the resource's own content
   // when it has none. It used to come from Math.random(), so re-importing
   // the same bundle minted a second record every time.
-  const id = identityKey(resource?.id, resource);
+  const id = identityKey(resource?.id, resource, idWarnings, 'GeneticTestOrder');
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:GeneticTestOrder:${sys}:${id}`)}`;
 }
@@ -81,10 +81,14 @@ export function parseServiceRequest(
   if (!resource || resource.resourceType !== 'ServiceRequest') return null;
 
   const sourceId: string = resource.id ?? '<no-id>';
-  const iri = mintOrderIri(resource, ctx);
   const quads: Quad[] = [];
   const warnings: ImportWarning[] = [];
   const gaps: VocabularyGap[] = [];
+  // The identity door reports a tier-4 collapse (no id, no content, no
+  // narrative) as a plain string; surface it as an import warning.
+  const idWarnings: string[] = [];
+  const iri = mintOrderIri(resource, ctx, idWarnings);
+  for (const m of idWarnings) warnings.push({ message: m });
 
   quads.push(tripleType(iri, GENOMICS_NS + 'GeneticTestOrder'));
   quads.push(tripleRef(iri, NS.cascade + 'dataProvenance', NS.cascade + 'ClinicalGenerated'));

--- a/src/lib/fhir-genomics-converter/service-request.ts
+++ b/src/lib/fhir-genomics-converter/service-request.ts
@@ -36,6 +36,7 @@ import {
   tripleDateTime,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 export interface ServiceRequestParseOutput {
   record: ParsedRecord;
@@ -44,7 +45,10 @@ export interface ServiceRequestParseOutput {
 }
 
 function mintOrderIri(resource: any, ctx: ImportContext): string {
-  const id = resource?.id ?? Math.random().toString(36);
+  // Identity comes from the source id, or from the resource's own content
+  // when it has none. It used to come from Math.random(), so re-importing
+  // the same bundle minted a second record every time.
+  const id = identityKey(resource?.id, resource);
   const sys = ctx.sourceSystem ?? 'fhir-genomics';
   return `urn:uuid:${deterministicUuid(`genomics:GeneticTestOrder:${sys}:${id}`)}`;
 }

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -86,6 +86,30 @@
  *      (see {@link identityCollapseWarning}); a caller that passes a `warnings`
  *      array to {@link identitySeed} receives it.
  *
+ *      That obligation is on the CALL SITE, so it is worth being precise about
+ *      where it is met, because a comment like the one above is exactly what a
+ *      future reader will trust:
+ *
+ *        * FHIR clinical — met. `mintSubjectUri` and `contentHashedUri` both
+ *          take an optional `warnings` array, and all 18 converter call sites
+ *          pass the one they already build. It is emitted where the identity is
+ *          MINTED, not at the dispatcher: an earlier revision emitted it from
+ *          `convertFhirResourceToQuads`, which looked like the right single
+ *          chokepoint but meant `convertCondition(...)` called directly
+ *          reported nothing.
+ *        * Genomics (6 sites), phenopacket subject + biosample, C-CDA document
+ *          id, C-CDA patient demographics — met, each threading its own array.
+ *        * C-CDA sections other than the patient — tier 4 is UNREACHABLE, not
+ *          unreported: every one keys on `patient: patientUri`, always a
+ *          non-empty `urn:uuid:`, so the content tier always fires.
+ *        * `convertMedicationStatement` — tier 4 is unreachable for a different
+ *          and less comfortable reason: it defaults the drug name to the literal
+ *          'Unknown Medication' before minting, so the content tier "succeeds"
+ *          with a constant. Same shape as the `resourceType` scaffold bug below,
+ *          but originating in the converter's choice of identity fields rather
+ *          than here. Pinned by a test and filed for the converter
+ *          identity-field review; deliberately NOT fixed in this module.
+ *
  *   There is no tier 5. Not `randomUUID()`, not `Math.random()`, not
  *   `Date.now()`, not `ctx.importedAt`.
  *

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -27,38 +27,102 @@
  * This module owns the rule, and `tests/identity-chokepoint.test.ts` is the
  * lock on every other way in.
  *
- * THE CASCADE, in strict order, with no fourth tier
- * ------------------------------------------------
+ * THE GOVERNING PRINCIPLE: WHEN IDENTITY IS UNCERTAIN, PREFER A SPLIT
+ * ------------------------------------------------------------------
+ * The two failure modes are not symmetric, and the asymmetry decides every
+ * judgement call in this module:
+ *
+ *   A SPLIT (one record minting two identities) is RECOVERABLE. All the data is
+ *   still present; the duplicates can be reconciled later, by a tool or a
+ *   person, because both copies are there to compare.
+ *
+ *   A MERGE (two records minting one identity) is NOT RECOVERABLE. The second
+ *   record's content is simply gone — overwritten by the first, or dropped as a
+ *   duplicate — and nothing downstream can know it existed.
+ *
+ * So an uncertain identity must err toward splitting.
+ *
+ * THE CASCADE, in strict order
+ * ---------------------------
  *   1. EXPLICIT ID — the source assigned an identifier. Use it verbatim.
  *      This tier is byte-for-byte what every call site did before this module
  *      existed, which is deliberate: changing an IRI that a source id already
  *      determines would break every pod in the field.
  *
  *   2. CONTENT HASH — the source assigned nothing, so identity comes from what
- *      the record IS. The resource is stripped of volatile fields (see
- *      {@link VOLATILE_FIELDS}), serialized with sorted keys at every level so
- *      source key order cannot perturb the digest, and hashed. Two byte-equal
- *      resources get one identity no matter how many times, from how many
- *      directories, or in what bundle position they are imported.
+ *      the record IS. The resource is stripped of volatile, derivative and
+ *      scaffold fields (see {@link VOLATILE_FIELDS}), serialized with sorted
+ *      keys at every level so source key order cannot perturb the digest, and
+ *      hashed. Two byte-equal resources get one identity no matter how many
+ *      times, from how many directories, or in what bundle position they are
+ *      imported.
  *
- *   3. THERE IS NO TIER 3. Not `randomUUID()`, not `Math.random()`, not
- *      `Date.now()`, not `ctx.importedAt`. A resource whose every
- *      identity-bearing field is empty is a resource that carries no identity,
- *      and the honest answer is a deterministic sentinel ({@link EMPTY_SEED})
- *      that collapses such records together — plus a `source: 'empty'` signal
- *      the caller can surface — NOT a fresh random IRI that splits them apart
- *      forever. Collapsing indistinguishable records is a decision a user can
- *      see and argue with. Duplicating them on every sync is not.
+ *   3. SALVAGE — nothing survived tier 2, but a DERIVATIVE field did. Hash the
+ *      resource again with the derivative fields put BACK. In practice this is
+ *      a narrative-only resource: no structured content, but prose that plainly
+ *      distinguishes it from the next one.
  *
- * WHY VOLATILE FIELDS ARE STRIPPED
- * --------------------------------
+ *      This tier exists because without it the exclusion list MANUFACTURES the
+ *      indistinguishability it then acts on. Two Conditions whose only content
+ *      is `text.div` — "Type 2 diabetes mellitus" and "Metastatic breast
+ *      cancer" — are trivially distinguishable to any reader, and an earlier
+ *      revision of this module collapsed them into one IRI because it had
+ *      thrown away the only field that told them apart. That is data
+ *      destruction dressed up as deduplication.
+ *
+ *      The cost of this tier is bounded and recoverable: a server that
+ *      regenerates a narrative can produce a DUPLICATE of a narrative-only
+ *      record. Per the principle above, that is the failure to prefer.
+ *
+ *   4. COLLAPSE, LOUDLY — there is nothing left at all: no id, no structured
+ *      content, no narrative. Such a record cannot be told apart from any other
+ *      record of its type by any means, so it lands on a deterministic sentinel
+ *      ({@link EMPTY_SEED}) and merges. Crucially, merging here destroys
+ *      NOTHING, because there is no content to destroy — the split-over-merge
+ *      rule has no force when both records are empty, while splitting them
+ *      would recreate the original defect (a fresh IRI on every sync, forever).
+ *
+ *      This tier MUST NOT be silent. It emits a warning naming what happened
+ *      (see {@link identityCollapseWarning}); a caller that passes a `warnings`
+ *      array to {@link identitySeed} receives it.
+ *
+ *   There is no tier 5. Not `randomUUID()`, not `Math.random()`, not
+ *   `Date.now()`, not `ctx.importedAt`.
+ *
+ * WHY FIELDS ARE EXCLUDED, AND THE THREE KINDS OF EXCLUSION
+ * --------------------------------------------------------
  * A content hash is only as stable as its least stable input. `meta.lastUpdated`
  * and `meta.versionId` are assigned by the FHIR server and change every time a
  * resource is re-fetched, so hashing them would mint a fresh IRI on every EHR
  * sync — this exact bug, reintroduced in a subtler and much harder-to-see form,
  * since it would look deterministic in any test that imports the same file
- * twice from disk. See {@link VOLATILE_FIELDS} for the full list and the reason
- * each entry is on it.
+ * twice from disk.
+ *
+ * But not every exclusion is excluded for that reason, and conflating them is
+ * what produced the data-destroying collapse described in tier 3. So each rule
+ * declares its `kind`:
+ *
+ *   'volatile'   — differs between two encounters with the SAME logical record.
+ *                  Never usable for identity at any tier, because using it IS
+ *                  the bug. Server metadata. Stripped at tiers 2 and 3.
+ *
+ *   'derivative' — stable for a given record, and content-bearing, but not the
+ *                  PREFERRED identity signal because the structured fields
+ *                  already say it. Stripped at tier 2, RESTORED at tier 3.
+ *
+ *   'scaffold'   — structural boilerplate present on every record of a kind,
+ *                  and already spliced into the call site's key template.
+ *                  Stripped at tiers 2 and 3, and — the part that matters — it
+ *                  must not count toward "does this resource have content".
+ *                  `resourceType` is the whole reason this kind exists: while it
+ *                  counted as content, a narrative-only Condition hashed to
+ *                  `{"resourceType":"Condition"}`, tier 2 "succeeded" with a
+ *                  value identical for every Condition in existence, and the
+ *                  salvage tier never ran. Tier 2 succeeding with a constant is
+ *                  indistinguishable from tier 2 failing, except that it merges.
+ *
+ * See {@link VOLATILE_FIELDS} for the full list and the reason each entry is on
+ * it.
  *
  * ANONYMOUS SEEDS CANNOT COLLIDE WITH REAL IDS
  * --------------------------------------------
@@ -93,11 +157,24 @@ export const VOLATILE_FIELDS: ReadonlyArray<{
   under: string | null;
   /** Only strip when the value has this shape. Guards against name collisions. */
   shape?: 'object';
+  /**
+   * 'volatile'   — changes for the same logical record; never an identity input.
+   * 'derivative' — stable and content-bearing, just not preferred; restored by
+   *                the tier-3 salvage pass so it can still tell records apart.
+   * 'scaffold'   — structural boilerplate that every record of a kind carries,
+   *                and that the call site ALREADY puts in its key template.
+   *                Never hashed, at any tier. Critically, it must not count
+   *                toward "does this resource have content", or a resource
+   *                whose only real content is narrative looks non-empty and
+   *                never reaches the salvage tier.
+   */
+  kind: 'volatile' | 'derivative' | 'scaffold';
   why: string;
 }> = [
   {
     field: 'lastUpdated',
     under: 'meta',
+    kind: 'volatile',
     why:
       'Server-assigned write timestamp. Changes on every re-fetch of an unchanged resource, so ' +
       'hashing it mints a new IRI on every EHR sync — the defect this module exists to end.',
@@ -105,6 +182,7 @@ export const VOLATILE_FIELDS: ReadonlyArray<{
   {
     field: 'versionId',
     under: 'meta',
+    kind: 'volatile',
     why:
       'Server-assigned version counter. Increments on any server-side touch, including ones that ' +
       'change nothing a patient would recognize as a different record.',
@@ -112,6 +190,7 @@ export const VOLATILE_FIELDS: ReadonlyArray<{
   {
     field: 'source',
     under: 'meta',
+    kind: 'volatile',
     why:
       'Meta.source is a pointer at the system/message a resource arrived through, not at what the ' +
       'resource says. It differs between a bulk export and a live FHIR read of the same resource, ' +
@@ -122,17 +201,38 @@ export const VOLATILE_FIELDS: ReadonlyArray<{
     field: 'text',
     under: null,
     shape: 'object',
+    kind: 'derivative',
     why:
-      'FHIR Narrative. Derivative by definition — the spec requires it to convey the same ' +
-      'information as the structured data, so it adds no identity the structured fields do not ' +
-      'already carry — and volatile in practice, because servers regenerate it with their own ' +
-      'formatting and can render timestamps into it. Restricted to object values so that ' +
+      'FHIR Narrative. Derivative rather than volatile — the spec requires it to convey the same ' +
+      'information as the structured data, so where structured fields exist it adds no identity ' +
+      'they do not already carry, and servers regenerate it with their own formatting. So it is ' +
+      'kept OUT of the preferred hash. But it is real content, and it is restored by the tier-3 ' +
+      'salvage pass, because for a narrative-only resource it is the only thing that tells one ' +
+      'record from another: dropping it there collapsed "Type 2 diabetes mellitus" and ' +
+      '"Metastatic breast cancer" into a single IRI. Restricted to object values so that ' +
       'CodeableConcept.text (a string, and often the ONLY human-meaningful content on a coding) ' +
-      'is preserved. Consequence accepted deliberately: a resource whose only content is narrative ' +
-      'hashes to EMPTY_SEED rather than to its prose, because a rendered timestamp inside prose ' +
-      'would reintroduce exactly the bug being fixed, one layer down where no test would see it.',
+      'is never stripped at any tier.',
+  },
+  {
+    field: 'resourceType',
+    under: null,
+    kind: 'scaffold',
+    why:
+      'The FHIR type discriminator. Every call site already splices the resource type into its ' +
+      'key template — `${resourceType}:${seed}`, `${resourceType}::${seed}`, ' +
+      '`genomics:Variant:${sys}:${seed}` — so hashing it as well is redundant and type separation ' +
+      'is preserved without it. It has to be stripped rather than merely deprioritized, because ' +
+      'while it is present EVERY resource looks like it has content: a Condition whose only real ' +
+      'content is narrative hashed to `{"resourceType":"Condition"}`, which is identical for every ' +
+      'Condition on earth, so tier 2 "succeeded" with a constant and the salvage tier never ran. ' +
+      'That is what silently merged two different diagnoses.',
   },
 ];
+
+/** Kinds stripped at tier 2 (the preferred hash) and at tier 3 (salvage). */
+type ExclusionKind = 'volatile' | 'derivative' | 'scaffold';
+const TIER2_STRIP: ReadonlyArray<ExclusionKind> = ['volatile', 'derivative', 'scaffold'];
+const TIER3_STRIP: ReadonlyArray<ExclusionKind> = ['volatile', 'scaffold'];
 
 /** Prefix on every content-derived seed. See the module header for why it cannot collide with a FHIR id. */
 export const ANON_PREFIX = 'anon-';
@@ -148,7 +248,7 @@ export const ANON_PREFIX = 'anon-';
 export const EMPTY_SEED = `${ANON_PREFIX}empty`;
 
 /** Which tier of the cascade produced a seed. */
-export type IdentitySource = 'explicit' | 'content' | 'empty';
+export type IdentitySource = 'explicit' | 'content' | 'salvage' | 'empty';
 
 export interface IdentitySeed {
   /** The seed to splice into a call site's key template. */
@@ -180,10 +280,16 @@ export function stableStringify(value: unknown): string {
   return `{${inner}}`;
 }
 
-/** True when a volatile rule matches this (parentKey, key, value) position. */
-function isVolatile(parentKey: string | null, key: string, value: unknown): boolean {
+/** True when a rule of one of `kinds` matches this (parentKey, key, value) position. */
+function isExcluded(
+  parentKey: string | null,
+  key: string,
+  value: unknown,
+  kinds: ReadonlyArray<ExclusionKind>,
+): boolean {
   for (const rule of VOLATILE_FIELDS) {
     if (rule.field !== key) continue;
+    if (!kinds.includes(rule.kind)) continue;
     if (rule.under !== null && rule.under !== parentKey) continue;
     if (rule.shape === 'object' && (value === null || typeof value !== 'object' || Array.isArray(value))) continue;
     return true;
@@ -199,17 +305,21 @@ function isVolatile(parentKey: string | null, key: string, value: unknown): bool
  * recognized as carrying no identity instead of hashing to the same
  * accidental-looking digest under different circumstances.
  */
-export function stripVolatile(value: unknown, parentKey: string | null = null): unknown {
+export function stripVolatile(
+  value: unknown,
+  parentKey: string | null = null,
+  kinds: ReadonlyArray<ExclusionKind> = TIER2_STRIP,
+): unknown {
   if (value === null || typeof value !== 'object') return value;
   if (Array.isArray(value)) {
-    const items = value.map((v) => stripVolatile(v, parentKey)).filter((v) => v !== undefined);
+    const items = value.map((v) => stripVolatile(v, parentKey, kinds)).filter((v) => v !== undefined);
     return items.length > 0 ? items : undefined;
   }
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
     if (v === undefined) continue;
-    if (isVolatile(parentKey, k, v)) continue;
-    const kept = stripVolatile(v, k);
+    if (isExcluded(parentKey, k, v, kinds)) continue;
+    const kept = stripVolatile(v, k, kinds);
     if (kept === undefined) continue;
     out[k] = kept;
   }
@@ -224,15 +334,35 @@ export function stripVolatile(value: unknown, parentKey: string | null = null): 
  * key, so there is no cross-SDK UUID-v5 compatibility constraint on it and no
  * reason to pick the weaker digest.
  */
-export function contentFingerprint(content: unknown): string {
-  const stripped = stripVolatile(content);
+export function contentFingerprint(
+  content: unknown,
+  kinds: ReadonlyArray<ExclusionKind> = TIER2_STRIP,
+): string {
+  const stripped = stripVolatile(content, null, kinds);
   if (stripped === undefined) return EMPTY_SEED;
   const serialized = stableStringify(stripped);
   // `{}` / `[]` / `null` / `""` carry no more identity than nothing at all.
   if (serialized === '{}' || serialized === '[]' || serialized === 'null' || serialized === '""') {
     return EMPTY_SEED;
   }
-  return ANON_PREFIX + createHash('sha256').update(serialized, 'utf8').digest('hex');
+  // Domain-separate the two passes so a tier-3 seed can never equal a tier-2
+  // seed, even for an input where the two serializations coincide.
+  const domain = kinds === TIER3_STRIP ? 'salvage:' : 'content:';
+  return ANON_PREFIX + createHash('sha256').update(domain + serialized, 'utf8').digest('hex');
+}
+
+/**
+ * The sentence emitted when tier 4 fires. Exported so tests can assert on it
+ * rather than on a string literal copied into three places.
+ */
+export function identityCollapseWarning(label: string): string {
+  return (
+    `${label}: this record carries no identifier and no identity-bearing content (no structured ` +
+    `fields and no narrative), so it cannot be distinguished from any other empty record of its ` +
+    `type. It has been given a shared, deterministic IRI, which means such records MERGE rather ` +
+    `than accumulating duplicates. Nothing is lost — there is no content to lose — but if you ` +
+    `expected separate records here, the source data is not carrying what would separate them.`
+  );
 }
 
 /**
@@ -248,21 +378,36 @@ export function contentFingerprint(content: unknown): string {
  *                   `null`, `0` or `"   "` is not an identifier.
  * @param content    the source object to hash when there is no explicit id.
  */
-export function identitySeed(opts: { explicitId?: unknown; content?: unknown }): IdentitySeed {
-  const { explicitId, content } = opts;
+export function identitySeed(opts: {
+  explicitId?: unknown;
+  content?: unknown;
+  /** Collected warnings. Tier 4 pushes {@link identityCollapseWarning} here. */
+  warnings?: string[];
+  /** How to name this record in a tier-4 warning. */
+  label?: string;
+}): IdentitySeed {
+  const { explicitId, content, warnings, label } = opts;
 
   // Tier 1 — explicit id.
   if (typeof explicitId === 'string' && explicitId.trim().length > 0) {
     return { seed: explicitId, source: 'explicit' };
   }
 
-  // Tier 2 — content hash.
-  const fingerprint = contentFingerprint(content);
+  // Tier 2 — content hash, derivative and scaffold fields excluded.
+  const fingerprint = contentFingerprint(content, TIER2_STRIP);
   if (fingerprint !== EMPTY_SEED) {
     return { seed: fingerprint, source: 'content' };
   }
 
-  // Tier 3 does not exist. See the module header.
+  // Tier 3 — salvage. Nothing structured survived, so put the derivative fields
+  // back rather than merging records that a narrative plainly tells apart.
+  const salvaged = contentFingerprint(content, TIER3_STRIP);
+  if (salvaged !== EMPTY_SEED) {
+    return { seed: salvaged, source: 'salvage' };
+  }
+
+  // Tier 4 — nothing at all. Collapse, but never silently.
+  warnings?.push(identityCollapseWarning(label ?? 'Record'));
   return { seed: EMPTY_SEED, source: 'empty' };
 }
 
@@ -270,6 +415,11 @@ export function identitySeed(opts: { explicitId?: unknown; content?: unknown }):
  * Convenience for the common call-site shape: resolve a seed and return only
  * the string. Use {@link identitySeed} where the tier is worth reporting.
  */
-export function identityKey(explicitId: unknown, content: unknown): string {
-  return identitySeed({ explicitId, content }).seed;
+export function identityKey(
+  explicitId: unknown,
+  content: unknown,
+  warnings?: string[],
+  label?: string,
+): string {
+  return identitySeed({ explicitId, content, warnings, label }).seed;
 }

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,0 +1,275 @@
+/**
+ * Record identity: ONE door every minted IRI goes through.
+ *
+ * WHY this module exists
+ * ----------------------
+ * Every importer in this codebase mints a subject IRI for each record it
+ * produces, and every one of them independently reached for the same shape:
+ * take the source resource's `id`, and if there isn't one, make something up.
+ * "Make something up" was spelled `randomUUID()` in the FHIR converter,
+ * `Math.random().toString(36)` in six genomics converters, and
+ * `${ctx.importedAt}:${Math.random()}` in two more. A per-run timestamp is the
+ * same defect wearing a disguise: `importedAt` changes on every invocation, so
+ * hashing it is randomness with extra steps.
+ *
+ * The consequence is that importing the same document twice mints two
+ * identities for the same record. Nothing reconciles, nothing dedupes, and the
+ * pod grows a duplicate record set on every re-import — silently, with no
+ * warning and no gap entry, because a fresh IRI looks exactly like a new
+ * record. It is the G-2 byte-reproducibility guarantee failing open.
+ *
+ * The pattern that ends it already existed in this repo, twice, and was
+ * propagated neither time: `contentSeed()` in the phenopacket variation
+ * descriptor (written in May 2026 to fix precisely this bug in ONE file) and
+ * `contentHashedUri()` in the FHIR converter. That is the actual root cause of
+ * this class — a correct pattern that exists, is enforced nowhere, and is
+ * re-broken by each new converter. So a patch per site does not end it either.
+ * This module owns the rule, and `tests/identity-chokepoint.test.ts` is the
+ * lock on every other way in.
+ *
+ * THE CASCADE, in strict order, with no fourth tier
+ * ------------------------------------------------
+ *   1. EXPLICIT ID — the source assigned an identifier. Use it verbatim.
+ *      This tier is byte-for-byte what every call site did before this module
+ *      existed, which is deliberate: changing an IRI that a source id already
+ *      determines would break every pod in the field.
+ *
+ *   2. CONTENT HASH — the source assigned nothing, so identity comes from what
+ *      the record IS. The resource is stripped of volatile fields (see
+ *      {@link VOLATILE_FIELDS}), serialized with sorted keys at every level so
+ *      source key order cannot perturb the digest, and hashed. Two byte-equal
+ *      resources get one identity no matter how many times, from how many
+ *      directories, or in what bundle position they are imported.
+ *
+ *   3. THERE IS NO TIER 3. Not `randomUUID()`, not `Math.random()`, not
+ *      `Date.now()`, not `ctx.importedAt`. A resource whose every
+ *      identity-bearing field is empty is a resource that carries no identity,
+ *      and the honest answer is a deterministic sentinel ({@link EMPTY_SEED})
+ *      that collapses such records together — plus a `source: 'empty'` signal
+ *      the caller can surface — NOT a fresh random IRI that splits them apart
+ *      forever. Collapsing indistinguishable records is a decision a user can
+ *      see and argue with. Duplicating them on every sync is not.
+ *
+ * WHY VOLATILE FIELDS ARE STRIPPED
+ * --------------------------------
+ * A content hash is only as stable as its least stable input. `meta.lastUpdated`
+ * and `meta.versionId` are assigned by the FHIR server and change every time a
+ * resource is re-fetched, so hashing them would mint a fresh IRI on every EHR
+ * sync — this exact bug, reintroduced in a subtler and much harder-to-see form,
+ * since it would look deterministic in any test that imports the same file
+ * twice from disk. See {@link VOLATILE_FIELDS} for the full list and the reason
+ * each entry is on it.
+ *
+ * ANONYMOUS SEEDS CANNOT COLLIDE WITH REAL IDS
+ * --------------------------------------------
+ * A tier-2 seed is `anon-` + 64 hex characters = 69 characters. FHIR constrains
+ * `Resource.id` to at most 64 characters of `[A-Za-z0-9\-\.]`, so a minted seed
+ * is structurally incapable of colliding with an id a source could legitimately
+ * assign. That matters because tiers 1 and 2 feed the SAME key template at each
+ * call site: an id-less resource can never be confused with an id-bearing one.
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * Fields excluded from every content hash, and why each one is here.
+ *
+ * The test `identity-volatile-fields.test.ts` pins this list. Adding an entry
+ * is a claim that the field can differ between two encounters with the SAME
+ * logical record; removing one is a claim that it cannot.
+ *
+ * Matching is by (enclosing key, field name) rather than by name alone, at any
+ * depth, so that a `contained[0].meta.lastUpdated` is stripped too — and, more
+ * importantly, so that stripping is precise. `source` is a volatile provenance
+ * pointer under `meta` and load-bearing content almost everywhere else, and
+ * `text` is generated narrative on a Resource but a genuine clinical label on a
+ * CodeableConcept ("Blood pressure"). A name-only ban would delete real
+ * identity content and quietly merge unrelated records.
+ */
+export const VOLATILE_FIELDS: ReadonlyArray<{
+  /** Field name to strip. */
+  field: string;
+  /** Only strip when the immediately enclosing object was reached under this key. `null` = any parent. */
+  under: string | null;
+  /** Only strip when the value has this shape. Guards against name collisions. */
+  shape?: 'object';
+  why: string;
+}> = [
+  {
+    field: 'lastUpdated',
+    under: 'meta',
+    why:
+      'Server-assigned write timestamp. Changes on every re-fetch of an unchanged resource, so ' +
+      'hashing it mints a new IRI on every EHR sync — the defect this module exists to end.',
+  },
+  {
+    field: 'versionId',
+    under: 'meta',
+    why:
+      'Server-assigned version counter. Increments on any server-side touch, including ones that ' +
+      'change nothing a patient would recognize as a different record.',
+  },
+  {
+    field: 'source',
+    under: 'meta',
+    why:
+      'Meta.source is a pointer at the system/message a resource arrived through, not at what the ' +
+      'resource says. It differs between a bulk export and a live FHIR read of the same resource, ' +
+      'and Epic-style servers append a per-version fragment to it. Scoped to `meta` because ' +
+      '`source` is content-bearing under nearly every other parent.',
+  },
+  {
+    field: 'text',
+    under: null,
+    shape: 'object',
+    why:
+      'FHIR Narrative. Derivative by definition — the spec requires it to convey the same ' +
+      'information as the structured data, so it adds no identity the structured fields do not ' +
+      'already carry — and volatile in practice, because servers regenerate it with their own ' +
+      'formatting and can render timestamps into it. Restricted to object values so that ' +
+      'CodeableConcept.text (a string, and often the ONLY human-meaningful content on a coding) ' +
+      'is preserved. Consequence accepted deliberately: a resource whose only content is narrative ' +
+      'hashes to EMPTY_SEED rather than to its prose, because a rendered timestamp inside prose ' +
+      'would reintroduce exactly the bug being fixed, one layer down where no test would see it.',
+  },
+];
+
+/** Prefix on every content-derived seed. See the module header for why it cannot collide with a FHIR id. */
+export const ANON_PREFIX = 'anon-';
+
+/**
+ * The seed for a resource with no explicit id and no non-volatile content.
+ *
+ * Deterministic on purpose. Records that reach it are indistinguishable to
+ * every part of this system, so they collapse to one identity instead of
+ * multiplying. Callers that can surface this to a user should branch on
+ * `source === 'empty'` rather than on the string.
+ */
+export const EMPTY_SEED = `${ANON_PREFIX}empty`;
+
+/** Which tier of the cascade produced a seed. */
+export type IdentitySource = 'explicit' | 'content' | 'empty';
+
+export interface IdentitySeed {
+  /** The seed to splice into a call site's key template. */
+  seed: string;
+  /** Which tier produced it. */
+  source: IdentitySource;
+}
+
+/**
+ * `JSON.stringify` with sorted keys at every level.
+ *
+ * Sorting is what makes the digest independent of source key order: the same
+ * resource serialized by two EHRs, or round-tripped through two JSON libraries,
+ * has to hash the same. Arrays keep their order, because array order in FHIR is
+ * meaningful (`name[0]` is the primary name).
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const inner = Object.keys(obj)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(',');
+  return `{${inner}}`;
+}
+
+/** True when a volatile rule matches this (parentKey, key, value) position. */
+function isVolatile(parentKey: string | null, key: string, value: unknown): boolean {
+  for (const rule of VOLATILE_FIELDS) {
+    if (rule.field !== key) continue;
+    if (rule.under !== null && rule.under !== parentKey) continue;
+    if (rule.shape === 'object' && (value === null || typeof value !== 'object' || Array.isArray(value))) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Recursively remove volatile fields, and prune anything that becomes empty.
+ *
+ * Pruning matters: a resource whose only field was `meta.lastUpdated` must land
+ * on "no content" rather than on `{"meta":{}}`, so that two such resources are
+ * recognized as carrying no identity instead of hashing to the same
+ * accidental-looking digest under different circumstances.
+ */
+export function stripVolatile(value: unknown, parentKey: string | null = null): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    const items = value.map((v) => stripVolatile(v, parentKey)).filter((v) => v !== undefined);
+    return items.length > 0 ? items : undefined;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (v === undefined) continue;
+    if (isVolatile(parentKey, k, v)) continue;
+    const kept = stripVolatile(v, k);
+    if (kept === undefined) continue;
+    out[k] = kept;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Hash a resource's non-volatile content into an anonymous seed.
+ *
+ * Returns `EMPTY_SEED` when nothing survives stripping. SHA-256 rather than the
+ * SHA-1 that `deterministicUuid` uses downstream: the seed is an intermediate
+ * key, so there is no cross-SDK UUID-v5 compatibility constraint on it and no
+ * reason to pick the weaker digest.
+ */
+export function contentFingerprint(content: unknown): string {
+  const stripped = stripVolatile(content);
+  if (stripped === undefined) return EMPTY_SEED;
+  const serialized = stableStringify(stripped);
+  // `{}` / `[]` / `null` / `""` carry no more identity than nothing at all.
+  if (serialized === '{}' || serialized === '[]' || serialized === 'null' || serialized === '""') {
+    return EMPTY_SEED;
+  }
+  return ANON_PREFIX + createHash('sha256').update(serialized, 'utf8').digest('hex');
+}
+
+/**
+ * THE DOOR. Resolve the identity seed for one record.
+ *
+ * Splice the returned `seed` into whatever key template the call site already
+ * uses. When `explicitId` is present the seed IS that id, so the key string is
+ * byte-identical to what the site produced before it took the door — which is
+ * the property that lets this change ship without moving a single existing IRI.
+ *
+ * @param explicitId the source-assigned identifier, if any. Non-strings and
+ *                   blank strings are treated as absent, because an id that is
+ *                   `null`, `0` or `"   "` is not an identifier.
+ * @param content    the source object to hash when there is no explicit id.
+ */
+export function identitySeed(opts: { explicitId?: unknown; content?: unknown }): IdentitySeed {
+  const { explicitId, content } = opts;
+
+  // Tier 1 — explicit id.
+  if (typeof explicitId === 'string' && explicitId.trim().length > 0) {
+    return { seed: explicitId, source: 'explicit' };
+  }
+
+  // Tier 2 — content hash.
+  const fingerprint = contentFingerprint(content);
+  if (fingerprint !== EMPTY_SEED) {
+    return { seed: fingerprint, source: 'content' };
+  }
+
+  // Tier 3 does not exist. See the module header.
+  return { seed: EMPTY_SEED, source: 'empty' };
+}
+
+/**
+ * Convenience for the common call-site shape: resolve a seed and return only
+ * the string. Use {@link identitySeed} where the tier is worth reporting.
+ */
+export function identityKey(explicitId: unknown, content: unknown): string {
+  return identitySeed({ explicitId, content }).seed;
+}

--- a/src/lib/phenopacket-converter/biosamples.ts
+++ b/src/lib/phenopacket-converter/biosamples.ts
@@ -195,7 +195,9 @@ export function parseBiosample(
   // none. This used to seed on `${ctx.importedAt}:${Math.random()}` — and note
   // that dropping only the Math.random() would have left it non-deterministic,
   // because importedAt is a fresh timestamp on every invocation.
-  const sourceId: string = identityKey(bs.id, bs);
+  const idWarnings: string[] = [];
+  const sourceId: string = identityKey(bs.id, bs, idWarnings, `${contextLabel}.biosample`);
+  for (const m of idWarnings) warnings.push({ message: m });
   const iri = mintSpecimenIri(sourceId, ctx);
   const sQuads: Quad[] = [];
 

--- a/src/lib/phenopacket-converter/biosamples.ts
+++ b/src/lib/phenopacket-converter/biosamples.ts
@@ -46,6 +46,7 @@ import {
   tripleRef,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 export interface BiosampleParseOutput {
   records: ParsedRecord[];
@@ -190,8 +191,11 @@ export function parseBiosample(
 
   if (!bs || typeof bs !== 'object') return { records, quads, warnings, gaps };
 
-  const sourceId: string =
-    typeof bs.id === 'string' && bs.id.length > 0 ? bs.id : `biosample:${ctx.importedAt}:${Math.random()}`;
+  // Identity comes from the biosample's own id, or from its content when it has
+  // none. This used to seed on `${ctx.importedAt}:${Math.random()}` — and note
+  // that dropping only the Math.random() would have left it non-deterministic,
+  // because importedAt is a fresh timestamp on every invocation.
+  const sourceId: string = identityKey(bs.id, bs);
   const iri = mintSpecimenIri(sourceId, ctx);
   const sQuads: Quad[] = [];
 

--- a/src/lib/phenopacket-converter/subject.ts
+++ b/src/lib/phenopacket-converter/subject.ts
@@ -40,6 +40,7 @@ import {
   tripleDate,
   deterministicUuid,
 } from '../fhir-converter/types.js';
+import { identityKey } from '../identity.js';
 
 export interface SubjectParseOutput {
   record: ParsedRecord;
@@ -49,7 +50,13 @@ export interface SubjectParseOutput {
 
 /**
  * Mint a deterministic Cascade IRI for a phenopacket subject. Falls back to
- * the parent phenopacket id when the subject itself has no id.
+ * the parent phenopacket id when the subject itself has no id, and to the
+ * subject's own content when neither exists.
+ *
+ * The final tier used to be `unknown:${ctx.importedAt}`. That reads as
+ * deterministic and is not: `importedAt` is stamped per invocation, so an
+ * anonymous subject became a NEW patient profile on every re-import of the same
+ * phenopacket. Same defect as the `Math.random()` sites, wearing a timestamp.
  */
 export function mintSubjectIri(
   subject: any,
@@ -60,7 +67,7 @@ export function mintSubjectIri(
   const sid: string =
     (typeof subject?.id === 'string' && subject.id) ||
     (typeof parentId === 'string' && parentId) ||
-    `unknown:${ctx.importedAt}`;
+    identityKey(undefined, subject);
   return `urn:uuid:${deterministicUuid(`PatientProfile:${sys}:${sid}`)}`;
 }
 

--- a/src/lib/phenopacket-converter/subject.ts
+++ b/src/lib/phenopacket-converter/subject.ts
@@ -62,12 +62,13 @@ export function mintSubjectIri(
   subject: any,
   parentId: string | undefined,
   ctx: ImportContext,
+  idWarnings: string[] = [],
 ): string {
   const sys = ctx.sourceSystem ?? 'phenopacket';
   const sid: string =
     (typeof subject?.id === 'string' && subject.id) ||
     (typeof parentId === 'string' && parentId) ||
-    identityKey(undefined, subject);
+    identityKey(undefined, subject, idWarnings, 'phenopacket subject');
   return `urn:uuid:${deterministicUuid(`PatientProfile:${sys}:${sid}`)}`;
 }
 
@@ -87,7 +88,10 @@ export function parseSubject(
   const gaps: VocabularyGap[] = [];
   const quads: Quad[] = [];
 
-  const iri = mintSubjectIri(subject, parentId, ctx);
+  // Surface a tier-4 identity collapse as an import warning.
+  const idWarnings: string[] = [];
+  const iri = mintSubjectIri(subject, parentId, ctx, idWarnings);
+  for (const m of idWarnings) warnings.push({ message: m });
   const sourceId: string =
     (typeof subject?.id === 'string' && subject.id) ||
     (typeof parentId === 'string' && parentId) ||

--- a/tests/fhir-converter.test.ts
+++ b/tests/fhir-converter.test.ts
@@ -1197,12 +1197,29 @@ describe('mintSubjectUri', () => {
     expect(r1).not.toBe(r2);
   });
 
-  it('should return random UUID when no id present', () => {
-    const r1 = mintSubjectUri({ resourceType: 'Patient' });
-    const r2 = mintSubjectUri({ resourceType: 'Patient' });
-    expect(r1).toMatch(/^urn:uuid:/);
-    // Two calls with no id should produce different URIs
+  // This test used to assert the opposite — "should return random UUID when no
+  // id present", with `expect(r1).not.toBe(r2)`. It was pinning the defect: a
+  // random IRI for an id-less resource means re-importing the same document
+  // mints a second copy of every id-less record in it, forever, with no signal
+  // that anything happened. `Resource.id` is optional in FHIR, so this is a case
+  // real payloads hit. Identity now comes from the resource's own content.
+  it('should return a CONTENT-derived URI when no id is present', () => {
+    const r1 = mintSubjectUri({ resourceType: 'Patient', birthDate: '1985-06-15', gender: 'female' });
+    const r2 = mintSubjectUri({ resourceType: 'Patient', birthDate: '1985-06-15', gender: 'female' });
+    expect(r1).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    expect(r1).toBe(r2);
+  });
+
+  it('should still distinguish two DIFFERENT id-less resources', () => {
+    const r1 = mintSubjectUri({ resourceType: 'Patient', birthDate: '1985-06-15', gender: 'female' });
+    const r2 = mintSubjectUri({ resourceType: 'Patient', birthDate: '1990-01-02', gender: 'male' });
     expect(r1).not.toBe(r2);
+  });
+
+  it('should not let an id-less resource collide with an id-bearing one', () => {
+    const withId = mintSubjectUri({ resourceType: 'Patient', id: 'patient-1', gender: 'female' });
+    const withoutId = mintSubjectUri({ resourceType: 'Patient', gender: 'female' });
+    expect(withId).not.toBe(withoutId);
   });
 });
 

--- a/tests/identity-chokepoint.test.ts
+++ b/tests/identity-chokepoint.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Identity minting is a DOOR, and this test is the lock on every other way in.
+ *
+ * Every importer in this repo independently reached for the same shape — take
+ * the source's `id`, and if there isn't one, make something up — and every one
+ * of them got it wrong in a slightly different dialect: `randomUUID()` in the
+ * FHIR converter, `Math.random().toString(36)` in five genomics converters,
+ * `${ctx.importedAt}:${Math.random()}` in two more, and a bare
+ * `doc:${importedAt}` in the C-CDA converter. The consequence in every dialect
+ * is identical: re-importing one document mints a second identity for each
+ * id-less record in it, so nothing reconciles and the pod duplicates on every
+ * sync, silently.
+ *
+ * Fixing eleven sites does not end that class. The correct pattern ALREADY
+ * existed in this repo, twice — `contentSeed()` in the phenopacket variation
+ * descriptor and `contentHashedUri()` in the FHIR converter — and was
+ * propagated neither time, so each new converter re-broke it on its first
+ * commit. That is the actual root cause, and the only fix for it is a fence.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DISTINCTION THIS TEST TURNS ON
+ * ---------------------------------------------------------------------------
+ * `randomUUID()` is not banned. Banning a function name would be both too
+ * strict and too weak: too strict because per-EVENT identifiers must be unique
+ * and randomness is exactly right for them, and too weak because `importedAt`
+ * and `Date.now()` are non-deterministic without containing the word "random".
+ *
+ * So the rule is about WHAT is being identified, not which function does it:
+ *
+ *   CONTENT IDENTITY — "which record is this?" Answered by the record. Two
+ *                      encounters with the same source record must produce the
+ *                      same IRI, forever, on any machine. Randomness, clocks
+ *                      and per-run values are all disqualified.
+ *
+ *   EVENT IDENTITY   — "which occurrence is this?" Answered by the occurrence.
+ *                      An audit entry, a user's resolution of a conflict, an
+ *                      annotation someone wrote: running the verb twice IS two
+ *                      events, and each is entitled to its own id. Randomness
+ *                      is correct here and determinism would be a bug.
+ *
+ * Three checks enforce that split:
+ *   1. IDENTITY_MODULES may contain no non-determinism at all, exempt or not.
+ *   2. Everywhere else, each use must be in EVENT_IDENTITY_ALLOWLIST.
+ *   3. No identity-minting call anywhere may take a non-deterministic argument.
+ *
+ * If check 1 or 3 fails on your new converter, the fix is not to widen a list:
+ * it is to take the door, `identitySeed`/`identityKey` in `src/lib/identity.ts`,
+ * which resolves explicit id → content hash and has no third tier.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+/**
+ * Directories and files that mint CONTENT identity. Nothing non-deterministic
+ * may appear anywhere inside them — there is no legitimate per-event id in an
+ * importer, so an exemption here would always be a mistake.
+ */
+const IDENTITY_MODULES: readonly string[] = [
+  'lib/identity.ts',
+  'lib/fhir-converter/',
+  'lib/fhir-genomics-converter/',
+  'lib/phenopacket-converter/',
+  'lib/ccda-converter/',
+  'lib/vcf-converter/',
+  'lib/clinvar-converter/',
+  'lib/vrs-converter/',
+];
+
+/**
+ * Uses of randomness that identify an EVENT rather than a record.
+ *
+ * Each entry is a claim that running the same operation twice legitimately
+ * produces two things, so a stable id would be wrong. That claim is what is
+ * being reviewed when someone adds to this list — not whether the code
+ * compiles.
+ */
+const EVENT_IDENTITY_ALLOWLIST: ReadonlyArray<{ file: string; why: string }> = [
+  {
+    file: 'lib/mcp/audit.ts',
+    why:
+      'Audit entry ids. One per audited access, and two identical accesses are two events in the ' +
+      'log; collapsing them would destroy the record the audit log exists to keep.',
+  },
+  {
+    file: 'lib/mcp/tools.ts',
+    why:
+      'pod_write mints the URI for a record an agent is AUTHORING. There is no source document to ' +
+      'reconcile against — this is a create verb, not an import — so there is no prior identity to ' +
+      'recover. (Whether repeated identical pod_write calls should dedupe is an idempotence ' +
+      'question about the write surface, not an identity-minting defect; tracked separately.)',
+  },
+  {
+    file: 'lib/annotations.ts',
+    why:
+      'mintUri() for overlay ACTS: annotations, amendments, retractions, tombstones, add-record. ' +
+      'Each carries its own prov:generatedAtTime because each is a thing a person did at a time. ' +
+      'Annotating the same record twice with the same text is two annotations, by design — unlike ' +
+      'importing the same document twice, which is one document.',
+  },
+  {
+    file: 'lib/user-resolutions.ts',
+    why: 're-exports randomUUID for the resolve/import commands below; contains no call of its own.',
+  },
+  {
+    file: 'commands/pod/import.ts',
+    why:
+      'The pending-conflict record URI. The conflict itself is deduped on the DETERMINISTIC ' +
+      'generateConflictId(recordType, matchedOn); the urn is the id of one detection event.',
+  },
+  {
+    file: 'commands/pod/resolve.ts',
+    why: 'The user-resolution record URI: one per decision a person made, stamped with resolvedAt.',
+  },
+  {
+    file: 'lib/advisory/applier.ts',
+    why:
+      'PROV activity IRIs for one advisory application. A prov:Activity is an occurrence by ' +
+      'definition, and the minter is injectable so callers needing stronger uniqueness can swap it.',
+  },
+];
+
+/**
+ * Sources of non-determinism.
+ *
+ * Split into two groups, because they are not equally out of place. RANDOM has
+ * no legitimate use anywhere in a converter, so it is banned outright there.
+ * CLOCK values are legitimate CONTENT in a converter — `clinical:importedAt` and
+ * `prov:generatedAtTime` are provenance literals every importer is supposed to
+ * emit — but they are never legitimate INPUTS to an identity key. So clocks are
+ * policed by where they flow, not by whether they appear.
+ *
+ * `importedAt` is in the clock group deliberately. It does not look random, and
+ * that disguise is exactly how two of these sites survived a previous sweep of
+ * this very defect: removing their visible `Math.random()` would have left them
+ * keyed on a per-run timestamp and just as non-deterministic.
+ */
+const RANDOM = [
+  { pattern: /\bMath\.random\s*\(/, name: 'Math.random()' },
+  { pattern: /\brandomUUID\s*\(/, name: 'randomUUID()' },
+] as const;
+
+const CLOCK = [
+  { pattern: /\bDate\.now\s*\(/, name: 'Date.now()' },
+  { pattern: /\bnew Date\s*\(\s*\)/, name: 'new Date()' },
+  { pattern: /\bimportedAt\b/, name: 'importedAt (a per-run timestamp)' },
+] as const;
+
+const NONDETERMINISM = [...RANDOM, ...CLOCK];
+
+/** Calls that mint an identity. Their arguments must be deterministic. */
+const IDENTITY_CALLS = ['deterministicUuid(', 'contentHashedUri(', 'identitySeed(', 'identityKey(', 'medicationUri('];
+
+/** Every `.ts` file under `src/`, as `/`-separated paths relative to src. */
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        out.push(path.relative(SRC_DIR, full).split(path.sep).join('/'));
+      }
+    }
+  };
+  walk(SRC_DIR);
+  return out.sort();
+}
+
+/** Strip line comments, block comments and string/template literals. */
+function stripNonCode(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+    .replace(/'(?:[^'\\\n]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\\n]|\\.)*"/g, '""');
+}
+
+/**
+ * Code with comments removed but template literals KEPT.
+ *
+ * Template literals are where identity keys are actually built
+ * (`` `genomics:Variant:${sys}:${id}` ``), so a check that strips them cannot
+ * see the very interpolations it is looking for.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+function isUnder(file: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((p) => (p.endsWith('/') ? file.startsWith(p) : file === p));
+}
+
+/** Extract the argument text of every `name(...)` call, balancing parens. */
+function callArguments(code: string, callName: string): string[] {
+  const out: string[] = [];
+  let from = 0;
+  for (;;) {
+    const start = code.indexOf(callName, from);
+    if (start === -1) break;
+    let depth = 0;
+    let i = start + callName.length - 1;
+    const open = i;
+    for (; i < code.length; i++) {
+      if (code[i] === '(') depth++;
+      else if (code[i] === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    out.push(code.slice(open + 1, i));
+    from = start + callName.length;
+  }
+  return out;
+}
+
+const FILES = sourceFiles();
+const CODE = new Map(FILES.map((f) => [f, fs.readFileSync(path.join(SRC_DIR, f), 'utf8')]));
+
+describe('identity minting has exactly one door', () => {
+  it('the door exists and exports the cascade', async () => {
+    const mod = await import('../src/lib/identity.js');
+    expect(typeof mod.identitySeed).toBe('function');
+    expect(typeof mod.identityKey).toBe('function');
+    // The cascade has exactly three outcomes and none of them is "random".
+    expect(mod.identitySeed({ explicitId: 'abc' })).toEqual({ seed: 'abc', source: 'explicit' });
+    expect(mod.identitySeed({ content: { a: 1 } }).source).toBe('content');
+    expect(mod.identitySeed({}).source).toBe('empty');
+  });
+
+  it('no identity-minting module contains randomness AT ALL — no exemptions', () => {
+    // An importer transcribes records that already exist. It has no events of
+    // its own to identify, so there is no reading of `Math.random()` inside one
+    // that is correct, and therefore no allowlist for this check.
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (!isUnder(file, IDENTITY_MODULES)) continue;
+      const code = stripComments(CODE.get(file)!);
+      for (const { pattern, name } of RANDOM) {
+        if (pattern.test(code)) offenders.push(`${file}: ${name}`);
+      }
+    }
+    expect(
+      offenders,
+      'An importer has no legitimate per-event id. Route this through identitySeed() ' +
+        'in src/lib/identity.ts. There is deliberately no way to exempt this.',
+    ).toEqual([]);
+  });
+
+  it('every remaining use of randomness is a declared EVENT identity', () => {
+    const allowed = new Set(EVENT_IDENTITY_ALLOWLIST.map((e) => e.file));
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (isUnder(file, IDENTITY_MODULES)) continue;  // covered by the stricter check above
+      if (allowed.has(file)) continue;
+      const code = stripNonCode(CODE.get(file)!);
+      for (const { pattern, name } of RANDOM) {
+        if (pattern.test(code)) offenders.push(`${file}: ${name}`);
+      }
+    }
+    expect(
+      offenders,
+      'If this identifies a RECORD, take the door. If it identifies an EVENT, add it to ' +
+        'EVENT_IDENTITY_ALLOWLIST with the reason two runs are legitimately two things.',
+    ).toEqual([]);
+  });
+
+  it('the allowlist carries no dead entries', () => {
+    // A stale exemption is a hole nobody is looking at.
+    const dead = EVENT_IDENTITY_ALLOWLIST.filter((e) => {
+      const code = CODE.get(e.file);
+      if (code === undefined) return true;
+      return !/\bMath\.random\s*\(|\brandomUUID\b/.test(stripNonCode(code));
+    }).map((e) => e.file);
+    expect(dead).toEqual([]);
+  });
+
+  it('every allowlist entry states WHY, at length', () => {
+    for (const entry of EVENT_IDENTITY_ALLOWLIST) {
+      expect(entry.why.length, `${entry.file} needs a real justification`).toBeGreaterThan(60);
+    }
+  });
+
+  it('no identity-minting call takes a non-deterministic argument', () => {
+    // The check that would have caught observation-variant.ts and biosamples.ts,
+    // where `Math.random()` was removed-adjacent but `ctx.importedAt` remained.
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (file === 'lib/identity.ts') continue;  // defines the door
+      const code = stripComments(CODE.get(file)!);
+      for (const call of IDENTITY_CALLS) {
+        for (const args of callArguments(code, call)) {
+          for (const { pattern, name } of NONDETERMINISM) {
+            if (pattern.test(args)) {
+              offenders.push(`${file}: ${call}…) receives ${name}`);
+            }
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      'An identity key must be a pure function of the source record. A per-run timestamp in ' +
+        'the key is the same defect as a random value, and harder to see.',
+    ).toEqual([]);
+  });
+
+  it('ctx.importedAt appears in no identity key anywhere', () => {
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      const code = stripComments(CODE.get(file)!);
+      // Any template literal that both interpolates importedAt and looks like a
+      // key (contains a `:` separator) inside an identity call is caught above;
+      // this is the blunter backstop for the converter tree.
+      if (!isUnder(file, IDENTITY_MODULES)) continue;
+      if (/importedAt/.test(code)) {
+        // Converters legitimately EMIT importedAt as a provenance literal. Only
+        // flag it when it is spliced into a template literal, which is how every
+        // one of these defects was written.
+        for (const lit of code.match(/`[^`]*`/g) ?? []) {
+          if (/\$\{[^}]*importedAt[^}]*\}/.test(lit) && lit.includes(':')) {
+            offenders.push(`${file}: ${lit.trim().slice(0, 80)}`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/identity-cross-process.test.ts
+++ b/tests/identity-cross-process.test.ts
@@ -30,7 +30,12 @@ import { fileURLToPath } from 'node:url';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const DIST = path.join(REPO, 'dist');
-const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'identity.js'));
+// Guard on a module that exists in EVERY revision, not on identity.js. Keying
+// the guard on the new module made this suite SKIP rather than FAIL when run
+// against a build that predates the fix, which would have made it useless as
+// a negative control — the exact way a determinism test can look green and
+// prove nothing.
+const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'fhir-converter', 'fhir-to-cascade.js'));
 
 /**
  * A self-contained script run in a fresh process. It imports the BUILT

--- a/tests/identity-cross-process.test.ts
+++ b/tests/identity-cross-process.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Identity must survive the process, and the working directory.
+ *
+ * A determinism test that mints twice inside one process proves less than it
+ * appears to. Both calls share a warm module cache, a single module-level
+ * `Math.random` seed, any memoization a converter happens to hold, and one
+ * `process.cwd()`. A defect that keys on ANY of those is invisible to it.
+ *
+ * That is not hypothetical here. The previous defect in this family (the VCF
+ * `SequencingRun` IRI, root 3.7) was path-dependent, and it stayed invisible for
+ * months for exactly this reason: everything ran from one directory, so the
+ * oracle reproduced and the suite was green. It only surfaced when CI ran from
+ * a different absolute path.
+ *
+ * So these cases spawn a SEPARATE `node` process per measurement, from a
+ * DIFFERENT working directory, and compare the IRIs across them. The importers
+ * are exercised through `dist/`, i.e. the built artifact an npm consumer
+ * actually installs, rather than through the TypeScript sources.
+ *
+ * They are skipped when `dist/` is absent, because `npm test` without a prior
+ * `npm run build` cannot honestly make this claim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'identity.js'));
+
+/**
+ * A self-contained script run in a fresh process. It imports the BUILT
+ * converters by absolute file URL, so it works from any cwd, and prints the
+ * minted IRIs as JSON on stdout.
+ */
+const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+
+const dist = process.env.CASCADE_DIST;
+const load = (p) => import(pathToFileURL(path.join(dist, p)).href);
+
+const { convertFhirResourceToQuads } = await load('lib/fhir-converter/fhir-to-cascade.js');
+const { convertGenomicsBundle } = await load('lib/fhir-genomics-converter/index.js');
+const { convertPhenopacket } = await load('lib/phenopacket-converter/index.js');
+const { convertCcda } = await load('lib/ccda-converter/index.js');
+
+const payload = JSON.parse(process.env.CASCADE_PAYLOAD);
+const ctx = {
+  inputPath: payload.inputPath,
+  outputSerialization: 'turtle',
+  importedAt: payload.importedAt,
+  options: {},
+};
+
+const out = {};
+
+const fhir = convertFhirResourceToQuads(payload.fhir);
+out.fhir = fhir._quads[0].subject.value;
+
+const genomics = await convertGenomicsBundle(payload.genomics, ctx);
+out.genomics = genomics.records.map((r) => r.iri);
+
+const pheno = await convertPhenopacket(payload.phenopacket, ctx);
+out.phenopacket = pheno.records.map((r) => r.iri);
+
+const ccda = await convertCcda(payload.ccda, { importedAt: payload.importedAt });
+out.ccda = [...new Set((ccda.output ?? '').match(/urn:uuid:[0-9a-f-]{36}/g) ?? [])].sort();
+
+// cwd is reported so a failure shows which directory produced which answer.
+out._cwd = process.cwd();
+process.stdout.write(JSON.stringify(out));
+`;
+
+/** The same id-less inputs the in-process suite uses. */
+const FHIR = {
+  resourceType: 'Observation',
+  status: 'final',
+  code: { coding: [{ system: 'http://loinc.org', code: '8867-4', display: 'Heart rate' }] },
+  subject: { reference: 'Patient/synthetic-1' },
+  effectiveDateTime: '2026-01-15T09:30:00Z',
+  valueQuantity: { value: 72, unit: '/min' },
+};
+
+const GENOMICS = {
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Observation',
+        meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant'] },
+        status: 'final',
+        code: { coding: [{ system: 'http://loinc.org', code: '69548-6' }] },
+        valueCodeableConcept: { coding: [{ system: 'http://loinc.org', code: 'LA9633-4', display: 'Present' }] },
+        component: [
+          {
+            code: { coding: [{ system: 'http://loinc.org', code: '48004-6' }] },
+            valueCodeableConcept: { text: 'NM_007294.4:c.5266dupC' },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const PHENOPACKET = {
+  id: 'synthetic-phenopacket-1',
+  subject: { sex: 'FEMALE' },
+  biosamples: [{ sampledTissue: { id: 'UBERON:0000178', label: 'blood' } }],
+  metaData: { created: '2026-01-01T00:00:00Z', phenopacketSchemaVersion: '2.0' },
+};
+
+const CCDA = `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1"/>
+  <title>Synthetic CCD</title>
+  <effectiveTime value="20260115093000"/>
+  <recordTarget><patientRole>
+    <id root="2.16.840.1.113883.19.5" extension="SYN-1"/>
+    <patient>
+      <name><given>Pat</given><family>Synthetic</family></name>
+      <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+      <birthTime value="19840301"/>
+    </patient>
+  </patientRole></recordTarget>
+  <custodian><assignedCustodian><representedCustodianOrganization>
+    <name>Synthetic Health System</name>
+  </representedCustodianOrganization></assignedCustodian></custodian>
+  <component><structuredBody><component><section>
+    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+    <code code="11450-4" codeSystem="2.16.840.1.113883.6.1"/>
+    <title>Problems</title>
+    <text>Hypertension, diagnosed 2019.</text>
+  </section></component></structuredBody></component>
+</ClinicalDocument>`;
+
+interface Minted {
+  fhir: string;
+  genomics: string[];
+  phenopacket: string[];
+  ccda: string[];
+  _cwd: string;
+}
+
+let scriptPath = '';
+const tempDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+/** Run the minting script in a FRESH process, from `cwd`. */
+function mintInFreshProcess(opts: { cwd: string; importedAt: string; inputPath: string }): Minted {
+  if (!scriptPath) {
+    const d = tempDir('cascade-identity-script-');
+    scriptPath = path.join(d, 'mint.mjs');
+    fs.writeFileSync(scriptPath, SCRIPT);
+  }
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd: opts.cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CASCADE_DIST: DIST,
+      CASCADE_PAYLOAD: JSON.stringify({
+        fhir: FHIR,
+        genomics: GENOMICS,
+        phenopacket: PHENOPACKET,
+        ccda: CCDA,
+        importedAt: opts.importedAt,
+        inputPath: opts.inputPath,
+      }),
+    },
+  });
+  return JSON.parse(stdout) as Minted;
+}
+
+describe.skipIf(!HAVE_DIST)('identity is stable across processes and directories', () => {
+  it('two separate processes from the SAME directory agree', () => {
+    const cwd = tempDir('cascade-identity-a-');
+    const a = mintInFreshProcess({ cwd, importedAt: '2026-01-01T00:00:00Z', inputPath: '/in/a.json' });
+    const b = mintInFreshProcess({ cwd, importedAt: '2026-01-01T00:00:00Z', inputPath: '/in/a.json' });
+    expect(a.fhir).toBe(b.fhir);
+    expect(a.genomics).toEqual(b.genomics);
+    expect(a.phenopacket).toEqual(b.phenopacket);
+    expect(a.ccda).toEqual(b.ccda);
+  });
+
+  it('two separate processes from DIFFERENT directories agree', () => {
+    // The 3.7 lesson: the previous defect in this family was invisible
+    // precisely because every run happened from one path.
+    const a = mintInFreshProcess({
+      cwd: tempDir('cascade-identity-b-'),
+      importedAt: '2026-01-01T00:00:00Z',
+      inputPath: '/in/a.json',
+    });
+    const b = mintInFreshProcess({
+      cwd: tempDir('cascade-identity-c-'),
+      importedAt: '2026-01-01T00:00:00Z',
+      inputPath: '/in/a.json',
+    });
+    expect(a._cwd).not.toBe(b._cwd);
+    expect(a.fhir).toBe(b.fhir);
+    expect(a.genomics).toEqual(b.genomics);
+    expect(a.phenopacket).toEqual(b.phenopacket);
+    expect(a.ccda).toEqual(b.ccda);
+  });
+
+  it('a different importedAt and a different inputPath change nothing', () => {
+    const a = mintInFreshProcess({
+      cwd: tempDir('cascade-identity-d-'),
+      importedAt: '2026-01-01T00:00:00Z',
+      inputPath: '/somewhere/original.json',
+    });
+    const b = mintInFreshProcess({
+      cwd: tempDir('cascade-identity-e-'),
+      importedAt: '2031-12-25T18:45:07Z',
+      inputPath: '/elsewhere/renamed-copy.json',
+    });
+    expect(a.fhir).toBe(b.fhir);
+    expect(a.genomics).toEqual(b.genomics);
+    expect(a.phenopacket).toEqual(b.phenopacket);
+    expect(a.ccda).toEqual(b.ccda);
+  });
+
+  it('and the IRIs are real, not empty', () => {
+    const a = mintInFreshProcess({
+      cwd: tempDir('cascade-identity-f-'),
+      importedAt: '2026-01-01T00:00:00Z',
+      inputPath: '/in/a.json',
+    });
+    expect(a.fhir).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    expect(a.genomics.length).toBeGreaterThan(0);
+    expect(a.phenopacket.length).toBeGreaterThan(0);
+    expect(a.ccda.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/identity-determinism.test.ts
+++ b/tests/identity-determinism.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Every importer must mint the SAME IRI for the same id-less record, forever.
+ *
+ * FHIR makes `Resource.id` optional and real payloads exercise that: a
+ * transaction Bundle POSTing new resources omits it, contained resources omit
+ * it, hand-authored and exported documents omit it. Every importer here used to
+ * answer that case with `randomUUID()` or `Math.random()` — or, in two places,
+ * with `ctx.importedAt`, a per-run timestamp, which is randomness with extra
+ * steps. Re-importing one document therefore minted a second identity for every
+ * record in it, so nothing ever reconciled and the pod grew a duplicate set on
+ * every sync. Silently: a fresh IRI is indistinguishable from a new record.
+ *
+ * These tests pin BOTH halves of the fix, because either alone is worthless:
+ *
+ *   DETERMINISM  — same content in, same IRI out. Across runs, across bundle
+ *                  positions, across `importedAt` values.
+ *   DISTINCTNESS — different content in, different IRI out. A function that
+ *                  returns a constant satisfies determinism perfectly and is
+ *                  useless; only the pair is the fix.
+ *
+ * Cross-PROCESS stability lives in `identity-cross-process.test.ts`. Minting
+ * twice inside one process can pass on a warm module cache, so it proves less
+ * than it looks like it does.
+ *
+ * Every fixture below is synthetic and PHI-free, and none of them carry an
+ * `id` — which is exactly why the pre-existing suites never saw this.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { convertFhirResourceToQuads } from '../src/lib/fhir-converter/fhir-to-cascade.js';
+import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
+import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import type { ImportContext } from '../src/lib/import-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ctx(importedAt = '2026-01-01T00:00:00Z'): ImportContext {
+  return {
+    inputPath: '/synthetic/input.json',
+    outputSerialization: 'turtle',
+    importedAt,
+    options: {},
+  };
+}
+
+/** Deep clone, so no test can accidentally share object identity with another. */
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+/** Every `urn:uuid:` IRI in a turtle string / quad list, in order. */
+function urisIn(text: string): string[] {
+  return text.match(/urn:uuid:[0-9a-f-]{36}/g) ?? [];
+}
+
+/**
+ * The minted subject IRI of a single-resource conversion.
+ *
+ * `ConversionResult` carries no `uri` field, and the per-resource path leaves
+ * `turtle` empty (only the batch path serializes), so the subject is read off
+ * the first emitted quad — which is the `rdf:type` triple on the subject.
+ */
+function subjectOf(result: { _quads: Array<{ subject: { value: string } }> } | null): string {
+  expect(result).not.toBeNull();
+  expect(result!._quads.length).toBeGreaterThan(0);
+  return result!._quads[0].subject.value;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures — none carry an `id`
+// ---------------------------------------------------------------------------
+
+const ID_LESS_VITAL = {
+  resourceType: 'Observation',
+  status: 'final',
+  category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] }],
+  code: { coding: [{ system: 'http://loinc.org', code: '8867-4', display: 'Heart rate' }] },
+  subject: { reference: 'Patient/synthetic-1' },
+  effectiveDateTime: '2026-01-15T09:30:00Z',
+  valueQuantity: { value: 72, unit: 'beats/minute', system: 'http://unitsofmeasure.org', code: '/min' },
+};
+
+const ID_LESS_PROCEDURE = {
+  resourceType: 'Procedure',
+  status: 'completed',
+  code: { coding: [{ system: 'http://snomed.info/sct', code: '80146002', display: 'Appendectomy' }] },
+  subject: { reference: 'Patient/synthetic-1' },
+  performedDateTime: '2025-06-02',
+};
+
+const ID_LESS_ENCOUNTER = {
+  resourceType: 'Encounter',
+  status: 'finished',
+  class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB', display: 'ambulatory' },
+  subject: { reference: 'Patient/synthetic-1' },
+  period: { start: '2026-01-15T09:00:00Z', end: '2026-01-15T09:45:00Z' },
+};
+
+const ID_LESS_CLAIM = {
+  resourceType: 'Claim',
+  status: 'active',
+  type: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/claim-type', code: 'professional' }] },
+  use: 'claim',
+  patient: { reference: 'Patient/synthetic-1' },
+  created: '2026-01-20',
+  total: { value: 240.0, currency: 'USD' },
+};
+
+const ID_LESS_COVERAGE = {
+  resourceType: 'Coverage',
+  status: 'active',
+  beneficiary: { reference: 'Patient/synthetic-1' },
+  payor: [{ display: 'Synthetic Health Plan' }],
+  period: { start: '2026-01-01' },
+};
+
+const ID_LESS_DEVICE = {
+  resourceType: 'Device',
+  status: 'active',
+  type: { coding: [{ system: 'http://snomed.info/sct', code: '706767009', display: 'Blood pressure monitor' }] },
+  patient: { reference: 'Patient/synthetic-1' },
+};
+
+const ID_LESS_PASSTHROUGH = {
+  resourceType: 'NutritionOrder',
+  status: 'active',
+  intent: 'order',
+  patient: { reference: 'Patient/synthetic-1' },
+  dateTime: '2026-01-15',
+};
+
+/** A FHIR Genomics Bundle whose every entry omits `id`. */
+function genomicsBundle(): any {
+  return {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Observation',
+          meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant'] },
+          status: 'final',
+          category: [{ coding: [{ code: 'laboratory' }] }],
+          code: { coding: [{ system: 'http://loinc.org', code: '69548-6', display: 'Genetic variant assessment' }] },
+          valueCodeableConcept: { coding: [{ system: 'http://loinc.org', code: 'LA9633-4', display: 'Present' }] },
+          component: [
+            {
+              code: { coding: [{ system: 'http://loinc.org', code: '48004-6' }] },
+              valueCodeableConcept: { text: 'NM_007294.4:c.5266dupC' },
+            },
+            {
+              code: { coding: [{ system: 'http://loinc.org', code: '48018-6' }] },
+              valueCodeableConcept: { coding: [{ system: 'http://www.genenames.org', code: 'HGNC:1100', display: 'BRCA1' }] },
+            },
+          ],
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Observation',
+          meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/genotype'] },
+          status: 'final',
+          code: { coding: [{ system: 'http://loinc.org', code: '84413-4' }] },
+          valueCodeableConcept: { text: 'CYP2C19 *1/*2' },
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Observation',
+          meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/haplotype'] },
+          status: 'final',
+          code: { coding: [{ system: 'http://loinc.org', code: '84414-2' }] },
+          valueCodeableConcept: { coding: [{ display: 'CYP2C19*2' }] },
+        },
+      },
+      {
+        resource: {
+          resourceType: 'ServiceRequest',
+          meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/genomics-service-request'] },
+          status: 'completed',
+          intent: 'order',
+          code: { coding: [{ system: 'http://loinc.org', code: '81247-9' }] },
+        },
+      },
+      {
+        resource: {
+          resourceType: 'DiagnosticReport',
+          meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/genomics-report'] },
+          status: 'final',
+          code: { coding: [{ system: 'http://loinc.org', code: '81247-9' }] },
+          effectiveDateTime: '2026-01-10',
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Observation',
+          meta: { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication'] },
+          status: 'final',
+          code: { coding: [{ system: 'http://loinc.org', code: '51969-4' }] },
+          component: [
+            {
+              code: { coding: [{ system: 'http://loinc.org', code: '53037-8' }] },
+              valueCodeableConcept: { coding: [{ system: 'http://loinc.org', code: 'LA6668-3', display: 'Pathogenic' }] },
+            },
+            {
+              code: { coding: [{ system: 'http://loinc.org', code: '81259-4' }] },
+              valueCodeableConcept: { coding: [{ system: 'http://purl.obolibrary.org/obo/mondo.owl', code: 'MONDO:0007254' }] },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+/** A phenopacket whose subject and biosample both omit `id`. */
+function phenopacket(): any {
+  return {
+    id: 'synthetic-phenopacket-1',
+    subject: {
+      sex: 'FEMALE',
+      timeAtLastEncounter: { age: { iso8601duration: 'P42Y' } },
+    },
+    biosamples: [
+      {
+        sampledTissue: { id: 'UBERON:0000178', label: 'blood' },
+        taxonomy: { id: 'NCBITaxon:9606', label: 'Homo sapiens' },
+        timeOfCollection: { age: { iso8601duration: 'P42Y' } },
+      },
+    ],
+    metaData: { created: '2026-01-01T00:00:00Z', createdBy: 'synthetic', phenopacketSchemaVersion: '2.0' },
+  };
+}
+
+/** A C-CDA whose ClinicalDocument carries NO <id> element at all. */
+function ccdaWithoutDocumentId(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of Episode Note"/>
+  <title>Synthetic Continuity of Care Document</title>
+  <effectiveTime value="20260115093000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5" extension="SYN-1"/>
+      <patient>
+        <name><given>Pat</given><family>Synthetic</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19840301"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <name>Synthetic Health System</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" displayName="Problem List"/>
+          <title>Problems</title>
+          <text>Hypertension, diagnosed 2019.</text>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>`;
+}
+
+// ---------------------------------------------------------------------------
+// FHIR clinical path — mintSubjectUri, the most reachable one
+// ---------------------------------------------------------------------------
+
+describe('id-less FHIR clinical resources mint a stable IRI', () => {
+  const cases: ReadonlyArray<{ name: string; resource: any }> = [
+    { name: 'Observation (vital)', resource: ID_LESS_VITAL },
+    { name: 'Procedure', resource: ID_LESS_PROCEDURE },
+    { name: 'Encounter', resource: ID_LESS_ENCOUNTER },
+    { name: 'Claim', resource: ID_LESS_CLAIM },
+    { name: 'Coverage', resource: ID_LESS_COVERAGE },
+    { name: 'Device', resource: ID_LESS_DEVICE },
+    { name: 'NutritionOrder (passthrough)', resource: ID_LESS_PASSTHROUGH },
+  ];
+
+  for (const { name, resource } of cases) {
+    it(`${name}: two conversions of the same content agree`, () => {
+      const a = subjectOf(convertFhirResourceToQuads(clone(resource)));
+      const b = subjectOf(convertFhirResourceToQuads(clone(resource)));
+      expect(a).toBe(b);
+      expect(a).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    });
+  }
+
+  it('different content yields different IRIs (the fix is not a constant)', () => {
+    const uris = cases.map(({ resource }) => subjectOf(convertFhirResourceToQuads(clone(resource))));
+    expect(new Set(uris).size).toBe(uris.length);
+  });
+
+  it('two Observations differing only in their value get different IRIs', () => {
+    const lo = clone(ID_LESS_VITAL);
+    const hi = clone(ID_LESS_VITAL);
+    hi.valueQuantity.value = 118;
+    const a = subjectOf(convertFhirResourceToQuads(lo));
+    const b = subjectOf(convertFhirResourceToQuads(hi));
+    expect(a).not.toBe(b);
+  });
+
+  it('source key ORDER does not perturb the IRI', () => {
+    const forward = clone(ID_LESS_VITAL);
+    const reversed: any = {};
+    for (const k of Object.keys(forward).reverse()) reversed[k] = (forward as any)[k];
+    expect(subjectOf(convertFhirResourceToQuads(reversed))).toBe(subjectOf(convertFhirResourceToQuads(forward)));
+  });
+
+  it('meta.lastUpdated / meta.versionId / meta.source do NOT move the IRI', () => {
+    const bare = clone(ID_LESS_VITAL);
+    const fetchedMonday: any = clone(ID_LESS_VITAL);
+    fetchedMonday.meta = { lastUpdated: '2026-01-15T09:31:00.000+00:00', versionId: '1', source: 'urn:oid:1.2.3#a' };
+    const fetchedFriday: any = clone(ID_LESS_VITAL);
+    fetchedFriday.meta = { lastUpdated: '2026-02-02T17:04:22.881+00:00', versionId: '7', source: 'urn:oid:1.2.3#z' };
+
+    const base = subjectOf(convertFhirResourceToQuads(bare));
+    expect(subjectOf(convertFhirResourceToQuads(fetchedMonday))).toBe(base);
+    expect(subjectOf(convertFhirResourceToQuads(fetchedFriday))).toBe(base);
+  });
+
+  it('a server-regenerated narrative does NOT move the IRI', () => {
+    const bare = clone(ID_LESS_VITAL);
+    const rendered: any = clone(ID_LESS_VITAL);
+    rendered.text = { status: 'generated', div: '<div xmlns="http://www.w3.org/1999/xhtml">Heart rate 72 /min (rendered 2026-02-02T17:04:22Z)</div>' };
+    const reRendered: any = clone(ID_LESS_VITAL);
+    reRendered.text = { status: 'generated', div: '<div xmlns="http://www.w3.org/1999/xhtml">Heart rate 72 /min (rendered 2026-03-09T08:00:00Z)</div>' };
+
+    const base = subjectOf(convertFhirResourceToQuads(bare));
+    expect(subjectOf(convertFhirResourceToQuads(rendered))).toBe(base);
+    expect(subjectOf(convertFhirResourceToQuads(reRendered))).toBe(base);
+  });
+
+  it('CodeableConcept.text IS identity — it is a string, not a Narrative', () => {
+    const a = clone(ID_LESS_PROCEDURE);
+    const b = clone(ID_LESS_PROCEDURE);
+    a.code.text = 'Appendectomy, laparoscopic';
+    b.code.text = 'Appendectomy, open';
+    expect(subjectOf(convertFhirResourceToQuads(a))).not.toBe(subjectOf(convertFhirResourceToQuads(b)));
+  });
+
+  it('an id-bearing resource is unaffected by the surrounding content hash', () => {
+    // The with-id path must be untouched: adding volatile fields to a resource
+    // that HAS an id must not move its IRI either, because the id decides.
+    const withId: any = clone(ID_LESS_VITAL);
+    withId.id = 'obs-heart-rate-1';
+    const withIdAndMeta: any = clone(withId);
+    withIdAndMeta.meta = { lastUpdated: '2026-02-02T17:04:22.881+00:00', versionId: '9' };
+    const withIdChangedValue: any = clone(withId);
+    withIdChangedValue.valueQuantity.value = 118;
+
+    const base = subjectOf(convertFhirResourceToQuads(withId));
+    expect(subjectOf(convertFhirResourceToQuads(withIdAndMeta))).toBe(base);
+    expect(subjectOf(convertFhirResourceToQuads(withIdChangedValue))).toBe(base);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Genomics path
+// ---------------------------------------------------------------------------
+
+describe('id-less FHIR Genomics resources mint stable IRIs', () => {
+  it('two imports of the same bundle agree on every IRI', async () => {
+    const a = await convertGenomicsBundle(genomicsBundle(), ctx());
+    const b = await convertGenomicsBundle(genomicsBundle(), ctx());
+    expect(a.records.length).toBeGreaterThan(0);
+    expect(a.records.map((r) => r.iri)).toEqual(b.records.map((r) => r.iri));
+  });
+
+  it('ctx.importedAt does NOT participate in identity', async () => {
+    const a = await convertGenomicsBundle(genomicsBundle(), ctx('2026-01-01T00:00:00Z'));
+    const b = await convertGenomicsBundle(genomicsBundle(), ctx('2027-11-30T23:59:59Z'));
+    expect(a.records.map((r) => r.iri)).toEqual(b.records.map((r) => r.iri));
+  });
+
+  it('every record in one bundle gets a DISTINCT IRI', async () => {
+    const a = await convertGenomicsBundle(genomicsBundle(), ctx());
+    const iris = a.records.map((r) => r.iri);
+    expect(new Set(iris).size).toBe(iris.length);
+  });
+
+  it('bundle POSITION does not decide identity', async () => {
+    const forward = genomicsBundle();
+    const reversed = genomicsBundle();
+    reversed.entry.reverse();
+    const a = await convertGenomicsBundle(forward, ctx());
+    const b = await convertGenomicsBundle(reversed, ctx());
+    expect(new Set(a.records.map((r) => r.iri))).toEqual(new Set(b.records.map((r) => r.iri)));
+  });
+
+  it('a changed variant yields a changed Variant IRI', async () => {
+    const original = genomicsBundle();
+    const edited = genomicsBundle();
+    edited.entry[0].resource.component[0].valueCodeableConcept.text = 'NM_007294.4:c.181T>G';
+
+    const a = await convertGenomicsBundle(original, ctx());
+    const b = await convertGenomicsBundle(edited, ctx());
+    const variantOf = (r: { records: Array<{ iri: string; cascadeType?: string }> }) =>
+      r.records.filter((x) => x.cascadeType === 'genomics:Variant').map((x) => x.iri);
+    expect(variantOf(a).length).toBeGreaterThan(0);
+    expect(variantOf(a)).not.toEqual(variantOf(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phenopacket path
+// ---------------------------------------------------------------------------
+
+describe('id-less phenopacket subject and biosample mint stable IRIs', () => {
+  it('two imports of the same phenopacket agree on every IRI', async () => {
+    const a = await convertPhenopacket(phenopacket(), ctx());
+    const b = await convertPhenopacket(phenopacket(), ctx());
+    expect(a.records.length).toBeGreaterThan(0);
+    expect(a.records.map((r) => r.iri)).toEqual(b.records.map((r) => r.iri));
+  });
+
+  it('ctx.importedAt does NOT participate in identity', async () => {
+    const a = await convertPhenopacket(phenopacket(), ctx('2026-01-01T00:00:00Z'));
+    const b = await convertPhenopacket(phenopacket(), ctx('2027-11-30T23:59:59Z'));
+    expect(a.records.map((r) => r.iri)).toEqual(b.records.map((r) => r.iri));
+  });
+
+  it('a subject with no id anywhere still mints stably across importedAt', async () => {
+    const anonymous = () => {
+      const p = phenopacket();
+      delete p.id;
+      return p;
+    };
+    const a = await convertPhenopacket(anonymous(), ctx('2026-01-01T00:00:00Z'));
+    const b = await convertPhenopacket(anonymous(), ctx('2029-06-06T06:06:06Z'));
+    expect(a.records.map((r) => r.iri)).toEqual(b.records.map((r) => r.iri));
+  });
+
+  it('two different biosamples get different Specimen IRIs', async () => {
+    const blood = phenopacket();
+    const saliva = phenopacket();
+    saliva.biosamples[0].sampledTissue = { id: 'UBERON:0001836', label: 'saliva' };
+    const a = await convertPhenopacket(blood, ctx());
+    const b = await convertPhenopacket(saliva, ctx());
+    const specimens = (r: { records: Array<{ iri: string; cascadeType?: string }> }) =>
+      r.records.filter((x) => (x.cascadeType ?? '').toLowerCase().includes('specimen')).map((x) => x.iri);
+    expect(specimens(a).length).toBeGreaterThan(0);
+    expect(specimens(a)).not.toEqual(specimens(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-CDA path — a document with no <id> used to key off the import timestamp
+// ---------------------------------------------------------------------------
+
+describe('a C-CDA document with no <id> mints stable IRIs', () => {
+  it('two imports at different times agree on every IRI', async () => {
+    const a = await convertCcda(ccdaWithoutDocumentId(), { importedAt: '2026-01-01T00:00:00Z' });
+    const b = await convertCcda(ccdaWithoutDocumentId(), { importedAt: '2027-11-30T23:59:59Z' });
+    const ua = urisIn(a.output ?? '');
+    const ub = urisIn(b.output ?? '');
+    expect(ua.length).toBeGreaterThan(0);
+    expect(new Set(ua)).toEqual(new Set(ub));
+  });
+
+  it('a DIFFERENT id-less document does not collide with the first', async () => {
+    const other = ccdaWithoutDocumentId()
+      .replace('<title>Synthetic Continuity of Care Document</title>', '<title>Synthetic Discharge Summary</title>')
+      .replace('Hypertension, diagnosed 2019.', 'Type 2 diabetes, diagnosed 2021.');
+    const a = await convertCcda(ccdaWithoutDocumentId(), { importedAt: '2026-01-01T00:00:00Z' });
+    const b = await convertCcda(other, { importedAt: '2026-01-01T00:00:00Z' });
+    const ua = new Set(urisIn(a.output ?? ''));
+    const ub = new Set(urisIn(b.output ?? ''));
+    // The two documents share a patient, so some IRIs legitimately match; the
+    // ClinicalDocument nodes must not.
+    expect([...ua].some((u) => !ub.has(u))).toBe(true);
+  });
+});

--- a/tests/identity-determinism.test.ts
+++ b/tests/identity-determinism.test.ts
@@ -29,6 +29,30 @@
 import { describe, it, expect } from 'vitest';
 
 import { convertFhirResourceToQuads } from '../src/lib/fhir-converter/fhir-to-cascade.js';
+import {
+  convertMedicationStatement,
+  convertCondition,
+  convertAllergyIntolerance,
+  convertObservationLab,
+  convertObservationVital,
+  convertProcedure,
+  convertClinicalDocument,
+  convertEncounter,
+  convertLaboratoryReport,
+  convertMedicationAdministration,
+  convertDevice,
+  convertImagingStudy,
+} from '../src/lib/fhir-converter/converters-clinical.js';
+import {
+  convertPatient,
+  convertImmunization,
+  convertCoverage,
+} from '../src/lib/fhir-converter/converters-demographics.js';
+import {
+  convertClaim,
+  convertExplanationOfBenefit,
+} from '../src/lib/fhir-converter/converters-clinical-admin.js';
+import { convertFhirPassthrough } from '../src/lib/fhir-converter/converters-passthrough.js';
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
@@ -475,6 +499,115 @@ describe('a truly empty record collapses, but never silently', () => {
   it('a resource WITH content is never warned about', () => {
     const r = convertFhirResourceToQuads(clone(ID_LESS_VITAL));
     expect(r!.warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The warning has to arrive in the CONVERTER's own output
+// ---------------------------------------------------------------------------
+
+/**
+ * These call the per-type converters DIRECTLY, not through the dispatcher, and
+ * that distinction is the entire point of this block.
+ *
+ * An earlier revision emitted the tier-4 warning from `convertFhirResourceToQuads`,
+ * which looked like the right single chokepoint. It was not: it only reached
+ * callers who came through the dispatcher, so `convertCondition(...)` returned an
+ * empty `warnings` array and the module's "this tier MUST NOT be silent" contract
+ * was true on the genomics and C-CDA paths and FALSE on the most reachable path in
+ * the repo.
+ *
+ * The identity unit test did not catch that, because it hands `identitySeed` a
+ * warnings array itself — which no production caller on that path was doing. A
+ * test that supplies the very wiring it is meant to be checking proves nothing.
+ * So these assert on what a real consumer receives: the converter's own
+ * `ConversionResult.warnings`.
+ */
+describe('the tier-4 warning reaches the converter API, not just the identity unit', () => {
+  const COLLAPSE = 'no identifier and no identity-bearing content';
+
+  const converters: ReadonlyArray<{ name: string; fn: (r: any) => { warnings: string[] } | null; bare: any }> = [
+    { name: 'convertCondition', fn: convertCondition, bare: { resourceType: 'Condition' } },
+    { name: 'convertAllergyIntolerance', fn: convertAllergyIntolerance, bare: { resourceType: 'AllergyIntolerance' } },
+    { name: 'convertObservationLab', fn: convertObservationLab, bare: { resourceType: 'Observation' } },
+    { name: 'convertObservationVital', fn: convertObservationVital, bare: { resourceType: 'Observation' } },
+    { name: 'convertProcedure', fn: convertProcedure, bare: { resourceType: 'Procedure' } },
+    { name: 'convertEncounter', fn: convertEncounter, bare: { resourceType: 'Encounter' } },
+    { name: 'convertDevice', fn: convertDevice, bare: { resourceType: 'Device' } },
+    { name: 'convertImagingStudy', fn: convertImagingStudy, bare: { resourceType: 'ImagingStudy' } },
+    { name: 'convertClinicalDocument', fn: convertClinicalDocument, bare: { resourceType: 'DocumentReference' } },
+    { name: 'convertLaboratoryReport', fn: convertLaboratoryReport, bare: { resourceType: 'DiagnosticReport' } },
+    { name: 'convertMedicationAdministration', fn: convertMedicationAdministration, bare: { resourceType: 'MedicationAdministration' } },
+    { name: 'convertPatient', fn: convertPatient, bare: { resourceType: 'Patient' } },
+    { name: 'convertImmunization', fn: convertImmunization, bare: { resourceType: 'Immunization' } },
+    { name: 'convertCoverage', fn: convertCoverage, bare: { resourceType: 'Coverage' } },
+    { name: 'convertClaim', fn: convertClaim, bare: { resourceType: 'Claim' } },
+    { name: 'convertExplanationOfBenefit', fn: convertExplanationOfBenefit, bare: { resourceType: 'ExplanationOfBenefit' } },
+    { name: 'convertFhirPassthrough', fn: convertFhirPassthrough, bare: { resourceType: 'NutritionOrder' } },
+  ];
+
+  for (const { name, fn, bare } of converters) {
+    it(`${name} reports the collapse in its own warnings`, () => {
+      const result = fn(clone(bare));
+      expect(result).not.toBeNull();
+      const collapse = result!.warnings.filter((w) => w.includes(COLLAPSE));
+      expect(collapse.length, `${name} swallowed the tier-4 collapse`).toBe(1);
+      expect(collapse[0]).toContain(bare.resourceType);
+    });
+  }
+
+  it('the dispatcher does not duplicate the warning', () => {
+    // The converters emit it now, so re-deriving it in the dispatcher would
+    // report the same collapse twice.
+    const r = convertFhirResourceToQuads({ resourceType: 'Condition' });
+    expect(r!.warnings.filter((w) => w.includes(COLLAPSE)).length).toBe(1);
+  });
+
+  it('converters with real content emit no collapse warning', () => {
+    for (const { name, fn } of converters) {
+      const withContent = fn(clone(ID_LESS_VITAL));
+      if (withContent === null) continue;
+      expect(
+        withContent.warnings.filter((w) => w.includes(COLLAPSE)),
+        `${name} warned about a resource that has content`,
+      ).toEqual([]);
+    }
+  });
+
+  it('a narrative-only resource is not warned about at the converter API either', () => {
+    const r = convertCondition({ resourceType: 'Condition', text: { status: 'generated', div: '<div>Type 2 diabetes mellitus</div>' } });
+    expect(r.warnings.filter((w) => w.includes(COLLAPSE))).toEqual([]);
+  });
+
+  /**
+   * DOCUMENTED EXCEPTION, pinned rather than fixed.
+   *
+   * `convertMedicationStatement` is the one FHIR converter that cannot reach
+   * tier 4, so it is deliberately absent from the list above. It defaults
+   * `medName` to the literal 'Unknown Medication' before minting, so the
+   * identity key always has a non-empty field and the content tier always
+   * "succeeds" — with a value identical for every content-free medication.
+   *
+   * That is the same shape as the `resourceType` scaffold bug this module fixed
+   * (tier 2 succeeding with a constant is indistinguishable from tier 2 failing,
+   * except that it merges), but the constant is supplied by the CONVERTER's
+   * choice of identity fields rather than by the identity door, so it is not
+   * this module's to fix. It belongs with the converter identity-field review
+   * that is deliberately sequenced after this change, and it is filed there.
+   *
+   * This test pins today's behavior so the follow-up has a starting point and so
+   * nobody reads the absence above as an oversight.
+   */
+  it('convertMedicationStatement does NOT reach tier 4 — placeholder constant, filed separately', () => {
+    const bare = convertMedicationStatement({ resourceType: 'MedicationStatement' });
+    const withNote = convertMedicationStatement({
+      resourceType: 'MedicationStatement',
+      note: [{ text: 'a different medication entirely' }],
+    });
+    expect(bare.warnings.filter((w) => w.includes(COLLAPSE))).toEqual([]);
+    // Documenting the consequence rather than asserting it is correct: two
+    // content-free medications currently share one identity, silently.
+    expect(subjectOf(bare)).toBe(subjectOf(withNote));
   });
 });
 

--- a/tests/identity-determinism.test.ts
+++ b/tests/identity-determinism.test.ts
@@ -374,6 +374,111 @@ describe('id-less FHIR clinical resources mint a stable IRI', () => {
 });
 
 // ---------------------------------------------------------------------------
+// The salvage tier: never merge records that a narrative tells apart
+// ---------------------------------------------------------------------------
+
+/**
+ * This is the regression that matters most in this file, because the bug it
+ * pins was introduced BY the first version of this fix rather than by the
+ * original defect.
+ *
+ * An earlier revision excluded FHIR Narrative from the content hash (correctly:
+ * it is derivative and servers regenerate it) and then, when nothing else
+ * remained, collapsed the resource onto a per-type sentinel. The result was
+ * that two Conditions whose only content was `text.div` — one saying "Type 2
+ * diabetes mellitus", the other "Metastatic breast cancer" — minted the SAME
+ * IRI, with no warning. The exclusion list manufactured the indistinguishability
+ * and the sentinel then acted on it, so one of the two records was destroyed.
+ *
+ * The governing rule, now encoded in the cascade: when identity is uncertain,
+ * PREFER A SPLIT. A duplicate is recoverable because all the data is still
+ * there; a merge is not, because the second record's content is gone.
+ */
+describe('narrative-only records must never merge', () => {
+  const narrativeOnly = (div: string) => ({
+    resourceType: 'Condition',
+    text: { status: 'generated', div },
+  });
+
+  it('two Conditions distinguished ONLY by narrative get different IRIs', () => {
+    const diabetes = subjectOf(
+      convertFhirResourceToQuads(narrativeOnly('<div>Type 2 diabetes mellitus</div>')),
+    );
+    const cancer = subjectOf(
+      convertFhirResourceToQuads(narrativeOnly('<div>Metastatic breast cancer</div>')),
+    );
+    expect(diabetes).not.toBe(cancer);
+  });
+
+  it('and each is still STABLE across repeated conversion', () => {
+    // Splitting is only acceptable if it does not also reintroduce the original
+    // bug: the same narrative must keep minting the same IRI.
+    for (const div of ['<div>Type 2 diabetes mellitus</div>', '<div>Metastatic breast cancer</div>']) {
+      const a = subjectOf(convertFhirResourceToQuads(narrativeOnly(div)));
+      const b = subjectOf(convertFhirResourceToQuads(narrativeOnly(div)));
+      expect(a).toBe(b);
+    }
+  });
+
+  it('salvage does not fire when structured content exists', () => {
+    // With real fields present, narrative stays excluded, so a server that
+    // re-renders the prose does not move the IRI.
+    const withCode = (div: string) => ({
+      resourceType: 'Condition',
+      code: { coding: [{ system: 'http://snomed.info/sct', code: '44054006' }] },
+      subject: { reference: 'Patient/synthetic-1' },
+      text: { status: 'generated', div },
+    });
+    expect(subjectOf(convertFhirResourceToQuads(withCode('<div>rendered Monday</div>')))).toBe(
+      subjectOf(convertFhirResourceToQuads(withCode('<div>rendered Friday</div>'))),
+    );
+  });
+
+  it('a narrative-only record is not warned about — it has identity', () => {
+    const r = convertFhirResourceToQuads(narrativeOnly('<div>Type 2 diabetes mellitus</div>'));
+    expect(r!.warnings).toEqual([]);
+  });
+});
+
+describe('a truly empty record collapses, but never silently', () => {
+  it('warns, naming what happened', () => {
+    const r = convertFhirResourceToQuads({ resourceType: 'Condition' });
+    expect(r!.warnings.length).toBe(1);
+    expect(r!.warnings[0]).toContain('no identifier and no identity-bearing content');
+    expect(r!.warnings[0]).toContain('MERGE');
+    expect(r!.warnings[0]).toContain('Condition');
+  });
+
+  it('warns even when only volatile server metadata is present', () => {
+    const r = convertFhirResourceToQuads({
+      resourceType: 'Condition',
+      meta: { lastUpdated: '2026-01-01T00:00:00Z', versionId: '3' },
+    });
+    expect(r!.warnings.length).toBe(1);
+    expect(r!.warnings[0]).toContain('no identity-bearing content');
+  });
+
+  it('collapses deterministically — merging empties destroys nothing', () => {
+    // The split-over-merge rule has no force here: there is no content to lose,
+    // and splitting would mint a fresh IRI on every sync, which is the original
+    // defect. So this case, and only this case, merges.
+    const a = subjectOf(convertFhirResourceToQuads({ resourceType: 'Condition' }));
+    const b = subjectOf(
+      convertFhirResourceToQuads({
+        resourceType: 'Condition',
+        meta: { lastUpdated: '2027-09-09T00:00:00Z', versionId: '9' },
+      }),
+    );
+    expect(a).toBe(b);
+  });
+
+  it('a resource WITH content is never warned about', () => {
+    const r = convertFhirResourceToQuads(clone(ID_LESS_VITAL));
+    expect(r!.warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Genomics path
 // ---------------------------------------------------------------------------
 

--- a/tests/identity-volatile-fields.test.ts
+++ b/tests/identity-volatile-fields.test.ts
@@ -52,14 +52,18 @@ describe('the volatile-field exclusion list', () => {
     }
   });
 
-  it('is exactly the list this test was written against', () => {
-    // Pinned so that adding or removing an exclusion is a deliberate act with a
-    // test change attached, not a drive-by edit.
-    expect(VOLATILE_FIELDS.map((r) => `${r.under ?? '*'}.${r.field}`).sort()).toEqual([
-      '*.text',
-      'meta.lastUpdated',
-      'meta.source',
-      'meta.versionId',
+  it('is exactly the list this test was written against, kinds included', () => {
+    // Pinned so that adding or removing an exclusion — or, just as importantly,
+    // RECLASSIFYING one — is a deliberate act with a test change attached.
+    // The kind is what decides whether a field can still rescue an otherwise
+    // empty record at tier 3, so a silent volatile/derivative swap would be a
+    // data-loss change that looked like a rename.
+    expect(VOLATILE_FIELDS.map((r) => `${r.kind}:${r.under ?? '*'}.${r.field}`).sort()).toEqual([
+      'derivative:*.text',
+      'scaffold:*.resourceType',
+      'volatile:meta.lastUpdated',
+      'volatile:meta.source',
+      'volatile:meta.versionId',
     ]);
   });
 
@@ -108,6 +112,24 @@ describe('the volatile-field exclusion list', () => {
     expect(contentFingerprint(a)).toBe(contentFingerprint(b));
   });
 
+  it('resourceType is scaffold: it does not change the FINGERPRINT...', () => {
+    // ...because every call site already splices it into the key template, so
+    // hashing it too is redundant. See the IRI-level test below for why that
+    // does not let two types collide.
+    const a = clone(BASE) as any;
+    a.resourceType = 'DiagnosticReport';
+    expect(contentFingerprint(a)).toBe(contentFingerprint(BASE));
+  });
+
+  it('...but it must not count as CONTENT, or salvage can never run', () => {
+    // The bug this encodes: while resourceType counted as content, a
+    // narrative-only resource stripped down to {"resourceType":"Condition"} —
+    // identical for every Condition in existence — so tier 2 "succeeded" with a
+    // constant and two different records merged.
+    expect(stripVolatile({ resourceType: 'Condition' })).toBeUndefined();
+    expect(identitySeed({ content: { resourceType: 'Condition' } }).source).toBe('empty');
+  });
+
   it('meta.profile is NOT stripped — it is structural, and it routes genomics', () => {
     const plain = clone(BASE) as any;
     const genomic = clone(BASE) as any;
@@ -139,7 +161,6 @@ describe('the volatile-field exclusion list', () => {
       (r) => { r.effectiveDateTime = '2026-02-02T00:00:00Z'; },
       (r) => { r.code.coding[0].code = '8480-6'; },
       (r) => { r.code.coding[0].system = 'http://snomed.info/sct'; },
-      (r) => { r.resourceType = 'DiagnosticReport'; },
     ];
     const base = contentFingerprint(BASE);
     for (const mutate of variants) {
@@ -198,6 +219,51 @@ describe('the cascade has no third tier', () => {
     const b = identitySeed({ content: { meta: { lastUpdated: '2027-09-09T00:00:00Z', versionId: '9' } } });
     expect(a).toEqual({ seed: EMPTY_SEED, source: 'empty' });
     expect(b).toEqual(a);
+  });
+
+  it('TIER 3 SALVAGE: a derivative field rescues an otherwise-empty record', () => {
+    const a = identitySeed({ content: { resourceType: 'Condition', text: { div: '<div>Type 2 diabetes mellitus</div>' } } });
+    const b = identitySeed({ content: { resourceType: 'Condition', text: { div: '<div>Metastatic breast cancer</div>' } } });
+    expect(a.source).toBe('salvage');
+    expect(b.source).toBe('salvage');
+    expect(a.seed).not.toBe(b.seed);
+    expect(a.seed).not.toBe(EMPTY_SEED);
+  });
+
+  it('salvage is stable for the same content', () => {
+    const mk = () => ({ resourceType: 'Condition', text: { div: '<div>Type 2 diabetes mellitus</div>' } });
+    expect(identitySeed({ content: mk() })).toEqual(identitySeed({ content: mk() }));
+  });
+
+  it('a VOLATILE field never rescues — using it IS the original bug', () => {
+    // If meta.lastUpdated could salvage, an empty resource would mint a new IRI
+    // on every EHR sync. Volatile fields are excluded at every tier for exactly
+    // this reason, which is why they are a separate kind from derivative ones.
+    const a = identitySeed({ content: { resourceType: 'X', meta: { lastUpdated: '2026-01-01T00:00:00Z' } } });
+    const b = identitySeed({ content: { resourceType: 'X', meta: { lastUpdated: '2026-08-02T00:00:00Z' } } });
+    expect(a.source).toBe('empty');
+    expect(a.seed).toBe(b.seed);
+  });
+
+  it('a tier-3 seed can never equal a tier-2 seed (domain separation)', () => {
+    const salvage = identitySeed({ content: { resourceType: 'C', text: { div: 'x' } } });
+    const content = identitySeed({ content: { resourceType: 'C', text: { div: 'x' }, code: 'k' } });
+    expect(salvage.source).toBe('salvage');
+    expect(content.source).toBe('content');
+    expect(salvage.seed).not.toBe(content.seed);
+  });
+
+  it('tier 4 emits a warning; tiers 1-3 do not', () => {
+    const w: string[] = [];
+    identitySeed({ explicitId: 'abc', content: {}, warnings: w, label: 'T1' });
+    identitySeed({ content: { code: 'k' }, warnings: w, label: 'T2' });
+    identitySeed({ content: { text: { div: 'x' } }, warnings: w, label: 'T3' });
+    expect(w).toEqual([]);
+
+    identitySeed({ content: { resourceType: 'Condition' }, warnings: w, label: 'Condition (no id)' });
+    expect(w.length).toBe(1);
+    expect(w[0]).toContain('Condition (no id)');
+    expect(w[0]).toContain('no identity-bearing content');
   });
 
   it('stripping prunes containers that become empty', () => {

--- a/tests/identity-volatile-fields.test.ts
+++ b/tests/identity-volatile-fields.test.ts
@@ -1,0 +1,215 @@
+/**
+ * A content hash is only as stable as its least stable input.
+ *
+ * This is the subtle way to reintroduce the bug the identity door exists to
+ * kill. Replace `randomUUID()` with a hash of the resource and the obvious
+ * defect is gone: import the same FILE twice and you get the same IRI, so every
+ * test passes. But a resource re-fetched from an EHR is not the same bytes — the
+ * server stamps a new `meta.lastUpdated` and bumps `meta.versionId` on every
+ * touch, and regenerates `text` with its own formatting. Hash those and the IRI
+ * moves on every sync, which is precisely the original defect, now wearing a
+ * content hash and invisible to any test that reads from disk twice.
+ *
+ * So the exclusion list is pinned here, in both directions:
+ *   - each excluded field must NOT move the identity, and
+ *   - the fields around it must, so the exclusions are not quietly overbroad.
+ *
+ * The second direction matters more than it looks. `text` is a generated
+ * Narrative on a Resource and a genuine clinical label on a CodeableConcept
+ * ("Blood pressure"); `source` is a volatile provenance pointer under `meta`
+ * and load-bearing content nearly everywhere else. A name-only exclusion would
+ * delete real identity content and silently merge unrelated records — a worse
+ * failure than the one being fixed, because a merge loses data where a split
+ * only duplicates it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  VOLATILE_FIELDS,
+  contentFingerprint,
+  stripVolatile,
+  stableStringify,
+  identitySeed,
+  EMPTY_SEED,
+  ANON_PREFIX,
+} from '../src/lib/identity.js';
+
+const BASE = {
+  resourceType: 'Observation',
+  status: 'final',
+  code: { coding: [{ system: 'http://loinc.org', code: '8867-4', display: 'Heart rate' }] },
+  effectiveDateTime: '2026-01-15T09:30:00Z',
+  valueQuantity: { value: 72, unit: '/min' },
+};
+
+const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+
+describe('the volatile-field exclusion list', () => {
+  it('documents a reason for every entry', () => {
+    expect(VOLATILE_FIELDS.length).toBeGreaterThan(0);
+    for (const rule of VOLATILE_FIELDS) {
+      expect(rule.why.length, `${rule.field} needs a stated reason`).toBeGreaterThan(60);
+    }
+  });
+
+  it('is exactly the list this test was written against', () => {
+    // Pinned so that adding or removing an exclusion is a deliberate act with a
+    // test change attached, not a drive-by edit.
+    expect(VOLATILE_FIELDS.map((r) => `${r.under ?? '*'}.${r.field}`).sort()).toEqual([
+      '*.text',
+      'meta.lastUpdated',
+      'meta.source',
+      'meta.versionId',
+    ]);
+  });
+
+  it('meta.lastUpdated does not move the identity', () => {
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.meta = { lastUpdated: '2026-01-15T09:31:00.000+00:00' };
+    b.meta = { lastUpdated: '2026-08-01T22:14:03.512+00:00' };
+    expect(contentFingerprint(a)).toBe(contentFingerprint(b));
+    expect(contentFingerprint(a)).toBe(contentFingerprint(BASE));
+  });
+
+  it('meta.versionId does not move the identity', () => {
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.meta = { versionId: '1' };
+    b.meta = { versionId: '48' };
+    expect(contentFingerprint(a)).toBe(contentFingerprint(b));
+    expect(contentFingerprint(a)).toBe(contentFingerprint(BASE));
+  });
+
+  it('meta.source does not move the identity', () => {
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.meta = { source: 'urn:oid:1.2.840.114350.1.13.1#v1' };
+    b.meta = { source: 'urn:oid:1.2.840.114350.1.13.1#v9' };
+    expect(contentFingerprint(a)).toBe(contentFingerprint(b));
+    expect(contentFingerprint(a)).toBe(contentFingerprint(BASE));
+  });
+
+  it('a generated Narrative does not move the identity', () => {
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.text = { status: 'generated', div: '<div>Heart rate 72 (rendered 2026-01-15)</div>' };
+    b.text = { status: 'generated', div: '<div>Heart rate 72 (rendered 2026-08-01)</div>' };
+    expect(contentFingerprint(a)).toBe(contentFingerprint(b));
+    expect(contentFingerprint(a)).toBe(contentFingerprint(BASE));
+  });
+
+  it('volatile fields are stripped at ANY depth, not just at the root', () => {
+    // A contained resource carries its own meta, and it is just as volatile.
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.contained = [{ resourceType: 'Practitioner', meta: { lastUpdated: '2026-01-01T00:00:00Z' }, name: [{ family: 'Chen' }] }];
+    b.contained = [{ resourceType: 'Practitioner', meta: { lastUpdated: '2026-08-01T00:00:00Z' }, name: [{ family: 'Chen' }] }];
+    expect(contentFingerprint(a)).toBe(contentFingerprint(b));
+  });
+
+  it('meta.profile is NOT stripped — it is structural, and it routes genomics', () => {
+    const plain = clone(BASE) as any;
+    const genomic = clone(BASE) as any;
+    genomic.meta = { profile: ['http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant'] };
+    expect(contentFingerprint(plain)).not.toBe(contentFingerprint(genomic));
+  });
+
+  it('CodeableConcept.text IS identity — the text rule is shape-scoped, not name-scoped', () => {
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.code.text = 'Heart rate, resting';
+    b.code.text = 'Heart rate, post-exercise';
+    expect(contentFingerprint(a)).not.toBe(contentFingerprint(b));
+  });
+
+  it('a `source` field outside meta IS identity', () => {
+    const a = clone(BASE) as any;
+    const b = clone(BASE) as any;
+    a.device = { source: 'left-wrist' };
+    b.device = { source: 'right-wrist' };
+    expect(contentFingerprint(a)).not.toBe(contentFingerprint(b));
+  });
+
+  it('the non-volatile fields around the exclusions all still move it', () => {
+    const variants: Array<(r: any) => void> = [
+      (r) => { r.status = 'amended'; },
+      (r) => { r.valueQuantity.value = 118; },
+      (r) => { r.valueQuantity.unit = 'bpm'; },
+      (r) => { r.effectiveDateTime = '2026-02-02T00:00:00Z'; },
+      (r) => { r.code.coding[0].code = '8480-6'; },
+      (r) => { r.code.coding[0].system = 'http://snomed.info/sct'; },
+      (r) => { r.resourceType = 'DiagnosticReport'; },
+    ];
+    const base = contentFingerprint(BASE);
+    for (const mutate of variants) {
+      const r = clone(BASE) as any;
+      mutate(r);
+      expect(contentFingerprint(r), `${JSON.stringify(r)} should not equal the base`).not.toBe(base);
+    }
+  });
+});
+
+describe('the hash is stable against representation, not just content', () => {
+  it('source key ORDER does not change the fingerprint', () => {
+    const forward = clone(BASE) as any;
+    const reversed: any = {};
+    for (const k of Object.keys(forward).reverse()) reversed[k] = forward[k];
+    expect(contentFingerprint(reversed)).toBe(contentFingerprint(forward));
+  });
+
+  it('nested key order does not change it either', () => {
+    const a = { x: { p: 1, q: 2 }, y: [{ m: 3, n: 4 }] };
+    const b = { y: [{ n: 4, m: 3 }], x: { q: 2, p: 1 } };
+    expect(stableStringify(a)).toBe(stableStringify(b));
+    expect(contentFingerprint(a)).toBe(contentFingerprint(b));
+  });
+
+  it('ARRAY order DOES change it — FHIR array order is meaningful', () => {
+    // name[0] is the primary name; reordering is a different resource.
+    const a = { name: [{ family: 'Smith' }, { family: 'Jones' }] };
+    const b = { name: [{ family: 'Jones' }, { family: 'Smith' }] };
+    expect(contentFingerprint(a)).not.toBe(contentFingerprint(b));
+  });
+});
+
+describe('the cascade has no third tier', () => {
+  it('an explicit id wins and is returned verbatim', () => {
+    expect(identitySeed({ explicitId: 'obs-1', content: BASE })).toEqual({ seed: 'obs-1', source: 'explicit' });
+  });
+
+  it('a blank or non-string id is not an id', () => {
+    for (const notAnId of ['', '   ', null, undefined, 0, false, {}, []]) {
+      expect(identitySeed({ explicitId: notAnId, content: BASE }).source).toBe('content');
+    }
+  });
+
+  it('a content seed cannot be mistaken for a FHIR id', () => {
+    const { seed } = identitySeed({ content: BASE });
+    expect(seed.startsWith(ANON_PREFIX)).toBe(true);
+    // FHIR caps Resource.id at 64 characters; `anon-` + 64 hex is 69.
+    expect(seed.length).toBe(ANON_PREFIX.length + 64);
+    expect(seed.length).toBeGreaterThan(64);
+  });
+
+  it('a resource with nothing but volatile fields lands on the sentinel, not on randomness', () => {
+    const nothing = { meta: { lastUpdated: '2026-01-01T00:00:00Z', versionId: '3' } };
+    const a = identitySeed({ content: nothing });
+    const b = identitySeed({ content: { meta: { lastUpdated: '2027-09-09T00:00:00Z', versionId: '9' } } });
+    expect(a).toEqual({ seed: EMPTY_SEED, source: 'empty' });
+    expect(b).toEqual(a);
+  });
+
+  it('stripping prunes containers that become empty', () => {
+    expect(stripVolatile({ meta: { lastUpdated: 'x' } })).toBeUndefined();
+    expect(stripVolatile({ a: 1, meta: { lastUpdated: 'x' } })).toEqual({ a: 1 });
+    expect(stripVolatile({ list: [{ meta: { versionId: '1' } }] })).toBeUndefined();
+  });
+
+  it('no input produces a different result on a second call', () => {
+    const inputs: unknown[] = [BASE, {}, null, undefined, [], 'x', 42, { meta: { versionId: '1' } }];
+    for (const input of inputs) {
+      expect(identitySeed({ content: input })).toEqual(identitySeed({ content: input }));
+    }
+  });
+});


### PR DESCRIPTION
Closes the last of the non-deterministic identity minting in the importers. This is the known limitation named in the 0.10.0 changelog.

## The defect

Every importer minted a subject IRI from the source resource's `id`, and when a resource had none, made one up. The dialect differed per module:

| Path | id-less fallback |
|---|---|
| `mintSubjectUri` (12 call sites, 6 modules) | `urn:uuid:${randomUUID()}` — no content fallback at all |
| `contentHashedUri` last resort | `urn:uuid:${randomUUID()}` |
| 5 genomics converters | `Math.random().toString(36)` |
| `observation-variant.ts` | `${ctx.importedAt}:${Math.random()}` |
| `phenopacket/biosamples.ts` | `biosample:${ctx.importedAt}:${Math.random()}` |
| `phenopacket/subject.ts` | `unknown:${ctx.importedAt}` |
| `ccda-converter/index.ts` | `doc:${importedAt}` |

The consequence is identical in every dialect: a fresh IRI is indistinguishable from a new record, so re-importing one document minted a second copy of every id-less record in it, on every import, with no warning and no gap entry. `Resource.id` is optional in FHIR, so this is reachable from real payloads — transaction Bundles, contained resources, exported and hand-authored documents, and C-CDA files with no `<id>`.

The last three rows were not in the original scope and are worth calling out: they key on `ctx.importedAt`, a per-run timestamp. They read as deterministic and are not, so removing only the visible `Math.random()` would have left them just as broken, in a form that is harder to see. The C-CDA one is on the main clinical path, and its own code comment already recorded the consequence without fixing it.

## Why a fence rather than eleven patches

The correct pattern already existed in this repo, twice — `contentSeed()` in the phenopacket variation descriptor (written in May 2026 to fix this exact bug in one file) and `contentHashedUri()` in the FHIR converter — and was propagated neither time, so each new converter re-broke it on its first commit. That is the root cause, and patching sites does not address it.

`src/lib/identity.ts` is now the one door, implementing one cascade:

**explicit id → content hash → salvage → collapse loudly. Never random.**

The governing rule, and the one that decides every judgement call: **when identity is uncertain, prefer a split over a merge.** A split is recoverable — all the data is present and duplicates can be reconciled later. A merge is not — the second record's content is gone. A fix must never make any case worse than what it replaced.

1. **Explicit id** — used verbatim.
2. **Content hash** — volatile, derivative and scaffold fields stripped.
3. **Salvage** — nothing survived tier 2, so re-hash with the *derivative* fields restored. A narrative-only record keeps its identity instead of merging.
4. **Collapse, loudly** — only when there is genuinely nothing: no id, no structured content, no narrative. Merging here destroys nothing because there is nothing to destroy, while splitting would recreate the original defect. Emits a warning naming what happened.

### The tier-4 warning is emitted where identity is minted, not at the dispatcher

Review round 2 found the "must not be silent" contract held on the genomics and C-CDA paths and **failed on the main clinical FHIR one**: `convertCondition({resourceType:'Condition'})` returned `warnings: []`. The warning was emitted from `convertFhirResourceToQuads`, which looked like the right single chokepoint but only reached callers coming through the *dispatcher* — and the per-type converters are exported and called directly.

`mintSubjectUri` and `contentHashedUri` now take an optional `warnings` array (optional, so any caller with nothing to pass stays source-compatible), and all 18 FHIR converter call sites pass the array they already build; `medicationUri` forwards it. The dispatcher no longer re-derives it, which would double-report. Also threaded into the C-CDA patient extractor.

The module doc now states **per path** where that obligation is met, rather than claiming it universally, because that comment is what a future reader trusts:

- FHIR clinical, genomics (6), phenopacket subject + biosample, C-CDA document id, C-CDA patient — met.
- Other C-CDA sections — tier 4 is *unreachable*, not unreported: each keys on `patient: patientUri`, always a non-empty `urn:uuid:`.
- `convertMedicationStatement` — unreachable for a less comfortable reason: it defaults the drug name to the literal `'Unknown Medication'` before minting, so the content tier succeeds with a constant and two content-free medications share one identity silently. Same shape as the `resourceType` scaffold bug, but originating in the converter's identity-field choice rather than in the identity door. **Pinned by a test and filed; deliberately not fixed here**, as it belongs to the converter identity-field review sequenced after this change.

### Review caught data loss in the first revision, and it is fixed

The first revision had no salvage tier. Two Conditions whose only content was `text.div` — "Type 2 diabetes mellitus" and "Metastatic breast cancer" — minted the **same IRI, with no warning**. The justification claimed such records were indistinguishable; both halves were false. They are trivially distinguishable, by the very narrative the exclusion list had removed, and nothing surfaced the merge. The exclusion list manufactured the indistinguishability and the sentinel acted on it.

Two things were wrong, and the second was the harder one:

- **The narrative was thrown away with no way back.** Fixed by the salvage tier, and by classifying exclusions with a `kind` — `volatile` (never an identity input at any tier; using it *is* the bug) versus `derivative` (real content, restored at tier 3).
- **`resourceType` counted as content.** While it did, a narrative-only Condition stripped down to `{"resourceType":"Condition"}` — identical for every Condition in existence — so tier 2 "succeeded" with a constant and the salvage tier never ran. Tier 2 succeeding with a constant is indistinguishable from tier 2 failing, except that it merges. It is now a third kind, `scaffold`: stripped at every tier, and excluded from the "does this have content" judgement. Type separation is unaffected, because every call site already splices the type into its key template.

The salvage tier was also **unreachable through `contentHashedUri`**, which received the source object at only 2 of its ~20 call sites. All of them now pass it, including through `medicationUri`.

## Volatile fields

A content hash is only as stable as its least stable input, and this is the subtle way to reintroduce the same bug. A resource re-fetched from an EHR is not the same bytes: the server stamps a new `meta.lastUpdated`, bumps `meta.versionId`, and regenerates narrative. Hashing those would move the IRI on every sync — the original defect, now wearing a content hash and invisible to any test that reads the same file twice.

Excluded, with the `kind` and the reason recorded next to each in `VOLATILE_FIELDS`:

- `meta.lastUpdated` — **volatile.** Server write timestamp, changes on every re-fetch of an unchanged resource.
- `meta.versionId` — **volatile.** Server version counter, increments on any server-side touch.
- `meta.source` — **volatile.** A pointer at the system a resource arrived through, not at what it says; differs between a bulk export and a live read, and Epic-style servers append a per-version fragment.
- `text` (object-valued only) — **derivative.** FHIR Narrative conveys what the structured data already says, and servers re-render it. Kept out of the preferred hash, but *restored at tier 3*, because for a narrative-only record it is the only thing that tells one record from another.
- `resourceType` — **scaffold.** Already in every call site's key template, so hashing it is redundant; and it must not count as content, or salvage can never run.

The `kind` distinction is load-bearing, not cosmetic: a volatile field can never rescue a record (using it *is* the original bug), while a derivative one must. Reclassifying an entry silently would be a data-loss change that looked like a rename, so the pinned list assertion includes the kinds.

The exclusions are **shape- and parent-scoped, not name-scoped**, which matters more than it looks: `CodeableConcept.text` is a string and is often the only human-meaningful content on a coding, and `source` is load-bearing under nearly every parent other than `meta`. A name-only ban would delete real identity content and silently merge unrelated records — a worse failure than the one being fixed, because a merge loses data where a split only duplicates it. Both directions are pinned by tests.

`meta.profile` is deliberately **kept**: it is structural and it routes genomics detection.

## The chokepoint test

`tests/identity-chokepoint.test.ts` does not ban a function name. That would be both too strict (per-event ids should be random) and too weak (`importedAt` and `Date.now()` are non-deterministic without containing the word "random"). The rule is about what is being identified:

- **content identity** — "which record is this?" Answered by the record. No randomness, no clocks, no per-run values.
- **event identity** — "which occurrence is this?" Answered by the occurrence. Running the verb twice IS two events.

Three checks: importers may contain no randomness at all (no exemption possible); everywhere else each use must be a declared event identity with a written justification; and no identity-minting call anywhere may take a clock or per-run value as an argument. Legitimate event ids are allowlisted with reasons — the MCP audit log, `pod_write`, the annotation overlay verbs (`annotate`/`amend`/`retract`/`erase`/`add-record`), the conflict and resolution records, and advisory PROV activities.

## Evidence

**Two negative controls, both run in isolated worktrees against the final test files.**

*A — versus `origin/main`:* `identity-determinism` **40 failed / 14 passed**, `identity-chokepoint` **3 failed / 4 passed**, `identity-cross-process` **3 failed / 1 passed**.

*B — versus each superseded revision of this PR:*
- vs the revision review rejected for data loss: **28 failures** (21 determinism + 7 volatile-fields), including the two-narratives merge and both silent-collapse cases.
- vs the revision with the silent clinical path: **17 failures**, every one of them a converter-level warning test, and nothing else.

Control A also exposed a flaw in my own test: the cross-process guard keyed on the new identity module, so it **skipped** rather than failed against a pre-fix build — useless as a control, and exactly how a determinism suite looks green while proving nothing. It now guards on a module present in every revision.

**Cross-process, not in-process.** `identity-cross-process.test.ts` spawns a separate `node` process per measurement, from different working directories, exercising `dist/` (the artifact npm consumers install). Minting twice in one process can pass on a warm module cache; this is the property that was missed last time, when a path-dependent identity stayed invisible for months because everything ran from one directory.

**Distinctness, not just determinism.** A constant is perfectly deterministic and useless. Different content, different bundle position, different `importedAt`, different working directory, and reordered source keys are all asserted alongside the stability cases.

**Warnings asserted at the converter API, not at the identity unit.** 17 converters are called directly rather than through the dispatcher. The identity unit test could not have caught the silent clinical path, because it hands `identitySeed` a warnings array itself — wiring that no production caller on that path was doing. A test that supplies the very thing it is meant to be checking proves nothing; that is the third instance of that shape found in this arc, after a corpus harness that digested `undefined` and the cross-process guard that skipped.

**Nothing with an id moved**, verified two ways beyond the suite:

- All 22 usable conformance fixtures (7 FHIR Genomics bundles, 8 phenopackets, 7 C-CDA documents, including the narrative-only one) produce **byte-identical output** on the pre- and post-change builds. 22 distinct digests, so the comparison is discriminating.
- The conformance repo carries no general clinical FHIR fixtures, so a direct probe covers 22 id-bearing resources across every converter reachable from `mintSubjectUri`/`contentHashedUri`, plus a 21-IRI bundle exercising reference resolution: **byte-identical, 22 distinct digests, all 21 bundle IRIs unchanged.**

Both were re-run after each rework, against `origin/main` built in a separate worktree, since the reworks touched every `contentHashedUri` and `mintSubjectUri` call site.

While building that probe I found and corrected a flaw in my own first harness (it digested `undefined` for 71 of 94 inputs and would have reported a vacuous pass), and separately confirmed that a `clinical:importedAt` wall-clock literal varies run-to-run on `origin/main` too. That is pre-existing output nondeterminism unrelated to identity; it is masked in the comparison rather than changed here, and is filed as a follow-up.

**Suite: 1259 → 1353 passed, 0 failed, 98 → 102 files.** No fixture regenerated and no existing expected output changed.

One existing test asserted the defect ("should return random UUID when no id present") and is inverted, with the reason recorded inline.

## Not IRI-breaking

Unlike the 0.10.0 genomics change, this moves no existing IRI. When a source resource carries an id the seed IS that id, so the key string is byte-identical to before. An anonymous seed is `anon-` + 64 hex = 69 characters and FHIR caps `Resource.id` at 64, so a content seed is structurally incapable of being confused with an id a source could assign.

## Fixtures

Every existing fixture carries an `id`, which is precisely why none of this was visible. New id-less fixtures are synthetic, PHI-free and inline in the tests, matching the precedent set by the VCF content-addressed identity suite so they run everywhere the suite runs including CI. The sibling `conformance` repo would also benefit from id-less fixtures; that is filed as a follow-up rather than done here, since it is shared.
