### PR TITLE
fix(identity): a lab result's identity must tell two lab results apart — both importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,29 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > results (see the first upgrade note), so it is not a patch release. Decide between a minor
 > and a major bump before cutting it.
 
+**This release is about record identity — the IRI each record gets, which decides whether a
+re-import updates a record or duplicates it, and whether two records stay two records.** Two
+things changed, and they pull in opposite directions, so it is worth being clear which is
+which:
+
+1. **Records the source never identified used to get a RANDOM IRI**, so re-importing the same
+   document duplicated them, forever. They now get an IRI derived from their own content, so
+   they reconcile. **No IRI that a source identifier already determined moves because of this.**
+2. **Lab results used to be identified too coarsely** — by patient, test code and calendar day,
+   ignoring the measured value, the time of day, and the source's own identifier — so two
+   genuinely different results on one day merged into one and a value was silently lost. Fixing
+   that necessarily moves lab IRIs. **This is the only IRI-breaking change in the release**, and
+   the upgrade note below says what to do about it.
+
 ### Upgrade notes
 
-- **Breaking for lab results imported from FHIR.** Lab result IRIs change in this release for
-  anything imported through a FHIR source — a SMART on FHIR connection, a FHIR bundle, an
-  Apple Health export. If you have imported labs with an earlier version, records imported by
-  this one will not match them. Labs imported from C-CDA documents are unchanged; see the
-  known limitation below.
+- **Breaking for lab results, from EVERY import source.** Lab result IRIs change in this
+  release, whether the results came from a FHIR source (a SMART on FHIR connection, a FHIR
+  bundle, an Apple Health export) or from a downloaded C-CDA document (a MyChart-style portal
+  export). If you have imported labs with an earlier version, records imported by this one
+  will not match them.
 
-  What was wrong: a lab result's identity was built from the patient, the LOINC code and the
+  What was wrong: a lab result's identity was built from the patient, the test code and the
   calendar DAY, and from nothing else. The measured result was not part of it, the time of day
   was thrown away, and the lab's own identifier from your provider's system was ignored. So two
   different results for the same test on the same day — a fasting glucose in the morning and a
@@ -30,10 +44,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in. Serial same-day labs are ordinary medicine (glucose curves, troponin series, repeat
   potassium, before-and-after dialysis), so this did not need unusual data to happen.
 
+  **Both importers carried the same defect, in the same shape, and both are fixed here** —
+  together, deliberately, so that lab identity changes exactly once rather than once per
+  importer across two releases.
+
   A lab result now takes its identity from the identifier your provider's system assigned it,
   the same way vital signs already did. When a result carries no identifier, its identity comes
-  from the patient, the LOINC code, the FULL timestamp, the measured value, the specimen and
-  the category — everything that actually tells two results apart.
+  from the patient, the test code, the FULL timestamp and the measured value, plus the specimen
+  and category where the source records them — everything that actually tells two results
+  apart.
 
   **What to do.** Re-import the sources your labs came from, into a fresh pod, and use that.
   Alternatively, keep the pod you have and accept that labs imported before and after this
@@ -47,20 +66,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   After this change no lab observation collides with another; the only records that still
   share an IRI are the same record appearing in two files, which is correct.
 
-  Nothing outside FHIR lab results moves. Vital signs, conditions, allergies, medications,
+  **Nothing but lab results moves.** Vital signs, conditions, allergies, medications,
   procedures, encounters, documents, immunizations, coverage and claims all keep the IRIs they
-  had. Verified across the conformance corpus: 46 of 91 converted resources were unchanged, and
-  every one of the 45 that moved was a lab observation.
+  had. Verified twice: across the FHIR conformance corpus, 46 of 91 converted resources were
+  unchanged and every one of the 45 that moved was a lab observation; across the C-CDA corpus,
+  40 of 43 identities were unchanged and all 3 that moved were lab results.
 
-### Known limitations in this release
-
-- **The same defect remains on the C-CDA import path, and is not fixed here.** A lab result
-  read from a C-CDA document is still identified by patient, test code, test name and calendar
-  day, with the measured value left out and the document's own identifier for the result
-  ignored. Two different same-day results for one test therefore still collapse into one
-  record on that path. It is called out rather than quietly fixed because closing it is a
-  second IRI-breaking change for labs, and breaking lab identity twice in two releases is
-  worse for anyone holding a pod than doing both at once. Verified reproducible.
+  **Lab PANELS keep their IRIs, with one narrow exception.** A panel read from a C-CDA document
+  whose source gave it neither an identifier nor a test code was previously indistinguishable
+  from any other panel drawn for the same patient on the same day, so several genuinely
+  different panels shared one record and pooled their results. Such a panel now takes its
+  identity from its full timestamp and the set of results it contains, and so moves. A panel
+  that carries an identifier — the common case — is unchanged.
 
 ### Fixed
 
@@ -94,10 +111,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   yields the same IRI across runs, across machines, across working directories, and
   regardless of its position in a bundle. Different records still yield different IRIs.
 
-  **This particular change moves no IRI that a source `id` already determined.** Where a
-  source resource carries an identifier, the IRI it produces here is byte-for-byte what
-  previous versions minted. (The lab-result change described under Upgrade notes above IS
-  IRI-breaking, and is the only thing in this release that is.)
+  **This change moves no IRI that a source identifier already determined** — see point 1 of
+  the summary at the top of this section. Where a source resource carries an identifier, the
+  IRI it produces here is byte-for-byte what previous versions minted. The lab-result change
+  under Upgrade notes is a separate change and is the release's only IRI break.
 
   Server-assigned volatile fields are excluded from the content hash — `meta.lastUpdated`,
   `meta.versionId` and `meta.source` — so a resource re-fetched from an EHR keeps its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,74 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+> **Version number not yet chosen.** This section contains an IRI-breaking change for lab
+> results (see the first upgrade note), so it is not a patch release. Decide between a minor
+> and a major bump before cutting it.
+
+### Upgrade notes
+
+- **Breaking for lab results imported from FHIR.** Lab result IRIs change in this release for
+  anything imported through a FHIR source — a SMART on FHIR connection, a FHIR bundle, an
+  Apple Health export. If you have imported labs with an earlier version, records imported by
+  this one will not match them. Labs imported from C-CDA documents are unchanged; see the
+  known limitation below.
+
+  What was wrong: a lab result's identity was built from the patient, the LOINC code and the
+  calendar DAY, and from nothing else. The measured result was not part of it, the time of day
+  was thrown away, and the lab's own identifier from your provider's system was ignored. So two
+  different results for the same test on the same day — a fasting glucose in the morning and a
+  post-prandial one before lunch — were treated as one record, and one of the two values was
+  silently discarded. Which one survived depended on the order the files happened to be read
+  in. Serial same-day labs are ordinary medicine (glucose curves, troponin series, repeat
+  potassium, before-and-after dialysis), so this did not need unusual data to happen.
+
+  A lab result now takes its identity from the identifier your provider's system assigned it,
+  the same way vital signs already did. When a result carries no identifier, its identity comes
+  from the patient, the LOINC code, the FULL timestamp, the measured value, the specimen and
+  the category — everything that actually tells two results apart.
+
+  **What to do.** Re-import the sources your labs came from, into a fresh pod, and use that.
+  Alternatively, keep the pod you have and accept that labs imported before and after this
+  release sit side by side as separate records. Records that were merged by the old behavior
+  cannot be recovered from the pod — the discarded value was never written — so a re-import
+  from the original source is the only way to get them back.
+
+  Measured on the published FHIR Genomics IG example bundles that ship with the conformance
+  fixtures: 16 groups of records, 49 records in total, shared an IRI with a record they
+  differed from — including six distinct HLA observations collapsed onto a single identity.
+  After this change no lab observation collides with another; the only records that still
+  share an IRI are the same record appearing in two files, which is correct.
+
+  Nothing outside FHIR lab results moves. Vital signs, conditions, allergies, medications,
+  procedures, encounters, documents, immunizations, coverage and claims all keep the IRIs they
+  had. Verified across the conformance corpus: 46 of 91 converted resources were unchanged, and
+  every one of the 45 that moved was a lab observation.
+
+### Known limitations in this release
+
+- **The same defect remains on the C-CDA import path, and is not fixed here.** A lab result
+  read from a C-CDA document is still identified by patient, test code, test name and calendar
+  day, with the measured value left out and the document's own identifier for the result
+  ignored. Two different same-day results for one test therefore still collapse into one
+  record on that path. It is called out rather than quietly fixed because closing it is a
+  second IRI-breaking change for labs, and breaking lab identity twice in two releases is
+  worse for anyone holding a pod than doing both at once. Verified reproducible.
+
 ### Fixed
+
+- **A missing drug name no longer merges unrelated medication records.** When a
+  `MedicationStatement` or `MedicationRequest` named no drug, the importer substituted the
+  literal text "Unknown Medication" and then used it to build the record's identity. Every
+  medication with no name therefore got the SAME identity, so they merged into one record
+  without warning. The substituted text is still what the record displays; it is no longer
+  what the record is identified by, so such records now stay separate and, when they carry
+  nothing at all to tell them apart, say so. **A medication that names a drug is unaffected
+  and its IRI does not move.**
+
+- **A collapse notice now names the resource type you imported.** Medications are identified
+  under a single shared key regardless of which FHIR resource they arrived as, and the notice
+  reported that shared key — telling someone who imported a `MedicationStatement` to go
+  looking for a `MedicationRequest`.
 
 - **Re-importing a document no longer duplicates the records in it that carry no `id`.**
   This closes the known limitation named in 0.10.0.
@@ -27,10 +94,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   yields the same IRI across runs, across machines, across working directories, and
   regardless of its position in a bundle. Different records still yield different IRIs.
 
-  **Nothing that already had an `id` changes.** If a source resource carries an identifier,
-  its IRI is byte-for-byte what previous versions minted, so no IRI in an existing pod moves
-  and no re-import is needed. This is not comparable to the 0.10.0 genomics change, which
-  was deliberately IRI-breaking.
+  **This particular change moves no IRI that a source `id` already determined.** Where a
+  source resource carries an identifier, the IRI it produces here is byte-for-byte what
+  previous versions minted. (The lab-result change described under Upgrade notes above IS
+  IRI-breaking, and is the only thing in this release that is.)
 
   Server-assigned volatile fields are excluded from the content hash — `meta.lastUpdated`,
   `meta.versionId` and `meta.source` — so a resource re-fetched from an EHR keeps its

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -3,18 +3,46 @@
  *
  * Two record families come out of this section:
  *  - health:LabResultRecord — one per member observation (standalone or inside an
- *    organizer). Subject minting is frozen (contentHashedUri('LabResult', ...)).
+ *    organizer).
  *  - clinical:LaboratoryReport — one per BATTERY organizer (a lab panel), with a
  *    clinical:hasLabResult edge to each of its member results. This mirrors the
  *    FHIR converter's convertLaboratoryReport so both import paths produce
- *    shape-compatible panel records (root backlog 3.11a / slice R2).
+ *    shape-compatible panel records.
  *
  * CLUSTER organizers in this section are left as plain member observations (no
  * panel record); results-section CLUSTER panels are a filed follow-up, not this
  * slice's scope.
+ *
+ * SUBJECT MINTING IS NO LONGER "FROZEN", AND THE FREEZE IS WHY IT HAD TO CHANGE
+ * ----------------------------------------------------------------------------
+ * This header used to say `health:LabResultRecord` minting was frozen at
+ * `contentHashedUri('LabResult', {patient, loincCode, testName, date})`. That
+ * claim is gone rather than worked around, because it was not describing a
+ * decision anyone would defend on the merits — it was describing a key set that
+ * SILENTLY MERGED DIFFERENT LAB RESULTS, and the freeze is a large part of why
+ * it survived long enough to be shipped by two importers at once.
+ *
+ * What was wrong with it, measured rather than argued: the MEASURED VALUE was
+ * extracted a few lines above the mint and never entered the key; `date` was
+ * `formatCcdaDate()`, truncated to a calendar day; and the observation's own
+ * `<id root= extension=>` was passed as `fallbackId`, which `contentHashedUri`
+ * consults only when every content field is empty — never true for a real lab,
+ * since `patient` is always populated. So a fasting glucose of 95 and a
+ * post-prandial glucose of 310, drawn the same morning with DISTINCT source
+ * ids, both minted `urn:uuid:dc68ecd7-acc0-5d61-981a-e51a3dbc0b0c`, and one of
+ * the two values was discarded downstream as a duplicate.
+ *
+ * The identical defect sat in the FHIR importer's `convertObservationLab` and
+ * is fixed in the same change, so both import paths now answer the same way.
+ *
+ * A comment is not an enforcement mechanism. If some future key set here really
+ * must not move, pin it with a golden-value test — `tests/ccda-lab-identity.test.ts`
+ * carries several, and a test states which property is protected instead of
+ * asking the next reader to guess.
  */
 
 import { NS, contentHashedUri, tripleDateTime } from '../../fhir-converter/types.js';
+import { contentFingerprint, EMPTY_SEED } from '../../identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { buildEncounterRecord } from './encounters.js';
 import { DataFactory } from 'n3';
@@ -73,8 +101,21 @@ interface LabObservation {
 }
 
 /**
- * Convert one C-CDA lab observation to a health:LabResultRecord. Subject minting
- * is frozen: contentHashedUri('LabResult', {patient, loincCode, testName, date}).
+ * Convert one C-CDA lab observation to a health:LabResultRecord.
+ *
+ * IDENTITY: a present source `<id>` wins outright. That is the same rule the
+ * FHIR importer's `convertObservationLab` applies to `resource.id`, and it makes
+ * a collision structurally impossible for any result the source identified.
+ * Identity answers "is this that record?"; deciding that two records are the
+ * same THING is a separate judgement, it needs a conflict trail, and it belongs
+ * to the layer that can see both records rather than to this one, which sees one
+ * at a time and can only overwrite.
+ *
+ * Without an id, the key carries what actually separates two results: patient,
+ * LOINC code, test name, the effective time at the FULL precision C-CDA gives
+ * (`YYYYMMDDHHMMSS±ZZZZ`, not the day-truncated `formatCcdaDate` output that is
+ * emitted as `health:performedDate`), and the measured value with its unit.
+ *
  * Returns null for an empty/absent observation.
  */
 function extractObservationQuads(
@@ -108,12 +149,26 @@ function extractObservationQuads(
 
   const sourceId = extractSourceId(obs);
 
-  const uri = contentHashedUri('LabResult', {
-    patient: patientUri,
-    loincCode: isLoinc ? code : undefined,
-    testName: displayName || undefined,
-    date: dateStr || undefined,
-  }, sourceId || undefined, obs);
+  // Tier 1 — the source identified this result. Nothing else is consulted, so
+  // two results the source kept apart can never be merged here. Passing the id
+  // as `contentHashedUri`'s `fallbackId` with an EMPTY field set produces
+  // exactly `deterministicUuid('LabResult:' + sourceId)`.
+  //
+  // Tier 2 — no id. Now the key has to do the separating, so it carries the
+  // full-precision effective time and the measured value, both of which the
+  // previous key set left out.
+  const uri = sourceId
+    ? contentHashedUri('LabResult', {}, sourceId, obs)
+    : contentHashedUri('LabResult', {
+        patient: patientUri,
+        loincCode: isLoinc ? code : undefined,
+        testName: displayName || undefined,
+        // `dateVal` raw, NOT `dateStr`. `formatCcdaDate` truncates to a calendar
+        // day, which merged a 07:00 draw with an 11:00 draw.
+        effective: dateVal || undefined,
+        value: value || undefined,
+        unit: unit || undefined,
+      }, undefined, obs);
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];
@@ -182,11 +237,36 @@ function buildPanelQuads(
   // while staying deterministic (the id is stable in the source) and dedupe-safe
   // (an exact re-import mints the same id and collapses to the same subject).
   // Timestamps that vary between imports (importedAt) are deliberately excluded.
+  //
+  // THAT PRE-EXISTING FIX IS WHY THIS PATH DOES NOT CARRY THE MEMBER PATH'S
+  // "the id was discarded" DEFECT: `panelId` is a content field, so an
+  // id-bearing organizer is already separated by it, and the id-bearing key is
+  // therefore left BYTE-IDENTICAL here. Moving it would break panel IRIs for no
+  // correctness gain.
+  //
+  // What it DID carry is the other half of that defect: `clinicalDate` is
+  // `formatCcdaDate`-truncated to a calendar day, and when the organizer has
+  // neither an id nor a code — the combination the comment above says is common
+  // in real exports — the whole key degenerates to {patient, day}. Measured: two
+  // id-less code-less BATTERY organizers four hours apart on one day, holding
+  // DIFFERENT results, both minted urn:uuid:0335391b-48fb-5d69-ab87-7bbf2429e434.
+  //
+  // So the id-less branch, and only the id-less branch, additionally carries the
+  // organizer's raw full-precision effectiveTime and a fingerprint of its member
+  // subjects — which is what a panel's content actually IS, since a panel has no
+  // measured value of its own. The cost is that an id-less panel which GAINS a
+  // result in a later export mints a new IRI, i.e. a duplicate; that is a split,
+  // and a split is the recoverable failure. A merge is not.
+  const memberKey = contentFingerprint(memberSubjects);
   const uri = contentHashedUri('LaboratoryReport', {
     patient: patientUri,
     panelCode: code || undefined,
     date: clinicalDate || undefined,
     panelId: sourceId || undefined,
+    ...(sourceId ? {} : {
+      effective: orgDateRaw || undefined,
+      members: memberKey === EMPTY_SEED ? undefined : memberKey,
+    }),
   }, sourceId || undefined, organizer);
 
   const subj = namedNode(uri);

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -45,6 +45,7 @@ import {
   pushIndicationEdges,
   pushParsedIndicationCandidates,
 } from './reference-resolution.js';
+import { contentFingerprint, EMPTY_SEED } from '../identity.js';
 
 // ---------------------------------------------------------------------------
 // Medication converter
@@ -54,17 +55,34 @@ export function convertMedicationStatement(resource: any): ConversionResult & { 
   const warnings: string[] = [];
   const patientRef = resource.subject?.reference ?? resource.patient?.reference ?? '';
 
-  // Medication name (needed for the identity URI, which keys on the normalized name).
-  const medName = codeableConceptText(resource.medicationCodeableConcept)
-    ?? resource.medicationReference?.display
-    ?? 'Unknown Medication';
+  // The DISPLAY name and the IDENTITY name are deliberately two different
+  // values, and conflating them was a silent record-merging bug.
+  //
+  // `medName` is what the record says on screen, so a placeholder is the right
+  // answer when the source names no drug. `identityMedName` is an input to the
+  // subject IRI, where a placeholder is never the right answer: it converts
+  // "we do not know what drug this is" into "these are the same drug". Measured
+  // before this split, with the placeholder feeding both: a bare
+  // `{resourceType:'MedicationStatement'}` and one carrying a distinct `note`
+  // minted ONE IRI, with no warning — because the content tier "succeeded" with
+  // a constant identical for every content-free medication, so the identity
+  // door's tier-4 collapse notice could never fire. A content hash that
+  // succeeds with a constant is indistinguishable from one that fails, except
+  // that it merges records instead of splitting them.
+  //
+  // Leaving the field `undefined` instead hands the decision back to the
+  // identity door, which falls through to the RxNorm code, the start date, the
+  // patient, then the resource's own content, and finally collapses LOUDLY.
+  const identityMedName = codeableConceptText(resource.medicationCodeableConcept)
+    ?? resource.medicationReference?.display;
+  const medName = identityMedName ?? 'Unknown Medication';
 
   const subjectUri = medicationUri({
     patient: patientRef,
     rxNormCode: resource.medicationCodeableConcept?.coding?.find((c: any) => c.system?.includes('rxnorm'))?.code,
-    medicationName: medName,
+    medicationName: identityMedName,
     startDate: (resource.authoredOn ?? resource.effectivePeriod?.start)?.split('T')[0],
-  }, resource.id, resource, warnings);
+  }, resource.id, resource, warnings, resource.resourceType);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.clinical + 'Medication'));
@@ -338,14 +356,129 @@ export function isVitalSignObservation(resource: any): boolean {
 // Observation (lab) converter
 // ---------------------------------------------------------------------------
 
+/**
+ * The FHIR `value[x]` choice element prefix. Every measured result a lab
+ * Observation can carry is spelled `value` + a type name.
+ */
+const VALUE_X_PREFIX = 'value';
+
+/**
+ * A stable token standing for THE MEASURED RESULT of a lab Observation, or
+ * `undefined` when the resource carries no result at all.
+ *
+ * Collected by PREFIX rather than from a hand-written list of the `value[x]`
+ * forms this converter happens to serialize today. A list would have to be kept
+ * in step with FHIR forever, and the failure mode of missing one is not a
+ * dropped display value — it is two genuinely different results sharing an
+ * identity. `component` is included because a panel-style Observation carries
+ * its readings there instead.
+ *
+ * Reduced to a fingerprint rather than embedded raw so that the identity string
+ * stays a fixed length regardless of how many components a panel has, and so
+ * that a free-text `valueString` cannot smuggle the `|` and `=` characters that
+ * `contentHashedUri` uses as its own field separators into the key.
+ */
+function labMeasuredValueKey(resource: any): string | undefined {
+  if (resource == null || typeof resource !== 'object') return undefined;
+  const measured: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(resource)) {
+    if (value === undefined || value === null) continue;
+    if (key === 'component' || (key.startsWith(VALUE_X_PREFIX) && key.length > VALUE_X_PREFIX.length)) {
+      measured[key] = value;
+    }
+  }
+  if (Object.keys(measured).length === 0) return undefined;
+  const fingerprint = contentFingerprint(measured);
+  return fingerprint === EMPTY_SEED ? undefined : fingerprint;
+}
+
+/**
+ * The Observation's category codes, or `undefined` when it carries none.
+ *
+ * Sorted, because `Observation.category` is a set rather than an ordered list
+ * and two servers may enumerate the same categories in different order. Sorting
+ * therefore removes a source of spurious SPLITS; it can never cause a merge,
+ * since a differing set still sorts to a differing string.
+ */
+function labCategoryKey(resource: any): string | undefined {
+  if (!Array.isArray(resource?.category)) return undefined;
+  const parts: string[] = [];
+  for (const cat of resource.category) {
+    if (Array.isArray(cat?.coding)) {
+      for (const c of cat.coding) {
+        if (c?.code) parts.push(`${c.system ?? ''}#${c.code}`);
+      }
+    }
+    if (typeof cat?.text === 'string' && cat.text.trim().length > 0) parts.push(cat.text.trim());
+  }
+  return parts.length > 0 ? parts.sort().join(',') : undefined;
+}
+
+/**
+ * The subject IRI for a lab Observation.
+ *
+ * WHY THIS IS NO LONGER `contentHashedUri('Observation', {patient, loincCode, date}, resource.id)`
+ * ------------------------------------------------------------------------------------------------
+ * That key set was a strict subset of the record. The MEASURED VALUE was not in
+ * it; the timestamp was truncated to a calendar day by `.split('T')[0]`; and the
+ * record's own server-assigned `id` was passed as `fallbackId`, which
+ * `contentHashedUri` consults ONLY when every content field is empty — which
+ * never happens on a real lab. So the id was discarded and identity was
+ * `{patient, LOINC, calendar day}`.
+ *
+ * Measured consequence: a fasting glucose of 95 (`id "obs-fasting-95"`) and a
+ * post-prandial glucose of 310 (`id "obs-postprandial-310"`) drawn the same
+ * morning minted ONE IRI. The reconciler then passed over the second as a
+ * re-import of the first, and WHICH value survived was decided by the order the
+ * input files enumerated. Serial same-day labs are routine clinical practice —
+ * glucose curves, troponin series, repeat potassium, pre/post dialysis — so
+ * this fired on ordinary EHR output, not on exotic input.
+ *
+ * THE RULE: A PRESENT `id` WINS.
+ * -----------------------------
+ * Identity answers "is this that record?". Two records that are the same
+ * *thing* may well need merging, but that is a different judgement, it needs a
+ * conflict trail, and it belongs to the reconciler — which can see both
+ * records, where the identity layer sees one at a time and can only silently
+ * overwrite. Honouring the id makes the collision structurally impossible.
+ *
+ * It is also what `convertObservationVital` has always done via
+ * `mintSubjectUri`, which is why same-day repeat VITALS survived as distinct
+ * records in a real 1,150-subject pod while same-day repeat LABS did not. The
+ * two Observation converters in this file no longer use opposite strategies, so
+ * an Observation rerouted from the vital converter to this one (see
+ * `VITAL_TYPE_TO_SHACL`) keeps the same IRI either way.
+ *
+ * WITHOUT AN ID, the key carries what actually tells two results apart:
+ * patient, LOINC code, the effective instant AT FULL PRECISION, the measured
+ * value in every `value[x]` form, the specimen, and the category.
+ *
+ * `testName` is deliberately NOT a key field. The converter defaults it to the
+ * literal 'Unknown Lab Test', and a placeholder default in an identity key is
+ * the same defect in a different costume.
+ */
+function labSubjectUri(resource: any, warnings: string[]): string {
+  // Tier 1 — the source assigned an identifier. Same door, same key template,
+  // and the same answer `convertObservationVital` gives for this resource.
+  if (typeof resource?.id === 'string' && resource.id.trim().length > 0) {
+    return mintSubjectUri(resource, warnings);
+  }
+  return contentHashedUri('Observation', {
+    patient: resource?.subject?.reference,
+    loincCode: resource?.code?.coding?.find((c: any) => c.system?.includes('loinc'))?.code,
+    // Full precision. `.split('T')[0]` merged a 07:00 draw with an 11:00 draw.
+    effective: resource?.effectiveDateTime ?? resource?.effectivePeriod?.start,
+    value: labMeasuredValueKey(resource),
+    specimen: resource?.specimen?.reference,
+    category: labCategoryKey(resource),
+    // No `fallbackId`: this branch runs only when there is no id to fall back
+    // to. Passing one here is what hid the defect above for so long.
+  }, undefined, resource, warnings);
+}
+
 export function convertObservationLab(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const patientRef = resource.subject?.reference ?? '';
-  const subjectUri = contentHashedUri('Observation', {
-    patient: patientRef,
-    loincCode: resource.code?.coding?.find((c: any) => c.system?.includes('loinc'))?.code,
-    date: (resource.effectiveDateTime ?? resource.effectivePeriod?.start)?.split('T')[0],
-  }, resource.id, resource, warnings);
+  const subjectUri = labSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'LabResultRecord'));

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -417,6 +417,16 @@ export function contentHashedUri(
   source?: unknown,
   /** Collects a tier-4 collapse notice. See `mintSubjectUri` for why it is optional. */
   warnings?: string[],
+  /**
+   * How to name the record in a tier-4 collapse notice. Defaults to
+   * `resourceType`, which is right at most call sites and wrong where the
+   * identity `resourceType` is a shared canonical key rather than the source's
+   * own type: a bare `MedicationStatement` mints under `MedicationRequest` (the
+   * single medication identity used by every importer), and reporting the
+   * collapse of a "MedicationRequest" to someone who imported a
+   * MedicationStatement sends them looking for a record that is not there.
+   */
+  label?: string,
 ): string {
   // Filter out undefined/empty values and sort keys for stability. Values are
   // coerced to string before trimming: the type says string, but real-world
@@ -440,7 +450,7 @@ export function contentHashedUri(
   const { seed } = identitySeed({
     content: source,
     warnings,
-    label: `${resourceType} (no id)`,
+    label: `${label ?? resourceType} (no id)`,
   });
   return `urn:uuid:${deterministicUuid(`${resourceType}::${seed}`)}`;
 }
@@ -465,6 +475,12 @@ export function medicationUri(
   source?: unknown,
   /** Forwarded to `contentHashedUri`; collects a tier-4 collapse notice. */
   warnings?: string[],
+  /**
+   * The SOURCE's own resource type, for the tier-4 notice only. Identity is
+   * always minted under `MedicationRequest` — that is the shared key every
+   * importer agrees on — but a warning should name what the caller imported.
+   */
+  label?: string,
 ): string {
   return contentHashedUri(
     'MedicationRequest',
@@ -477,6 +493,7 @@ export function medicationUri(
     fallbackId,
     source,
     warnings,
+    label,
   );
 }
 

--- a/tests/ccda-lab-identity.test.ts
+++ b/tests/ccda-lab-identity.test.ts
@@ -1,0 +1,340 @@
+/**
+ * The C-CDA importer must tell two lab results apart, exactly as the FHIR one must.
+ *
+ * THE DEFECT THESE PIN
+ * --------------------
+ * `extractObservationQuads` minted a `health:LabResultRecord` as
+ * `contentHashedUri('LabResult', { patient, loincCode, testName, date }, sourceId)`.
+ * The same three things were wrong with it as with the FHIR importer's version,
+ * in the same function:
+ *
+ *   1. The MEASURED VALUE was extracted a few lines above the mint (`value`,
+ *      `unit`), emitted as quads, and never entered the key.
+ *   2. `date` was `formatCcdaDate()`, truncated from the HL7
+ *      `YYYYMMDDHHMMSS±ZZZZ` to a calendar day.
+ *   3. The observation's own `<id root= extension=>` was passed as `fallbackId`,
+ *      which `contentHashedUri` consults only when EVERY content field is empty
+ *      — never true here, because `patient` is always populated.
+ *
+ * Measured against the previous build: a fasting glucose of 95 and a
+ * post-prandial glucose of 310, same patient, same LOINC, same day, with
+ * DISTINCT source ids, both minted
+ * `urn:uuid:dc68ecd7-acc0-5d61-981a-e51a3dbc0b0c` — and so did the id-less
+ * versions of both. Four genuinely different results, one identity.
+ *
+ * That is the path a downloaded portal export (MyChart and friends) actually
+ * takes, so it is not a lesser case than the FHIR one.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT
+ * ------------------------------------------
+ * Most of them FAIL against the previous behavior, which was verified rather
+ * than assumed. The ones that pass either way are labelled STABILITY PIN in
+ * place and say what they actually guard — an IRI that must NOT move, or an
+ * invariant the change could plausibly have broken. None is counted as evidence
+ * for the fix.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { extractLabQuads } from '../src/lib/ccda-converter/sections/labs.js';
+
+// ---------------------------------------------------------------------------
+// Helpers and fixtures — the shapes fast-xml-parser produces from real C-CDA
+// ---------------------------------------------------------------------------
+
+const PATIENT = 'urn:uuid:synthetic-patient-1';
+const SOURCE = 'SyntheticEHR';
+const IMPORTED_AT = '2026-08-03T00:00:00Z';
+
+const LOINC_OID = '2.16.840.1.113883.6.1';
+
+/** One `<observation>` inside a results section. */
+function labObs(opts: {
+  id?: string;
+  value?: string;
+  unit?: string;
+  /** Raw HL7 `effectiveTime/@value`, full precision. */
+  time?: string;
+  code?: string;
+  name?: string;
+}): any {
+  const o: any = {
+    code: {
+      '@_code': opts.code ?? '2339-0',
+      '@_codeSystem': LOINC_OID,
+      '@_displayName': opts.name ?? 'Glucose',
+    },
+    effectiveTime: { '@_value': opts.time ?? '20260802070000-0500' },
+    value: { '@_value': opts.value ?? '95', '@_unit': opts.unit ?? 'mg/dL' },
+  };
+  if (opts.id !== undefined) o.id = { '@_root': '1.2.840.114350', '@_extension': opts.id };
+  return o;
+}
+
+/** A BATTERY `<organizer>` wrapping member observations. */
+function panel(opts: { id?: string; code?: string; time?: string; members: any[] }): any {
+  const org: any = {
+    '@_classCode': 'BATTERY',
+    component: opts.members.map((observation) => ({ observation })),
+  };
+  if (opts.id !== undefined) org.id = { '@_root': '1.2.840.114350', '@_extension': opts.id };
+  if (opts.code !== undefined) {
+    org.code = { '@_code': opts.code, '@_codeSystem': LOINC_OID, '@_displayName': 'Basic metabolic panel' };
+  }
+  if (opts.time !== undefined) org.effectiveTime = { '@_value': opts.time };
+  return { organizer: org };
+}
+
+function convert(entries: any[]): any[] {
+  return extractLabQuads(entries, PATIENT, SOURCE, undefined, IMPORTED_AT);
+}
+
+/** Every subject carrying an `rdf:type` of the given local name, in emission order. */
+function subjectsOfType(quads: any[], localName: string): string[] {
+  return quads
+    .filter((q) => q.predicate.value.endsWith('#type') && q.object.value.endsWith(localName))
+    .map((q) => q.subject.value);
+}
+
+/** The single `health:LabResultRecord` subject minted for one observation. */
+function resultUri(obs: any): string {
+  const subs = subjectsOfType(convert([{ observation: obs }]), 'LabResultRecord');
+  expect(subs.length, 'expected exactly one lab result record').toBe(1);
+  return subs[0];
+}
+
+/** The single `clinical:LaboratoryReport` subject minted for one BATTERY organizer. */
+function panelUri(entry: any): string {
+  const subs = subjectsOfType(convert([entry]), 'LaboratoryReport');
+  expect(subs.length, 'expected exactly one panel record').toBe(1);
+  return subs[0];
+}
+
+// ---------------------------------------------------------------------------
+// 1. Member observations: the reported collision
+// ---------------------------------------------------------------------------
+
+describe('C-CDA lab results that differ are two records', () => {
+  it('the repro: fasting 95 and post-prandial 310, distinct source ids, same day', () => {
+    // Previously BOTH minted urn:uuid:dc68ecd7-acc0-5d61-981a-e51a3dbc0b0c.
+    const fasting = labObs({ id: 'obs-fasting-95', value: '95', time: '20260802070000-0500' });
+    const post = labObs({ id: 'obs-postprandial-310', value: '310', time: '20260802110000-0500' });
+    expect(resultUri(fasting)).not.toBe(resultUri(post));
+  });
+
+  it('a present source id decides, so identical content does NOT merge', () => {
+    // Two draws the source deliberately kept apart. Nothing in the content
+    // separates them; the ids are the source saying they are two records.
+    expect(resultUri(labObs({ id: 'obs-draw-a' }))).not.toBe(resultUri(labObs({ id: 'obs-draw-b' })));
+  });
+
+  it('id-less results are separated by the measured value', () => {
+    expect(resultUri(labObs({ value: '95' }))).not.toBe(resultUri(labObs({ value: '310' })));
+  });
+
+  it('id-less results are separated by the unit — 5 mg/dL is not 5 mmol/L', () => {
+    expect(resultUri(labObs({ value: '5', unit: 'mg/dL' })))
+      .not.toBe(resultUri(labObs({ value: '5', unit: 'mmol/L' })));
+  });
+
+  it('id-less results keep the effective time at FULL precision, not a calendar day', () => {
+    // A glucose curve: same test, same value, four hours apart. `formatCcdaDate`
+    // truncated both to 2026-08-02 and made them one record.
+    expect(resultUri(labObs({ time: '20260802070000-0500' })))
+      .not.toBe(resultUri(labObs({ time: '20260802110000-0500' })));
+  });
+
+  it('is deterministic AND discriminating, not merely deterministic', () => {
+    // A function returning a constant satisfies determinism perfectly, which is
+    // exactly what the previous key set did. Both halves, or neither is evidence.
+    const a = labObs({ id: 'obs-draw-a', value: '95' });
+    const b = labObs({ id: 'obs-draw-b', value: '310' });
+    expect(resultUri(a)).toBe(resultUri(structuredClone(a)));
+    expect(resultUri(b)).toBe(resultUri(structuredClone(b)));
+    expect(resultUri(a)).not.toBe(resultUri(b));
+  });
+
+  it('four results that used to be one record are now four', () => {
+    const uris = [
+      labObs({ id: 'obs-f-95', value: '95', time: '20260802070000-0500' }),
+      labObs({ id: 'obs-p-310', value: '310', time: '20260802110000-0500' }),
+      labObs({ value: '95', time: '20260802070000-0500' }),
+      labObs({ value: '310', time: '20260802110000-0500' }),
+    ].map(resultUri);
+    expect(new Set(uris).size, `collapsed: ${uris.join(' ')}`).toBe(4);
+  });
+
+  it('re-importing the same document mints the same identities', () => {
+    // STABILITY PIN. The fix must not turn a merge bug into its mirror image, a
+    // fresh IRI on every import. Determinism here is the whole point of content
+    // hashing and would be silently lost by, say, keying on a parse timestamp.
+    const doc = [
+      { observation: labObs({ id: 'obs-1', value: '95' }) },
+      { observation: labObs({ value: '310', time: '20260802110000-0500' }) },
+    ];
+    expect(subjectsOfType(convert(structuredClone(doc)), 'LabResultRecord'))
+      .toEqual(subjectsOfType(convert(structuredClone(doc)), 'LabResultRecord'));
+  });
+
+  it('the day-truncated date is still what the record REPORTS', () => {
+    // STABILITY PIN. Full precision moved into the identity key only; the
+    // emitted `health:performedDate` literal is unchanged, so no consumer that
+    // reads or queries the date sees a different value.
+    const quads = convert([{ observation: labObs({ id: 'obs-1', time: '20260802070000-0500' }) }]);
+    const dates = quads
+      .filter((q: any) => q.predicate.value.endsWith('performedDate'))
+      .map((q: any) => q.object.value);
+    expect(dates).toEqual(['2026-08-02']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Panel (BATTERY organizer) identity
+// ---------------------------------------------------------------------------
+
+/**
+ * The panel path did NOT carry the member path's "the id was discarded" defect:
+ * `panelId` was already a first-class content field, put there by an earlier fix
+ * for a related collision. So an id-bearing organizer was already separated by
+ * its id, and its IRI is deliberately left byte-identical by this change.
+ *
+ * What it DID carry is the other half — a day-truncated `clinicalDate` — which
+ * bites when the organizer has neither an id nor a code, the combination the
+ * code's own comment reports is common in real Epic exports (47 of 55 panels in
+ * an acceptance export carry no code).
+ */
+describe('C-CDA lab panels', () => {
+  const memberA = labObs({ id: 'm-a', value: '95', time: '20260802070000-0500' });
+  const memberB = labObs({ id: 'm-b', value: '310', time: '20260802110000-0500' });
+
+  it('an id-bearing panel mints exactly the IRI it always has', () => {
+    // GOLDEN PIN, and it passes with or without this change BY DESIGN — that is
+    // what it is asserting. The value was measured against the previous build.
+    // A drift here means panel IRIs moved in an existing pod for no reason.
+    expect(panelUri(panel({ id: 'org-1', code: '24323-8', time: '20260802070000-0500', members: [memberA] })))
+      .toBe('urn:uuid:f9e45f8f-0927-571b-bee2-e1cf609cda5a');
+  });
+
+  it('two id-less, code-less panels on one day are two records', () => {
+    // Previously both minted urn:uuid:0335391b-48fb-5d69-ab87-7bbf2429e434: with
+    // no id and no code the key degenerated to {patient, calendar day}.
+    const p1 = panel({ time: '20260802070000-0500', members: [memberA] });
+    const p2 = panel({ time: '20260802110000-0500', members: [memberB] });
+    expect(panelUri(p1)).not.toBe(panelUri(p2));
+  });
+
+  it('two id-less panels distinguished ONLY by their members are two records', () => {
+    // Real Epic organizers routinely omit effectiveTime as well as code, so the
+    // member set is the last thing left that can separate them. A panel has no
+    // measured value of its own; its members ARE its content.
+    const p1 = panel({ members: [memberA] });
+    const p2 = panel({ members: [memberB] });
+    expect(panelUri(p1)).not.toBe(panelUri(p2));
+  });
+
+  it('an id-less panel is deterministic AND discriminating', () => {
+    const p = panel({ time: '20260802070000-0500', members: [memberA] });
+    const other = panel({ time: '20260802110000-0500', members: [memberB] });
+    expect(panelUri(structuredClone(p))).toBe(panelUri(structuredClone(p)));
+    expect(panelUri(p)).not.toBe(panelUri(other));
+  });
+
+  it('every hasLabResult edge still points at a member this walk actually minted', () => {
+    // STABILITY PIN, and the invariant most at risk from changing how members
+    // are minted: the panel's edges are built from the member subjects computed
+    // in the same walk, so a second, differently-derived mint would produce
+    // edges that resolve to nothing.
+    const quads = convert([panel({ id: 'org-1', code: '24323-8', members: [memberA, memberB] })]);
+    const members = new Set(subjectsOfType(quads, 'LabResultRecord'));
+    const edges = quads
+      .filter((q: any) => q.predicate.value.endsWith('hasLabResult'))
+      .map((q: any) => q.object.value);
+    expect(edges.length).toBe(2);
+    for (const e of edges) expect(members.has(e), `dangling hasLabResult -> ${e}`).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Across processes and across working directories
+// ---------------------------------------------------------------------------
+
+/**
+ * Minting twice in one process shares a warm module cache and one
+ * `process.cwd()`. The previous identity defect in this repo was
+ * path-dependent and stayed green for months for exactly that reason, so this
+ * spawns separate processes from different directories, through `dist/`.
+ *
+ * The skip guard keys on a module present in EVERY revision, not on anything
+ * this change introduces — a guard on a new file SKIPS rather than FAILS
+ * against a pre-fix build, which is how a determinism suite looks green while
+ * proving nothing.
+ */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'ccda-converter', 'sections', 'labs.js'));
+
+const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+const dist = process.env.CASCADE_DIST;
+const { extractLabQuads } = await import(
+  pathToFileURL(path.join(dist, 'lib/ccda-converter/sections/labs.js')).href
+);
+const p = JSON.parse(process.env.CASCADE_PAYLOAD);
+const quads = extractLabQuads(p.entries, p.patient, p.source, undefined, p.importedAt);
+const uris = quads
+  .filter((q) => q.predicate.value.endsWith('#type'))
+  .map((q) => q.subject.value);
+process.stdout.write(JSON.stringify({ cwd: process.cwd(), uris }));
+`;
+
+function mintIn(dir: string, entries: any[]): { cwd: string; uris: string[] } {
+  const scriptPath = path.join(dir, 'mint-ccda.mjs');
+  fs.writeFileSync(scriptPath, SCRIPT, 'utf8');
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      CASCADE_DIST: DIST,
+      CASCADE_PAYLOAD: JSON.stringify({ entries, patient: PATIENT, source: SOURCE, importedAt: IMPORTED_AT }),
+    },
+    encoding: 'utf8',
+  });
+  return JSON.parse(stdout);
+}
+
+describe.skipIf(!HAVE_DIST)('C-CDA lab identity survives the process and the working directory', () => {
+  it('two processes in two directories agree, and still tell the results apart', () => {
+    const entries = [
+      { observation: labObs({ id: 'obs-f-95', value: '95', time: '20260802070000-0500' }) },
+      { observation: labObs({ id: 'obs-p-310', value: '310', time: '20260802110000-0500' }) },
+      { observation: labObs({ value: '95', time: '20260802070000-0500' }) },
+      { observation: labObs({ value: '310', time: '20260802110000-0500' }) },
+    ];
+
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-ccda-a-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-ccda-b-'));
+    try {
+      const a = mintIn(dirA, structuredClone(entries));
+      const b = mintIn(dirB, structuredClone(entries));
+
+      expect(a.cwd).not.toBe(b.cwd);
+      // DETERMINISM: two processes, two directories, one answer.
+      expect(a.uris, `cwd ${a.cwd} disagreed with cwd ${b.cwd}`).toEqual(b.uris);
+      // DISTINCTNESS: and the answer is not a constant. Without this half, a
+      // function returning one string passes the line above perfectly.
+      expect(new Set(a.uris).size, `four results shared an IRI: ${a.uris.join(' ')}`).toBe(4);
+      for (const uri of a.uris) expect(uri).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    } finally {
+      fs.rmSync(dirA, { recursive: true, force: true });
+      fs.rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/identity-determinism.test.ts
+++ b/tests/identity-determinism.test.ts
@@ -527,6 +527,15 @@ describe('the tier-4 warning reaches the converter API, not just the identity un
   const COLLAPSE = 'no identifier and no identity-bearing content';
 
   const converters: ReadonlyArray<{ name: string; fn: (r: any) => { warnings: string[] } | null; bare: any }> = [
+    // `convertMedicationStatement` was the one FHIR converter absent from this
+    // table, because it could not reach tier 4 at all: it defaulted the drug
+    // name to the literal 'Unknown Medication' before minting, so the content
+    // tier always "succeeded" — with a constant identical for every content-free
+    // medication. The converter no longer feeds a placeholder into its identity
+    // key, so the whole table is now exceptionless, and this list is the standing
+    // guard on the class: any converter that starts baking a placeholder default
+    // into an identity key stops reporting its collapse and fails here.
+    { name: 'convertMedicationStatement', fn: convertMedicationStatement, bare: { resourceType: 'MedicationStatement' } },
     { name: 'convertCondition', fn: convertCondition, bare: { resourceType: 'Condition' } },
     { name: 'convertAllergyIntolerance', fn: convertAllergyIntolerance, bare: { resourceType: 'AllergyIntolerance' } },
     { name: 'convertObservationLab', fn: convertObservationLab, bare: { resourceType: 'Observation' } },
@@ -580,34 +589,43 @@ describe('the tier-4 warning reaches the converter API, not just the identity un
   });
 
   /**
-   * DOCUMENTED EXCEPTION, pinned rather than fixed.
+   * THE EXCEPTION THAT WAS PINNED HERE IS NOW FIXED, and this is what replaced
+   * it. Kept as its own case rather than folded into the table because the
+   * mechanism is worth naming.
    *
-   * `convertMedicationStatement` is the one FHIR converter that cannot reach
-   * tier 4, so it is deliberately absent from the list above. It defaults
+   * `convertMedicationStatement` could not reach tier 4 at all: it defaulted
    * `medName` to the literal 'Unknown Medication' before minting, so the
-   * identity key always has a non-empty field and the content tier always
-   * "succeeds" — with a value identical for every content-free medication.
+   * identity key always carried a non-empty field and the content tier always
+   * "succeeded" — with a value identical for every content-free medication.
+   * Measured then: a bare MedicationStatement and one carrying a distinct
+   * `note` minted urn:uuid:6fdb46b2-be25-52f9-80b8-2a356c4c3a87, both of them,
+   * with empty `warnings`.
    *
-   * That is the same shape as the `resourceType` scaffold bug this module fixed
-   * (tier 2 succeeding with a constant is indistinguishable from tier 2 failing,
-   * except that it merges), but the constant is supplied by the CONVERTER's
-   * choice of identity fields rather than by the identity door, so it is not
-   * this module's to fix. It belongs with the converter identity-field review
-   * that is deliberately sequenced after this change, and it is filed there.
-   *
-   * This test pins today's behavior so the follow-up has a starting point and so
-   * nobody reads the absence above as an oversight.
+   * Same shape as the `resourceType` scaffold bug this module fixed — tier 2
+   * succeeding with a constant is indistinguishable from tier 2 failing, except
+   * that it MERGES records instead of splitting them — but the constant came
+   * from the CONVERTER's choice of identity fields rather than from the identity
+   * door, which is why the door could not see it. The converter now passes the
+   * drug name only when the source actually supplies one.
    */
-  it('convertMedicationStatement does NOT reach tier 4 — placeholder constant, filed separately', () => {
+  it('a placeholder default no longer stands in for a drug name in the identity key', () => {
     const bare = convertMedicationStatement({ resourceType: 'MedicationStatement' });
     const withNote = convertMedicationStatement({
       resourceType: 'MedicationStatement',
       note: [{ text: 'a different medication entirely' }],
     });
-    expect(bare.warnings.filter((w) => w.includes(COLLAPSE))).toEqual([]);
-    // Documenting the consequence rather than asserting it is correct: two
-    // content-free medications currently share one identity, silently.
-    expect(subjectOf(bare)).toBe(subjectOf(withNote));
+    expect(subjectOf(bare)).not.toBe(subjectOf(withNote));
+    expect(bare.warnings.filter((w) => w.includes(COLLAPSE)).length).toBe(1);
+    expect(withNote.warnings.filter((w) => w.includes(COLLAPSE))).toEqual([]);
+  });
+
+  it('the collapse notice names the resource type the caller imported', () => {
+    // Medication identity is minted under the shared `MedicationRequest` key by
+    // every importer, so the notice used to say "MedicationRequest (no id)" to
+    // someone who had imported a MedicationStatement — sending them to look for
+    // a record that is not in their data.
+    const bare = convertMedicationStatement({ resourceType: 'MedicationStatement' });
+    expect(bare.warnings.find((w) => w.includes(COLLAPSE))).toContain('MedicationStatement (no id)');
   });
 });
 

--- a/tests/lab-identity.test.ts
+++ b/tests/lab-identity.test.ts
@@ -1,0 +1,564 @@
+/**
+ * A lab result's identity must be able to tell two lab results apart.
+ *
+ * THE DEFECT THESE PIN
+ * --------------------
+ * `convertObservationLab` minted its subject as
+ * `contentHashedUri('Observation', { patient, loincCode, date }, resource.id)`.
+ * Three things were wrong with that at once:
+ *
+ *   1. The MEASURED VALUE was not in the key. The whole point of a lab result.
+ *   2. The timestamp was truncated to a calendar day by `.split('T')[0]`.
+ *   3. `resource.id` was passed as `fallbackId`, which `contentHashedUri`
+ *      consults ONLY when every content field is empty — which never happens on
+ *      a real lab. So a perfectly good, distinct, server-assigned id was
+ *      discarded on every single record.
+ *
+ * Measured against the published build: a fasting glucose of 95 (`id
+ * "obs-fasting-95"`) and a post-prandial glucose of 310 (`id
+ * "obs-postprandial-310"`), same patient, same LOINC, same morning, both minted
+ * `urn:uuid:d2257c58-3d9f-5fe7-a34d-e48f97f6f27e`. The reconciler then passed
+ * over the second as a re-import of the first, and WHICH of the two values
+ * survived was decided by the order the input files happened to enumerate.
+ *
+ * Serial same-day labs are routine clinical practice — glucose curves, troponin
+ * series, repeat potassium, pre- and post-dialysis — so this fired on ordinary
+ * EHR output, not on hand-crafted input.
+ *
+ * WHAT THESE TESTS WOULD DO IF THE FIX WERE ABSENT
+ * ------------------------------------------------
+ * Almost every case below FAILS against the previous behavior; that is the
+ * point, and it was verified rather than assumed. The handful that pass either
+ * way are labelled STABILITY PIN in place, and each states what it is really
+ * guarding (an IRI that must NOT move, or a guarantee from the identity-door
+ * work that must not regress). Nothing here is counted as evidence for the fix
+ * unless it fails without it.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  convertObservationLab,
+  convertObservationVital,
+  convertMedicationStatement,
+} from '../src/lib/fhir-converter/converters-clinical.js';
+
+// ---------------------------------------------------------------------------
+// Helpers and fixtures
+// ---------------------------------------------------------------------------
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+/** The minted subject IRI: the first quad is the `rdf:type` triple on it. */
+function subjectOf(result: { _quads: Array<{ subject: { value: string } }> }): string {
+  expect(result._quads.length).toBeGreaterThan(0);
+  return result._quads[0].subject.value;
+}
+
+const labUri = (r: any): string => subjectOf(convertObservationLab(clone(r)));
+
+/**
+ * A glucose result. The exact shape a FHIR server returns for a basic metabolic
+ * panel member: LOINC-coded, `laboratory` category, quantity value, and a
+ * server-assigned id.
+ */
+function glucose(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Observation',
+    status: 'final',
+    category: [{
+      coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'laboratory' }],
+    }],
+    code: { coding: [{ system: 'http://loinc.org', code: '2339-0', display: 'Glucose [Mass/volume] in Blood' }] },
+    subject: { reference: 'Patient/synthetic-1' },
+    effectiveDateTime: '2026-08-02T07:00:00Z',
+    valueQuantity: { value: 95, unit: 'mg/dL', system: 'http://unitsofmeasure.org', code: 'mg/dL' },
+    ...overrides,
+  };
+}
+
+/** The same result with no server-assigned id — the FHIR-optional case. */
+function idLessGlucose(overrides: Record<string, unknown> = {}): any {
+  const r = glucose(overrides);
+  delete r.id;
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// 1. The reported collision: two same-day results are two records
+// ---------------------------------------------------------------------------
+
+describe('two lab results that differ are two records', () => {
+  it('the reported repro: fasting 95 and post-prandial 310, same patient, LOINC and day', () => {
+    const fasting = glucose({
+      id: 'obs-fasting-95',
+      effectiveDateTime: '2026-08-02T07:00:00Z',
+      valueQuantity: { value: 95, unit: 'mg/dL' },
+    });
+    const postPrandial = glucose({
+      id: 'obs-postprandial-310',
+      effectiveDateTime: '2026-08-02T11:00:00Z',
+      valueQuantity: { value: 310, unit: 'mg/dL' },
+    });
+
+    // Previously BOTH were urn:uuid:d2257c58-3d9f-5fe7-a34d-e48f97f6f27e, and
+    // the 310 was dropped as a duplicate of the 95.
+    expect(labUri(fasting)).not.toBe(labUri(postPrandial));
+  });
+
+  it('a present id decides identity, so identical content does NOT merge', () => {
+    // Two records the source deliberately kept apart. Nothing in their content
+    // distinguishes them; the ids are the source telling us they are two draws.
+    const a = glucose({ id: 'obs-draw-a' });
+    const b = glucose({ id: 'obs-draw-b' });
+    expect(labUri(a)).not.toBe(labUri(b));
+  });
+
+  it('the id path is deterministic AND discriminating, not merely deterministic', () => {
+    // Determinism alone is satisfied by returning a constant, which is exactly
+    // what the defect did. Both halves, or neither is evidence.
+    const a = glucose({ id: 'obs-draw-a' });
+    const b = glucose({ id: 'obs-draw-b', valueQuantity: { value: 310, unit: 'mg/dL' } });
+    expect(labUri(a)).toBe(labUri(clone(a)));
+    expect(labUri(b)).toBe(labUri(clone(b)));
+    expect(labUri(a)).not.toBe(labUri(b));
+  });
+
+  it('re-importing the SAME id-bearing record stays one record', () => {
+    // STABILITY PIN (passes without the fix too). The fix must not convert the
+    // collision bug into its mirror image — a fresh IRI on every sync. Server
+    // metadata churns between fetches and must not move the identity.
+    const first = glucose({ id: 'obs-fasting-95' });
+    const refetched = glucose({
+      id: 'obs-fasting-95',
+      meta: { lastUpdated: '2026-08-03T19:22:41.881+00:00', versionId: '4', source: 'urn:oid:1.2.3#z' },
+    });
+    expect(labUri(first)).toBe(labUri(refetched));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The id-less path: the discriminating fields are in the key
+// ---------------------------------------------------------------------------
+
+describe('id-less lab results are separated by what actually differs', () => {
+  it('the measured value is part of identity', () => {
+    const normal = idLessGlucose({ valueQuantity: { value: 95, unit: 'mg/dL' } });
+    const critical = idLessGlucose({ valueQuantity: { value: 310, unit: 'mg/dL' } });
+    expect(labUri(normal)).not.toBe(labUri(critical));
+  });
+
+  it('the unit is part of identity — 5 mg/dL is not 5 mmol/L', () => {
+    const mgdl = idLessGlucose({ valueQuantity: { value: 5, unit: 'mg/dL' } });
+    const mmoll = idLessGlucose({ valueQuantity: { value: 5, unit: 'mmol/L' } });
+    expect(labUri(mgdl)).not.toBe(labUri(mmoll));
+  });
+
+  it('the timestamp is identity at FULL precision, not truncated to a day', () => {
+    // A glucose curve: same patient, same test, same value, four hours apart.
+    // `.split('T')[0]` made these one record.
+    const morning = idLessGlucose({ effectiveDateTime: '2026-08-02T07:00:00Z' });
+    const midday = idLessGlucose({ effectiveDateTime: '2026-08-02T11:00:00Z' });
+    expect(labUri(morning)).not.toBe(labUri(midday));
+  });
+
+  it('value forms this converter does not special-case still separate results', () => {
+    // Collected by `value[x]` PREFIX rather than from a hand-written list, so a
+    // form the converter has never met still splits instead of merging. If this
+    // were a list, each miss would be a silent merge.
+    const uris = [
+      idLessGlucose({ valueQuantity: undefined, valueString: 'Reactive' }),
+      idLessGlucose({ valueQuantity: undefined, valueString: 'Non-reactive' }),
+      idLessGlucose({
+        valueQuantity: undefined,
+        valueCodeableConcept: { coding: [{ system: 'http://snomed.info/sct', code: '10828004', display: 'Positive' }] },
+      }),
+      idLessGlucose({
+        valueQuantity: undefined,
+        valueCodeableConcept: { coding: [{ system: 'http://snomed.info/sct', code: '260385009', display: 'Negative' }] },
+      }),
+      idLessGlucose({ valueQuantity: undefined, valueRatio: { numerator: { value: 1 }, denominator: { value: 40 } } }),
+      idLessGlucose({ valueQuantity: undefined, valueRatio: { numerator: { value: 1 }, denominator: { value: 320 } } }),
+      idLessGlucose({ valueQuantity: undefined, valueInteger: 3 }),
+      idLessGlucose({ valueQuantity: undefined, valueInteger: 4 }),
+    ].map(labUri);
+    expect(new Set(uris).size, 'two results with different values shared an IRI').toBe(uris.length);
+  });
+
+  it('a panel-style Observation is separated by its components', () => {
+    const survey = (answer: string) => idLessGlucose({
+      valueQuantity: undefined,
+      component: [{
+        code: { coding: [{ system: 'http://loinc.org', code: '63586-2', display: 'Total income' }] },
+        valueString: answer,
+      }],
+    });
+    expect(labUri(survey('under 10000'))).not.toBe(labUri(survey('over 100000')));
+  });
+
+  it('the specimen is part of identity', () => {
+    const blood = idLessGlucose({ specimen: { reference: 'Specimen/blood-1' } });
+    const csf = idLessGlucose({ specimen: { reference: 'Specimen/csf-1' } });
+    expect(labUri(blood)).not.toBe(labUri(csf));
+  });
+
+  it('the category is part of identity', () => {
+    const lab = idLessGlucose();
+    const survey = idLessGlucose({
+      category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'survey' }] }],
+    });
+    expect(labUri(lab)).not.toBe(labUri(survey));
+  });
+
+  it('category ORDER does not move the IRI, so two servers agree', () => {
+    // Category is a set. Sorting removes a source of spurious splits; it can
+    // never cause a merge, because a differing set still sorts differently.
+    const twoCats = (order: string[]) => idLessGlucose({
+      category: order.map((code) => ({
+        coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code }],
+      })),
+    });
+    expect(labUri(twoCats(['laboratory', 'survey']))).toBe(labUri(twoCats(['survey', 'laboratory'])));
+  });
+
+  it('the same id-less record converted twice yields one IRI, and a different one two', () => {
+    const r = idLessGlucose();
+    const other = idLessGlucose({ valueQuantity: { value: 310, unit: 'mg/dL' } });
+    expect(labUri(r)).toBe(labUri(clone(r)));
+    expect(labUri(r)).not.toBe(labUri(other));
+  });
+
+  it('source key ORDER does not perturb an id-less lab IRI', () => {
+    // STABILITY PIN. Guards the sorted-key serialization the identity door
+    // relies on; two EHRs emitting the same record must agree.
+    const forward = idLessGlucose();
+    const reversed: any = {};
+    for (const k of Object.keys(forward).reverse()) reversed[k] = forward[k];
+    expect(labUri(reversed)).toBe(labUri(forward));
+  });
+
+  it('server metadata does not move an id-less lab IRI', () => {
+    // STABILITY PIN. `meta.lastUpdated`/`versionId`/`source` churn on every
+    // re-fetch; hashing them would mint a fresh IRI on every sync.
+    const base = idLessGlucose();
+    const refetched = idLessGlucose({
+      meta: { lastUpdated: '2026-08-03T19:22:41.881+00:00', versionId: '4', source: 'urn:oid:1.2.3#z' },
+    });
+    expect(labUri(base)).toBe(labUri(refetched));
+  });
+
+  it('the display name alone does not split a result — the LOINC code decides', () => {
+    // STABILITY PIN, and the reason `testName` is NOT an identity field: the
+    // converter defaults it to the literal 'Unknown Lab Test'. A placeholder in
+    // an identity key turns "we do not know" into "these are the same record".
+    const short = idLessGlucose();
+    const verbose = idLessGlucose({
+      code: { coding: [{ system: 'http://loinc.org', code: '2339-0', display: 'GLUCOSE, BLOOD' }] },
+    });
+    expect(labUri(short)).toBe(labUri(verbose));
+  });
+
+  it('a content-free Observation still collapses LOUDLY (identity-door tier 4 intact)', () => {
+    // STABILITY PIN for the identity-door guarantee: a record with no id, no
+    // structured content and no narrative merges, but never silently.
+    const r = convertObservationLab({ resourceType: 'Observation' });
+    const collapse = r.warnings.filter((w) => w.includes('no identifier and no identity-bearing content'));
+    expect(collapse.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The two real-world corpus shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Measured on a real imported pod of 1,150 subjects, 659 of them lab results
+ * across 30 draw days: 144 same-(LOINC, day) groups, every one a pair, every
+ * pair cross-source with a byte-identical timestamp, and 3 of the 144
+ * DISAGREEING on value.
+ *
+ * The corpus is undamaged today only because cross-source records carry
+ * different `subject.reference` values and `patient` is in the key. Any
+ * normalization that unifies patient references across sources — which
+ * reconciliation naturally wants, and which that corpus's own remediation plan
+ * calls for — would have made all 144 pairs collide at import, merging them
+ * silently at the wrong layer, with no conflict record and no review. The 3
+ * that disagree on value are the case where that loses a real measurement.
+ */
+describe('the shapes measured on a real 659-lab corpus survive', () => {
+  const CROSS_SOURCE_TIMESTAMP = '2011-05-14T14:32:00Z';
+
+  function crossSourcePair(normalizePatient: boolean, values: [number, number]) {
+    const mk = (i: 0 | 1) => glucose({
+      id: i === 0 ? 'epic-obs-88213' : 'cerner-obs-4471',
+      subject: { reference: normalizePatient ? 'Patient/unified-1' : `Patient/source-${i}` },
+      effectiveDateTime: CROSS_SOURCE_TIMESTAMP,
+      valueQuantity: { value: values[i], unit: 'mg/dL' },
+    });
+    return [labUri(mk(0)), labUri(mk(1))] as const;
+  }
+
+  it('cross-source pairs stay distinct — and stay distinct after patient normalization', () => {
+    // As they arrive today: distinct because `patient` differs.
+    const [a1, b1] = crossSourcePair(false, [95, 95]);
+    expect(a1).not.toBe(b1);
+
+    // After the remediation that unifies patient references across sources.
+    // This is the half that the previous behavior failed: LOINC, calendar day
+    // and patient all now agree, so the two records collapsed onto one IRI.
+    const [a2, b2] = crossSourcePair(true, [95, 95]);
+    expect(a2, 'patient normalization silently merged a cross-source pair').not.toBe(b2);
+  });
+
+  it('the 3-of-144 pairs that DISAGREE on value stay two records', () => {
+    // Same source-normalized patient, same LOINC, byte-identical timestamp,
+    // different measurements. This is the human-review case, and under the
+    // previous key it became an invisible merge — the disagreement that is the
+    // whole reason a person is asked simply disappeared.
+    const [a, b] = crossSourcePair(true, [95, 310]);
+    expect(a).not.toBe(b);
+  });
+
+  it('same-source repeat draws on one day stay distinct', () => {
+    // The serial-lab shape: a troponin series, three draws, one day, one source.
+    const uris = ['2026-08-02T06:00:00Z', '2026-08-02T09:00:00Z', '2026-08-02T12:00:00Z'].map((t, i) =>
+      labUri(glucose({
+        id: `epic-trop-${i}`,
+        code: { coding: [{ system: 'http://loinc.org', code: '6598-7', display: 'Troponin T' }] },
+        effectiveDateTime: t,
+        valueQuantity: { value: [0.01, 0.42, 1.9][i], unit: 'ng/mL' },
+      })),
+    );
+    expect(new Set(uris).size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Vitals must not move
+// ---------------------------------------------------------------------------
+
+/**
+ * STABILITY PINS, all of them. `convertObservationVital` mints via
+ * `mintSubjectUri`, which honours the FHIR id, and that is precisely why the
+ * real corpus's 318 same-source same-(LOINC, day) vital pairs survived as
+ * distinct records while the lab pairs did not. This change must not disturb
+ * that, and must not "helpfully" content-hash vitals on the way past.
+ */
+describe('vital signs keep their existing identity', () => {
+  function heartRate(overrides: Record<string, unknown> = {}): any {
+    return {
+      resourceType: 'Observation',
+      status: 'final',
+      category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] }],
+      code: { coding: [{ system: 'http://loinc.org', code: '8867-4', display: 'Heart rate' }] },
+      subject: { reference: 'Patient/synthetic-1' },
+      effectiveDateTime: '2026-01-15T09:30:00Z',
+      valueQuantity: { value: 72, unit: 'beats/minute' },
+      ...overrides,
+    };
+  }
+  const vitalUri = (r: any) => subjectOf(convertObservationVital(clone(r)));
+
+  it('an id-bearing vital mints exactly the IRI it always has', () => {
+    // Golden value, computed before this change. A drift here means an existing
+    // pod's vitals moved.
+    expect(vitalUri(heartRate({ id: 'obs-hr-1' })))
+      .toBe('urn:uuid:4075fcee-43dd-5011-b531-1946a2c41849');
+  });
+
+  it('a vital whose value changes keeps its IRI, because the id decides', () => {
+    const base = heartRate({ id: 'obs-hr-1' });
+    const changed = heartRate({ id: 'obs-hr-1', valueQuantity: { value: 118, unit: 'beats/minute' } });
+    expect(vitalUri(base)).toBe(vitalUri(changed));
+  });
+
+  it('the 318-pair shape: same-source same-day repeat vitals stay distinct', () => {
+    const uris = ['13:25', '14:00', '15:00'].map((hhmm, i) =>
+      vitalUri(heartRate({
+        id: `epic-hr-${i}`,
+        effectiveDateTime: `2026-01-15T${hhmm}:00Z`,
+        valueQuantity: { value: [88, 76, 72][i], unit: 'beats/minute' },
+      })),
+    );
+    expect(new Set(uris).size).toBe(3);
+  });
+
+  it('both Observation converters now agree on one id-bearing resource', () => {
+    // The two Observation converters in this file used OPPOSITE identity
+    // strategies: the vital one honoured the FHIR id, the lab one discarded it
+    // for a {patient, LOINC, calendar day} hash. So the same resource minted two
+    // different IRIs depending on which converter saw it, and which one that is
+    // depends on `VITAL_TYPE_TO_SHACL` — a routing table that can change.
+    //
+    // Deliberately NOT written as `vitalUri(x) === labUri(x)` on a resource the
+    // vital converter REROUTES to the lab converter: that comparison is
+    // tautological, since both sides end up calling the same function, and it
+    // passes with or without this change.
+    const hr = heartRate({ id: 'obs-hr-1' });
+    expect(vitalUri(hr)).toBe(labUri(hr));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. The placeholder-default class
+// ---------------------------------------------------------------------------
+
+/**
+ * A placeholder default that reaches an identity key converts "we do not know"
+ * into "these are the same record", which is the merge failure mode. It is
+ * invisible to the identity door's four-tier cascade, because the constant
+ * arrives pre-baked from the converter: the content tier "succeeds" with a
+ * value identical for every content-free record of that type, so the tier-4
+ * collapse warning can never fire.
+ *
+ * The class-wide guard lives in `identity-determinism.test.ts`, which now
+ * requires EVERY FHIR converter — `convertMedicationStatement` included — to
+ * report the collapse for a bare resource. These cases pin the specific
+ * medication instance and, just as importantly, pin that fixing it did not move
+ * the IRI of a medication that actually names a drug.
+ */
+describe('placeholder defaults do not reach an identity key', () => {
+  it('two content-free MedicationStatements are two records, and say so', () => {
+    const bare = convertMedicationStatement({ resourceType: 'MedicationStatement' });
+    const withNote = convertMedicationStatement({
+      resourceType: 'MedicationStatement',
+      note: [{ text: 'a different medication entirely' }],
+    });
+    // Previously both minted urn:uuid:6fdb46b2-be25-52f9-80b8-2a356c4c3a87.
+    expect(subjectOf(bare)).not.toBe(subjectOf(withNote));
+    // And the genuinely empty one now reaches the tier-4 collapse notice, which
+    // the placeholder constant had made structurally unreachable.
+    expect(bare.warnings.filter((w) => w.includes('no identifier and no identity-bearing content')).length).toBe(1);
+    expect(withNote.warnings.filter((w) => w.includes('no identifier and no identity-bearing content'))).toEqual([]);
+  });
+
+  it('a medication that names a drug keeps the IRI it already had', () => {
+    // STABILITY PIN, and the reason this half is NOT an IRI-breaking change:
+    // when the source names a drug, the identity input is unchanged. Golden
+    // value measured against the previous build.
+    const lisinopril = {
+      resourceType: 'MedicationStatement',
+      subject: { reference: 'Patient/synthetic-1' },
+      medicationCodeableConcept: {
+        text: 'Lisinopril 10 MG',
+        coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '314076' }],
+      },
+      effectivePeriod: { start: '2024-01-01' },
+    };
+    expect(subjectOf(convertMedicationStatement(clone(lisinopril))))
+      .toBe('urn:uuid:c133ddb5-e7c3-5251-b4c7-17ffc20d735c');
+  });
+
+  it('a medication named only by medicationReference.display also keeps its IRI', () => {
+    // STABILITY PIN. The second real source of a drug name must keep feeding
+    // identity; only the placeholder was removed.
+    const byReference = {
+      resourceType: 'MedicationStatement',
+      subject: { reference: 'Patient/synthetic-1' },
+      medicationReference: { reference: 'Medication/m1', display: 'Lisinopril 10 MG' },
+      effectivePeriod: { start: '2024-01-01' },
+    };
+    const byConcept = {
+      resourceType: 'MedicationStatement',
+      subject: { reference: 'Patient/synthetic-1' },
+      medicationCodeableConcept: { text: 'Lisinopril 10 MG' },
+      effectivePeriod: { start: '2024-01-01' },
+    };
+    expect(subjectOf(convertMedicationStatement(clone(byReference))))
+      .toBe(subjectOf(convertMedicationStatement(clone(byConcept))));
+  });
+
+  it('the placeholder is still what the record DISPLAYS', () => {
+    // STABILITY PIN. Removing the constant from identity must not remove it
+    // from the output — a nameless medication still reads as one.
+    const bare = convertMedicationStatement({ resourceType: 'MedicationStatement' });
+    const names = bare._quads
+      .filter((q: any) => q.predicate.value.endsWith('drugName'))
+      .map((q: any) => q.object.value);
+    expect(names).toEqual(['Unknown Medication']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Across processes and across working directories
+// ---------------------------------------------------------------------------
+
+/**
+ * Minting twice inside one process shares a warm module cache, one
+ * `process.cwd()`, and any memoization a converter holds, so a defect keyed on
+ * any of those is invisible to it. That is not hypothetical in this repo: the
+ * previous identity defect in this family was path-dependent and stayed green
+ * for months because everything ran from one directory.
+ *
+ * So this spawns SEPARATE node processes from DIFFERENT working directories and
+ * compares across them, through `dist/` — the artifact an npm consumer installs.
+ *
+ * The skip guard keys on a module present in EVERY revision of this repo, not
+ * on anything this change introduces. A guard that keys on a new file SKIPS
+ * instead of FAILING when run against a pre-fix build, which is exactly how a
+ * determinism suite looks green while proving nothing.
+ */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'fhir-converter', 'converters-clinical.js'));
+
+const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+const dist = process.env.CASCADE_DIST;
+const { convertObservationLab } = await import(
+  pathToFileURL(path.join(dist, 'lib/fhir-converter/converters-clinical.js')).href
+);
+const payload = JSON.parse(process.env.CASCADE_PAYLOAD);
+const out = { cwd: process.cwd(), uris: payload.map((r) => convertObservationLab(r)._quads[0].subject.value) };
+process.stdout.write(JSON.stringify(out));
+`;
+
+function mintIn(dir: string, resources: any[]): { cwd: string; uris: string[] } {
+  const scriptPath = path.join(dir, 'mint.mjs');
+  fs.writeFileSync(scriptPath, SCRIPT, 'utf8');
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    env: { ...process.env, CASCADE_DIST: DIST, CASCADE_PAYLOAD: JSON.stringify(resources) },
+    encoding: 'utf8',
+  });
+  return JSON.parse(stdout);
+}
+
+describe.skipIf(!HAVE_DIST)('lab identity survives the process and the working directory', () => {
+  it('two processes in two directories agree, and still tell the two results apart', () => {
+    const resources = [
+      glucose({ id: 'obs-fasting-95', effectiveDateTime: '2026-08-02T07:00:00Z', valueQuantity: { value: 95, unit: 'mg/dL' } }),
+      glucose({ id: 'obs-postprandial-310', effectiveDateTime: '2026-08-02T11:00:00Z', valueQuantity: { value: 310, unit: 'mg/dL' } }),
+      idLessGlucose({ valueQuantity: { value: 95, unit: 'mg/dL' } }),
+      idLessGlucose({ valueQuantity: { value: 310, unit: 'mg/dL' } }),
+    ];
+
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-lab-a-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-lab-b-'));
+    try {
+      const a = mintIn(dirA, clone(resources));
+      const b = mintIn(dirB, clone(resources));
+
+      expect(a.cwd).not.toBe(b.cwd);
+      // DETERMINISM: two processes, two directories, one answer.
+      expect(a.uris, `cwd ${a.cwd} disagreed with cwd ${b.cwd}`).toEqual(b.uris);
+      // DISTINCTNESS: and the answer is not a constant. Without this half a
+      // function returning one string would pass the line above perfectly.
+      expect(new Set(a.uris).size, `four different results shared an IRI: ${a.uris.join(' ')}`).toBe(4);
+      for (const uri of a.uris) expect(uri).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    } finally {
+      fs.rmSync(dirA, { recursive: true, force: true });
+      fs.rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The defect

Two importers minted a lab result's identity from `{patient, test code, calendar DAY}` and nothing else. Both had the same three faults, and the C-CDA one had them in the same function:

1. **The measured value was not in the key.** In the C-CDA importer it is extracted a few lines above the mint, emitted as quads, and never consulted.
2. **The timestamp was truncated to a calendar day** — `.split('T')[0]` on the FHIR path, `formatCcdaDate()` on the C-CDA path.
3. **The record's own source identifier was passed as `fallbackId`**, which `contentHashedUri` consults *only* when every content field is empty — never true for a real lab, since `patient` is always populated. So a perfectly good, distinct, server-assigned id was discarded on every single record.

Measured against the previous build:

| | fixture | result |
|---|---|---|
| FHIR | fasting glucose 95 (`id "obs-fasting-95"`) vs post-prandial 310 (`id "obs-postprandial-310"`) | both `urn:uuid:d2257c58-3d9f-5fe7-a34d-e48f97f6f27e` |
| C-CDA | same pair, distinct `<id root= extension=>`, **and** the id-less versions of both | all four `urn:uuid:dc68ecd7-acc0-5d61-981a-e51a3dbc0b0c` |

The second record was then passed over as a re-import of the first, and *which* value survived was decided by the order the input files enumerated. Serial same-day labs are ordinary medicine — glucose curves, troponin series, repeat potassium, before-and-after dialysis — so this fired on ordinary EHR output, not on hand-crafted input.

## Why both importers are in one PR

Not "break lab IRIs once rather than twice" — that is achievable with two PRs in one release, so it decides nothing. The reason is **coupling**: shipped separately the two PRs *must* merge together, because merging either alone leaves `main` with lab identity fixed in one importer and broken in the other while the CHANGELOG announces that lab identity changed. A must-merge-together pair is an ordering hazard someone eventually gets wrong. One PR removes it, and it is one CHANGELOG statement about one behaviour.

## The fix

**A present source id decides.** Exactly as `convertObservationVital` already did via `mintSubjectUri` — which is why same-day repeat *vitals* survived as distinct records in a real 1,150-subject pod while same-day repeat *labs* did not. Identity answers "is this that record?". Deciding that two records are the same *thing* is a separate judgement, it needs a conflict trail, and it belongs to the layer that can see both records; the identity layer sees one at a time and can only silently overwrite.

**Without an id**, the key carries what actually separates two results:

- **FHIR** — patient, LOINC code, effective instant at **full precision**, the measured value across every `value[x]` form, specimen, category.
- **C-CDA** — patient, LOINC code, test name, the raw HL7 `effectiveTime` at **full precision** (`YYYYMMDDHHMMSS±ZZZZ`, not the day-truncated `formatCcdaDate` output, which is still exactly what `health:performedDate` reports), and the measured value with its unit.

The FHIR value is collected by `value[x]` **prefix** rather than from a hand-written list, so a form the converter has never met (`valueRatio`, `valueSampledData`, a future extension) still splits instead of merging. A list silently merges every form it misses; prefix collection at worst splits. Category is sorted, because it is a set and two servers may enumerate it in different order — sorting can only remove spurious splits, never cause a merge.

`testName` is excluded from the FHIR key: it defaults to the literal `'Unknown Lab Test'`. The C-CDA `displayName` has no placeholder, so it stays.

### `LaboratoryReport` (C-CDA panels) — checked, and a different case

**It never had the "id discarded" defect.** `panelId: sourceId` was already a first-class content field, put there by an earlier fix for a related collision, so an id-bearing organizer was already separated by its id. **That key is left byte-identical** — verified by golden value `urn:uuid:f9e45f8f-0927-571b-bee2-e1cf609cda5a`. Moving it would break panel IRIs for no correctness gain.

It *did* have the truncation half. `clinicalDate` is day-truncated, and when an organizer carries neither an id nor a code — the combination the code's own comment reports is common in real Epic exports, **47 of 55 panels in an acceptance export carrying no code** — the key degenerated to `{patient, day}`. Measured: two such organizers four hours apart, holding different results, both minted `urn:uuid:0335391b-48fb-5d69-ab87-7bbf2429e434`. The **id-less branch, and only that branch**, now also carries the organizer's raw full-precision `effectiveTime` and a fingerprint of its member subjects — which is what a panel's content actually is, since a panel has no measured value of its own.

### "Subject minting is frozen" — replaced, not worked around

The C-CDA file header claimed lab minting was frozen. That claim is gone. It was not describing a decision anyone would defend on the merits; it was describing a key set that silently merged different lab results, and a freeze enforced only by politeness is a large part of why the defect survived long enough to be shipped by two importers at once. The header now states what changed, why, and points at the golden-value tests that actually protect what must not move — because a test names the property it protects, where a comment asks the next reader to guess.

### Second class of defect, also fixed

`convertMedicationStatement` defaulted the drug name to the literal `'Unknown Medication'` **before minting**, so its content tier always "succeeded" — with a value identical for every content-free medication. A content hash that succeeds with a constant is indistinguishable from one that fails, except that it merges records instead of splitting them, and it is invisible to the identity door because the constant arrives pre-baked from the converter. Measured before: a bare `MedicationStatement` and one carrying a distinct `note` both minted `urn:uuid:6fdb46b2-be25-52f9-80b8-2a356c4c3a87`, with empty `warnings`.

The placeholder is still what the record **displays**; it is no longer what the record is **identified by**. **A medication that names a drug keeps its IRI**, verified by golden value. `contentHashedUri`/`medicationUri` gained an optional `label` so the tier-4 collapse notice names the resource type the caller imported instead of the shared `MedicationRequest` identity key.

## IRI-breaking, and by how much

Documented in `CHANGELOG.md` under `[Unreleased]`, now covering **both** importers, with a short orientation at the top of the section so the two identity changes in this release — one that moves no id-determined IRI, one that deliberately moves lab IRIs — read coherently to someone who was not here. The version number is deliberately left unchosen and flagged.

**FHIR conformance corpus (91 converted resources):**

| | before | after |
|---|---|---|
| colliding IRI groups | 16 | 6 |
| records sharing an IRI with a record they differ from | 49 | 13 |
| lab observations colliding | 45 | **0** |
| distinct IRIs | 58 | 84 |

Worst case before: **six distinct HLA observations from the published HL7 FHIR Genomics IG example bundle**, each with its own server-assigned id, all on `urn:uuid:993400b1-8e3d-5d29-b0aa-20ae84a66c0b`. All six *remaining* shared IRIs after the change are the same record appearing in two fixture files, which is correct. **45 of 91 moved, every one a lab observation; the other 46 byte-identical.**

**C-CDA corpus: 40 of 43 distinct identities unchanged, all 3 that moved are lab results.**

## Verification

**Negative control — run against a separately built `origin/main` worktree, not assumed:**

| suite | failures on `origin/main` |
|---|---|
| `tests/lab-identity.test.ts` | **16 of 29** |
| `tests/ccda-lab-identity.test.ts` | **11 of 15** |
| `tests/identity-determinism.test.ts` | **3 of 56** changed cases |

The cases that pass either way are **labelled in place** and say what they actually guard: golden IRIs that must not move (vitals, a named medication, an id-bearing panel), invariants the change could plausibly have broken (`hasLabResult` edges still resolving after members are re-minted; `health:performedDate` still reporting the day-truncated literal), and identity-door guarantees that must not regress (key-order independence, `meta` volatility, tier-4 loudness). None is counted as evidence for the fix.

One test was rewritten mid-build after failing that standard: it compared `convertObservationVital(x)` with `convertObservationLab(x)` on a resource the vital converter *reroutes* to the lab converter, so both sides called the same function and it passed with or without the change. It now compares the two converters on a resource each handles itself.

**Determinism AND distinctness, across processes and directories.** Both new suites spawn separate `node` processes from two different working directories, assert the IRIs agree across them, **and** assert all four inputs produced four distinct IRIs — because a function returning a constant satisfies the first half perfectly. Both skip guards key on a module present in every revision, not on anything this change introduces, so they fail rather than skip against an older build.

**Real-world corpus shapes pinned as fixtures.** Measured on a real imported pod of 659 lab results across 30 draw days: cross-source same-`(LOINC, day)` pairs with differing `subject.reference` stay distinct **and stay distinct after those references are normalized to one patient** (the second half is what the previous behavior failed), and same-source pairs that disagree on value stay two records.

**Suite: 1353 → 1399 passed, 0 failed, 102 → 104 files.** The identity chokepoint test and the four-tier cascade with its `volatile`/`derivative`/`scaffold` exclusions are untouched and still pass; everything routes through `identitySeed`, with no new bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)