### PR TITLE
fix(reconciler): tell an identity collision apart from a re-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,60 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Two records that share one subject IRI but disagree on content are no longer silently
+  reduced to one.**
+
+  Cascade subject IRIs are content-hashed, so the reconciler treated a second arrival of an
+  IRI as a re-import of the same record and passed over it. That is right for a re-import
+  and wrong for an identity COLLISION — two genuinely different records that an identity key
+  narrower than the records themselves minted onto one IRI. A fasting glucose of 95 and a
+  post-prandial of 310, drawn the same day, are exactly that shape, and serial same-day
+  results are ordinary clinical practice (glucose curves, troponin series, repeat potassium,
+  pre/post dialysis).
+
+  The consequence was silent clinical data loss on the primary import path: one of the two
+  values was discarded, the loss was reported as successful deduplication, no conflict was
+  written, nothing was printed — and WHICH value survived was decided by the order the
+  inputs happened to be enumerated, i.e. by the filesystem. The same two files imported on
+  two machines could leave a normal glucose in one pod and a critical hyperglycemia reading
+  in the other.
+
+  The reconciler now compares the records behind a shared IRI:
+
+  - **Identical content is still a re-import**, handled exactly as before. Per-run
+    bookkeeping (`clinical:importedAt`, `cascade:reconciliationStatus`, merge lineage,
+    ingestion source labels) is not content, and neither is the difference between a
+    reference edge stored resolved in the pod and the same edge carried as an unresolved
+    placeholder by a fresh conversion. Nothing here changes for an ordinary re-sync.
+  - **Differing content is a COLLISION**, and it is split rather than merged: every distinct
+    content keeps its own record. This follows the rule the identity layer already states —
+    when identity is uncertain, prefer a split, because a duplicate is recoverable and a
+    merge is not. The IRI the identity layer minted stays occupied by one of them, so
+    nothing that referenced it starts dangling, and which one that is depends only on the
+    records' own contents, never on input order. Reversing the input order now produces a
+    byte-identical pod.
+  - **The collision is raised as an unresolved conflict** through the existing queue:
+    `settings/pending-conflicts.ttl`, `cascade pod conflicts` (which exits 1), and
+    `cascade pod resolve`. The conflict names which predicates disagree. `pod import` prints
+    a warning rather than reporting the collision as a duplicate, and the two split records
+    are kept out of each other's match candidates for that run, so a question raised for a
+    person is not answered by an automatic merge in the same breath.
+
+  The import summary gains `identityCollisionsSplit`, and `duplicateSubjectsDropped` now
+  means only what it says: a record the pod already held, byte for byte.
+
+  **No IRI moves for any pod that has no collision in it.** Where a collision does exist,
+  the record that previously survived keeps its IRI and the record that was previously
+  DELETED reappears under a new derived one, so this recovers data rather than relocating
+  it.
+
+- **`src/lib/reconciler.ts` is searchable again.** It used NUL as a key delimiter written as
+  a raw byte rather than as an escape, which made `file(1)` classify the source as binary
+  and made `grep` and `ripgrep` skip all 1,339 lines of it without saying so — a content
+  search returned "no matches" for symbols the file demonstrably contains. The three sites
+  now use `\u0000`, which is the same string, and a test rejects a raw NUL anywhere under
+  `src/`.
+
 - **Re-importing a document no longer duplicates the records in it that carry no `id`.**
   This closes the known limitation named in 0.10.0.
 

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -674,6 +674,22 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         reconciledEdgeRewrites = reconcileResult.report.summary.edgeObjectsRewritten;
         printVerbose(`Reconciliation complete. Final records: ${reconcileResult.report.summary.finalRecordCount}`, globalOpts);
 
+        // Not printVerbose: an identity collision means two records this import
+        // treats as different were minted onto ONE IRI, so the identity key that
+        // produced it is narrower than the records it is identifying. That is a
+        // defect in the source data or in a converter, and a user who is never
+        // told has no way to discover it — the records look reconciled.
+        const collisionsSplit = reconcileResult.report.summary.identityCollisionsSplit;
+        if (collisionsSplit > 0) {
+          printWarning(
+            `${collisionsSplit} identity collision(s): two or more records with DIFFERENT content were ` +
+            `assigned the same IRI. They have been kept as separate records rather than one being ` +
+            `dropped as a duplicate, and raised as unresolved conflicts — run \`cascade pod conflicts\` ` +
+            `to review them.`,
+            globalOpts,
+          );
+        }
+
         // Persist unresolved conflicts to settings/pending-conflicts.ttl
         if (!dryRun) {
           const pendingConflicts: PendingConflict[] = (reconcileResult.report.unresolvedConflicts as Array<{
@@ -681,12 +697,14 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
             matchedOn: string;
             sources?: string[];
             candidateUris?: string[];
+            label?: string;
           }>).map((c) => ({
             uri: `urn:uuid:conflict-${randomUUID()}`,
             conflictId: generateConflictId(c.recordType, c.matchedOn),
             recordType: c.recordType,
             detectedAt: new Date(),
             candidateRecordUris: c.candidateUris ?? [],
+            label: c.label,
             sourceA: c.sources?.[0],
             sourceB: c.sources?.[1],
           }));

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -5,9 +5,10 @@
  * without going through the CLI layer.
  */
 
+import { createHash } from 'node:crypto';
 import { Parser, Writer, DataFactory } from 'n3';
 import type { Quad, Quad_Subject, Quad_Object } from 'n3';
-import { NS, TURTLE_PREFIXES } from './fhir-converter/types.js';
+import { NS, TURTLE_PREFIXES, deterministicUuid } from './fhir-converter/types.js';
 import {
   buildReferenceResolver,
   buildResourceRefsFromQuads,
@@ -77,6 +78,20 @@ export interface ReconcilerResult {
       duplicateSubjectsDropped: number;
       conflictsResolved: number;
       conflictsUnresolved: number;
+      /**
+       * Minted IRIs that two or more MATERIALLY DIFFERENT records claimed, and
+       * that were therefore split apart instead of one being dropped as a
+       * duplicate.
+       *
+       * Disjoint from `duplicateSubjectsDropped` by construction, and the point
+       * of the distinction: a shared IRI whose holders agree is a re-import and
+       * is counted there; a shared IRI whose holders disagree is an identity
+       * collision, counted here, and every one of them also appears in
+       * `unresolvedConflicts` (so it reaches `settings/pending-conflicts.ttl`).
+       * Non-zero means the identity key that minted those IRIs is narrower than
+       * the records it is identifying.
+       */
+      identityCollisionsSplit: number;
       finalRecordCount: number;
       /** Subjects preserved verbatim because their type is not reconcilable. */
       passthroughSubjects: number;
@@ -285,11 +300,11 @@ const SINGLE_CARDINALITY_PASSTHROUGH_PREDICATES: ReadonlySet<string> = new Set<s
  * single-cardinality predicate is present.
  */
 function collapseSingleCardinalityPassthrough(quads: Quad[]): Quad[] {
-  const keep = new Map<string, string>(); // `${subjectKey} ${predicate}` -> winning object value
+  const keep = new Map<string, string>(); // `${subjectKey}\u0000${predicate}` -> winning object value
   const subjectKey = (q: Quad) => `${q.subject.termType}:${q.subject.value}`;
   for (const q of quads) {
     if (!SINGLE_CARDINALITY_PASSTHROUGH_PREDICATES.has(q.predicate.value)) continue;
-    const key = `${subjectKey(q)} ${q.predicate.value}`;
+    const key = `${subjectKey(q)}\u0000${q.predicate.value}`;
     const cur = keep.get(key);
     if (cur === undefined || q.object.value < cur) keep.set(key, q.object.value);
   }
@@ -299,7 +314,7 @@ function collapseSingleCardinalityPassthrough(quads: Quad[]): Quad[] {
   const out: Quad[] = [];
   for (const q of quads) {
     if (SINGLE_CARDINALITY_PASSTHROUGH_PREDICATES.has(q.predicate.value)) {
-      const key = `${subjectKey(q)} ${q.predicate.value}`;
+      const key = `${subjectKey(q)}\u0000${q.predicate.value}`;
       if (q.object.value !== keep.get(key)) continue; // drop a later run's duplicate value
       if (emitted.has(key)) continue;                 // keep exactly one winning quad
       emitted.add(key);
@@ -395,6 +410,315 @@ function collapseResolvedEquivalentEdges(
     out.push(winner.get(key) ?? q);
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Identity collisions: telling a collision apart from a re-import
+// ---------------------------------------------------------------------------
+//
+// Two records can arrive under the SAME subject IRI for two completely
+// different reasons, and until this section existed the reconciler could not
+// tell them apart:
+//
+//   RE-IMPORT   — the same source record, imported twice. Cascade subjects are
+//                 content-hashed, so this is the expected and overwhelmingly
+//                 common case. Passing over the second arrival is correct: it
+//                 carries nothing the first does not.
+//
+//   COLLISION   — two DIFFERENT records that the identity layer minted onto one
+//                 IRI, because the minting key was narrower than the records
+//                 (e.g. a lab key of {patient, LOINC, date} for a fasting and a
+//                 post-prandial glucose drawn on the same day). Passing over the
+//                 second arrival here silently destroys a clinical value, and
+//                 WHICH value survives is decided by the order the inputs were
+//                 enumerated — i.e. by the filesystem.
+//
+// The old code assumed the first case unconditionally (`assigned.has(uri)`), so
+// the second was invisible: the run reported the loser as a duplicate, wrote no
+// conflict, and printed nothing.
+//
+// THE RULE APPLIED HERE is the one stated in `lib/identity.ts`: when identity is
+// uncertain, PREFER A SPLIT OVER A MERGE. A split is recoverable because both
+// records are still present and can be reconciled later by a tool or a person; a
+// merge is not, because the loser's content is simply gone. So a collision does
+// not pick a winner — every distinct content gets its own IRI, and the collision
+// is raised as an unresolved conflict so a human is asked which (if either) is
+// the duplicate.
+//
+// WHY THE ASSIGNMENT IS ORDER-INDEPENDENT. The colliding contents are ranked by
+// their own fingerprints, not by arrival order: the lexicographically smallest
+// fingerprint keeps the original IRI and every other distinct fingerprint moves
+// to an IRI derived from (original IRI, fingerprint). Reversing the input order
+// therefore produces a byte-identical pod, which is the actual repair for "the
+// filesystem decides which glucose value you keep". Keeping the smallest at the
+// original IRI also means the IRI stays occupied, so nothing that referenced it
+// starts dangling.
+//
+// WHY IT IS STABLE ACROSS RE-IMPORTS. The derived IRI is a pure function of the
+// original IRI and the record's own content fingerprint, so importing the same
+// pair of records again re-derives the same two IRIs, matches the pod's existing
+// copies, and drops them as the re-imports they are. The pod does not grow.
+
+/**
+ * Predicates ignored when fingerprinting a record's content for collision
+ * detection.
+ *
+ * Every entry is a claim that the predicate can legitimately DIFFER between two
+ * encounters with the same logical record, so a difference in it is not evidence
+ * of two different records. Getting this list wrong in the permissive direction
+ * hides a collision; getting it wrong in the strict direction turns every
+ * re-import into a false conflict and grows the pod on every sync, which is the
+ * defect `lib/identity.ts` exists to prevent. Both errors are visible in tests.
+ */
+const COLLISION_IGNORED_PREDICATES: ReadonlySet<string> = new Set<string>([
+  // Stamped `new Date().toISOString()` at conversion time; changes every run.
+  NS.clinical + 'importedAt',
+  NS.prov + 'generatedAtTime',
+  // Written by the reconciler itself, so a record read back out of the pod
+  // carries them and a freshly converted one does not.
+  NS.cascade + 'reconciliationStatus',
+  NS.cascade + 'mergedFrom',
+  NS.cascade + 'mergedSources',
+  NS.cascade + 'discardedRecords',
+  NS.cascade + 'conflictResolution',
+  NS.cascade + 'conflictField',
+  NS.cascade + 'conflictValues',
+  NS.prov + 'wasDerivedFrom',
+  // Ingestion bookkeeping, not clinical content. `sourceSystem` in particular is
+  // re-derived at serialization and is the axis two cross-source copies of one
+  // result differ on — those are duplicates for the matcher to merge, not
+  // evidence that two different results exist.
+  NS.cascade + 'sourceSystem',
+  NS.cascade + 'dataProvenance',
+  NS.cascade + 'schemaVersion',
+  // The originating server's record id, and the EHR it came from. Two copies of
+  // ONE result retrieved from two systems carry different values here while
+  // saying the same clinical thing, and the identity layer has already declared
+  // them one record by minting them one IRI. Treating that as evidence of two
+  // different results would raise a conflict on every cross-source duplicate —
+  // the common, benign case — and bury the ones where the VALUES disagree, which
+  // are the whole point. A genuine collision differs on clinical content too.
+  NS.cascade + 'sourceRecordId',
+  NS.clinical + 'sourceRecordId',
+  NS.health + 'sourceRecordId',
+  NS.clinical + 'sourceEHR',
+]);
+
+/**
+ * One property value as the POD will hold it.
+ *
+ * A record-to-record edge exists in three spellings that all mean one thing, and
+ * a comparison that cannot see through them cannot tell a re-import from a
+ * collision:
+ *
+ *   - resolved (`urn:uuid:…`)  — how the pod stores it, once an import has
+ *                                resolved the reference;
+ *   - placeholder, resolvable  — how a freshly converted record carries it,
+ *                                because reference resolution happens once per
+ *                                import invocation (R5), after conversion;
+ *   - placeholder, unresolvable — a reference to a record that is not in the
+ *                                batch and not in the pod. The import pipeline
+ *                                DROPS these rather than persisting them, so the
+ *                                pod's copy of the record simply has no such
+ *                                property. Returning `undefined` here is what
+ *                                makes the fresh copy agree with it.
+ *
+ * Measured against this repo's `apple-health-multifile` fixture, which carries a
+ * deliberately dangling `Encounter/enc-MISSING`: without the resolvable case, 3
+ * false collisions on the second import and 6 on the third; without the
+ * unresolvable case, 1 and 2. Both grow without bound, because each false split
+ * mints a new IRI that the next import collides with in turn.
+ */
+function normalizeEdgeValue(
+  value: string,
+  resolveRef?: (raw: string) => string | null,
+): string | undefined {
+  if (!isReferencePlaceholder(value)) return value;
+  return resolveRef?.(decodeReferencePlaceholder(value)) ?? undefined;
+}
+
+/**
+ * A content fingerprint for one parsed record: SHA-256 over its
+ * (predicate, value, datatype) triples, sorted, with
+ * {@link COLLISION_IGNORED_PREDICATES} removed.
+ *
+ * Sorted because the parser's property order follows the input document's, and
+ * two serializations of one record may order their triples differently.
+ * Exported so a test can assert the fingerprint itself is order-independent
+ * rather than only observing its effect.
+ */
+export function recordContentFingerprint(
+  r: ParsedRecord,
+  resolveRef?: (raw: string) => string | null,
+): string {
+  const parts: string[] = [];
+  for (const [pred, vals] of r.properties) {
+    if (COLLISION_IGNORED_PREDICATES.has(pred)) continue;
+    for (const v of vals) {
+      const value = normalizeEdgeValue(v.value, resolveRef);
+      if (value === undefined) continue;  // an unresolvable edge is never persisted
+      // `\u0000` as an ESCAPE, never as a raw byte: a literal NUL in a .ts file
+      // makes grep and ripgrep classify it as binary and silently skip the whole
+      // file, which is how a defect in this very module went unfound.
+      parts.push(`${pred}\u0000${value}\u0000${v.datatype ?? ''}`);
+    }
+  }
+  parts.sort();
+  return createHash('sha256').update(parts.join('\u0001'), 'utf8').digest('hex');
+}
+
+/** `https://ns.cascadeprotocol.org/health/v1#resultValue` -> `health:resultValue`. */
+function shortPredicate(iri: string): string {
+  for (const [prefix, ns] of Object.entries(NS)) {
+    if (iri.startsWith(ns)) return `${prefix}:${iri.slice(ns.length)}`;
+  }
+  return iri;
+}
+
+/** One IRI that two or more materially different records both claimed. */
+export interface IdentityCollision {
+  /** The IRI the identity layer minted for all of them. */
+  mintedUri: string;
+  recordType: CascadeRecordType;
+  /** Final IRI of each distinct content, smallest fingerprint first. */
+  resultingUris: string[];
+  /** Source systems involved, deduplicated, in the order first seen. */
+  sourceSystems: string[];
+  /**
+   * Predicates the colliding records DISAGREE on, sorted.
+   *
+   * The answer to the only question a person resolving this conflict has ("what
+   * is actually different about these two?"), and the answer a bare pair of
+   * IRIs cannot give. Surfaced as the pending conflict's label.
+   */
+  differingPredicates: string[];
+}
+
+/**
+ * The IRI a colliding content is moved to.
+ *
+ * Domain-separated (`identity-collision:`) so it can never equal an IRI any
+ * converter mints, and derived from nothing but the original IRI and the
+ * record's own fingerprint, so it is reproducible on any machine, in any
+ * directory, in any input order.
+ */
+function collisionSplitUri(mintedUri: string, fingerprint: string): string {
+  return `urn:uuid:${deterministicUuid(`identity-collision:${mintedUri}::${fingerprint}`)}`;
+}
+
+/**
+ * Which predicates a set of colliding records disagree on: present-with-
+ * different-values on at least two of them, or present on some and absent on
+ * others. Ignored predicates are excluded, so this always explains the same
+ * difference the fingerprint saw.
+ */
+function differingPredicates(
+  bucket: ParsedRecord[],
+  resolveRef?: (raw: string) => string | null,
+): string[] {
+  const normalize = (r: ParsedRecord, pred: string): string | undefined => {
+    const vals = r.properties.get(pred);
+    if (!vals) return undefined;
+    const normalized = vals
+      .map((v) => normalizeEdgeValue(v.value, resolveRef))
+      .filter((v): v is string => v !== undefined)
+      .sort();
+    return normalized.length > 0 ? normalized.join(', ') : undefined;
+  };
+  const preds = new Set<string>();
+  for (const r of bucket) for (const p of r.properties.keys()) {
+    if (!COLLISION_IGNORED_PREDICATES.has(p)) preds.add(p);
+  }
+  const out: string[] = [];
+  for (const p of preds) {
+    const seen = new Set(bucket.map((r) => normalize(r, p)));
+    if (seen.size > 1) out.push(p);
+  }
+  return out.sort();
+}
+
+/**
+ * Re-key every record whose minted IRI is shared by two or more materially
+ * different records, so that no record is dropped for being a "duplicate" of
+ * something it does not match.
+ *
+ * Records that share an IRI *and* a fingerprint are left completely alone: they
+ * are a re-import, and the caller's existing `assigned.has(uri)` pass-over is
+ * the correct handling for them.
+ *
+ * Runs to a fixpoint because a split can move a record onto an IRI that an
+ * earlier import already assigned to different content (a pod record edited
+ * between runs). The bound is defensive; one round settles every real case.
+ */
+export function splitIdentityCollisions(
+  records: ParsedRecord[],
+  resolveRef?: (raw: string) => string | null,
+): {
+  records: ParsedRecord[];
+  collisions: IdentityCollision[];
+  /**
+   * Which collision each split record came out of, keyed by its FINAL uri.
+   *
+   * The matcher must not pair two records from one collision back together: the
+   * identity layer said they were the same record, their contents said
+   * otherwise, and that disagreement has just been raised as a question for a
+   * person. Auto-merging them by trust priority in the same run would answer
+   * that question silently, by discarding one of the two values — which is the
+   * behaviour this whole change exists to remove, reintroduced one layer later.
+   */
+  collisionGroupByUri: Map<string, string>;
+} {
+  const collisions: IdentityCollision[] = [];
+  const collisionGroupByUri = new Map<string, string>();
+  const fingerprints = new Map<ParsedRecord, string>();
+  for (const r of records) fingerprints.set(r, recordContentFingerprint(r, resolveRef));
+
+  let current = records;
+  for (let round = 0; round < 8; round++) {
+    const byUri = new Map<string, ParsedRecord[]>();
+    for (const r of current) {
+      const bucket = byUri.get(r.uri);
+      if (bucket) bucket.push(r);
+      else byUri.set(r.uri, [r]);
+    }
+
+    const rekeyed = new Map<ParsedRecord, string>();
+    for (const [uri, bucket] of byUri) {
+      if (bucket.length < 2) continue;
+      const distinct = [...new Set(bucket.map((r) => fingerprints.get(r)!))].sort();
+      if (distinct.length < 2) continue;  // a re-import, not a collision
+
+      // Smallest fingerprint keeps `uri`; the rest move. Ranking on the
+      // fingerprint rather than on position is what makes this independent of
+      // the order the inputs were enumerated.
+      const target = new Map<string, string>();
+      for (let i = 1; i < distinct.length; i++) target.set(distinct[i], collisionSplitUri(uri, distinct[i]));
+      for (const r of bucket) {
+        const to = target.get(fingerprints.get(r)!);
+        if (to) rekeyed.set(r, to);
+      }
+      for (const u of [uri, ...distinct.slice(1).map((fp) => target.get(fp)!)]) {
+        collisionGroupByUri.set(u, uri);
+      }
+      collisions.push({
+        mintedUri: uri,
+        recordType: bucket[0].type,
+        resultingUris: [uri, ...distinct.slice(1).map((fp) => target.get(fp)!)],
+        sourceSystems: [...new Set(bucket.map((r) => r.sourceSystem))],
+        differingPredicates: differingPredicates(bucket, resolveRef),
+      });
+    }
+
+    if (rekeyed.size === 0) return { records: current, collisions, collisionGroupByUri };
+    current = current.map((r) => {
+      const to = rekeyed.get(r);
+      if (!to) return r;
+      const moved: ParsedRecord = { ...r, uri: to };
+      fingerprints.set(moved, fingerprints.get(r)!);
+      return moved;
+    });
+  }
+  return { records: current, collisions, collisionGroupByUri };
 }
 
 // ---------------------------------------------------------------------------
@@ -1063,7 +1387,7 @@ export async function runReconciliation(
   const resolver = options?.terminologyResolver ?? cascadeTerminologyResolver();
 
   // Parse all inputs
-  const allRecords: ParsedRecord[] = [];
+  let allRecords: ParsedRecord[] = [];
   const sourceInfo: Array<{ system: string; count: number }> = [];
 
   // Subjects the reconciler cannot reconcile are carried through verbatim,
@@ -1103,10 +1427,38 @@ export async function runReconciliation(
   // input, so quad-identity dedup keeps both and the caller's resolution pass
   // turns them into two copies of one statement. Collapse on where each object
   // RESOLVES TO (root backlog 2.22).
+  const referenceResolver = buildReferenceResolver(buildResourceRefsFromQuads(allInputQuads));
   const dedupedPassthroughQuads = collapseResolvedEquivalentEdges(
     singleValuedPassthroughQuads,
-    buildReferenceResolver(buildResourceRefsFromQuads(allInputQuads)),
+    referenceResolver,
   );
+
+  // Identity collisions. Everything below treats a second arrival of an IRI as a
+  // re-import and passes over it (`assigned.has(...)`), which destroys the loser
+  // when the two are actually different records that the identity layer minted
+  // onto one IRI. Split those apart FIRST, so the pass-over below only ever sees
+  // records it is right about. The reference resolver is passed for the same
+  // reason it is passed above: a stated edge arrives resolved from the pod and as
+  // a placeholder from the new input, and without normalizing the two spellings
+  // every re-import of an edge-bearing record reads as a collision.
+  const split = splitIdentityCollisions(allRecords, referenceResolver);
+  allRecords = split.records;
+  const identityCollisions = split.collisions;
+
+  /**
+   * True when two records are the two halves of one identity collision.
+   *
+   * They are deliberately kept out of each other's candidate lists. The split
+   * has already asked a person which of the two readings is right; letting the
+   * matcher merge them by trust in the same run would answer that question by
+   * throwing one of the values away, which is the exact behaviour being fixed.
+   * Each still matches freely against every OTHER record.
+   */
+  const sameCollision = (a: ParsedRecord, b: ParsedRecord): boolean => {
+    if (split.collisionGroupByUri.size === 0) return false;
+    const ga = split.collisionGroupByUri.get(a.uri);
+    return ga !== undefined && ga === split.collisionGroupByUri.get(b.uri);
+  };
 
   // Match and group
   const groups: Group[] = [];
@@ -1145,7 +1497,7 @@ export async function runReconciliation(
 
       const candidates = existingIndex.get(a.type) ?? [];
       for (const b of candidates) {
-        if (assigned.has(b.uri) || a.sourceSystem === b.sourceSystem) continue;
+        if (assigned.has(b.uri) || a.sourceSystem === b.sourceSystem || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -1180,7 +1532,7 @@ export async function runReconciliation(
 
       for (let j = i + 1; j < newRecords.length; j++) {
         const b = newRecords[j];
-        if (assigned.has(b.uri) || a.sourceSystem === b.sourceSystem) continue;
+        if (assigned.has(b.uri) || a.sourceSystem === b.sourceSystem || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -1234,7 +1586,7 @@ export async function runReconciliation(
 
       const candidates = typeIndex.get(a.type) ?? [];
       for (const b of candidates) {
-        if (b === a || assigned.has(b.uri) || a.sourceSystem === b.sourceSystem) continue;
+        if (b === a || assigned.has(b.uri) || a.sourceSystem === b.sourceSystem || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -1317,6 +1669,30 @@ export async function runReconciliation(
     if (!res.resolved) unresolvedList.push({ ...t, candidateUris: g.records.map(r => r.uri) });
   }
 
+  // An identity collision is a conflict, not a duplicate: the identity layer
+  // asserted these records are the same and their contents say otherwise, and
+  // only a person can say which reading is right. Raised through the SAME queue
+  // as every other unresolved conflict — `settings/pending-conflicts.ttl`,
+  // `pod conflicts` (exit 1), `pod resolve` — rather than through a private
+  // channel nobody is watching. The records themselves have already been split,
+  // so this reports a question, not a loss.
+  for (const c of identityCollisions) {
+    unresolved++;
+    const entry = {
+      type: 'identity_collision',
+      recordType: c.recordType,
+      canonicalUri: c.mintedUri,
+      sources: c.sourceSystems,
+      matchedOn: `identity-collision:${c.mintedUri}`,
+      strategy: 'split_unresolved',
+      resolved: false,
+      candidateUris: c.resultingUris,
+      label: `differs on ${c.differingPredicates.map(shortPredicate).join(', ')}`,
+    };
+    transformations.push(entry);
+    unresolvedList.push(entry);
+  }
+
   return {
     turtle,
     report: {
@@ -1328,6 +1704,7 @@ export async function runReconciliation(
         duplicateSubjectsDropped,
         conflictsResolved: resolved,
         conflictsUnresolved: unresolved,
+        identityCollisionsSplit: identityCollisions.length,
         finalRecordCount: groups.length,
         passthroughSubjects: passthroughSubjectKeys.size,
         edgeObjectsRewritten,

--- a/tests/reconciler-identity-collision.test.ts
+++ b/tests/reconciler-identity-collision.test.ts
@@ -1,0 +1,361 @@
+/**
+ * An identity collision is a CONFLICT, not a duplicate.
+ *
+ * Two records can arrive under one subject IRI for two different reasons, and
+ * the reconciler used to assume the harmless one unconditionally:
+ *
+ *   RE-IMPORT  — the same record imported twice. Cascade subjects are
+ *                content-hashed, so this is expected and overwhelmingly common,
+ *                and passing over the second arrival is correct.
+ *
+ *   COLLISION  — two DIFFERENT records that the identity layer minted onto one
+ *                IRI because its key was narrower than the records. A fasting
+ *                glucose of 95 and a post-prandial of 310, drawn the same day
+ *                and keyed on {patient, LOINC, date}, are one IRI.
+ *
+ * `assigned.has(uri)` handled both the same way, so the second glucose was
+ * counted as a duplicate and dropped — and WHICH value survived was decided by
+ * the order the inputs were enumerated, i.e. by the filesystem. A normal glucose
+ * and a critical hyperglycemia reading were interchangeable outputs of the same
+ * bytes, with no warning, no conflict record, and a summary line reporting the
+ * loss as successful deduplication.
+ *
+ * These tests are written against RECONCILER inputs (hand-authored Turtle with
+ * colliding subject IRIs) rather than against a FHIR fixture, on purpose. The
+ * reconciler must not silently lose a record regardless of what any converter
+ * upstream mints, so nothing here depends on a particular converter continuing
+ * to produce a collision.
+ *
+ * All data is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolve } from 'node:path';
+import { Parser } from 'n3';
+import { runReconciliation, recordContentFingerprint, parseTurtle } from '../src/lib/reconciler.js';
+
+const CLI_PATH = resolve(__dirname, '../dist/index.js');
+
+const PREFIXES = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix loinc: <http://loinc.org/rdf#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+`;
+
+/** The IRI a {patient, LOINC, date} key mints for BOTH of the labs below. */
+const COLLIDING_IRI = 'urn:uuid:d2257c58-3d9f-5fe7-a34d-e48f97f6f27e';
+const RESULT_VALUE = 'https://ns.cascadeprotocol.org/health/v1#resultValue';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/**
+ * One glucose result, at whatever subject IRI is passed. Two calls with
+ * different values and the SAME IRI are the collision; two calls with the same
+ * value and the same IRI are a re-import.
+ */
+function glucose(uri: string, value: string, time: string): string {
+  return `${PREFIXES}
+<${uri}> a health:LabResultRecord ;
+  health:testName "Glucose" ;
+  health:testCode loinc:2339-0 ;
+  health:resultValue "${value}" ;
+  health:resultUnit "mg/dL" ;
+  health:performedDate "${time}"^^xsd:dateTime .
+`;
+}
+
+const FASTING = glucose(COLLIDING_IRI, '95', '2026-08-02T07:30:00Z');
+const POST_PRANDIAL = glucose(COLLIDING_IRI, '310', '2026-08-02T13:00:00Z');
+
+/** Every subject in `ttl` that is a lab result, sorted. */
+function labSubjects(ttl: string): string[] {
+  return new Parser({ format: 'Turtle' }).parse(ttl)
+    .filter(q => q.predicate.value === RDF_TYPE
+      && q.object.value === 'https://ns.cascadeprotocol.org/health/v1#LabResultRecord')
+    .map(q => q.subject.value)
+    .sort();
+}
+
+/** Every asserted `health:resultValue` in `ttl`, sorted. */
+function resultValues(ttl: string): string[] {
+  return new Parser({ format: 'Turtle' }).parse(ttl)
+    .filter(q => q.predicate.value === RESULT_VALUE)
+    .map(q => q.object.value)
+    .sort();
+}
+
+describe('a collision keeps both records instead of dropping one', () => {
+  it('keeps BOTH values when two different results share one IRI', async () => {
+    const result = await runReconciliation([
+      { content: FASTING, systemName: 'lab-a' },
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+    ]);
+
+    // The whole defect in one assertion: before this change, one of these two
+    // clinical values was simply gone from the output.
+    expect(resultValues(result.turtle)).toEqual(['310', '95']);
+    // And they are two RECORDS, not one record asserting both values (which is
+    // the other bad outcome: a single subject a consumer reads as "95, 310").
+    const subjects = labSubjects(result.turtle);
+    expect(subjects).toHaveLength(2);
+    expect(new Set(subjects).size).toBe(2);
+    // The IRI the identity layer minted is still one of them, so nothing that
+    // referenced it starts dangling.
+    expect(subjects).toContain(COLLIDING_IRI);
+  });
+
+  it('reports the collision as an unresolved conflict, not as a duplicate', async () => {
+    const result = await runReconciliation([
+      { content: FASTING, systemName: 'lab-a' },
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+    ]);
+    const { summary, unresolvedConflicts } = result.report;
+
+    // "The pod deduplicated 1 record" used to mean "the pod discarded a record
+    // that was not a duplicate". Nothing was dropped, so nothing is counted.
+    expect(summary.duplicateSubjectsDropped).toBe(0);
+    expect(summary.identityCollisionsSplit).toBe(1);
+    expect(summary.conflictsUnresolved).toBeGreaterThanOrEqual(1);
+
+    // It reaches the SAME queue every other unresolved conflict reaches, which
+    // is what puts it in settings/pending-conflicts.ttl and `pod conflicts`.
+    const collision = (unresolvedConflicts as Array<{
+      type?: string; candidateUris?: string[]; label?: string; recordType?: string;
+    }>).find(c => c.type === 'identity_collision');
+    expect(collision, 'the collision must appear in unresolvedConflicts').toBeDefined();
+    expect(collision!.recordType).toBe('health:LabResultRecord');
+    // The candidates are the records as they now exist in the pod, so `pod
+    // resolve` points at something real rather than at a URI that was dropped.
+    expect([...(collision!.candidateUris ?? [])].sort()).toEqual(labSubjects(result.turtle));
+    // The conflict names WHAT disagrees, which is the only question a person
+    // resolving it has.
+    expect(collision!.label).toContain('health:resultValue');
+  });
+
+  it('stops counting a collision as a deduplicated duplicate', async () => {
+    // Both results from ONE source, which is what a folder import looks like:
+    // every file gets the same source label. The matcher never compares two
+    // records of the same source, so this is the path where the old code
+    // reached `assigned.has(uri)` and dropped the second record outright — and
+    // then reported the loss in `duplicateSubjectsDropped`, i.e. as a successful
+    // deduplication. Measured on this input before the change:
+    // duplicateSubjectsDropped 1, one record in the pod, zero conflicts.
+    const result = await runReconciliation([
+      { content: FASTING, systemName: 'quest' },
+      { content: POST_PRANDIAL, systemName: 'quest' },
+    ]);
+
+    expect(resultValues(result.turtle)).toEqual(['310', '95']);
+    expect(result.report.summary.duplicateSubjectsDropped).toBe(0);
+    expect(result.report.summary.identityCollisionsSplit).toBe(1);
+    expect(result.report.summary.conflictsUnresolved).toBe(1);
+  });
+
+  it('is decided by content, not by the order the inputs were enumerated', async () => {
+    const forward = await runReconciliation([
+      { content: FASTING, systemName: 'lab-a' },
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+    ]);
+    const reversed = await runReconciliation([
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+      { content: FASTING, systemName: 'lab-a' },
+    ]);
+
+    // Before this change these two runs produced DIFFERENT pods: 95 survived one
+    // way and 310 the other, and the only variable was `fs.readdir` order.
+    expect(resultValues(reversed.turtle)).toEqual(['310', '95']);
+    expect(labSubjects(reversed.turtle)).toEqual(labSubjects(forward.turtle));
+    expect(reversed.report.summary.identityCollisionsSplit).toBe(1);
+  });
+});
+
+describe('a re-import is still a re-import', () => {
+  it('does not split two byte-identical arrivals of one record', async () => {
+    // One source, imported twice: the shape the `assigned.has(uri)` pass-over
+    // was written for, and the one it is right about.
+    const result = await runReconciliation([
+      { content: FASTING, systemName: 'lab-a' },
+      { content: FASTING, systemName: 'lab-a' },
+    ]);
+
+    // Splitting here would be the deterministic-identity defect wearing new
+    // clothes: a pod that grows a copy of every record on every sync.
+    expect(labSubjects(result.turtle)).toEqual([COLLIDING_IRI]);
+    expect(resultValues(result.turtle)).toEqual(['95']);
+    expect(result.report.summary.identityCollisionsSplit).toBe(0);
+    expect(result.report.summary.duplicateSubjectsDropped).toBe(1);
+    expect(result.report.summary.conflictsUnresolved).toBe(0);
+  });
+
+  it('does not split a re-import whose only difference is per-run bookkeeping', async () => {
+    // What a real re-sync looks like: the pod's copy carries an importedAt, a
+    // reconciliationStatus and a source label the fresh conversion does not.
+    // Treating any of those as content would raise a conflict on every record of
+    // every import, forever.
+    const podCopy = `${FASTING.trimEnd().slice(0, -1)} ;
+  <https://ns.cascadeprotocol.org/clinical/v1#importedAt> "2026-01-01T00:00:00Z" ;
+  cascade:reconciliationStatus "canonical" ;
+  cascade:sourceSystem "existing-pod" .
+`;
+    const result = await runReconciliation([
+      { content: podCopy, systemName: 'existing-pod' },
+      { content: FASTING, systemName: 'lab-a' },
+    ]);
+    expect(result.report.summary.identityCollisionsSplit).toBe(0);
+    expect(labSubjects(result.turtle)).toEqual([COLLIDING_IRI]);
+    expect(resultValues(result.turtle)).toEqual(['95']);
+  });
+
+  it('does not grow the pod when the SAME collision is imported again', async () => {
+    const first = await runReconciliation([
+      { content: FASTING, systemName: 'lab-a' },
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+    ]);
+    const firstSubjects = labSubjects(first.turtle);
+    expect(firstSubjects).toHaveLength(2);
+
+    // Feed the pod's own output back as existing content, alongside a re-import
+    // of the two originals — the monthly re-sync. The split IRI is derived from
+    // the record's content, so it re-derives to the same place and matches.
+    const second = await runReconciliation([
+      { content: first.turtle, systemName: 'existing-pod' },
+      { content: FASTING, systemName: 'lab-a' },
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+    ]);
+    expect(labSubjects(second.turtle)).toEqual(firstSubjects);
+    expect(resultValues(second.turtle)).toEqual(['310', '95']);
+
+    const third = await runReconciliation([
+      { content: second.turtle, systemName: 'existing-pod' },
+      { content: FASTING, systemName: 'lab-a' },
+      { content: POST_PRANDIAL, systemName: 'lab-b' },
+    ]);
+    expect(labSubjects(third.turtle)).toEqual(firstSubjects);
+  });
+});
+
+describe('the content fingerprint that separates the two cases', () => {
+  it('is blind to the order properties were written in', async () => {
+    const a = (await parseTurtle(`${PREFIXES}
+<${COLLIDING_IRI}> a health:LabResultRecord ;
+  health:testName "Glucose" ; health:resultValue "95" ; health:resultUnit "mg/dL" .
+`, 's'))[0];
+    const b = (await parseTurtle(`${PREFIXES}
+<${COLLIDING_IRI}> a health:LabResultRecord ;
+  health:resultUnit "mg/dL" ; health:resultValue "95" ; health:testName "Glucose" .
+`, 's'))[0];
+    expect(recordContentFingerprint(a)).toBe(recordContentFingerprint(b));
+  });
+
+  it('separates records that differ, and ignores per-run bookkeeping', async () => {
+    const base = (await parseTurtle(FASTING, 's'))[0];
+    const other = (await parseTurtle(POST_PRANDIAL, 's'))[0];
+    // A constant is perfectly deterministic and perfectly useless: assert the
+    // fingerprint actually DISTINGUISHES.
+    expect(recordContentFingerprint(base)).not.toBe(recordContentFingerprint(other));
+
+    // ... while a per-run import timestamp and the reconciler's own status
+    // predicate must not make one record look like two.
+    const withBookkeeping = (await parseTurtle(`${PREFIXES}
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+<${COLLIDING_IRI}> a health:LabResultRecord ;
+  health:testName "Glucose" ;
+  health:testCode loinc:2339-0 ;
+  health:resultValue "95" ;
+  health:resultUnit "mg/dL" ;
+  health:performedDate "2026-08-02T07:30:00Z"^^xsd:dateTime ;
+  clinical:importedAt "2026-08-03T11:22:33Z"^^xsd:dateTime ;
+  cascade:reconciliationStatus "canonical" ;
+  cascade:sourceSystem "some-other-ehr" .
+`, 's'))[0];
+    expect(recordContentFingerprint(withBookkeeping)).toBe(recordContentFingerprint(base));
+  });
+});
+
+describe('the split IRI is reproducible off this machine', () => {
+  /**
+   * Run the reconciliation in a CHILD process, from `cwd`, and return the lab
+   * subject IRIs it produced.
+   *
+   * A separate process and a different working directory together rule out the
+   * two things an in-process assertion cannot: module-level state carried
+   * between calls, and any dependence on where the tool was invoked from (the
+   * exact defect root 3.7 shipped, where an IRI hashed an absolute path).
+   */
+  function subjectsFromChild(cwd: string): string[] {
+    const script = `
+      const { runReconciliation } = await import(${JSON.stringify(resolve(__dirname, '../dist/lib/reconciler.js'))});
+      const r = await runReconciliation([
+        { content: ${JSON.stringify(FASTING)}, systemName: 'lab-a' },
+        { content: ${JSON.stringify(POST_PRANDIAL)}, systemName: 'lab-b' },
+      ]);
+      // Extracted with a regex rather than with n3: the child runs from a temp
+      // directory with no node_modules, and resolving a bare specifier there
+      // would silently reintroduce a dependency on where it was started.
+      const subs = [...r.turtle.matchAll(/<(urn:uuid:[^>]+)> a health:LabResultRecord/g)]
+        .map(m => m[1]).sort();
+      console.log(JSON.stringify(subs));
+    `;
+    const out = execFileSync('node', ['--input-type=module', '-e', script], {
+      cwd, encoding: 'utf-8', timeout: 120000,
+    });
+    return JSON.parse(out.trim().split('\n').pop()!) as string[];
+  }
+
+  it('mints the same two IRIs from two processes in two directories', () => {
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'collision-a-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'collision-b-'));
+
+    const fromA = subjectsFromChild(dirA);
+    const fromB = subjectsFromChild(dirB);
+
+    // Determinism...
+    expect(fromA).toEqual(fromB);
+    // ...and DISTINCTNESS, without which determinism is satisfied by a constant.
+    expect(fromA).toHaveLength(2);
+    expect(new Set(fromA).size).toBe(2);
+    expect(fromA).toContain(COLLIDING_IRI);
+    // The derived IRI is a real urn:uuid, not a decorated copy of the original.
+    const derived = fromA.filter(u => u !== COLLIDING_IRI);
+    expect(derived).toHaveLength(1);
+    expect(derived[0]).toMatch(/^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+describe('pod import surfaces a collision to the user', () => {
+  /** Both streams: the collision notice is a warning, so it goes to stderr. */
+  function cli(args: string[]): { output: string; status: number } {
+    const r = spawnSync('node', [CLI_PATH, ...args], { encoding: 'utf-8', timeout: 120000 });
+    return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+  }
+
+  it('keeps both records, writes a pending conflict, and says so', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'collision-pod-'));
+    const podDir = path.join(root, 'pod');
+    const inputs = path.join(root, 'inputs');
+    fs.mkdirSync(inputs);
+    fs.writeFileSync(path.join(inputs, 'a-fasting.ttl'), FASTING);
+    fs.writeFileSync(path.join(inputs, 'b-postprandial.ttl'), POST_PRANDIAL);
+    cli(['pod', 'init', podDir]);
+
+    const imported = cli(['pod', 'import', podDir, inputs]);
+    expect(imported.output).toMatch(/identity collision/i);
+
+    // Both clinical values are in the pod. Before this change one of them was
+    // gone, chosen by directory enumeration order.
+    const labFile = path.join(podDir, 'clinical', 'lab-results.ttl');
+    const podTurtle = fs.readFileSync(labFile, 'utf-8');
+    expect(resultValues(podTurtle)).toEqual(['310', '95']);
+    expect(labSubjects(podTurtle)).toHaveLength(2);
+
+    // And the user is asked about it through the conflict queue that already
+    // exists, rather than through a channel nobody is watching.
+    const conflicts = cli(['pod', 'conflicts', podDir]);
+    expect(conflicts.status).toBe(1);          // CI-friendly: unresolved work remains
+    expect(conflicts.output).toMatch(/health:LabResultRecord/);
+    expect(fs.existsSync(path.join(podDir, 'settings', 'pending-conflicts.ttl'))).toBe(true);
+  });
+});

--- a/tests/source-is-text.test.ts
+++ b/tests/source-is-text.test.ts
@@ -1,0 +1,71 @@
+/**
+ * No TypeScript source may contain a raw NUL byte.
+ *
+ * `src/lib/reconciler.ts` used NUL as a key delimiter and wrote it as a LITERAL
+ * byte inside three template literals rather than as a backslash-u escape. The
+ * two spell the same string, TypeScript compiles either, and every test passed —
+ * but `file(1)` reclassifies the source as binary data, and grep and ripgrep
+ * skip binary files silently. The result was that 1,339 lines of the core
+ * merge-and-drop logic answered "no matches" to strings it demonstrably
+ * contained:
+ *
+ *     grep -rn "resolveGroup" src/   # exit 1, no output, 5 occurrences present
+ *     rg -n  "defaultTrust"  src/    # exit 1, no output
+ *
+ * A file that reports a clean result for a string it contains is worse than an
+ * unaudited file, because a clean result is what an audit is looking for. Every
+ * sweep of this repo — human or automated — starts with a content search, and
+ * this is the mechanism by which the very defect the sibling test file covers
+ * survived earlier sweeps of exactly its own defect class.
+ *
+ * Repairing the three sites is a one-character-per-site change; this test is the
+ * part that keeps it repaired, since the bug is reintroduced by pasting.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('every TypeScript source is greppable text', () => {
+  it('contains no raw NUL byte anywhere under src/', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(SRC_DIR)) {
+      const bytes = fs.readFileSync(file);
+      const at = bytes.indexOf(0);
+      if (at !== -1) {
+        const line = bytes.subarray(0, at).toString('utf8').split('\n').length;
+        offenders.push(`${path.relative(SRC_DIR, file)}:${line}`);
+      }
+    }
+    expect(
+      offenders,
+      'Write the delimiter as the escape `\\u0000`. A raw NUL makes grep and ripgrep ' +
+        'skip the whole file without saying so, which turns every future audit of it into ' +
+        'a false clean.',
+    ).toEqual([]);
+  });
+
+  it('finds the symbols a content search must be able to find', () => {
+    // The concrete symptom, pinned so a regression is recognizable rather than
+    // merely counted: these symbols exist in the file that carried the NULs.
+    const reconciler = fs.readFileSync(path.join(SRC_DIR, 'lib', 'reconciler.ts'));
+    expect(reconciler.indexOf(0)).toBe(-1);
+    const text = reconciler.toString('utf8');
+    for (const symbol of ['resolveGroup', 'defaultTrust', 'splitIdentityCollisions']) {
+      expect(text, `${symbol} must be findable`).toContain(symbol);
+    }
+  });
+});


### PR DESCRIPTION
## The defect

Cascade subject IRIs are content-hashed, so the reconciler treated a second arrival of an IRI as a re-import of the same record and passed over it. The comment at the drop site stated the assumption plainly: *"a second arrival of the same IRI is a re-import of the same record"*. That is right for a re-import and wrong for an identity **collision** — two genuinely different records that an identity key narrower than the records themselves minted onto one IRI — and nothing in the code distinguished the two cases.

Two same-day glucose results for one patient (a fasting 95 mg/dL and a post-prandial 310 mg/dL) share a `{patient, LOINC, date}` key. Serial same-day results are ordinary clinical practice: glucose curves, troponin series, repeat potassium, pre- and post-dialysis.

What happened to them:

- one of the two values was discarded;
- the loss was counted in `duplicateSubjectsDropped`, i.e. reported as a successful deduplication;
- no conflict was written and nothing was printed;
- and **which** value survived was decided by the order the inputs happened to be enumerated. The same two files on two machines could leave a normal glucose in one pod and a critical hyperglycemia reading in the other.

## The change

The reconciler now fingerprints the records behind a shared IRI before deciding what it is looking at.

**Identical content is still a re-import**, handled exactly as before. Per-run bookkeeping is not content — `clinical:importedAt`, `cascade:reconciliationStatus`, merge lineage, ingestion source labels — and neither is the difference between a reference edge stored resolved in the pod and the same edge carried as an unresolved placeholder by a fresh conversion. That last one is not a detail: reference resolution happens once per import invocation, so without normalizing it every re-import of an edge-bearing record reads as a collision. Measured against `test-fixtures/apple-health-multifile`, which carries a deliberately dangling `Encounter/enc-MISSING`: 3 false collisions on the second import and 6 on the third, growing without bound because each false split mints an IRI the next import collides with.

**Differing content is a collision, and it is split rather than merged.** Each distinct content keeps its own record. This is the rule `lib/identity.ts` already states — when identity is uncertain, prefer a split, because a duplicate is recoverable (both copies are present and can be reconciled later) and a merge is not (the second record's content is simply gone).

- The IRI the identity layer minted stays occupied, by the member whose own fingerprint sorts first, so nothing that referenced it starts dangling.
- Ranking on the fingerprint rather than on arrival position is what removes the filesystem from the outcome. **Reversing the input order now produces a byte-identical pod.**
- The derived IRI is a pure function of the minted IRI and the record's content, so re-importing the same pair re-derives the same two IRIs, matches the pod's copies, and drops them as the re-imports they are. The pod does not grow.

**The collision is raised as a conflict, through the machinery that already exists** — `settings/pending-conflicts.ttl`, `cascade pod conflicts` (exit 1), `cascade pod resolve` — and the conflict names which predicates disagree, which is the only question a person resolving it has. `pod import` prints a warning. The two split records are also kept out of each other's match candidates for that run, so a question raised for a person is not answered by an automatic merge in the same breath.

`identityCollisionsSplit` is added to the import summary. `duplicateSubjectsDropped` now means only what it says: a record the pod already held, byte for byte.

**No IRI moves for a pod with no collision in it.** Where one exists, the record that previously survived keeps its IRI and the record that was previously deleted reappears under a derived one — this recovers data rather than relocating it.

## Also in this PR

`src/lib/reconciler.ts` used NUL as a key delimiter written as a **raw byte** rather than as an escape. TypeScript compiles either and the tests passed, but `file(1)` classified the source as binary and `grep`/`ripgrep` skipped all 1,339 lines of it without saying so:

```
grep -rn "resolveGroup" src/    # exit 1, no output, 5 occurrences present
rg -n  "defaultTrust"  src/     # exit 1, no output
```

A file that answers "no matches" for a string it contains is worse than an unaudited file, because a clean result is what an audit is looking for — and every sweep of this repo starts with a content search. The three sites now use the escape, which is the same string, and `tests/source-is-text.test.ts` rejects a raw NUL anywhere under `src/`.

## Verification

**Suite: 1353 → 1365 passing, 102 → 104 files, 0 failing.** The 12 new tests are all new; no existing test changed.

**Negative control: all 12 fail against `main`. None skips.**

| | on `main` |
|---|---|
| keeps BOTH values when two results share one IRI | `expected [ '95' ] to deeply equal [ '310', '95' ]` |
| stops counting a collision as a deduplicated duplicate | `expected [ '95' ] to deeply equal [ '310', '95' ]` |
| is decided by content, not by input order | `expected [ '310' ] to deeply equal [ '310', '95' ]` |
| does not grow the pod when the same collision is re-imported | `expected [ Array(1) ] to have a length of 2 but got 1` |
| reports the collision as an unresolved conflict | `expected undefined to be 1` |
| fingerprint is order-blind / separates records | `recordContentFingerprint is not a function` |
| same two IRIs from two processes in two directories | `expected [ Array(1) ] to have a length of 2 but got 1` |
| pod import surfaces the collision | `expected '…Import complete…' to match /identity collision/i` |
| no raw NUL byte under src/ | `expected [ 'lib/reconciler.ts:288' ] to deeply equal []` |

The third row is the whole bug in one line: forward order keeps `95`, reversed order keeps `310`, and the only variable is which file was read first.

Two of the twelve — the pair asserting a re-import is still treated as a re-import — fail on `main` only because they read the new summary counter. Their job is to pin that the split does **not** over-fire, which is a direction `main` has no way to get wrong.

Determinism is proven in **separate processes from two different working directories**, and asserted together with **distinctness**: two IRIs, both `urn:uuid:`, not equal to each other, one of them the originally minted IRI. A constant would satisfy determinism alone.

The tests are written against reconciler inputs (hand-authored Turtle with colliding subject IRIs) rather than against a FHIR fixture, deliberately: the reconciler must not silently lose a record regardless of what any converter upstream mints, so nothing here depends on a particular converter continuing to produce a collision.

---

## Related, and deliberately NOT in this PR

- **#38** wires a new general-clinical-FHIR identity corpus into the suite. It is split out because it is the only piece with a cross-repo merge dependency (`the-cascade-protocol/conformance#4` must land first, since CI checks that repo out with no `ref:`). This PR touches no fixture path and merges independently.
- The reconciler’s own `dateOnly()` matcher truncation is untouched. It is a layer above identity, and it is what would have re-merged the split pair had the same-collision guard above not been added.
