### PR TITLE
fix(identity): a source's own record id must decide, in four more types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-> **Version number not yet chosen.** This section contains an IRI-breaking change for lab
-> results (see the first upgrade note), so it is not a patch release. Decide between a minor
-> and a major bump before cutting it.
+> **Version number not yet chosen.** This section contains IRI-breaking changes for lab
+> results, conditions, allergies, immunizations and patient profiles (see the first upgrade
+> note), so it is not a patch release. Decide between a minor and a major bump before cutting
+> it.
 
 **This release is about record identity — the IRI each record gets, which decides whether a
 re-import updates a record or duplicates it, and whether two records stay two records.** Two
@@ -21,11 +22,12 @@ which:
 1. **Records the source never identified used to get a RANDOM IRI**, so re-importing the same
    document duplicated them, forever. They now get an IRI derived from their own content, so
    they reconcile. **No IRI that a source identifier already determined moves because of this.**
-2. **Lab results used to be identified too coarsely** — by patient, test code and calendar day,
-   ignoring the measured value, the time of day, and the source's own identifier — so two
-   genuinely different results on one day merged into one and a value was silently lost. Fixing
-   that necessarily moves lab IRIs. **This is the only IRI-breaking change in the release**, and
-   the upgrade note below says what to do about it.
+2. **Five kinds of record were identified too coarsely, and ignored the identifier their own
+   source assigned them** — lab results by patient, test code and calendar day; conditions,
+   allergies, immunizations and patient profiles by a similarly short list. So two genuinely
+   different records merged into one and one of them was silently lost. Fixing that necessarily
+   moves those IRIs. **These are the release's IRI-breaking changes**, and the upgrade note
+   below says what to do about them.
 
 ### Upgrade notes
 
@@ -66,11 +68,11 @@ which:
   After this change no lab observation collides with another; the only records that still
   share an IRI are the same record appearing in two files, which is correct.
 
-  **Nothing but lab results moves.** Vital signs, conditions, allergies, medications,
-  procedures, encounters, documents, immunizations, coverage and claims all keep the IRIs they
-  had. Verified twice: across the FHIR conformance corpus, 46 of 91 converted resources were
-  unchanged and every one of the 45 that moved was a lab observation; across the C-CDA corpus,
-  40 of 43 identities were unchanged and all 3 that moved were lab results.
+  **What this particular change moved.** Across the FHIR conformance corpus, 46 of 91 converted
+  resources were unchanged by it and every one of the 45 that moved was a lab observation;
+  across the C-CDA corpus, 40 of 43 identities were unchanged and all 3 that moved were lab
+  results. Four more record types move for their own reason, described in the next note; those
+  are the only other IRIs in the release that change.
 
   **Lab PANELS keep their IRIs, with one narrow exception.** A panel read from a C-CDA document
   whose source gave it neither an identifier nor a test code was previously indistinguishable
@@ -78,6 +80,68 @@ which:
   different panels shared one record and pooled their results. Such a panel now takes its
   identity from its full timestamp and the set of results it contains, and so moves. A panel
   that carries an identifier — the common case — is unchanged.
+
+- **Breaking for conditions, allergies, immunizations and patient profiles, from FHIR
+  sources.** These four kinds of record change IRI in this release, for the same reason lab
+  results do and as part of the same one-time change. If you have imported them with an earlier
+  version, records imported by this one will not match them.
+
+  What was wrong: each was identified by a short list of fields and by nothing else — a
+  condition by patient, one SNOMED code, one ICD code and a calendar day; an allergy by
+  patient and a single code read WITHOUT the coding system it came from; an immunization by
+  patient, a similarly system-blind vaccine code and a calendar day; a patient by birth date,
+  sex, surname and FIRST given name. And in all four, the identifier the source's own system
+  had assigned the record was passed in a position the code only reads when every one of those
+  fields is empty, which never happens on a real record. So the identifier was discarded on
+  every record that carried one, and two records the source had deliberately kept apart became
+  one.
+
+  What that cost, concretely:
+
+  - A penicillin allergy recorded as a **mild rash** and one recorded as an **anaphylaxis**
+    were one record, and which survived depended on the order the files were read in. Nothing
+    about the reaction was part of the identity at all.
+  - A condition marked **active and confirmed** and the same code marked **resolved and
+    refuted** were one record, on the same terms.
+  - Two immunizations of the same vaccine on one day — a **left-arm** and a **right-arm**
+    injection, or a dose that was **given** and an entry saying one was **not done** — were one
+    record. Lot number, dose, site, route and status were all outside the identity.
+  - Two people sharing a first name, a surname, a sex and a birthday were one patient profile,
+    and every record belonging to either of them hung off it. Medical record numbers, middle
+    names and suffixes were not consulted.
+
+  Each of these takes its identity from the source's identifier now. Where a record carries
+  none, the identity is built from everything the importer stores about it, so two records that
+  differ in anything the pod will show also differ in identity.
+
+  **What to do.** The same as for lab results: re-import the sources into a fresh pod and use
+  that, or accept that records imported before and after this release sit side by side.
+
+  **The merge that was wanted still happens, one layer up.** Two exports of one person from two
+  different systems now arrive as two records rather than one, and the reconciler merges them —
+  matching a condition on its SNOMED code, an allergy on the allergen, an immunization on the
+  vaccine code and date, and a patient on date of birth and sex. The difference is that the
+  merge is now counted in the import summary, attributed to the sources it came from, and
+  raised as a conflict when the two disagree, instead of happening inside a hash where nothing
+  could see it. Measured: importing one person's records from two EHRs into one pod previously
+  left TWO patient profiles and an unresolved conflict that `cascade pod conflicts` reported as
+  an identity collision — a question invented by the identity layer about two records that were
+  never ambiguous. It now leaves one profile and no conflict.
+
+  Measured across the conformance fixture corpus, 121 FHIR resources: **18 moved** (7 patients,
+  5 conditions, 3 allergies, 3 immunizations) and 103 were byte-identical. Groups of records
+  sharing an IRI with a record they differ from fell from **9 covering 21 records to 6 covering
+  13**, and all 6 that remain are the same record appearing in two fixture files, which is
+  correct. The worst case in the corpus was in published HL7 example data: one stock example
+  patient appears in three Genomics IG bundles under three different server-assigned ids, one
+  of them carrying a donor-registry identifier the others do not, and all three collapsed onto
+  a single profile — a merge across three documents decided by four demographic fields and
+  nothing else, which no test noticed.
+
+  **Nothing else moves.** Vital signs, medications, procedures, encounters, documents, coverage
+  and claims all keep the IRIs they had. Verified across the same corpus: every one of the 18
+  resources that moved was one of the four types named here, and across the C-CDA corpus
+  identities are unchanged.
 
 ### Fixed
 
@@ -94,6 +158,22 @@ which:
   under a single shared key regardless of which FHIR resource they arrived as, and the notice
   reported that shared key — telling someone who imported a `MedicationStatement` to go
   looking for a `MedicationRequest`.
+
+- **A code the importer did not recognize no longer erases a record's identity.** A condition
+  coded in anything other than SNOMED or ICD — a local hospital code, or nothing but the
+  problem's name in `code.text`, which is ordinary in portal exports — contributed nothing at
+  all to its own identity, so every such condition recorded for one patient on one day was one
+  record. Allergies and immunizations had a narrower version of the same fault: they read only
+  the FIRST code on the record and read it WITHOUT the coding system it came from, so two
+  systems that happen to reuse a number were indistinguishable. All the codes now count, each
+  paired with the system it belongs to.
+
+- **A placeholder name is no longer part of what a record IS.** "Unknown Condition", "Unknown
+  Allergen" and "Unknown Vaccine" are still what a record with no name DISPLAYS. Widening the
+  identity keys above could have pulled them into identity, where a placeholder turns "we do
+  not know" into "these are the same record"; the keys read the source's own fields instead,
+  and a test now holds each of the three to displaying the placeholder while still telling the
+  records apart.
 - **Two records that share one subject IRI but disagree on content are no longer silently
   reduced to one.**
 

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -37,7 +37,10 @@ import {
   commonTriples,
   quadsToJsonLd,
   mintSubjectUri,
-  contentHashedUri,
+  idOrContentUri,
+  codeableConceptKey,
+  codeableConceptSetKey,
+  structuredKey,
 } from './types.js';
 import {
   referencePlaceholder,
@@ -45,7 +48,6 @@ import {
   pushIndicationEdges,
   pushParsedIndicationCandidates,
 } from './reference-resolution.js';
-import { contentFingerprint, EMPTY_SEED } from '../identity.js';
 
 // ---------------------------------------------------------------------------
 // Medication converter
@@ -181,15 +183,104 @@ export function convertMedicationStatement(resource: any): ConversionResult & { 
 // Condition converter
 // ---------------------------------------------------------------------------
 
+/**
+ * The subject IRI for a Condition.
+ *
+ * WHY THIS IS NO LONGER
+ * `contentHashedUri('Condition', {patient, snomedCode, icd10Code, onsetDate}, resource.id)`
+ * -----------------------------------------------------------------------------------------
+ * Two separate defects, the same pair the lab converter had:
+ *
+ *   1. The `resource.id` was passed as `fallbackId`, which `contentHashedUri`
+ *      consults only when every content field is empty — never true of a real
+ *      Condition. Measured: the same problem carrying id `server-id-A` and id
+ *      `server-id-B` minted ONE IRI. See {@link idOrContentUri}.
+ *
+ *   2. The key was a strict subset of the record. Only two of the codings were
+ *      read (SNOMED and ICD), by substring match on the system URL, so a
+ *      Condition coded in any other system — or in `code.text` alone, which is
+ *      ordinary in portal exports — contributed NOTHING to its own identity and
+ *      merged with every other such Condition for that patient. And onset was
+ *      truncated to a calendar day.
+ *
+ * THE PART WORTH READING BEFORE CALLING THIS HARMLESS
+ * --------------------------------------------------
+ * This was originally judged low severity on the grounds that the merged pairs
+ * "really are the same clinical fact, and no data is lost". That is half right,
+ * and the wrong half is the dangerous one: the IDENTITY fields agreed, but the
+ * NON-identity fields did not have to. Two Conditions sharing patient, code and
+ * onset can disagree on `clinicalStatus` and `verificationStatus` — one saying
+ * ACTIVE and CONFIRMED, the other RESOLVED and REFUTED — and under the old key
+ * they merged, with the winner decided by which file was read first. That is
+ * the glucose bug wearing different clothes.
+ *
+ * What kept it from being an emergency is not that the merges were harmless: it
+ * is that a differing-content collision is now SPLIT and raised as a conflict
+ * rather than silently overwritten. Visible, not safe.
+ *
+ * WITHOUT AN ID the key carries everything that can make two Conditions for one
+ * patient genuinely different records: the full code (all codings, plus text),
+ * onset AT FULL PRECISION, abatement, both status fields, the category, and the
+ * encounter it was recorded at.
+ *
+ * `conditionName` is deliberately NOT a key field: the converter defaults it to
+ * the literal 'Unknown Condition', and a placeholder default in an identity key
+ * is a content hash that succeeds with a constant. `codeableConceptKey` reads
+ * the raw concept instead, and yields `undefined` where the placeholder would
+ * have appeared.
+ *
+ * `recordedDate` is also deliberately excluded. It says when a system wrote the
+ * record down, not what the record says, and it differs between two systems
+ * holding the same problem — so keying on it would split a genuine duplicate
+ * rather than separate two different problems.
+ *
+ * THE COMPLETENESS RULE THESE KEYS ARE BUILT TO, AND ITS LIMIT
+ * -----------------------------------------------------------
+ * A curated key is narrower than the record on purpose, so "which fields" is a
+ * judgement rather than a formula. The one it is held to here: EVERY FIELD THE
+ * CONVERTER SERIALIZES IS EITHER IN THE KEY OR EXCLUDED IN WRITING ABOVE.
+ * Anything else is a field on which two records sharing an IRI can disagree,
+ * which is the lab defect restated — and it is not hypothetical drafting
+ * caution: writing this key without `note` left two id-less Conditions reading
+ * "Provisional" and "Ruled out" on one IRI, and only the mechanical audit in
+ * `clinical-identity.test.ts` found it. That test walks every serialized field
+ * of all four types and fails on the next one anybody forgets.
+ */
+function conditionSubjectUri(resource: any, warnings: string[]): string {
+  return idOrContentUri('Condition', resource, {
+    patient: resource?.subject?.reference,
+    code: codeableConceptKey(resource?.code),
+    // Full precision. `.split('T')[0]` merged two problems recorded hours apart.
+    onset: resource?.onsetDateTime
+      ?? resource?.onsetPeriod?.start
+      ?? resource?.onsetString
+      ?? structuredKey(resource?.onsetAge ?? resource?.onsetRange),
+    abatement: resource?.abatementDateTime
+      ?? resource?.abatementPeriod?.start
+      ?? resource?.abatementString
+      ?? (resource?.abatementBoolean !== undefined ? String(resource.abatementBoolean) : undefined)
+      ?? structuredKey(resource?.abatementAge ?? resource?.abatementRange),
+    // "active" and "resolved" are two different claims about a patient.
+    clinicalStatus: codeableConceptKey(resource?.clinicalStatus),
+    // "confirmed" and "refuted" are opposite claims. This converter does not
+    // serialize it yet, so today two records differing only here produce
+    // identical quads — but identity must describe the SOURCE record, not the
+    // subset this converter happens to write, or adding a field to the
+    // serializer later silently changes which records merge.
+    verificationStatus: codeableConceptKey(resource?.verificationStatus),
+    category: codeableConceptSetKey(resource?.category),
+    // An encounter-diagnosis recorded at each of two visits is two records.
+    encounter: resource?.encounter?.reference,
+    // See the note on completeness below: `note` is serialized as health:notes,
+    // so two Conditions differing only in it are two DIFFERENT records in the
+    // pod, and an identity that cannot see it merges them.
+    note: structuredKey(resource?.note),
+  }, warnings);
+}
+
 export function convertCondition(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const patientRef = resource.subject?.reference ?? '';
-  const subjectUri = contentHashedUri('Condition', {
-    patient: patientRef,
-    snomedCode: resource.code?.coding?.find((c: any) => c.system?.includes('snomed'))?.code,
-    icd10Code: resource.code?.coding?.find((c: any) => c.system?.includes('icd'))?.code,
-    onsetDate: (resource.onsetDateTime ?? resource.onsetPeriod?.start)?.split('T')[0],
-  }, resource.id, resource, warnings);
+  const subjectUri = conditionSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'ConditionRecord'));
@@ -263,14 +354,62 @@ export function convertCondition(resource: any): ConversionResult & { _quads: Qu
 // AllergyIntolerance converter
 // ---------------------------------------------------------------------------
 
+/**
+ * The subject IRI for an AllergyIntolerance.
+ *
+ * WHY THIS IS NO LONGER
+ * `contentHashedUri('AllergyIntolerance', {patient, allergenCode, allergenName}, resource.id)`
+ * ---------------------------------------------------------------------------------------------
+ * Same two defects as Condition, plus a third the shape of the key made worse:
+ *
+ *   1. `resource.id` was dead as a `fallbackId`. Measured: the same allergen
+ *      carrying id `server-id-A` and id `server-id-B` minted ONE IRI.
+ *
+ *   2. `allergenCode` read `code.coding[0].code` — the FIRST coding, WITHOUT its
+ *      system. Two different code systems that reuse the same digits therefore
+ *      collided outright, and a resource whose first coding is the local EHR's
+ *      own numbering keyed on that rather than on the RxNorm or SNOMED code
+ *      sitting beside it.
+ *
+ *   3. The key held NOTHING about the reaction. A "mild rash on penicillin" and
+ *      an "anaphylaxis on penicillin" merged, and which of the two survived was
+ *      decided by input order. An allergy record's severity is the part a
+ *      clinician acts on, so this is the merge with the sharpest consequence in
+ *      this file: it can report a life-threatening allergy as mild.
+ *
+ * WITHOUT AN ID the key carries the full code, both status fields, the type
+ * (allergy vs intolerance), the category, the criticality, the onset, and a
+ * fingerprint of the whole `reaction` array — manifestations, severity,
+ * substance and all.
+ *
+ * `allergen` (the serialized display value) is NOT a key field: it defaults to
+ * the literal 'Unknown Allergen'.
+ */
+function allergySubjectUri(resource: any, warnings: string[]): string {
+  return idOrContentUri('AllergyIntolerance', resource, {
+    patient: resource?.patient?.reference,
+    code: codeableConceptKey(resource?.code),
+    clinicalStatus: codeableConceptKey(resource?.clinicalStatus),
+    verificationStatus: codeableConceptKey(resource?.verificationStatus),
+    type: typeof resource?.type === 'string' ? resource.type : codeableConceptKey(resource?.type),
+    category: codeableConceptSetKey(resource?.category),
+    criticality: resource?.criticality,
+    onset: resource?.onsetDateTime
+      ?? resource?.onsetPeriod?.start
+      ?? resource?.onsetString
+      ?? structuredKey(resource?.onsetAge ?? resource?.onsetRange),
+    // The whole array, fingerprinted: manifestation, severity, substance,
+    // exposure route and description. A key that omitted these merged a mild
+    // rash into an anaphylaxis.
+    reaction: structuredKey(resource?.reaction),
+    // Serialized as health:notes; see the completeness rule on `conditionSubjectUri`.
+    note: structuredKey(resource?.note),
+  }, warnings);
+}
+
 export function convertAllergyIntolerance(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const patientRef = resource.patient?.reference ?? '';
-  const subjectUri = contentHashedUri('AllergyIntolerance', {
-    patient: patientRef,
-    allergenCode: resource.code?.coding?.[0]?.code,
-    allergenName: resource.code?.text,
-  }, resource.id, resource, warnings);
+  const subjectUri = allergySubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'AllergyRecord'));
@@ -376,7 +515,8 @@ const VALUE_X_PREFIX = 'value';
  * Reduced to a fingerprint rather than embedded raw so that the identity string
  * stays a fixed length regardless of how many components a panel has, and so
  * that a free-text `valueString` cannot smuggle the `|` and `=` characters that
- * `contentHashedUri` uses as its own field separators into the key.
+ * `contentHashedUri` uses as its own field separators into the key. That is
+ * `structuredKey`, now shared with the four sibling converters.
  */
 function labMeasuredValueKey(resource: any): string | undefined {
   if (resource == null || typeof resource !== 'object') return undefined;
@@ -388,8 +528,7 @@ function labMeasuredValueKey(resource: any): string | undefined {
     }
   }
   if (Object.keys(measured).length === 0) return undefined;
-  const fingerprint = contentFingerprint(measured);
-  return fingerprint === EMPTY_SEED ? undefined : fingerprint;
+  return structuredKey(measured);
 }
 
 /**
@@ -456,14 +595,16 @@ function labCategoryKey(resource: any): string | undefined {
  * `testName` is deliberately NOT a key field. The converter defaults it to the
  * literal 'Unknown Lab Test', and a placeholder default in an identity key is
  * the same defect in a different costume.
+ *
+ * The two-tier gate itself now lives in {@link idOrContentUri}, shared with
+ * Condition, AllergyIntolerance, Immunization and Patient. It was written here
+ * first, and having one copy per converter is how the rule ends up applied in
+ * some of them and not others — which is precisely what happened: this
+ * converter was fixed while four siblings kept the dead-`fallbackId` shape. The
+ * IRIs are unchanged by the move; the lab suites pin that.
  */
 function labSubjectUri(resource: any, warnings: string[]): string {
-  // Tier 1 — the source assigned an identifier. Same door, same key template,
-  // and the same answer `convertObservationVital` gives for this resource.
-  if (typeof resource?.id === 'string' && resource.id.trim().length > 0) {
-    return mintSubjectUri(resource, warnings);
-  }
-  return contentHashedUri('Observation', {
+  return idOrContentUri('Observation', resource, {
     patient: resource?.subject?.reference,
     loincCode: resource?.code?.coding?.find((c: any) => c.system?.includes('loinc'))?.code,
     // Full precision. `.split('T')[0]` merged a 07:00 draw with an 11:00 draw.
@@ -471,9 +612,7 @@ function labSubjectUri(resource: any, warnings: string[]): string {
     value: labMeasuredValueKey(resource),
     specimen: resource?.specimen?.reference,
     category: labCategoryKey(resource),
-    // No `fallbackId`: this branch runs only when there is no id to fall back
-    // to. Passing one here is what hid the defect above for so long.
-  }, undefined, resource, warnings);
+  }, warnings);
 }
 
 export function convertObservationLab(resource: any): ConversionResult & { _quads: Quad[] } {

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -22,7 +22,9 @@ import {
   commonTriples,
   quadsToJsonLd,
   mintSubjectUri,
-  contentHashedUri,
+  idOrContentUri,
+  codeableConceptKey,
+  structuredKey,
 } from './types.js';
 import { pushEncounterEdge } from './reference-resolution.js';
 
@@ -30,17 +32,72 @@ import { pushEncounterEdge } from './reference-resolution.js';
 // Patient converter
 // ---------------------------------------------------------------------------
 
+/**
+ * The subject IRI for a Patient.
+ *
+ * WHY THIS IS NO LONGER
+ * `contentHashedUri('Patient', {dob, sex, family, given}, resource.id)`
+ * --------------------------------------------------------------------
+ * The `resource.id` was passed as `fallbackId`, which is dead on any Patient
+ * carrying a name or a birth date. Measured: the same demographics under id
+ * `server-id-A` and id `server-id-B` minted ONE IRI.
+ *
+ * And the key was four fields: birth date, gender, `name[0].family` and
+ * `name[0].given[0]`. It read the FIRST given name only and no other name
+ * entry, so middle names, suffixes, maiden names and every `identifier` — the
+ * medical record number, the member id, the fields an EHR itself uses to tell
+ * two patients apart — contributed nothing. Two different people sharing a
+ * first name, a surname, a sex and a date of birth therefore merged into one
+ * profile, and every record belonging to either of them then hung off it. In a
+ * store whose whole premise is that the record is about one person, that is the
+ * worst merge available.
+ *
+ * WHAT DOES NOT CHANGE: THE SAME PERSON FROM TWO SOURCES STILL RECONCILES.
+ * -----------------------------------------------------------------------
+ * Two exports of one person from two EHRs carry two server ids and so now mint
+ * two profile IRIs where they previously minted one. They do not stay two
+ * records: `matchPatientProfiles` in the reconciler matches on date of birth
+ * plus sex at 0.95 confidence, far above the 0.65 threshold, and merges them —
+ * with a merge trail, and with a conflict raised where the two disagree. The
+ * merge moves from a hash nobody can inspect to the layer built to make it
+ * reviewable. That is the whole of the change.
+ *
+ * WITHOUT AN ID the key adds the complete `name` array (every entry, every
+ * given name, prefixes and suffixes) and the complete `identifier` array, both
+ * fingerprinted.
+ *
+ * `address` is in the key even though it changes for the same person, because
+ * it is SERIALIZED (as `cascade:addressCity` and its siblings) and the rule
+ * these keys are built to — stated in full on `conditionSubjectUri` — is that a
+ * serialized field outside the key is a field two records sharing an IRI can
+ * disagree on. The cost is the recoverable direction: an id-less patient whose
+ * address changed splits, and `matchPatientProfiles` puts the two back together
+ * on date of birth plus sex while raising the differing address as a conflict,
+ * which is the outcome a person can actually act on. Excluding it would instead
+ * merge two same-named people at two addresses, and that is unrecoverable.
+ *
+ * `telecom` is excluded, and can be: this converter does not serialize it, so
+ * two Patients differing only there produce identical records.
+ */
+function patientSubjectUri(resource: any, warnings: string[]): string {
+  return idOrContentUri('Patient', resource, {
+    dob: resource?.birthDate,
+    sex: resource?.gender,
+    // The whole name array, not `name[0].family` + `name[0].given[0]`.
+    name: structuredKey(resource?.name),
+    // The strongest discriminator a Patient resource carries, and it was
+    // absent from the key entirely.
+    identifier: structuredKey(resource?.identifier),
+    maritalStatus: codeableConceptKey(resource?.maritalStatus),
+    address: structuredKey(resource?.address),
+    deceased: resource?.deceasedDateTime
+      ?? (resource?.deceasedBoolean !== undefined ? String(resource.deceasedBoolean) : undefined),
+  }, warnings);
+}
+
 export function convertPatient(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const subjectUri = contentHashedUri('Patient', {
-    dob: resource.birthDate,
-    sex: resource.gender,
-    family: resource.name?.[0]?.family,
-    given: resource.name?.[0]?.given?.[0],
-    // A Patient with no name, no birthDate, no gender and no id used to fall
-    // through to a random UUID. Passing the resource gives the last tier the
-    // rest of the demographics (address, telecom, identifier) to key on.
-  }, resource.id, resource, warnings);
+  const subjectUri = patientSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.cascade + 'PatientProfile'));
@@ -120,14 +177,67 @@ export function convertPatient(resource: any): ConversionResult & { _quads: Quad
 // Immunization converter
 // ---------------------------------------------------------------------------
 
+/**
+ * The subject IRI for an Immunization.
+ *
+ * WHY THIS IS NO LONGER
+ * `contentHashedUri('Immunization', {patient, cvxCode, date}, resource.id)`
+ * ------------------------------------------------------------------------
+ * The `resource.id` was dead as a `fallbackId`. Measured: the same dose under
+ * id `server-id-A` and id `server-id-B` minted ONE IRI.
+ *
+ * The key itself was defended on the grounds that two flu shots recorded on one
+ * day really are one dose. That is true of two RECORDS OF one dose and false of
+ * two doses, and the key could not tell those apart, because it read
+ * `vaccineCode.coding[0].code` — the first coding, without its system, so a CVX
+ * code and an NDC or local code sharing digits collided — and truncated the
+ * occurrence to a calendar day. Everything that distinguishes two same-day
+ * administrations was outside it: the LOT NUMBER, the dose quantity, the body
+ * SITE, the route, the manufacturer, and the status. A left-arm and a right-arm
+ * injection given in one visit were one record; so were a `completed` dose and
+ * a `not-done` entry for the same vaccine on the same day, which is the pair
+ * whose merge tells a reader a dose was given when the source says it was not.
+ *
+ * That was the standing assumption this entry was filed to remove: the safety
+ * of `{patient, code, date}` was a claim about the data, not a property of the
+ * key, and it expired the moment any discriminating field was looked at.
+ *
+ * WITHOUT AN ID the key carries the full vaccine code, the occurrence at FULL
+ * precision, the status, the lot number, the dose, the site, the route, the
+ * manufacturer and the encounter.
+ *
+ * `vaccineName` is NOT a key field: the converter defaults it to 'Unknown
+ * Vaccine'. Neither is the serialized status, which defaults to 'completed' —
+ * the key reads `resource.status` raw, so an absent status stays absent instead
+ * of arriving as a constant.
+ */
+function immunizationSubjectUri(resource: any, warnings: string[]): string {
+  return idOrContentUri('Immunization', resource, {
+    patient: resource?.patient?.reference,
+    vaccine: codeableConceptKey(resource?.vaccineCode),
+    // Full precision, and `occurrenceString` where the source gives prose.
+    occurrence: resource?.occurrenceDateTime ?? resource?.occurrenceString,
+    // Raw, not the serialized `?? 'completed'`.
+    status: resource?.status,
+    lotNumber: resource?.lotNumber,
+    dose: structuredKey(resource?.doseQuantity),
+    site: codeableConceptKey(resource?.site),
+    route: codeableConceptKey(resource?.route),
+    manufacturer: resource?.manufacturer?.display ?? resource?.manufacturer?.reference,
+    encounter: resource?.encounter?.reference,
+    // Serialized as health:administeringProvider / administeringLocation /
+    // notes. See the completeness rule on `conditionSubjectUri`: a serialized
+    // field outside the key is a field two records sharing an IRI can disagree
+    // on.
+    performer: structuredKey(resource?.performer),
+    location: resource?.location?.display ?? resource?.location?.reference,
+    note: structuredKey(resource?.note),
+  }, warnings);
+}
+
 export function convertImmunization(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
-  const patientRef = resource.patient?.reference ?? '';
-  const subjectUri = contentHashedUri('Immunization', {
-    patient: patientRef,
-    cvxCode: resource.vaccineCode?.coding?.[0]?.code,
-    date: resource.occurrenceDateTime?.split('T')[0],
-  }, resource.id, resource, warnings);
+  const subjectUri = immunizationSubjectUri(resource, warnings);
   const quads: Quad[] = [];
 
   quads.push(tripleType(subjectUri, NS.health + 'ImmunizationRecord'));

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -7,7 +7,7 @@
 import { DataFactory, Writer, type Quad } from 'n3';
 import { createHash } from 'node:crypto';
 import { normalizeMedName } from '../medication-normalize.js';
-import { identitySeed } from '../identity.js';
+import { contentFingerprint, EMPTY_SEED, identitySeed } from '../identity.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
@@ -453,6 +453,150 @@ export function contentHashedUri(
     label: `${label ?? resourceType} (no id)`,
   });
   return `urn:uuid:${deterministicUuid(`${resourceType}::${seed}`)}`;
+}
+
+// ---------------------------------------------------------------------------
+// The rule: a present `resource.id` wins
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a subject IRI for a converter that carries its own curated content key:
+ * THE SOURCE'S OWN IDENTIFIER DECIDES, and the curated key is what answers the
+ * question when there is no identifier.
+ *
+ * WHY THIS EXISTS RATHER THAN `contentHashedUri(type, fields, resource.id, …)`
+ * ---------------------------------------------------------------------------
+ * That call reads as "identify by content, and fall back to the id", but
+ * `contentHashedUri` consults `fallbackId` ONLY when every content field is
+ * empty. On a real record they never are. So the id was not a fallback, it was
+ * DEAD, and a distinct, stable, server-assigned identifier was discarded on
+ * every record that carried one.
+ *
+ * That is how two records the source had deliberately kept apart ended up on
+ * one IRI. It was measured first for lab results — a fasting glucose of 95 and
+ * a post-prandial of 310, each with its own id, minting a single subject — and
+ * the same call shape was in four more converters, so the same thing happened
+ * to Conditions, allergies, immunizations and patients.
+ *
+ * THE RULE
+ * --------
+ * Identity answers "is this that record?", and the source's identifier is the
+ * source answering it. Deciding that two records are the same THING is a
+ * different judgement: it needs both records side by side and a trail saying it
+ * happened, so it belongs to the reconciler, which has both, and not to the
+ * identity layer, which sees one record at a time and can only overwrite.
+ *
+ * The merges this stops being silent are NOT lost. Every type routed through
+ * here has a reconciler matcher that still finds them — a Condition on its
+ * SNOMED code, an allergy on the allergen, an immunization on CVX plus date, a
+ * patient on date of birth plus sex — all well above the match threshold. What
+ * changes is that the merge now happens where it can be seen, counted, and
+ * argued with, instead of in a hash.
+ *
+ * `convertObservationVital`, `convertProcedure`, `convertEncounter` and nine
+ * other converters already did exactly this via `mintSubjectUri`. This is not a
+ * new strategy; it is the end of a second one.
+ *
+ * WHAT THE CURATED KEY IS FOR
+ * ---------------------------
+ * Without an id, `mintSubjectUri` would hash the whole resource, which splits
+ * on any incidental difference between two renderings of the same record. A
+ * curated key is deliberately narrower and therefore tolerant — but only of
+ * things that do not distinguish two records. Every field a converter
+ * SERIALIZES and leaves out of its key is a field on which two records sharing
+ * an IRI can disagree, which is the lab defect restated. So a key is widened
+ * until that set is empty, and no further.
+ *
+ * @param resourceType the identity key's type prefix. Both tiers feed the same
+ *                     template (`{type}:{id}` and `{type}::{fields}`), and an
+ *                     anonymous content seed is 69 characters where FHIR caps
+ *                     `Resource.id` at 64, so the two tiers cannot collide.
+ */
+export function idOrContentUri(
+  resourceType: string,
+  resource: any,
+  contentFields: Record<string, string | undefined>,
+  warnings?: string[],
+): string {
+  // Tier 1 — the source assigned an identifier. `mintSubjectUri` routes it
+  // through the identity door, so the explicit-id tier is the same code path
+  // every other converter in this file uses.
+  if (typeof resource?.id === 'string' && resource.id.trim().length > 0) {
+    return mintSubjectUri(resource, warnings);
+  }
+  // No `fallbackId`: this branch runs only when there is no id to fall back to.
+  // Passing one here is what hid the defect above for so long.
+  return contentHashedUri(resourceType, contentFields, undefined, resource, warnings);
+}
+
+/**
+ * A stable token for a FHIR CodeableConcept, or `undefined` when it carries
+ * nothing.
+ *
+ * Every coding is included as `system|code`, not just `coding[0].code`, because
+ * reading one coding without its system is how a key stops telling two records
+ * apart: two different code systems reusing the same digits collide, and a
+ * resource whose first coding happens to be the local EHR's own numbering keys
+ * on that instead of the standard code. Sorted, because `coding` is a set in
+ * practice and two servers may enumerate it in different order — sorting can
+ * only remove spurious SPLITS, never cause a merge, since a differing set still
+ * sorts to a differing string.
+ *
+ * `text` is included because it is frequently the ONLY thing a record carries:
+ * a Condition with `code.text: "Asthma"` and no coding would otherwise
+ * contribute nothing to its own identity and merge with every other uncoded
+ * condition for that patient.
+ *
+ * NOTE FOR CALLERS: pass the RAW concept. Do not pass a converter's display
+ * value, which is typically `codeableConceptText(x) ?? 'Unknown …'`. A
+ * placeholder in an identity key turns "we do not know" into "these are the
+ * same record", and a content hash that succeeds with a constant is
+ * indistinguishable from one that fails except that it merges.
+ */
+export function codeableConceptKey(cc: any): string | undefined {
+  if (cc == null || typeof cc !== 'object') return undefined;
+  const parts: string[] = [];
+  if (Array.isArray(cc.coding)) {
+    for (const c of cc.coding) {
+      if (c?.code) parts.push(`${c.system ?? ''}|${c.code}`);
+    }
+  }
+  if (typeof cc.text === 'string' && cc.text.trim().length > 0) parts.push(cc.text.trim());
+  return parts.length > 0 ? parts.sort().join(',') : undefined;
+}
+
+/**
+ * The same, for a repeating CodeableConcept element (`Condition.category`,
+ * `Immunization.programEligibility`, …), and tolerating the plain-string
+ * members FHIR uses for `AllergyIntolerance.category`.
+ */
+export function codeableConceptSetKey(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts: string[] = [];
+  for (const item of value) {
+    if (typeof item === 'string') {
+      if (item.trim().length > 0) parts.push(item.trim());
+      continue;
+    }
+    const key = codeableConceptKey(item);
+    if (key) parts.push(key);
+  }
+  return parts.length > 0 ? parts.sort().join(';') : undefined;
+}
+
+/**
+ * A fixed-length token standing for an arbitrary sub-object of a resource
+ * (`AllergyIntolerance.reaction`, `Immunization.doseQuantity`, a `name` array).
+ *
+ * Reduced to a fingerprint rather than embedded raw for two reasons: the
+ * identity string stays a fixed length however large the structure is, and free
+ * text inside it cannot smuggle the `|` and `=` characters that
+ * `contentHashedUri` uses as its own field separators into the key.
+ */
+export function structuredKey(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const fingerprint = contentFingerprint(value);
+  return fingerprint === EMPTY_SEED ? undefined : fingerprint;
 }
 
 /**

--- a/tests/clinical-identity.test.ts
+++ b/tests/clinical-identity.test.ts
@@ -1,0 +1,736 @@
+/**
+ * A Condition, an allergy, an immunization and a patient must be identified by
+ * the identifier their source assigned them.
+ *
+ * THE DEFECT THESE PIN
+ * --------------------
+ * Four converters minted their subject as
+ * `contentHashedUri(type, {…narrow key…}, resource.id)`. That reads as "identify
+ * by content, fall back to the id", but `contentHashedUri` consults
+ * `fallbackId` ONLY when every content field is empty — which never happens on a
+ * real record. So the id was not a fallback, it was DEAD, and a distinct,
+ * stable, server-assigned identifier was thrown away on every record.
+ *
+ * Measured against `origin/main`, same content under two different ids:
+ *
+ *     convertCondition          'server-id-A' vs 'server-id-B' -> ONE IRI
+ *     convertAllergyIntolerance 'server-id-A' vs 'server-id-B' -> ONE IRI
+ *     convertImmunization       'server-id-A' vs 'server-id-B' -> ONE IRI
+ *     convertPatient            'server-id-A' vs 'server-id-B' -> ONE IRI
+ *
+ * It is the same mechanism already fixed for lab results, in four more types.
+ *
+ * READ THIS BEFORE REPEATING "NO DATA IS LOST"
+ * -------------------------------------------
+ * These merges were originally called low severity because the merged pairs
+ * "really are the same clinical fact". The identity fields did agree. The
+ * NON-identity fields did not have to, and that is the whole defect: two
+ * Conditions sharing patient, code and onset can disagree on `clinicalStatus`
+ * and `verificationStatus`, so an ACTIVE, CONFIRMED problem and a RESOLVED,
+ * REFUTED one merged, with the winner decided by which file was read first.
+ * `it('the reading a reader will assume is safe')` below is exactly that pair.
+ *
+ * What kept it from being an emergency is not that the merges were harmless: it
+ * is that a differing-content collision is now split and raised as a conflict
+ * instead of silently overwritten. Visible, not safe.
+ *
+ * WHAT THESE TESTS WOULD DO IF THE FIX WERE ABSENT
+ * ------------------------------------------------
+ * Measured, not assumed: every case in sections 1-4 FAILS against `origin/main`.
+ * The cases that pass either way are the whole of section 5 and are labelled
+ * STABILITY PIN in place; each states which guarantee it is guarding rather than
+ * being counted as evidence for this change.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  convertCondition,
+  convertAllergyIntolerance,
+} from '../src/lib/fhir-converter/converters-clinical.js';
+import {
+  convertImmunization,
+  convertPatient,
+} from '../src/lib/fhir-converter/converters-demographics.js';
+
+// ---------------------------------------------------------------------------
+// Helpers and base fixtures
+// ---------------------------------------------------------------------------
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+type Converted = { _quads: Array<{ subject: { value: string }; predicate: { value: string }; object: { value: string } }> };
+
+/** The minted subject IRI: the first quad is the `rdf:type` triple on it. */
+function subjectOf(result: Converted): string {
+  expect(result._quads.length).toBeGreaterThan(0);
+  return result._quads[0].subject.value;
+}
+
+/**
+ * Everything the converter WROTE about the record, with the subject IRI removed.
+ *
+ * Two resources whose serialized statements differ are two different records in
+ * the pod, whatever their identity says. Comparing this to identity is what
+ * section 4 does.
+ */
+function statementsOf(result: Converted): string[] {
+  return result._quads.map((q) => `${q.predicate.value} ${q.object.value}`).sort();
+}
+
+/** A hypertension problem as a FHIR server returns it. */
+function condition(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Condition',
+    subject: { reference: 'Patient/synthetic-1' },
+    code: {
+      coding: [{ system: 'http://snomed.info/sct', code: '38341003', display: 'Essential hypertension' }],
+      text: 'Essential hypertension',
+    },
+    onsetDateTime: '2021-04-02',
+    ...overrides,
+  };
+}
+
+/** A penicillin allergy. */
+function allergy(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'AllergyIntolerance',
+    patient: { reference: 'Patient/synthetic-1' },
+    code: {
+      coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '7980', display: 'Penicillin G' }],
+      text: 'Penicillin G',
+    },
+    criticality: 'high',
+    ...overrides,
+  };
+}
+
+/** A seasonal influenza dose. */
+function immunization(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Immunization',
+    status: 'completed',
+    patient: { reference: 'Patient/synthetic-1' },
+    vaccineCode: {
+      coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '141', display: 'Influenza, seasonal' }],
+      text: 'Influenza, seasonal',
+    },
+    occurrenceDateTime: '2025-10-15',
+    ...overrides,
+  };
+}
+
+/** A patient. */
+function patient(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Patient',
+    name: [{ family: 'Rivera', given: ['Alex'] }],
+    gender: 'female',
+    birthDate: '1985-03-15',
+    ...overrides,
+  };
+}
+
+const condUri = (r: any): string => subjectOf(convertCondition(clone(r)));
+const algUri = (r: any): string => subjectOf(convertAllergyIntolerance(clone(r)));
+const immUri = (r: any): string => subjectOf(convertImmunization(clone(r)));
+const patUri = (r: any): string => subjectOf(convertPatient(clone(r)));
+
+/** The four types under one description, so a case can be stated once. */
+const TYPES = [
+  { name: 'Condition', base: condition, uri: condUri, convert: convertCondition },
+  { name: 'AllergyIntolerance', base: allergy, uri: algUri, convert: convertAllergyIntolerance },
+  { name: 'Immunization', base: immunization, uri: immUri, convert: convertImmunization },
+  { name: 'Patient', base: patient, uri: patUri, convert: convertPatient },
+] as const;
+
+// ---------------------------------------------------------------------------
+// 1. A present `resource.id` decides
+// ---------------------------------------------------------------------------
+
+describe('the identifier a source assigned is what identifies the record', () => {
+  for (const { name, base, uri } of TYPES) {
+    it(`${name}: two records the source kept apart stay two records`, () => {
+      // Nothing in the content distinguishes them. The ids ARE the source
+      // saying these are two records, and discarding them merged the pair.
+      expect(uri(base({ id: 'server-id-A' }))).not.toBe(uri(base({ id: 'server-id-B' })));
+    });
+
+    it(`${name}: the id path is deterministic AND discriminating, not merely deterministic`, () => {
+      // Determinism on its own is satisfied by returning a constant — which is
+      // very nearly what the defect did. Both halves, or neither is evidence.
+      const a = base({ id: 'server-id-A' });
+      const b = base({ id: 'server-id-B' });
+      expect(uri(a)).toBe(uri(clone(a)));
+      expect(uri(b)).toBe(uri(clone(b)));
+      expect(uri(a)).not.toBe(uri(b));
+      expect(uri(a)).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    });
+  }
+
+  it('the reading a reader will assume is safe: ACTIVE+CONFIRMED and RESOLVED+REFUTED', () => {
+    // This is the pair the original "no data is lost" argument was wrong about.
+    // Patient, code and onset all agree, so the old key called them one record —
+    // but one says the patient HAS essential hypertension and the other says the
+    // claim was investigated and REFUTED. They are opposite assertions, each
+    // with its own server id, and merging them let file read order decide which
+    // one the pod ends up asserting.
+    const active = condition({
+      id: 'cond-active',
+      clinicalStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active' }] },
+      verificationStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'confirmed' }] },
+    });
+    const refuted = condition({
+      id: 'cond-refuted',
+      clinicalStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'resolved' }] },
+      verificationStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'refuted' }] },
+    });
+
+    expect(condUri(active)).not.toBe(condUri(refuted));
+    // And the disagreement really is present in the records, so the merge would
+    // have destroyed something rather than being a harmless tidy-up.
+    expect(statementsOf(convertCondition(clone(active))))
+      .not.toEqual(statementsOf(convertCondition(clone(refuted))));
+  });
+
+  it('the same pair with no ids is also two records', () => {
+    // The id-less half of the same scenario: with no identifier to honour, the
+    // content key has to carry both status fields or the merge simply moves.
+    const active = condition({
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      verificationStatus: { coding: [{ code: 'confirmed' }] },
+    });
+    const refuted = condition({
+      clinicalStatus: { coding: [{ code: 'resolved' }] },
+      verificationStatus: { coding: [{ code: 'refuted' }] },
+    });
+    expect(condUri(active)).not.toBe(condUri(refuted));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The id-less path: the discriminating fields are in the key
+// ---------------------------------------------------------------------------
+
+describe('id-less Conditions are separated by what actually differs', () => {
+  it('a code the old key could not read still identifies the problem', () => {
+    // The old key read exactly two codings, found by substring match on the
+    // system URL: `snomed` and `icd`. A Condition coded in any other system
+    // contributed NOTHING to its own identity and merged with every other such
+    // Condition for that patient on that day.
+    const local = (code: string): any => ({
+      resourceType: 'Condition',
+      subject: { reference: 'Patient/synthetic-1' },
+      code: { coding: [{ system: 'http://epic.example.org/dx', code }] },
+      onsetDateTime: '2021-04-02',
+    });
+    expect(condUri(local('E11-LOCAL'))).not.toBe(condUri(local('J45-LOCAL')));
+  });
+
+  it('a text-only code identifies the problem', () => {
+    // Portal exports routinely carry `code.text` and no coding at all. Under
+    // the old key those Conditions were indistinguishable from one another.
+    const textOnly = (text: string): any => ({
+      resourceType: 'Condition',
+      subject: { reference: 'Patient/synthetic-1' },
+      code: { text },
+      onsetDateTime: '2021-04-02',
+    });
+    expect(condUri(textOnly('Asthma'))).not.toBe(condUri(textOnly('Migraine')));
+  });
+
+  it('onset is identity at FULL precision, not truncated to a day', () => {
+    expect(condUri(condition({ onsetDateTime: '2021-04-02T08:00:00Z' })))
+      .not.toBe(condUri(condition({ onsetDateTime: '2021-04-02T16:00:00Z' })));
+  });
+
+  it('an abatement date is identity — a resolved problem is not the active one', () => {
+    expect(condUri(condition({ abatementDateTime: '2023-01-01' })))
+      .not.toBe(condUri(condition({ abatementDateTime: '2024-06-01' })));
+  });
+
+  it('the category is identity — a problem-list entry is not an encounter diagnosis', () => {
+    expect(condUri(condition({ category: [{ coding: [{ code: 'problem-list-item' }] }] })))
+      .not.toBe(condUri(condition({ category: [{ coding: [{ code: 'encounter-diagnosis' }] }] })));
+  });
+
+  it('the encounter is identity — the same diagnosis recorded at two visits is two records', () => {
+    expect(condUri(condition({ encounter: { reference: 'Encounter/visit-may' } })))
+      .not.toBe(condUri(condition({ encounter: { reference: 'Encounter/visit-june' } })));
+  });
+
+  it('a note is identity — "Provisional" is not "Ruled out"', () => {
+    // The hole the mechanical audit in section 4 found in the first draft of
+    // this very change: `note` is SERIALIZED as health:notes but was outside
+    // the key, so two Conditions saying opposite things shared an IRI.
+    const noted = (text: string): any => ({
+      resourceType: 'Condition',
+      subject: { reference: 'Patient/synthetic-1' },
+      onsetDateTime: '2021-04-02',
+      note: [{ text }],
+    });
+    expect(condUri(noted('Provisional'))).not.toBe(condUri(noted('Ruled out')));
+  });
+});
+
+describe('id-less allergies are separated by what actually differs', () => {
+  it('a coding system is part of the code — two systems reusing digits are not one allergen', () => {
+    // The old key read `code.coding[0].code` WITHOUT its system, so any two
+    // systems that reuse a number collided outright, and a resource whose first
+    // coding is the local EHR's own numbering keyed on that instead of on the
+    // RxNorm code beside it.
+    const coded = (system: string): any => ({
+      resourceType: 'AllergyIntolerance',
+      patient: { reference: 'Patient/synthetic-1' },
+      code: { coding: [{ system, code: '7980' }] },
+    });
+    expect(algUri(coded('http://www.nlm.nih.gov/research/umls/rxnorm')))
+      .not.toBe(algUri(coded('http://snomed.info/sct')));
+  });
+
+  it('THE REACTION IS IDENTITY — a mild rash is not an anaphylaxis', () => {
+    // The sharpest merge in this file. Severity is the part a clinician acts
+    // on, and the old key held nothing about the reaction at all, so which of
+    // the two survived was decided by input order — meaning a pod could report
+    // a life-threatening allergy as mild.
+    const rash = allergy({ reaction: [{ manifestation: [{ text: 'Rash' }], severity: 'mild' }] });
+    const anaphylaxis = allergy({ reaction: [{ manifestation: [{ text: 'Anaphylaxis' }], severity: 'severe' }] });
+    expect(algUri(rash)).not.toBe(algUri(anaphylaxis));
+  });
+
+  it('criticality is identity', () => {
+    expect(algUri(allergy({ criticality: 'low' }))).not.toBe(algUri(allergy({ criticality: 'high' })));
+  });
+
+  it('onset is identity', () => {
+    expect(algUri(allergy({ onsetDateTime: '2019-01-01' })))
+      .not.toBe(algUri(allergy({ onsetDateTime: '2022-07-01' })));
+  });
+
+  it('the category is identity — a medication allergy is not a food allergy', () => {
+    expect(algUri(allergy({ category: ['medication'] }))).not.toBe(algUri(allergy({ category: ['food'] })));
+  });
+
+  it('verificationStatus is identity — confirmed is not refuted', () => {
+    expect(algUri(allergy({ verificationStatus: { coding: [{ code: 'confirmed' }] } })))
+      .not.toBe(algUri(allergy({ verificationStatus: { coding: [{ code: 'refuted' }] } })));
+  });
+});
+
+describe('id-less immunizations are separated by what actually differs', () => {
+  it('the lot number is identity', () => {
+    expect(immUri(immunization({ lotNumber: 'AAJN11K' }))).not.toBe(immUri(immunization({ lotNumber: 'BBKP22L' })));
+  });
+
+  it('the body site is identity — a left-arm and a right-arm injection are two doses', () => {
+    // Two vaccines administered in one visit at two sites is ordinary practice,
+    // and "two flu shots on one day really are one dose" — the argument the old
+    // key rested on — cannot tell that case from a duplicate record.
+    expect(immUri(immunization({ site: { text: 'Left deltoid' } })))
+      .not.toBe(immUri(immunization({ site: { text: 'Right deltoid' } })));
+  });
+
+  it('the status is identity — a `not-done` entry is not a dose that was given', () => {
+    // The merge here tells a reader a vaccine was administered when the source
+    // says it was not.
+    expect(immUri(immunization({ status: 'completed' }))).not.toBe(immUri(immunization({ status: 'not-done' })));
+  });
+
+  it('the dose quantity is identity — a paediatric half-dose is not a full one', () => {
+    expect(immUri(immunization({ doseQuantity: { value: 0.25, unit: 'mL' } })))
+      .not.toBe(immUri(immunization({ doseQuantity: { value: 0.5, unit: 'mL' } })));
+  });
+
+  it('the occurrence instant is identity at FULL precision', () => {
+    expect(immUri(immunization({ occurrenceDateTime: '2025-10-15T09:00:00Z' })))
+      .not.toBe(immUri(immunization({ occurrenceDateTime: '2025-10-15T15:30:00Z' })));
+  });
+
+  it('a coding system is part of the vaccine code', () => {
+    const coded = (system: string): any => ({
+      resourceType: 'Immunization',
+      status: 'completed',
+      patient: { reference: 'Patient/synthetic-1' },
+      vaccineCode: { coding: [{ system, code: '141' }] },
+      occurrenceDateTime: '2025-10-15',
+    });
+    expect(immUri(coded('http://hl7.org/fhir/sid/cvx'))).not.toBe(immUri(coded('http://hl7.org/fhir/sid/ndc')));
+  });
+
+  it('the manufacturer is identity', () => {
+    expect(immUri(immunization({ manufacturer: { display: 'Sanofi Pasteur' } })))
+      .not.toBe(immUri(immunization({ manufacturer: { display: 'Seqirus' } })));
+  });
+});
+
+describe('id-less patients are separated by what actually differs', () => {
+  it('an identifier is identity — two people with one name and one birthday are two people', () => {
+    // The old key was {birthDate, gender, name[0].family, name[0].given[0]}. It
+    // never looked at `identifier` — the medical record number, the very field
+    // an EHR uses to tell two patients apart. Merging two patients merges the
+    // subject every record in the pod hangs off, which is the worst merge
+    // available in this system.
+    const withMrn = (value: string): any => patient({ identifier: [{ system: 'urn:oid:1.2.3', value }] });
+    expect(patUri(withMrn('MRN-100200'))).not.toBe(patUri(withMrn('MRN-300400')));
+  });
+
+  it('every given name is identity, not just the first', () => {
+    expect(patUri(patient({ name: [{ family: 'Rivera', given: ['Alex', 'Marie'] }] })))
+      .not.toBe(patUri(patient({ name: [{ family: 'Rivera', given: ['Alex', 'Jordan'] }] })));
+  });
+
+  it('a suffix is identity — Jr is not Sr', () => {
+    expect(patUri(patient({ name: [{ family: 'Rivera', given: ['Alex'], suffix: ['Jr'] }] })))
+      .not.toBe(patUri(patient({ name: [{ family: 'Rivera', given: ['Alex'], suffix: ['Sr'] }] })));
+  });
+
+  it('a second name entry is identity — a maiden name is not invisible', () => {
+    expect(patUri(patient()))
+      .not.toBe(patUri(patient({
+        name: [{ family: 'Rivera', given: ['Alex'] }, { use: 'maiden', family: 'Okonkwo', given: ['Alex'] }],
+      })));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Placeholder defaults are display values, never identity
+// ---------------------------------------------------------------------------
+
+/**
+ * `?? 'Unknown Condition'`, `?? 'Unknown Allergen'`, `?? 'Unknown Vaccine'`.
+ *
+ * A placeholder is the right answer for what a record DISPLAYS and never for
+ * what it IS: it converts "we do not know" into "these are the same record". A
+ * content hash that succeeds with a constant is indistinguishable from one that
+ * fails, except that it merges records instead of splitting them.
+ *
+ * These placeholders were judged safe by an earlier sweep specifically BECAUSE
+ * they were not in an identity key. Widening the keys is what could have made
+ * that judgement stale, so each is re-checked here rather than assumed.
+ */
+describe('a placeholder display name never reaches an identity key', () => {
+  const cases = [
+    {
+      name: 'Condition',
+      predicate: 'https://ns.cascadeprotocol.org/health/v1#conditionName',
+      placeholder: 'Unknown Condition',
+      convert: convertCondition,
+      a: { resourceType: 'Condition', subject: { reference: 'Patient/synthetic-1' }, note: [{ text: 'Provisional' }] },
+      b: { resourceType: 'Condition', subject: { reference: 'Patient/synthetic-1' }, note: [{ text: 'Ruled out' }] },
+    },
+    {
+      name: 'AllergyIntolerance',
+      predicate: 'https://ns.cascadeprotocol.org/health/v1#allergen',
+      placeholder: 'Unknown Allergen',
+      convert: convertAllergyIntolerance,
+      a: { resourceType: 'AllergyIntolerance', patient: { reference: 'Patient/synthetic-1' }, criticality: 'low' },
+      b: { resourceType: 'AllergyIntolerance', patient: { reference: 'Patient/synthetic-1' }, criticality: 'high' },
+    },
+    {
+      name: 'Immunization',
+      predicate: 'https://ns.cascadeprotocol.org/health/v1#vaccineName',
+      placeholder: 'Unknown Vaccine',
+      convert: convertImmunization,
+      a: { resourceType: 'Immunization', patient: { reference: 'Patient/synthetic-1' }, lotNumber: 'AAJN11K' },
+      b: { resourceType: 'Immunization', patient: { reference: 'Patient/synthetic-1' }, lotNumber: 'BBKP22L' },
+    },
+  ] as const;
+
+  for (const c of cases) {
+    it(`${c.name}: '${c.placeholder}' is still displayed, and does not merge the records`, () => {
+      const ra = c.convert(clone(c.a) as any);
+      const rb = c.convert(clone(c.b) as any);
+
+      // The placeholder is still what the record says on screen...
+      for (const r of [ra, rb]) {
+        const displayed = r._quads.filter((q) => q.predicate.value === c.predicate).map((q) => q.object.value);
+        expect(displayed, `${c.name} should still display the placeholder`).toEqual([c.placeholder]);
+      }
+      // ...and it is not what the record is identified by.
+      expect(subjectOf(ra)).not.toBe(subjectOf(rb));
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. The mechanical audit: no serialized difference may share an identity
+// ---------------------------------------------------------------------------
+
+/**
+ * The property that actually has to hold, stated once instead of field by field.
+ *
+ * If two resources produce DIFFERENT statements in the pod, they are two
+ * different records, and an identity that cannot tell them apart merges them.
+ * (The converse is deliberately NOT asserted: identity may split records that
+ * serialize identically, because a split is recoverable and a merge is not.)
+ *
+ * This is the check that found `note` missing from the Condition, allergy and
+ * immunization keys, and `performer` / `location` missing from the
+ * immunization key, in the first draft of this change. Case-by-case tests
+ * cannot find the field nobody thought of; this can, and it will fail on the
+ * next one a future edit forgets.
+ */
+describe('two records that serialize differently never share an identity', () => {
+  const AUDIT: Array<{ name: string; base: () => any; convert: (r: any) => Converted; mutations: Array<[string, Record<string, unknown>]> }> = [
+    {
+      name: 'Condition',
+      base: condition,
+      convert: convertCondition as any,
+      mutations: [
+        ['code', { code: { coding: [{ system: 'http://snomed.info/sct', code: '195967001' }], text: 'Asthma' } }],
+        ['category', { category: [{ coding: [{ code: 'encounter-diagnosis' }] }] }],
+        ['clinicalStatus', { clinicalStatus: { coding: [{ code: 'resolved' }] } }],
+        ['onsetDateTime', { onsetDateTime: '2022-09-09' }],
+        ['onsetPeriod', { onsetDateTime: undefined, onsetPeriod: { start: '2019-01-01' } }],
+        ['abatementDateTime', { abatementDateTime: '2024-01-01' }],
+        ['note', { note: [{ text: 'Ruled out' }] }],
+        ['encounter', { encounter: { reference: 'Encounter/visit-june' } }],
+        ['id', { id: 'cond-1' }],
+      ],
+    },
+    {
+      name: 'AllergyIntolerance',
+      base: allergy,
+      convert: convertAllergyIntolerance as any,
+      mutations: [
+        ['code', { code: { coding: [{ system: 'http://snomed.info/sct', code: '387406002' }], text: 'Sulfonamide' } }],
+        ['category', { category: ['food'] }],
+        ['criticality', { criticality: 'low' }],
+        ['reaction', { reaction: [{ manifestation: [{ text: 'Anaphylaxis' }], severity: 'severe' }] }],
+        ['onsetDateTime', { onsetDateTime: '2019-01-01' }],
+        ['note', { note: [{ text: 'Reported by patient' }] }],
+        ['id', { id: 'alg-1' }],
+      ],
+    },
+    {
+      name: 'Immunization',
+      base: immunization,
+      convert: convertImmunization as any,
+      mutations: [
+        ['vaccineCode', { vaccineCode: { coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '208' }], text: 'COVID-19' } }],
+        ['occurrenceDateTime', { occurrenceDateTime: '2024-10-15' }],
+        ['status', { status: 'not-done' }],
+        ['manufacturer', { manufacturer: { display: 'Seqirus' } }],
+        ['lotNumber', { lotNumber: 'BBKP22L' }],
+        ['doseQuantity', { doseQuantity: { value: 0.5, unit: 'mL' } }],
+        ['route', { route: { text: 'Intramuscular' } }],
+        ['site', { site: { text: 'Right deltoid' } }],
+        ['performer', { performer: [{ actor: { display: 'Community Pharmacy' } }] }],
+        ['location', { location: { display: 'Riverside Clinic' } }],
+        ['note', { note: [{ text: 'Given at a drive-through clinic' }] }],
+        ['encounter', { encounter: { reference: 'Encounter/visit-october' } }],
+        ['id', { id: 'imm-1' }],
+      ],
+    },
+    {
+      name: 'Patient',
+      base: patient,
+      convert: convertPatient as any,
+      mutations: [
+        ['birthDate', { birthDate: '1972-11-08' }],
+        ['gender', { gender: 'male' }],
+        ['address', { address: [{ city: 'Portland', state: 'OR', postalCode: '97201', line: ['1 Main St'] }] }],
+        // Needs a display or text: the converter reads marital status through
+        // `codeableConceptText`, which returns nothing for a bare code, so a
+        // code-only mutation would change no statement and the guard below
+        // would (correctly) call this case vacuous.
+        ['maritalStatus', { maritalStatus: { coding: [{ code: 'M', display: 'Married' }], text: 'Married' } }],
+        ['id', { id: 'pat-1' }],
+      ],
+    },
+  ];
+
+  for (const { name, base, convert, mutations } of AUDIT) {
+    it(`${name}: every field it serializes is inside its identity`, () => {
+      const baseline = convert(clone(base()));
+      const baseStatements = statementsOf(baseline);
+      const baseUri = subjectOf(baseline);
+
+      const merged: string[] = [];
+      let compared = 0;
+      for (const [field, override] of mutations) {
+        const mutated = convert(clone(base(override)));
+        // Only meaningful where the mutation actually changed the record.
+        if (statementsOf(mutated).join('\n') === baseStatements.join('\n')) continue;
+        compared++;
+        if (subjectOf(mutated) === baseUri) merged.push(field);
+      }
+
+      // Guard the guard: a mutation list that stopped changing anything would
+      // make this test vacuous while staying green.
+      expect(compared, `${name}: no mutation changed the record — this test proves nothing`)
+        .toBe(mutations.length);
+      expect(
+        merged,
+        `${name}: these fields change what the pod stores but not the record's identity, so two ` +
+          `records differing only in them collide: ${merged.join(', ')}`,
+      ).toEqual([]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. STABILITY PINS — what must NOT change
+// ---------------------------------------------------------------------------
+
+/**
+ * These pass against `origin/main` too, and are not evidence for this change.
+ * They guard the mirror-image failure: a fix that split records on every sync
+ * would be worse than the merge it replaced, because the pod would grow
+ * forever and never say so.
+ */
+describe('STABILITY PIN: a true re-import still deduplicates', () => {
+  for (const { name, base, uri } of TYPES) {
+    it(`${name}: byte-identical input twice is one record, with an id`, () => {
+      const r = base({ id: 'server-id-A' });
+      expect(uri(r)).toBe(uri(clone(r)));
+    });
+
+    it(`${name}: byte-identical input twice is one record, with no id`, () => {
+      const r = base();
+      expect(uri(r)).toBe(uri(clone(r)));
+    });
+
+    it(`${name}: server metadata churn between two fetches does not move the identity`, () => {
+      // `meta.versionId`, `meta.lastUpdated` and `meta.source` change on every
+      // re-fetch of an UNCHANGED resource. Hashing them would mint a fresh IRI
+      // on every EHR sync — this defect's mirror image, and much harder to see.
+      const first = base({ id: 'server-id-A' });
+      const refetched = base({
+        id: 'server-id-A',
+        meta: { versionId: '17', lastUpdated: '2026-08-03T19:22:41.881+00:00', source: 'urn:oid:1.2.3#z' },
+      });
+      expect(uri(first)).toBe(uri(refetched));
+    });
+
+    it(`${name}: an id-less record re-fetched with churned metadata keeps its identity`, () => {
+      const first = base();
+      const refetched = base({
+        meta: { versionId: '17', lastUpdated: '2026-08-03T19:22:41.881+00:00', source: 'urn:oid:1.2.3#z' },
+      });
+      expect(uri(first)).toBe(uri(refetched));
+    });
+  }
+
+  it('Patient: a telephone number is not identity', () => {
+    // `telecom` is NOT serialized by this converter, so two Patients differing
+    // only there are the same record and must not split. This is the boundary
+    // of the completeness rule the keys are built to, asserted rather than
+    // asserted-about.
+    expect(patUri(patient())).toBe(patUri(patient({ telecom: [{ system: 'phone', value: '555-0100' }] })));
+  });
+});
+
+describe('STABILITY PIN: the identity door still collapses an empty record loudly', () => {
+  for (const { name, convert } of TYPES) {
+    it(`${name}: a resource with no id and no content warns rather than passing silently`, () => {
+      const type = name === 'Patient' ? 'Patient' : name;
+      const bare = convert({ resourceType: type } as any) as unknown as { warnings: string[] };
+      expect(
+        bare.warnings.some((w) => w.includes('carries no identifier and no identity-bearing content')),
+        `${name} collapsed to the shared sentinel without saying so`,
+      ).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Across processes and across working directories
+// ---------------------------------------------------------------------------
+
+/**
+ * Minting twice inside one process shares a warm module cache, one
+ * `process.cwd()`, and any memoization a converter holds, so a defect keyed on
+ * any of those is invisible to it — and this repo has actually shipped a
+ * path-dependent identity defect that stayed green for months for exactly that
+ * reason.
+ *
+ * So this spawns SEPARATE node processes from DIFFERENT working directories and
+ * compares across them, through `dist/` — the artifact an npm consumer installs.
+ *
+ * The skip guard keys on a module present in EVERY revision of this repo, not
+ * on anything this change introduces. A guard that keys on a new file SKIPS
+ * instead of FAILING when run against a pre-fix build, which is how a
+ * determinism suite looks green while proving nothing.
+ */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'fhir-converter', 'converters-demographics.js'));
+
+const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+const dist = process.env.CASCADE_DIST;
+const clinical = await import(pathToFileURL(path.join(dist, 'lib/fhir-converter/converters-clinical.js')).href);
+const demographics = await import(pathToFileURL(path.join(dist, 'lib/fhir-converter/converters-demographics.js')).href);
+const byType = {
+  Condition: clinical.convertCondition,
+  AllergyIntolerance: clinical.convertAllergyIntolerance,
+  Immunization: demographics.convertImmunization,
+  Patient: demographics.convertPatient,
+};
+const payload = JSON.parse(process.env.CASCADE_PAYLOAD);
+const out = {
+  cwd: process.cwd(),
+  uris: payload.map((r) => byType[r.resourceType](r)._quads[0].subject.value),
+};
+process.stdout.write(JSON.stringify(out));
+`;
+
+function mintIn(dir: string, resources: any[]): { cwd: string; uris: string[] } {
+  const scriptPath = path.join(dir, 'mint.mjs');
+  fs.writeFileSync(scriptPath, SCRIPT, 'utf8');
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    env: { ...process.env, CASCADE_DIST: DIST, CASCADE_PAYLOAD: JSON.stringify(resources) },
+    encoding: 'utf8',
+  });
+  return JSON.parse(stdout);
+}
+
+describe.skipIf(!HAVE_DIST)('clinical identity survives the process and the working directory', () => {
+  it('two processes in two directories agree, and still tell every record apart', () => {
+    // Eight resources: an id-bearing and an id-less pair of each type, where
+    // the members of each pair are meant to be DIFFERENT records.
+    const resources = [
+      condition({ id: 'cond-A' }),
+      condition({ id: 'cond-B' }),
+      condition({ clinicalStatus: { coding: [{ code: 'active' }] } }),
+      condition({ clinicalStatus: { coding: [{ code: 'resolved' }] } }),
+      allergy({ id: 'alg-A' }),
+      allergy({ reaction: [{ manifestation: [{ text: 'Anaphylaxis' }], severity: 'severe' }] }),
+      immunization({ id: 'imm-A' }),
+      immunization({ lotNumber: 'BBKP22L' }),
+      patient({ id: 'pat-A' }),
+      patient({ identifier: [{ system: 'urn:oid:1.2.3', value: 'MRN-100200' }] }),
+    ];
+
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-clin-a-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-clin-b-'));
+    try {
+      const a = mintIn(dirA, clone(resources));
+      const b = mintIn(dirB, clone(resources));
+
+      expect(a.cwd).not.toBe(b.cwd);
+      // DETERMINISM: two processes, two directories, one answer.
+      expect(a.uris, `cwd ${a.cwd} disagreed with cwd ${b.cwd}`).toEqual(b.uris);
+      // DISTINCTNESS: and the answer is not a constant. Without this half, a
+      // function returning one string would pass the line above perfectly.
+      expect(new Set(a.uris).size, `records shared an IRI: ${a.uris.join(' ')}`).toBe(resources.length);
+      for (const uri of a.uris) expect(uri).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+    } finally {
+      fs.rmSync(dirA, { recursive: true, force: true });
+      fs.rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/pod-import-clinical-identity.test.ts
+++ b/tests/pod-import-clinical-identity.test.ts
@@ -1,0 +1,305 @@
+/**
+ * What honouring `resource.id` for Conditions, allergies, immunizations and
+ * patients does to a real pod.
+ *
+ * The converter-level cases live in `clinical-identity.test.ts`. This file
+ * answers the two questions a unit test cannot:
+ *
+ *   1. Does the fix actually stop the merge on the import path a user runs?
+ *   2. Does it stop MERGING WHAT SHOULD MERGE? A change that split every
+ *      re-import would be worse than the defect it replaced, because the pod
+ *      would grow forever and never say so.
+ *
+ * THE MEASUREMENT THAT MOTIVATED THIS FILE
+ * ----------------------------------------
+ * Importing one person's records from two EHRs into one pod, against
+ * `origin/main`, raises an UNRESOLVED IDENTITY-COLLISION CONFLICT on
+ * `cascade:PatientProfile` and exits `pod conflicts` with 1. The two Patient
+ * resources carry different server ids and different `Patient/…` references,
+ * and the old key looked at neither — only at {birthDate, gender, family name,
+ * first given name} — so two records the sources had deliberately identified
+ * separately landed on one IRI, and the reconciler's collision split (which is
+ * working exactly as designed) had to raise the question.
+ *
+ * That is the defect making work for a person: a conflict manufactured by the
+ * identity layer, about two records that were never ambiguous. After the fix
+ * the conflict does not arise, and the merge — which is genuinely wanted here,
+ * since it IS one person — happens in the reconciler, where it is counted,
+ * attributed to its sources, and reversible.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolve } from 'node:path';
+
+const CLI_PATH = resolve(__dirname, '../dist/index.js');
+const HAVE_DIST = fs.existsSync(CLI_PATH);
+
+function cli(args: string[]): string {
+  return execFileSync('node', [CLI_PATH, ...args], { encoding: 'utf-8', timeout: 120000 });
+}
+
+/** Run a verb that is allowed to exit non-zero, and report the exit status. */
+function cliStatus(args: string[]): { status: number; stdout: string } {
+  try {
+    return { status: 0, stdout: cli(args) };
+  } catch (e: any) {
+    return { status: e.status ?? -1, stdout: String(e.stdout ?? '') };
+  }
+}
+
+function workspace(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function newPod(dir: string, name: string): string {
+  const podDir = path.join(dir, name);
+  cli(['pod', 'init', podDir]);
+  return podDir;
+}
+
+/** `{bucket: count}` for every data type the pod holds. */
+function counts(podDir: string): Record<string, number> {
+  const parsed = JSON.parse(cli(['pod', 'query', podDir, '--all', '--json'])) as {
+    dataTypes: Record<string, { count: number }>;
+  };
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(parsed.dataTypes)) out[k] = v.count;
+  return out;
+}
+
+/**
+ * One person's records as ONE EHR exports them. `tag` distinguishes the
+ * server-assigned identifiers and the patient reference, exactly as two
+ * different systems would.
+ */
+function bundleFor(tag: string): string {
+  const patientId = `${tag}-pat-1`;
+  return JSON.stringify({
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: patientId,
+          name: [{ family: 'Rivera', given: ['Alex'] }],
+          gender: 'female',
+          birthDate: '1985-03-15',
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Condition',
+          id: `${tag}-cond-1`,
+          subject: { reference: `Patient/${patientId}` },
+          code: {
+            coding: [{ system: 'http://snomed.info/sct', code: '38341003', display: 'Essential hypertension' }],
+            text: 'Essential hypertension',
+          },
+          onsetDateTime: '2021-04-02',
+        },
+      },
+      {
+        resource: {
+          resourceType: 'AllergyIntolerance',
+          id: `${tag}-alg-1`,
+          patient: { reference: `Patient/${patientId}` },
+          code: {
+            coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '7980', display: 'Penicillin G' }],
+            text: 'Penicillin G',
+          },
+          criticality: 'high',
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Immunization',
+          id: `${tag}-imm-1`,
+          status: 'completed',
+          patient: { reference: `Patient/${patientId}` },
+          vaccineCode: {
+            coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '141', display: 'Influenza, seasonal' }],
+            text: 'Influenza, seasonal',
+          },
+          occurrenceDateTime: '2025-10-15',
+        },
+      },
+    ],
+  }, null, 2);
+}
+
+/**
+ * Two documents from ONE system: one patient, and the same clinical facts
+ * carrying DIFFERENT record identifiers — plus a real disagreement, because the
+ * second document says the hypertension was later refuted.
+ */
+function documentFrom(docTag: string, clinicalStatus: string, verificationStatus: string): string {
+  return JSON.stringify({
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [{
+      resource: {
+        resourceType: 'Condition',
+        id: `${docTag}-cond`,
+        subject: { reference: 'Patient/one-person' },
+        code: {
+          coding: [{ system: 'http://snomed.info/sct', code: '38341003', display: 'Essential hypertension' }],
+          text: 'Essential hypertension',
+        },
+        onsetDateTime: '2021-04-02',
+        clinicalStatus: { coding: [{ code: clinicalStatus }] },
+        verificationStatus: { coding: [{ code: verificationStatus }] },
+      },
+    }],
+  }, null, 2);
+}
+
+describe.skipIf(!HAVE_DIST)('pod import: clinical record identity', () => {
+  it('one person from two EHRs no longer manufactures an identity-collision conflict', () => {
+    // Against origin/main this pod ends with 1 unresolved conflict and
+    // `pod conflicts` exits 1: the two Patient resources, distinctly identified
+    // by their own servers, were minted onto ONE IRI and the collision split had
+    // to ask a person about it.
+    const ws = workspace('cascade-clin-e2e-a-');
+    try {
+      const a = path.join(ws, 'epic.json');
+      const b = path.join(ws, 'cerner.json');
+      fs.writeFileSync(a, bundleFor('epic'), 'utf8');
+      fs.writeFileSync(b, bundleFor('cerner'), 'utf8');
+
+      const pod = newPod(ws, 'pod');
+      cli(['pod', 'import', pod, a]);
+      cli(['pod', 'import', pod, b]);
+
+      const conflicts = cliStatus(['pod', 'conflicts', pod]);
+      expect(
+        conflicts.status,
+        `pod conflicts raised a question the identity layer invented:\n${conflicts.stdout}`,
+      ).toBe(0);
+      expect(conflicts.stdout).not.toMatch(/identity-collision/);
+
+      // And the pod holds ONE of each: the merge still happens, in the
+      // reconciler, which matches the two profiles on date of birth plus sex.
+      // Against origin/main this line reads `'patient-profile': 2` — the
+      // collision split left two — while the three clinical types merged, so
+      // the profile is the record this assertion is really about.
+      expect(counts(pod)).toMatchObject({
+        'patient-profile': 1, conditions: 1, allergies: 1, immunizations: 1,
+      });
+    } finally {
+      fs.rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('explicitly labelled sources reconcile to one record each, patient profile included', () => {
+    // The same claim with `--source-system` given by hand rather than derived
+    // from the file name, so the test does not rest on that derivation.
+    const ws = workspace('cascade-clin-e2e-b-');
+    try {
+      const a = path.join(ws, 'epic.json');
+      const b = path.join(ws, 'cerner.json');
+      fs.writeFileSync(a, bundleFor('epic'), 'utf8');
+      fs.writeFileSync(b, bundleFor('cerner'), 'utf8');
+
+      const pod = newPod(ws, 'pod');
+      cli(['pod', 'import', pod, a, '--source-system', 'epic']);
+      cli(['pod', 'import', pod, b, '--source-system', 'cerner']);
+
+      expect(counts(pod)).toMatchObject({
+        'patient-profile': 1, conditions: 1, allergies: 1, immunizations: 1,
+      });
+      expect(cliStatus(['pod', 'conflicts', pod]).status).toBe(0);
+    } finally {
+      fs.rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('two documents that disagree raise a question about the RECORDS, not about a hash', () => {
+    // The scenario the original "these are the same clinical fact" reasoning
+    // was wrong about. Patient, code and onset agree; one document says the
+    // problem is ACTIVE and CONFIRMED and the other says RESOLVED and REFUTED,
+    // and each carries its own record id.
+    //
+    // Against origin/main this pod ends with a conflict whose id begins
+    // `identity-collision:` — the two records were minted onto one IRI and the
+    // question put to the user is about the IRI. The clinical disagreement was
+    // never classified, because the pair never reached the matcher.
+    //
+    // With the ids honoured, the pair reaches the matcher, is merged there on
+    // the SNOMED code, and the conflict raised is the CLINICAL one: same
+    // problem, two irreconcilable statuses. Same number of questions, but this
+    // one is answerable from the medicine rather than from the hash.
+    const ws = workspace('cascade-clin-e2e-c-');
+    try {
+      const first = path.join(ws, 'doc-1.json');
+      const second = path.join(ws, 'doc-2.json');
+      fs.writeFileSync(first, documentFrom('doc1', 'active', 'confirmed'), 'utf8');
+      fs.writeFileSync(second, documentFrom('doc2', 'resolved', 'refuted'), 'utf8');
+
+      const pod = newPod(ws, 'pod');
+      cli(['pod', 'import', pod, first]);
+      cli(['pod', 'import', pod, second]);
+
+      const conflicts = cliStatus(['pod', 'conflicts', pod]);
+      expect(conflicts.status, 'the disagreement must still be raised').toBe(1);
+      expect(
+        conflicts.stdout,
+        `the conflict is still about the identity layer rather than the records:\n${conflicts.stdout}`,
+      ).not.toMatch(/identity-collision/);
+      expect(conflicts.stdout).toMatch(/snomed:38341003/);
+    } finally {
+      fs.rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('STABILITY PIN: a true re-import is still one record, not two', () => {
+    // Passes against origin/main too, and is the row that separates a fix from
+    // a blunt split. Byte-identical input twice must leave the pod exactly as
+    // it was.
+    const ws = workspace('cascade-clin-e2e-d-');
+    try {
+      const file = path.join(ws, 'epic.json');
+      fs.writeFileSync(file, bundleFor('epic'), 'utf8');
+
+      const pod = newPod(ws, 'pod');
+      cli(['pod', 'import', pod, file]);
+      const afterFirst = counts(pod);
+      cli(['pod', 'import', pod, file]);
+      const afterSecond = counts(pod);
+
+      expect(afterFirst).toMatchObject({
+        'patient-profile': 1, conditions: 1, allergies: 1, immunizations: 1,
+      });
+      expect(afterSecond, 'a re-import duplicated records').toEqual(afterFirst);
+      expect(cliStatus(['pod', 'conflicts', pod]).status).toBe(0);
+    } finally {
+      fs.rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('STABILITY PIN: a third import of the same file still adds nothing', () => {
+    // Guards the mirror-image failure specifically: an identity that moved on
+    // each sync would show up as unbounded growth, and one extra import is
+    // enough to see it.
+    const ws = workspace('cascade-clin-e2e-e-');
+    try {
+      const file = path.join(ws, 'epic.json');
+      fs.writeFileSync(file, bundleFor('epic'), 'utf8');
+
+      const pod = newPod(ws, 'pod');
+      cli(['pod', 'import', pod, file]);
+      cli(['pod', 'import', pod, file]);
+      const before = counts(pod);
+      cli(['pod', 'import', pod, file]);
+      expect(counts(pod)).toEqual(before);
+    } finally {
+      fs.rmSync(ws, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Four FHIR converters — `convertCondition`, `convertAllergyIntolerance`, `convertImmunization` and `convertPatient` — minted their subject as `contentHashedUri(type, {…narrow key…}, resource.id)`. That reads as "identify by content, fall back to the id", but `contentHashedUri` consults `fallbackId` only when **every** content field is empty, which never happens on a real record. So the id was not a fallback, it was dead, and a distinct, stable, server-assigned identifier was discarded on every record that carried one.

Measured against `origin/main`, same content under two different ids:

```
convertCondition          'server-id-A' vs 'server-id-B' -> ONE IRI
convertAllergyIntolerance 'server-id-A' vs 'server-id-B' -> ONE IRI
convertImmunization       'server-id-A' vs 'server-id-B' -> ONE IRI
convertPatient            'server-id-A' vs 'server-id-B' -> ONE IRI
```

It is the same mechanism already fixed for lab results, in four more types, and it ships under the same version tag so record identity moves once rather than twice.

## Why "the merged pairs are the same clinical fact, so no data is lost" is half wrong

The IDENTITY fields did agree. The NON-identity fields did not have to:

- Two Conditions sharing patient, code and onset can disagree on `clinicalStatus` and `verificationStatus`. An **active, confirmed** problem and a **resolved, refuted** one merged, with the winner decided by file read order.
- An allergy's key held nothing about the REACTION, so a **mild rash** and an **anaphylaxis** to one allergen were one record. Severity is the part a clinician acts on.
- An immunization's key held nothing about lot, dose, site, route or status, so a **left-arm** and a **right-arm** injection given in one visit were one record, and so were a dose that was **given** and an entry saying one was **not done**.

What kept these from being an emergency is not that they were harmless: it is that a differing-content collision is split and raised as a conflict rather than silently overwritten. Visible, not safe.

## What changed

**A present `id` decides**, exactly as the vital-sign, lab, procedure, encounter and nine other converters already did. The two-tier gate moves into one shared `idOrContentUri`, because one copy per converter is precisely how the rule ended up applied in some and not others — the lab converter was fixed while four siblings kept the dead-`fallbackId` shape. `labSubjectUri` routes through it and its IRIs are unchanged.

**Without an id**, each key is widened until every field the converter SERIALIZES is either in the key or excluded in writing. Codes are read as system+code across every coding rather than `coding[0].code`, which collided outright for two systems reusing a number; a Condition coded in neither SNOMED nor ICD, or carrying only `code.text`, previously contributed nothing at all to its own identity. Timestamps are full precision. Placeholder display names were re-checked and stay out — `'Unknown Condition'`, `'Unknown Allergen'` and `'Unknown Vaccine'` are what a record shows, never what it is.

**`Patient` is the fourth type**, and it was not in the original report. It was found by measuring all 16 converters rather than by reading a list. Its key was `{birthDate, gender, family name, FIRST given name}` — no medical record number, no middle name, no suffix — so two people sharing those four fields became one profile with every record from both hanging off it.

**The merge that was wanted still happens, one layer up.** Two exports of one person from two systems now arrive as two records and the reconciler merges them, on SNOMED code / allergen / vaccine+date / date-of-birth+sex. The difference is that the merge is counted, attributed to its sources, and raised as a conflict when the two disagree. Measured end to end: importing one person's records from two EHRs previously left **two** patient profiles and an unresolved conflict that `cascade pod conflicts` reported as an identity collision — a question invented by the identity layer about two records that were never ambiguous — and exited 1. It now leaves one profile, no conflict, exit 0.

`convertMedicationStatement` deliberately still identifies by content: that key is shared by every importer and every SDK and is pinned by a literal cross-SDK vector, so changing it is a cross-SDK decision, not a per-importer one.

## IRI impact

IRI-breaking for these four types; the CHANGELOG's existing upgrade note is extended to name them rather than a competing one being added. Measured over the 121 FHIR resources in the conformance corpus:

- **18 moved** (7 Patient, 5 Condition, 3 AllergyIntolerance, 3 Immunization); **103 byte-identical**.
- Groups of records sharing an IRI with a record they differ from: **9 covering 21 records → 6 covering 13**. All 6 that remain are the same record appearing in two fixture files, which is correct.
- The worst case was in published HL7 example data: one stock example patient appears in three Genomics IG bundles under three different server ids, one carrying a donor-registry identifier the others do not, and all three collapsed onto a single profile.

Vital signs, medications, procedures, encounters, documents, coverage and claims keep the IRIs they had, and the C-CDA corpus is unchanged.

## Verification

- **42 of the 63** cases in `tests/clinical-identity.test.ts` and **3 of the 5** in `tests/pod-import-clinical-identity.test.ts` FAIL against a clean `origin/main` worktree. The 23 that pass are labelled `STABILITY PIN` in place and each states what it guards.
- **A true re-import still deduplicates**: byte-identical input imported twice is one record, and a third import adds nothing. Those rows are what separate a fix from a blunt split.
- **Determinism is asserted together with distinctness**, from two separate processes in two different working directories, through `dist/`. A constant satisfies determinism perfectly and carries no identity.
- The mechanical audit — "two records that serialize differently never share an identity" — found `note` missing from three keys and `performer`/`location` missing from a fourth in the first draft of this change, and carries its own guard against becoming vacuous.
- Suite **1426 → 1494 passed, 0 failed, 0 skipped, 107 → 109 files**.

## Merge order

A companion `conformance` PR adds five `*-id-bearing-differs-from-id-less` expectations and corrects the inventory prose that recorded the old reasoning. **Merge this PR first**; three of those five expectations fail against `origin/main` and pass here.

## Scope: the C-CDA importer is deliberately NOT in this PR

The C-CDA importer carries the same shape for the same three clinical types, and it is worth stating rather than leaving to be found. Measured, two records identical except for their `<id>` extension:

```
extractProblemQuads       (Condition)     ID-A vs ID-B -> MERGED (source id ignored)
extractAllergyQuads       (Allergy)       ID-A vs ID-B -> MERGED
extractImmunizationQuads  (Immunization)  ID-A vs ID-B -> MERGED
```

On that path the id is not merely usually dead but *unconditionally* dead: every C-CDA section keys on `patient: patientUri`, always a non-empty `urn:uuid:`, so the content tier can never be empty and `fallbackId` is never reached.

It is left out because the C-CDA patient is a different size of decision. `extractPatientQuads` does not even pass the source `<id>`, and its `patientUri` is spliced into every other C-CDA section's key — so changing patient identity there moves **every** C-CDA record's IRI, not just the patient's. That cascade deserves its own analysis rather than arriving as a side effect of a FHIR fix. Whether it should ride this same version tag is a release decision; the measurement above is what it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
