### PR TITLE
fix(identity): a C-CDA record's own <id> must decide, at all ten sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 > **Version number not yet chosen.** This section contains IRI-breaking changes for lab
-> results, conditions, allergies, immunizations and patient profiles (see the first upgrade
-> note), so it is not a patch release. Decide between a minor and a major bump before cutting
-> it.
+> results, conditions, allergies, immunizations and patient profiles from FHIR sources, and for
+> EVERY record type read from a C-CDA document (see the upgrade notes), so it is not a patch
+> release. Decide between a minor and a major bump before cutting it.
 
 **This release is about record identity — the IRI each record gets, which decides whether a
 re-import updates a record or duplicates it, and whether two records stay two records.** Two
@@ -22,12 +22,14 @@ which:
 1. **Records the source never identified used to get a RANDOM IRI**, so re-importing the same
    document duplicated them, forever. They now get an IRI derived from their own content, so
    they reconcile. **No IRI that a source identifier already determined moves because of this.**
-2. **Five kinds of record were identified too coarsely, and ignored the identifier their own
+2. **Many kinds of record were identified too coarsely, and ignored the identifier their own
    source assigned them** — lab results by patient, test code and calendar day; conditions,
-   allergies, immunizations and patient profiles by a similarly short list. So two genuinely
-   different records merged into one and one of them was silently lost. Fixing that necessarily
-   moves those IRIs. **These are the release's IRI-breaking changes**, and the upgrade note
-   below says what to do about them.
+   allergies, immunizations and patient profiles by a similarly short list; and on the C-CDA
+   path, EVERY record type, because the identifier was passed in a position the code reads only
+   when nothing else is present, and something else always was. So two genuinely different
+   records merged into one and one of them was silently lost. Fixing that necessarily moves
+   those IRIs. **These are the release's IRI-breaking changes**, and the upgrade notes below
+   say what to do about them.
 
 ### Upgrade notes
 
@@ -71,8 +73,8 @@ which:
   **What this particular change moved.** Across the FHIR conformance corpus, 46 of 91 converted
   resources were unchanged by it and every one of the 45 that moved was a lab observation;
   across the C-CDA corpus, 40 of 43 identities were unchanged and all 3 that moved were lab
-  results. Four more record types move for their own reason, described in the next note; those
-  are the only other IRIs in the release that change.
+  results. Four more FHIR record types move for their own reason, described in the next note,
+  and the whole C-CDA path moves for a third reason described in the note after that.
 
   **Lab PANELS keep their IRIs, with one narrow exception.** A panel read from a C-CDA document
   whose source gave it neither an identifier nor a test code was previously indistinguishable
@@ -138,12 +140,92 @@ which:
   a single profile — a merge across three documents decided by four demographic fields and
   nothing else, which no test noticed.
 
-  **Nothing else moves.** Vital signs, medications, procedures, encounters, documents, coverage
-  and claims all keep the IRIs they had. Verified across the same corpus: every one of the 18
-  resources that moved was one of the four types named here, and across the C-CDA corpus
-  identities are unchanged.
+  **Nothing else moves ON THE FHIR PATH.** Vital signs, medications, procedures, encounters,
+  documents, coverage and claims all keep the IRIs they had when they arrive as FHIR. Verified
+  across the same corpus: every one of the 18 resources that moved was one of the four types
+  named here. The C-CDA path is a separate matter and is covered by the next note.
+
+- **Breaking for EVERY record type read from a C-CDA document.** If you have imported a
+  downloaded portal export — a MyChart or HealtheLife C-CDA, or an IHE XDM zip of them — every
+  record from it changes IRI in this release. Not one type: all of them.
+
+  What was wrong, and why it was all of them at once: every C-CDA section built its record's
+  identity from a list of fields that began with the DOCUMENT'S PATIENT, and passed the source
+  record's own `<id>` in a position the code consults only when every one of those fields is
+  empty. The patient field was never empty. So the identifier your provider's system assigned
+  the record was read on no record at all — not "usually ignored", never read — at all ten
+  places a C-CDA record gets an identity. Measured: two entries identical in every field except
+  their `<id>` produced ONE record, in all ten sections, and one of the two was discarded.
+
+  It also failed in the opposite direction, from the same cause. That patient field was not
+  your patient identifier; it was a value derived from four demographic fields — birth date,
+  sex, surname and FIRST given name. So one document recording "John" and another recording
+  "Johnny", for the same person with the same medical record number, produced two different
+  patient values, and every clinical record in both documents was re-identified along with
+  them. Measured: a byte-identical procedure carrying the SAME source identifier became two
+  records. So the same design both merged records your provider kept apart and split records
+  that were the same.
+
+  And on most real documents there was no identifier left to read anyway. C-CDA's ordinary form
+  for a locally minted identifier is `<id root="9a6d1bac-…"/>` with no `extension` attribute,
+  which is what Epic and Cerner emit, and nine of ten sections extracted an identifier ONLY
+  when `extension` was present. On those records the identifier was discarded outright — which
+  is also why `cascade:sourceRecordId` was missing from them, a loss visible in pod output
+  today and not only in identity.
+
+  What it is now: a C-CDA record takes its identity from the `<id>` its source assigned it, in
+  all four of the forms a real export uses (root plus extension, extension alone, root alone,
+  and several `<id>` elements where the first may be a `nullFlavor` placeholder). Where a
+  record carries no identifier, identity comes from what the record IS — its codes, its full
+  timestamp, its measured value and unit, and the other fields the pod will display. The
+  derived patient value is in no key at all: within a pod it either never varies, and so told no
+  two records apart, or varied, and every variation was one of the splits above.
+
+  **The patient profile from a C-CDA now uses the medical record number.** It is in
+  `patientRole/id` in every real export and was not consulted at all, so two different people
+  sharing a birth date, a sex, a surname and a first given name were one profile. Where a
+  document carries no MRN, the profile is identified by the whole name (every given name, not
+  the first), the whole address and the contact details — all of which the pod displays and none
+  of which were in the old key.
+
+  **What to do.** The same as for the FHIR changes above: re-import your C-CDA documents into a
+  fresh pod and use that, or accept that records imported before and after this release sit
+  side by side. Re-importing the same document twice still produces one record set, before and
+  after — that behaviour is unchanged and is held by a test.
+
+  **The scale, measured.** Across the nine C-CDA documents in the conformance corpus and this
+  repo's own fixtures, which convert to 56 records: **28 move and 28 do not.** The 28 that keep
+  their IRIs are the 19 section-narrative document nodes and the 9 lab results that already
+  carried an identifier — a lab result identified by its `<id>` mints exactly the IRI it did
+  before, deliberately. Everything else moves: 9 patient profiles, 5 allergies, 5 lab panels,
+  3 conditions, 3 immunizations, 2 medications and 1 encounter. Counted as distinct IRIs rather
+  than per document, 17 of 44 move. **The FHIR import path is untouched by this change**: 266
+  distinct IRIs across the same fixtures, 0 moved.
 
 ### Fixed
+
+- **Allergies written in C-CDA's standard nesting were dropped entirely.** An allergy in a
+  C-CDA document is normally recorded as a concern act wrapping the allergy observation
+  (`act` → `entryRelationship` → `observation`), which is what Epic and Cerner emit. The
+  importer only walked the looser `act` → `observation` shape, so on a standard document it
+  produced NO allergy records at all — not a wrong allergy, none. Both shapes are read now.
+
+- **Family history was dropped entirely, for the same class of reason.** The section handler
+  read an organizer's component observations as a single object where the parser always
+  produces a list, so every field came back empty and no family history record was ever
+  emitted from a real document.
+
+- **A root-only `<id>` is no longer discarded, so `cascade:sourceRecordId` survives.** Nine of
+  ten C-CDA sections read a record's identifier only when it carried an `extension` attribute,
+  so `<id root="9a6d1bac-…"/>` — the ordinary form for a locally minted identifier — was thrown
+  away and the record was stored with no `cascade:sourceRecordId` at all. This is the same fix
+  as the identity change above and is listed separately because the loss was visible in pod
+  output independently of identity.
+
+- **Two C-CDA identity keys were missing the record's own source object.** The vital-sign
+  observation re-routed to a lab result, and every medication, passed no source object to the
+  last identity tier, so a record with nothing else to go on landed on a shared per-type
+  sentinel instead of a hash of itself.
 
 - **A missing drug name no longer merges unrelated medication records.** When a
   `MedicationStatement` or `MedicationRequest` named no drug, the importer substituted the

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -41,15 +41,22 @@ import { extractNarrativeQuads } from './narrative.js';
 import { deriveSourceEhr, ensureProvenanceQuads, ensureSourceEhrQuads } from './provenance.js';
 import { identityKey } from '../identity.js';
 
-// Map templateId → extractor function and LOINC code
+// Map templateId → extractor function and LOINC code.
+//
+// NOTE THE ABSENT PARAMETER. Every handler used to take the document's derived
+// `patientUri` and splice it into each record's identity key. It is gone from
+// this signature deliberately, and not merely unused: while it was a parameter,
+// the next key written here would have reached for it. See
+// `record-identity.ts` for why a per-document patient component both merged
+// records the source kept apart and split records that were the same.
 const SECTION_HANDLERS: Record<string, {
   loinc: string;
   extract: (
     entries: any[],
-    patientUri: string,
     sourceSystem: string,
     sectionText?: any,
     importedAt?: string,
+    warnings?: string[],
   ) => any[];
 }> = {
   [IMMUNIZATIONS_TEMPLATE_ID]:  { loinc: '11369-6', extract: extractImmunizationQuads },
@@ -247,7 +254,9 @@ function convertSingleCcda(
     return { quads: allQuads, count };
   }
 
-  const { quads: patientQuads, patientUri } = extractPatientQuads(
+  // The patient profile is a record like any other. Its IRI is NOT threaded into
+  // the section handlers below — see the note on SECTION_HANDLERS.
+  const { quads: patientQuads } = extractPatientQuads(
     Array.isArray(recordTarget) ? recordTarget : [recordTarget],
     sourceSystem,
     warnings,
@@ -299,7 +308,7 @@ function convertSingleCcda(
         sectionCode || (matchedTemplateId ? (SECTION_HANDLERS[matchedTemplateId]?.loinc ?? '') : '');
       const narrativeQuads = extractNarrativeQuads(
         sectionText, effectiveLoinc, documentType, documentId, sourceSystem, importedAt,
-        requiresLLMExtraction, sourceEhr,
+        requiresLLMExtraction, sourceEhr, warnings,
       );
       allQuads.push(...narrativeQuads);
     }
@@ -307,7 +316,7 @@ function convertSingleCcda(
     // Extract structured entries
     if (matchedTemplateId && SECTION_HANDLERS[matchedTemplateId]) {
       const handler = SECTION_HANDLERS[matchedTemplateId];
-      const quads = handler.extract(entries, patientUri, sourceSystem, sectionText, importedAt);
+      const quads = handler.extract(entries, sourceSystem, sectionText, importedAt, warnings);
 
       // Tag each structured record from a summarization document so the
       // reconciler can apply a lower confidence threshold for deduplication.

--- a/src/lib/ccda-converter/narrative.ts
+++ b/src/lib/ccda-converter/narrative.ts
@@ -5,7 +5,8 @@
  * cascade:requiresLLMExtraction (true when section has no <entry> children).
  */
 
-import { NS, contentHashedUri } from '../fhir-converter/types.js';
+import { NS } from '../fhir-converter/types.js';
+import { ccdaRecordUri } from './record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 import { extractNarrativeText } from './narrative-extractor.js';
@@ -23,6 +24,7 @@ export function extractNarrativeQuads(
   importedAt: string,
   requiresLLMExtraction: boolean = false,
   sourceEhr: string = '',
+  warnings?: string[],
 ): Quad[] {
   if (!sectionText && !requiresLLMExtraction) return [];
 
@@ -32,13 +34,23 @@ export function extractNarrativeQuads(
   // If no text and not a narrative-only section, skip
   if (!narrativeStr.trim() && !requiresLLMExtraction) return [];
 
-  const uri = contentHashedUri('ClinicalDocument', {
-    section: sectionLoincCode,
-    document: documentId,
-    source: sourceSystem,
+  // A section narrative node has no `<id>` of its own — the id in play is the
+  // enclosing DOCUMENT's, which is already a content field — so this takes the
+  // door with no source id rather than being the one mint that sits outside it.
+  // The IRI is byte-identical to what this call produced before.
+  const uri = ccdaRecordUri({
+    type: 'ClinicalDocument',
+    content: {
+      section: sectionLoincCode,
+      document: documentId,
+      source: sourceSystem,
+    },
     // The narrative itself is the salvage-tier content for a section document
     // that somehow carries no section code, document id or source system.
-  }, undefined, sectionText);
+    source: sectionText,
+    warnings,
+    label: 'C-CDA section narrative',
+  });
 
   const subj = namedNode(uri);
   const quads: Quad[] = [

--- a/src/lib/ccda-converter/record-identity.ts
+++ b/src/lib/ccda-converter/record-identity.ts
@@ -1,0 +1,248 @@
+/**
+ * C-CDA record identity: ONE door, and ONE `<id>` reader.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Every C-CDA section handler minted its subject IRI with the same call shape:
+ *
+ *     contentHashedUri('X', { patient: patientUri, … }, sourceId || undefined, entry)
+ *
+ * That reads as "identify by content, and fall back to the source's id", but
+ * `contentHashedUri` consults `fallbackId` ONLY when every content field is
+ * empty — and `patient` is always a non-empty `urn:uuid:`. So on this path the
+ * id tier was not merely usually dead, it was UNCONDITIONALLY dead. Measured on
+ * `main`, two entries identical in every content field and differing only in
+ * their `<id extension>`: all ten C-CDA identity sites minted ONE IRI, so a
+ * record the source had deliberately kept apart from another was silently
+ * overwritten by it.
+ *
+ * That is the same defect the FHIR path fixed with `idOrContentUri`, and this is
+ * its C-CDA-shaped sibling. It is not a second strategy: both express one rule.
+ *
+ * THE RULE
+ * --------
+ * Identity answers "is this that record?", and the source's own identifier is
+ * the source answering it. Deciding that two records are the same THING is a
+ * different judgement — it needs both records side by side and a trail saying it
+ * happened — so it belongs to the reconciler, which has both, and not to the
+ * identity layer, which sees one record at a time and can only overwrite.
+ *
+ *   1. The source's `<id>` decides. Nothing else is consulted.
+ *   2. No id — the curated content key decides.
+ *   3. No content either — `contentHashedUri` hashes the raw source element,
+ *      and failing that collapses LOUDLY through the shared identity door.
+ *
+ * WHY THE DERIVED `patientUri` IS NOT IN ANY KEY
+ * ---------------------------------------------
+ * It used to be spliced into every section's key, and it was derived from four
+ * mutable demographic fields (`dob`, `sex`, `family`, `given[0]`). That produced
+ * a bidirectional failure from a single cause. It MERGED records the source kept
+ * apart, by making the id tier dead (above). And it SPLIT records that are the
+ * same: measured, one document recording "John" and another "Johnny" for the
+ * same person with the same MRN derive two different `patientUri`s, so a
+ * byte-identical procedure carrying the SAME source id became two records.
+ *
+ * Within a pod that component is either constant — in which case it tells no two
+ * records apart and is dead weight in a key — or varying, in which case every
+ * variation is one of those spurious splits. A Cascade pod holds one person:
+ * `pod init` takes a single `--owner-name`, `pod import` populates the profile
+ * from the FIRST `cascade:PatientProfile` it finds, `PodReader.readPatientProfile`
+ * reads "the pod owner's" fields first-wins, and core v3.3 models a caregiver as
+ * a `cascade:ProxyAgent` acting for the patient precisely BECAUSE the second
+ * person in the room is not a second patient profile.
+ *
+ * It is also never an edge: no C-CDA quad has the patient IRI as its object, so
+ * removing it from the keys severs nothing that `pod query --neighbors` can
+ * traverse.
+ *
+ * And removing it has a second effect worth stating, because the safety net was
+ * switched off by exactly this field: while `patient` was in the key the content
+ * tier could never be empty, so tiers 2–4 of the shared identity door — the
+ * salvage pass and the LOUD COLLAPSE warning — were unreachable on this path.
+ * `src/lib/identity.ts` documented that as a known hole. They are reachable now.
+ */
+
+import {
+  contentHashedUri,
+  deterministicUuid,
+  medicationUri,
+} from '../fhir-converter/types.js';
+
+/**
+ * The single medication identity type, shared by every importer. Medication
+ * identity is minted under `MedicationRequest` whatever the source's own element
+ * was, so a C-CDA `<substanceAdministration>` and a FHIR MedicationRequest for
+ * the same prescription agree.
+ */
+const MEDICATION_IDENTITY_TYPE = 'MedicationRequest';
+
+/**
+ * One HL7 II (`<id root= extension=/>`) reduced to a stable string, or
+ * `undefined` when the element carries no usable identifier.
+ *
+ * WHY THIS IS SHARED RATHER THAN INLINED TEN TIMES
+ * ------------------------------------------------
+ * Eight of the nine section handlers wrote this inline, and all eight wrote it
+ * the same wrong way:
+ *
+ *     idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : ''
+ *
+ * which returns nothing at all for `<id root="9a6d1bac-…"/>` — no `@extension`.
+ * That is the CANONICAL C-CDA form for a locally-minted identifier and it is
+ * everywhere in real Epic and Cerner output. Measured on `main`: nine of ten
+ * sections threw a root-only id away entirely, so `cascade:sourceRecordId` was
+ * never emitted for those records either. The loss was already visible in pod
+ * output, not only in identity.
+ *
+ * `encounters.ts` was the one section that handled it, and this generalizes from
+ * its shape.
+ *
+ * WHAT IT HANDLES
+ * ---------------
+ *  - `root` + `extension`  -> `"root:extension"` (byte-identical to what every
+ *    section produced before, so no id-bearing IRI moves for this reason).
+ *  - `extension` only      -> `":extension"`     (likewise byte-identical).
+ *  - `root` only           -> `"root"`.
+ *  - Attribute spelling (`@_root`) and the bare spelling (`root`) that some
+ *    parser configurations produce. `immunizations.ts` handled both; the others
+ *    handled only the first.
+ *  - MULTIPLE `<id>` elements: the FIRST that carries a usable root or extension,
+ *    in document order. Deterministic, and strictly better than the `id[0]` every
+ *    section used, which returned nothing when the first id was a `nullFlavor`
+ *    placeholder — a common way for a vendor to say "this act has no id of its
+ *    own, but here is the one that follows".
+ *
+ *    Document order rather than a sort, and the FIRST rather than all of them:
+ *    an HL7 II set lists alternative identifiers for one act, so any single one
+ *    identifies it, and combining them would SPLIT a document that carries
+ *    `{A, B}` from one that carries only `{A}`. Order within one document's bytes
+ *    is stable, which is what determinism requires.
+ *
+ * WHY IT ACCEPTS EITHER THE ELEMENT OR ITS `id`
+ * ---------------------------------------------
+ * `ccdaSourceId(organizer)` and `ccdaSourceId(organizer.id)` are both correct.
+ * They are, because writing this the other way cost a real defect during the
+ * change that introduced it: `ccdaSourceId(organizer)` against an id-VALUE-only
+ * signature returned `undefined` with no error, so every lab panel silently fell
+ * to the content tier and two panels with different ids MERGED. A chokepoint
+ * whose two plausible call shapes differ by a silent `undefined` is not a
+ * chokepoint. So this resolves both, and a caller cannot get it wrong.
+ *
+ * ROOT-ONLY IDS ARE TAKEN AT THE SOURCE'S WORD. HL7 v3 II says the root alone
+ * may be the entire instance identifier, so two entries carrying the same
+ * root-only id are the SOURCE asserting they are one act, and honouring that is
+ * deferring to the standard rather than second-guessing it. The cost, if a
+ * vendor misuses a shared assigning-authority OID as a root-only id, is a merge;
+ * it is filed rather than guarded against by heuristic, and the conformance
+ * corpus currently contains zero root-only ids of any kind.
+ */
+export function ccdaSourceId(idOrElement: unknown): string | undefined {
+  const value = isIdElement(idOrElement)
+    ? idOrElement
+    : (idOrElement as Record<string, unknown> | null | undefined)?.['id'];
+
+  const candidates = Array.isArray(value) ? value : value == null ? [] : [value];
+  for (const el of candidates) {
+    if (el == null || typeof el !== 'object') continue;
+    const raw = el as Record<string, unknown>;
+    const root = str(raw['@_root'] ?? raw['root']);
+    const extension = str(raw['@_extension'] ?? raw['extension']);
+    if (extension) return `${root}:${extension}`;
+    if (root) return root;
+    // Neither: a nullFlavor placeholder, or an empty element. Try the next id
+    // rather than reporting the whole act as unidentified.
+  }
+  return undefined;
+}
+
+/** True when this value is itself an HL7 II (or an array of them), not a wrapper. */
+function isIdElement(value: unknown): boolean {
+  if (value == null || typeof value !== 'object') return false;
+  const probe = Array.isArray(value) ? value[0] : value;
+  if (probe == null || typeof probe !== 'object') return Array.isArray(value);
+  const raw = probe as Record<string, unknown>;
+  return (
+    '@_root' in raw || '@_extension' in raw || 'root' in raw || 'extension' in raw ||
+    '@_nullFlavor' in raw || 'nullFlavor' in raw
+  );
+}
+
+/** A trimmed string, or `''` for anything that is not usable identifier text. */
+function str(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  return '';
+}
+
+/**
+ * THE DOOR. Mint the subject IRI for one C-CDA record.
+ *
+ * @param type    the identity key's type prefix. Both tiers feed the same
+ *                template (`{type}:{id}` and `{type}::{fields}`), and an
+ *                anonymous content seed is `anon-` + 64 hex = 69 characters,
+ *                so the two tiers cannot collide.
+ * @param sourceId the value from {@link ccdaSourceId}. Pass it; do not pass a
+ *                hand-rolled one.
+ * @param content the curated key used when the source assigned no id. It must
+ *                contain every field the caller SERIALIZES that could differ
+ *                between two records — a serialized field outside the key is a
+ *                field two records sharing an IRI can disagree on.
+ * @param source  the raw source element. Only reached when `content` is empty
+ *                too, where it gives the salvage tier something real to hash.
+ */
+export function ccdaRecordUri(opts: {
+  type: string;
+  sourceId?: string;
+  content: Record<string, string | undefined>;
+  source?: unknown;
+  /** Collects the tier-4 loud-collapse notice. Pass the converter's array. */
+  warnings?: string[];
+  /** How to name this record in that notice. */
+  label?: string;
+}): string {
+  const { type, sourceId, content, source, warnings, label } = opts;
+
+  // Tier 1 — the source identified this record. Nothing else is consulted, so
+  // two records the source kept apart can never be merged here.
+  //
+  // The key is `{type}:{id}`, id PLUS type: the same template `mintSubjectUri`
+  // applies to `resource.id` on the FHIR path, and byte-identical to the
+  // `contentHashedUri(type, {}, id)` that the C-CDA lab observation path already
+  // ships — so no id-bearing lab IRI moves for this reason.
+  if (typeof sourceId === 'string' && sourceId.trim().length > 0) {
+    return `urn:uuid:${deterministicUuid(`${type}:${sourceId}`)}`;
+  }
+
+  // Tiers 2-4 — the curated key, then the raw element, then a loud collapse.
+  // `undefined` in the fallbackId slot is deliberate and is enforced by
+  // `tests/ccda-identity-chokepoint.test.ts`: passing an id there is the shape
+  // that made the id tier dead in the first place, and it is only ever reached
+  // when there is no id to pass.
+  return contentHashedUri(type, content, undefined, source, warnings, label);
+}
+
+/**
+ * The same door for medications, which mint under the shared medication identity
+ * key (`medicationUri`: RxNorm + normalized drug name + start date) rather than
+ * a per-section one, so a C-CDA medication and a FHIR MedicationRequest for the
+ * same prescription agree.
+ *
+ * Tier 1 is the identical rule and the identical template as
+ * {@link ccdaRecordUri}; only the no-id key differs.
+ */
+export function ccdaMedicationRecordUri(opts: {
+  sourceId?: string;
+  fields: { rxNormCode?: string; medicationName?: string; startDate?: string };
+  source?: unknown;
+  warnings?: string[];
+  label?: string;
+}): string {
+  const { sourceId, fields, source, warnings, label } = opts;
+
+  if (typeof sourceId === 'string' && sourceId.trim().length > 0) {
+    return `urn:uuid:${deterministicUuid(`${MEDICATION_IDENTITY_TYPE}:${sourceId}`)}`;
+  }
+
+  // `undefined` in the fallbackId slot, for the same reason as above.
+  return medicationUri(fields, undefined, source, warnings, label);
+}

--- a/src/lib/ccda-converter/record-identity.ts
+++ b/src/lib/ccda-converter/record-identity.ts
@@ -55,11 +55,30 @@
  * removing it from the keys severs nothing that `pod query --neighbors` can
  * traverse.
  *
- * And removing it has a second effect worth stating, because the safety net was
- * switched off by exactly this field: while `patient` was in the key the content
- * tier could never be empty, so tiers 2–4 of the shared identity door — the
- * salvage pass and the LOUD COLLAPSE warning — were unreachable on this path.
- * `src/lib/identity.ts` documented that as a known hole. They are reachable now.
+ * And removing it has a second effect, which is worth stating PRECISELY because
+ * the obvious version of the claim is wrong. While `patient` was in the key the
+ * curated key could never be empty, so `contentHashedUri` never fell through to
+ * the shared identity door at all: two entries with no usable key fields and
+ * PLAINLY different content — a problem noted "left knee" and one noted "right
+ * shoulder", neither coded — minted one IRI. They mint two now, because identity
+ * falls through to a hash of the entry's own bytes.
+ *
+ * What does NOT follow is that the tier-4 LOUD COLLAPSE warning now fires in
+ * practice. Every section passes its raw source element as `source`, and a
+ * parsed C-CDA element is essentially never empty, so tier 2 of the door
+ * answers. Tier 4 is reachable THROUGH the door — `ccdaRecordUri` with an empty
+ * key and an empty source emits it, and the chokepoint test exercises exactly
+ * that — but from a real document it stays as unreached as
+ * `src/lib/identity.ts` says. Measured, not assumed: a problem entry whose only
+ * `<value>` is `nullFlavor="NI"` emits zero collapse warnings on this build.
+ *
+ * The other half of the same lesson, learned the expensive way while writing
+ * this: the first draft of the problems key included `status`, which the
+ * converter DEFAULTS to the literal 'active'. That made the key a non-empty
+ * CONSTANT, the fall-through above never happened, and the two differently-noted
+ * problems still merged. A placeholder default in an identity key turns "we do
+ * not know" into "these are the same record". Only the STATED status is in the
+ * key now.
  */
 
 import {

--- a/src/lib/ccda-converter/sections/allergies.ts
+++ b/src/lib/ccda-converter/sections/allergies.ts
@@ -2,7 +2,8 @@
  * Extract allergies from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.6.1)
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -13,8 +14,10 @@ export const ALLERGIES_LOINC = '48765-2';
 
 export function extractAllergyQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
 
@@ -22,8 +25,26 @@ export function extractAllergyQuads(
     // entry.act is always an array from fast-xml-parser's isArray config — unwrap first element
     const actRaw = entry?.act;
     const act = Array.isArray(actRaw) ? actRaw[0] : (actRaw ?? entry);
-    const obs = act?.entryRelationship?.observation ?? act?.observation ?? act;
-    const obsArr = Array.isArray(obs) ? obs : [obs];
+    // The allergy observation sits under `act/entryRelationship/observation` in
+    // canonical C-CDA R2.1, and directly under `act/observation` in the looser
+    // shape some exports (and this repo's own corpus fixture) use. BOTH have to
+    // be walked, and `entryRelationship` is always an ARRAY from the parser's
+    // isArray config — so `act?.entryRelationship?.observation` was always
+    // `undefined` and the canonical nesting produced NO allergy record at all.
+    // Measured on the previous build: a canonical allergy entry yielded zero
+    // `health:AllergyRecord`s. `problems.ts` already walked it correctly; this
+    // is the same walk.
+    const entryRelArr = Array.isArray(act?.entryRelationship)
+      ? act.entryRelationship
+      : act?.entryRelationship ? [act.entryRelationship] : [];
+    const nested = entryRelArr.flatMap((er: any) => {
+      const o = er?.observation;
+      return Array.isArray(o) ? o : (o ? [o] : []);
+    });
+    const direct = act?.observation
+      ? (Array.isArray(act.observation) ? act.observation : [act.observation])
+      : [];
+    const obsArr = nested.length > 0 ? nested : (direct.length > 0 ? direct : [act]);
 
     for (const observation of obsArr) {
       // Allergen is typically in participant/playingEntity
@@ -51,15 +72,24 @@ export function extractAllergyQuads(
 
       if (!allergenName) continue;
 
-      const sourceId = (() => {
-        const idEl = Array.isArray(act?.id) ? act.id[0] : act?.id;
-        return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-      })();
+      // The allergy CONCERN act carries the id in most exports; the reaction
+      // observation carries its own where the act does not.
+      const sourceId = ccdaSourceId(act?.id) ?? ccdaSourceId(observation?.id);
 
-      const uri = contentHashedUri('Allergy', {
-        patient: patientUri,
-        allergenName: allergenName.toLowerCase(),
-      }, sourceId || undefined, entry);
+      const uri = ccdaRecordUri({
+        type: 'Allergy',
+        sourceId,
+        content: {
+          allergenName: allergenName.toLowerCase(),
+          // Serialized as health:allergySeverity, so it has to be in the key:
+          // a "mild" and a "severe" reaction to one allergen are two claims,
+          // and merging them lets whichever was read first decide.
+          severity: severityCode ? severityCode.toLowerCase() : undefined,
+        },
+        source: entry,
+        warnings,
+        label: 'C-CDA allergy',
+      });
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'AllergyRecord')));

--- a/src/lib/ccda-converter/sections/devices.ts
+++ b/src/lib/ccda-converter/sections/devices.ts
@@ -3,7 +3,8 @@
  * Minimal implementation — narrative is preserved by the main converter.
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -14,8 +15,10 @@ export const DEVICES_LOINC = '46264-8';
 
 export function extractDeviceQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
 
@@ -39,16 +42,21 @@ export function extractDeviceQuads(
       ? `${dateVal.slice(0, 4)}-${dateVal.slice(4, 6)}-${dateVal.slice(6, 8)}`
       : dateVal;
 
-    const sourceId = (() => {
-      const idEl = Array.isArray(supply?.id) ? supply.id[0] : supply?.id;
-      return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-    })();
+    // The <supply> carries the id in most exports; the device participantRole
+    // carries its own (typically the UDI) where the supply does not.
+    const sourceId = ccdaSourceId(supply?.id) ?? ccdaSourceId(participant?.participantRole?.id);
 
-    const uri = contentHashedUri('Device', {
-      patient: patientUri,
-      displayName: displayName.toLowerCase(),
-      date: dateStr || undefined,
-    }, sourceId || undefined, entry);
+    const uri = ccdaRecordUri({
+      type: 'Device',
+      sourceId,
+      content: {
+        displayName: displayName.toLowerCase(),
+        date: dateStr || undefined,
+      },
+      source: entry,
+      warnings,
+      label: 'C-CDA implanted device',
+    });
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'ImplantedDevice')));

--- a/src/lib/ccda-converter/sections/encounters.ts
+++ b/src/lib/ccda-converter/sections/encounters.ts
@@ -9,7 +9,8 @@
  * dedupe-safe encounter records (root 3.11 encounter completeness).
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -61,14 +62,16 @@ function formatCcdaDate(dateVal: string): string {
 /**
  * Build one clinical:Encounter record from a C-CDA <encounter> element, or null
  * when the element carries no usable identity (no id, type, or date — a bare
- * reference rather than a real definition). The subject is content-hashed on
- * stable identity (patient + type + date + id) so the same encounter, appearing
- * across many lab organizers or documents, dedupes to one record.
+ * reference rather than a real definition).
+ *
+ * Identity is the shared C-CDA rule: the encounter's own `<id>` decides, and
+ * without one the key is type + date. The same encounter appearing across many
+ * lab organizers or documents therefore dedupes to one record.
  */
 export function buildEncounterRecord(
   enc: any,
-  patientUri: string,
   sourceSystem: string,
+  warnings?: string[],
 ): CcdaEncounterRecord | null {
   if (!enc || typeof enc !== 'object' || Array.isArray(enc)) return null;
 
@@ -80,22 +83,23 @@ export function buildEncounterRecord(
     effTime?.['@_value'] ?? effTime?.value ?? effTime?.low?.['@_value'] ?? effTime?.low?.value ?? '';
   const dateStr = formatCcdaDate(dateVal);
 
-  const idEl = Array.isArray(enc?.id) ? enc.id[0] : enc?.id;
-  const sourceId = idEl?.['@_extension']
-    ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}`
-    : idEl?.['@_root']
-      ? String(idEl['@_root'])
-      : '';
+  const sourceId = ccdaSourceId(enc?.id);
 
   // Require real content: an id, a type, or a date. A bare <encounter> with none
   // of these is a stray reference, not a visit — do not mint a record for it.
   if (!sourceId && !displayName && !dateStr) return null;
 
-  const uri = contentHashedUri('Encounter', {
-    patient: patientUri,
-    displayName: displayName || undefined,
-    date: dateStr || undefined,
-  }, sourceId || undefined, enc);
+  const uri = ccdaRecordUri({
+    type: 'Encounter',
+    sourceId,
+    content: {
+      displayName: displayName || undefined,
+      date: dateStr || undefined,
+    },
+    source: enc,
+    warnings,
+    label: 'C-CDA encounter',
+  });
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];
@@ -110,8 +114,10 @@ export function buildEncounterRecord(
 
 export function extractEncounterQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
 
@@ -126,7 +132,7 @@ export function extractEncounterQuads(
         ? [entry.encounter]
         : [entry];
     for (const enc of encList) {
-      const built = buildEncounterRecord(enc, patientUri, sourceSystem);
+      const built = buildEncounterRecord(enc, sourceSystem, warnings);
       if (built) quads.push(...built.quads);
     }
   }

--- a/src/lib/ccda-converter/sections/family-history.ts
+++ b/src/lib/ccda-converter/sections/family-history.ts
@@ -3,7 +3,8 @@
  * Minimal implementation — narrative is preserved by the main converter.
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -13,10 +14,28 @@ const { namedNode, literal, quad: makeQuad } = DataFactory;
 export const FAMILY_HISTORY_TEMPLATE_ID = '2.16.840.1.113883.10.20.22.2.15';
 export const FAMILY_HISTORY_LOINC = '10157-6';
 
+/**
+ * A family-history record describes a RELATIVE, not the pod's patient, which
+ * makes it the section most exposed to losing the (removed) patient component
+ * from its key. Measured, it is not: two sisters with the same diagnosis
+ * ALREADY collided on `main` at every id level, because a patient component that
+ * is constant within a pod cannot tell two of that pod's records apart. What
+ * separates them now is the observation's own `<id>`, which the source assigns
+ * per relative and which this section previously discarded — so honouring it
+ * fixes the collision rather than causing it.
+ *
+ * The key additionally carries the relative's OWN id where the organizer's
+ * `<relatedSubject>` supplies one, so two same-relation relatives separate even
+ * when the source gave neither observation an id. Where it supplies none — the
+ * residual case, unchanged from `main` — they still collapse; keying on the
+ * relative's demographics is the remaining fix and is filed, not papered over.
+ */
 export function extractFamilyHistoryQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const snomedOid = '2.16.840.1.113883.6.96';
@@ -30,10 +49,21 @@ export function extractFamilyHistoryQuads(
     const relationCode = subject?.code ?? {};
     const relation = relationCode?.['@_displayName'] ?? relationCode?.displayName ?? '';
 
-    // Observations within the organizer
-    const components = Array.isArray(organizer?.component) ? organizer.component : [];
-    for (const comp of components) {
-      const obs = comp?.observation;
+    // Observations within the organizer. `component` AND `observation` are both
+    // always arrays from the parser's isArray config, so reading
+    // `comp.observation` as an object made every field `undefined` and the whole
+    // section produced NO records. Measured on the previous build: a family
+    // history organizer yielded zero `health:FamilyHistoryRecord`s. The
+    // conformance corpus carries no family history section, which is why the
+    // section handler was never exercised against real parser output.
+    const components = Array.isArray(organizer?.component)
+      ? organizer.component
+      : organizer?.component ? [organizer.component] : [];
+    const observations = components.flatMap((comp: any) => {
+      const o = comp?.observation;
+      return Array.isArray(o) ? o : (o ? [o] : []);
+    });
+    for (const obs of observations) {
       if (!obs) continue;
 
       const valueEl = obs?.value ?? {};
@@ -44,17 +74,23 @@ export function extractFamilyHistoryQuads(
 
       if (!displayName && !code) continue;
 
-      const sourceId = (() => {
-        const idEl = Array.isArray(obs?.id) ? obs.id[0] : obs?.id;
-        return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-      })();
+      const sourceId = ccdaSourceId(obs?.id);
 
-      const uri = contentHashedUri('FamilyHistory', {
-        patient: patientUri,
-        relation: relation || undefined,
-        condition: displayName || undefined,
-        code: code || undefined,
-      }, sourceId || undefined, entry);
+      const uri = ccdaRecordUri({
+        type: 'FamilyHistory',
+        sourceId,
+        content: {
+          relation: relation || undefined,
+          condition: displayName || undefined,
+          code: code || undefined,
+          // The relative's own id, where the organizer carries one. Two sisters
+          // are two subjects even when the source gave neither observation an id.
+          relative: ccdaSourceId(subject?.id) ?? ccdaSourceId(subject?.subject?.id),
+        },
+        source: entry,
+        warnings,
+        label: 'C-CDA family history',
+      });
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'FamilyHistoryRecord')));

--- a/src/lib/ccda-converter/sections/immunizations.ts
+++ b/src/lib/ccda-converter/sections/immunizations.ts
@@ -2,7 +2,8 @@
  * Extract immunizations from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.2.1)
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -14,8 +15,10 @@ export const IMMUNIZATIONS_LOINC = '11369-6';
 
 export function extractImmunizationQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
 
@@ -42,21 +45,22 @@ export function extractImmunizationQuads(
       ? `${dateVal.slice(0, 4)}-${dateVal.slice(4, 6)}-${dateVal.slice(6, 8)}`
       : dateVal;
 
-    // Extract source ID for fallback
-    const idEl = Array.isArray(sa?.id) ? sa.id[0] : sa?.id;
-    const sourceId = idEl?.['@_extension']
-      ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}`
-      : idEl?.extension
-        ? `${idEl.root ?? ''}:${idEl.extension}`
-        : '';
+    const sourceId = ccdaSourceId(sa?.id);
 
-    // Deterministic URI
-    const uri = contentHashedUri('Immunization', {
-      patient: patientUri,
-      cvxCode: codeSystem.includes('292') || codeSystem === cvxOid ? code : undefined,
-      vaccineName: displayName !== 'Unknown Vaccine' ? displayName.toLowerCase() : undefined,
-      date: dateStr,
-    }, sourceId || undefined, entry);
+    const uri = ccdaRecordUri({
+      type: 'Immunization',
+      sourceId,
+      content: {
+        cvxCode: codeSystem.includes('292') || codeSystem === cvxOid ? code : undefined,
+        // 'Unknown Vaccine' is a placeholder default, and a placeholder in an
+        // identity key turns "we do not know" into "these are the same record".
+        vaccineName: displayName !== 'Unknown Vaccine' ? displayName.toLowerCase() : undefined,
+        date: dateStr,
+      },
+      source: entry,
+      warnings,
+      label: 'C-CDA immunization',
+    });
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'ImmunizationRecord')));

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -41,7 +41,8 @@
  * asking the next reader to guess.
  */
 
-import { NS, contentHashedUri, tripleDateTime } from '../../fhir-converter/types.js';
+import { NS, tripleDateTime } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { contentFingerprint, EMPTY_SEED } from '../../identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { buildEncounterRecord } from './encounters.js';
@@ -87,12 +88,6 @@ function formatCcdaDate(dateVal: string): string {
     : dateVal;
 }
 
-/** Extract an HL7 II (id) element's "root:extension" string, or '' if no extension. */
-function extractSourceId(node: any): string {
-  const idEl = Array.isArray(node?.id) ? node.id[0] : node?.id;
-  return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-}
-
 /** The subject IRI, quads, and clinical date for one converted lab observation. */
 interface LabObservation {
   subject: string;
@@ -120,8 +115,8 @@ interface LabObservation {
  */
 function extractObservationQuads(
   obs: any,
-  patientUri: string,
   sourceSystem: string,
+  warnings?: string[],
 ): LabObservation | null {
   if (!obs) return null;
 
@@ -147,28 +142,37 @@ function extractObservationQuads(
   const refRange = obs?.referenceRange?.observationRange;
   const refRangeText = refRange?.text?.['#text'] ?? refRange?.text ?? '';
 
-  const sourceId = extractSourceId(obs);
+  const sourceId = ccdaSourceId(obs?.id);
 
   // Tier 1 — the source identified this result. Nothing else is consulted, so
-  // two results the source kept apart can never be merged here. Passing the id
-  // as `contentHashedUri`'s `fallbackId` with an EMPTY field set produces
-  // exactly `deterministicUuid('LabResult:' + sourceId)`.
+  // two results the source kept apart can never be merged here. The door's
+  // `{type}:{id}` template is byte-identical to the `contentHashedUri('LabResult',
+  // {}, sourceId, obs)` this call used to spell inline, so no id-bearing lab IRI
+  // moves. What DOES move: `ccdaSourceId` also reads a root-only `<id>`, which
+  // the old reader here discarded, so an observation identified that way stops
+  // falling through to the content tier.
   //
   // Tier 2 — no id. Now the key has to do the separating, so it carries the
   // full-precision effective time and the measured value, both of which the
-  // previous key set left out.
-  const uri = sourceId
-    ? contentHashedUri('LabResult', {}, sourceId, obs)
-    : contentHashedUri('LabResult', {
-        patient: patientUri,
-        loincCode: isLoinc ? code : undefined,
-        testName: displayName || undefined,
-        // `dateVal` raw, NOT `dateStr`. `formatCcdaDate` truncates to a calendar
-        // day, which merged a 07:00 draw with an 11:00 draw.
-        effective: dateVal || undefined,
-        value: value || undefined,
-        unit: unit || undefined,
-      }, undefined, obs);
+  // pre-#36 key set left out.
+  const uri = ccdaRecordUri({
+    type: 'LabResult',
+    sourceId,
+    content: {
+      loincCode: isLoinc ? code : undefined,
+      testName: displayName || undefined,
+      // `dateVal` raw, NOT `dateStr`. `formatCcdaDate` truncates to a calendar
+      // day, which merged a 07:00 draw with an 11:00 draw.
+      effective: dateVal || undefined,
+      value: value || undefined,
+      unit: unit || undefined,
+      // Serialized as health:referenceRangeText and was outside the key.
+      refRange: refRangeText || undefined,
+    },
+    source: obs,
+    warnings,
+    label: 'C-CDA lab result',
+  });
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];
@@ -200,12 +204,12 @@ function extractObservationQuads(
  */
 function buildPanelQuads(
   organizer: any,
-  patientUri: string,
   sourceSystem: string,
   importedAt: string,
   memberSubjects: string[],
   memberDates: string[],
   encounterSubjects: string[],
+  warnings?: string[],
 ): Quad[] {
   const codeEl = organizer?.code ?? {};
   const code = codeEl?.['@_code'] ?? codeEl?.code ?? '';
@@ -225,49 +229,47 @@ function buildPanelQuads(
     memberDates.filter((d) => d).sort()[0] ||
     '';
 
-  const sourceId = extractSourceId(organizer);
+  const sourceId = ccdaSourceId(organizer);
 
-  // Panel identity: patient + panel code + clinical date + the organizer's own
-  // id (root:extension). The id must be a first-class identity field, not just
-  // the contentHashedUri fallback: real Epic exports routinely omit the
-  // organizer-level <code> (verified: 47 of 55 panels in the acceptance export
-  // carry no code), so keying on code+date alone collapses genuinely distinct
-  // same-day panels into one record and pools their members. The organizer id is
-  // present and unique per panel, so it yields one record per BATTERY organizer
-  // while staying deterministic (the id is stable in the source) and dedupe-safe
-  // (an exact re-import mints the same id and collapses to the same subject).
+  // Panel identity, tier 1: the organizer's own id decides. That is the same
+  // rule every other C-CDA record now follows, and this path had already reached
+  // most of the way to it on its own — the id was a first-class CONTENT field
+  // (`panelId`) rather than a dead `fallbackId`, because real Epic exports
+  // routinely omit the organizer-level <code> (verified: 47 of 55 panels in the
+  // acceptance export carry no code), so keying on code+date alone collapsed
+  // genuinely distinct same-day panels and pooled their members.
+  //
+  // Tier 2, and only tier 2: `clinicalDate` is `formatCcdaDate`-truncated to a
+  // calendar day, so for an organizer with neither id nor code the key would
+  // degenerate to a single day. Measured: two id-less code-less BATTERY
+  // organizers four hours apart on one day, holding DIFFERENT results, both
+  // minted urn:uuid:0335391b-48fb-5d69-ab87-7bbf2429e434. So the id-less branch
+  // additionally carries the organizer's raw full-precision effectiveTime and a
+  // fingerprint of its members and encounters — which is what a panel's content
+  // actually IS, since a panel has no measured value of its own. The cost is
+  // that an id-less panel which GAINS a result in a later export mints a new
+  // IRI, i.e. a duplicate; that is a split, and a split is the recoverable
+  // failure. A merge is not.
+  //
   // Timestamps that vary between imports (importedAt) are deliberately excluded.
-  //
-  // THAT PRE-EXISTING FIX IS WHY THIS PATH DOES NOT CARRY THE MEMBER PATH'S
-  // "the id was discarded" DEFECT: `panelId` is a content field, so an
-  // id-bearing organizer is already separated by it, and the id-bearing key is
-  // therefore left BYTE-IDENTICAL here. Moving it would break panel IRIs for no
-  // correctness gain.
-  //
-  // What it DID carry is the other half of that defect: `clinicalDate` is
-  // `formatCcdaDate`-truncated to a calendar day, and when the organizer has
-  // neither an id nor a code — the combination the comment above says is common
-  // in real exports — the whole key degenerates to {patient, day}. Measured: two
-  // id-less code-less BATTERY organizers four hours apart on one day, holding
-  // DIFFERENT results, both minted urn:uuid:0335391b-48fb-5d69-ab87-7bbf2429e434.
-  //
-  // So the id-less branch, and only the id-less branch, additionally carries the
-  // organizer's raw full-precision effectiveTime and a fingerprint of its member
-  // subjects — which is what a panel's content actually IS, since a panel has no
-  // measured value of its own. The cost is that an id-less panel which GAINS a
-  // result in a later export mints a new IRI, i.e. a duplicate; that is a split,
-  // and a split is the recoverable failure. A merge is not.
   const memberKey = contentFingerprint(memberSubjects);
-  const uri = contentHashedUri('LaboratoryReport', {
-    patient: patientUri,
-    panelCode: code || undefined,
-    date: clinicalDate || undefined,
-    panelId: sourceId || undefined,
-    ...(sourceId ? {} : {
+  const encounterKey = contentFingerprint(encounterSubjects);
+  const uri = ccdaRecordUri({
+    type: 'LaboratoryReport',
+    sourceId,
+    content: {
+      panelCode: code || undefined,
+      // Serialized as clinical:panelName and was outside the key.
+      panelName: displayName || undefined,
+      date: clinicalDate || undefined,
       effective: orgDateRaw || undefined,
       members: memberKey === EMPTY_SEED ? undefined : memberKey,
-    }),
-  }, sourceId || undefined, organizer);
+      encounters: encounterKey === EMPTY_SEED ? undefined : encounterKey,
+    },
+    source: organizer,
+    warnings,
+    label: 'C-CDA lab panel',
+  });
 
   const subj = namedNode(uri);
   const quads: Quad[] = [];
@@ -319,10 +321,10 @@ function buildPanelQuads(
 
 export function extractLabQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
   _sectionText?: any,
   importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const stamp = importedAt ?? new Date().toISOString();
@@ -346,7 +348,7 @@ export function extractLabQuads(
         if (!comp?.observation) continue;
         const obsList = Array.isArray(comp.observation) ? comp.observation : [comp.observation];
         for (const obs of obsList) {
-          const member = extractObservationQuads(obs, patientUri, sourceSystem);
+          const member = extractObservationQuads(obs, sourceSystem, warnings);
           if (!member) continue;
           quads.push(...member.quads);
           memberSubjects.push(member.subject);
@@ -369,7 +371,7 @@ export function extractLabQuads(
         const encounterSubjects: string[] = [];
         const seenThisOrganizer = new Set<string>();
         for (const enc of rawEncounters) {
-          const built = buildEncounterRecord(enc, patientUri, sourceSystem);
+          const built = buildEncounterRecord(enc, sourceSystem, warnings);
           if (!built) continue;
           if (!seenThisOrganizer.has(built.subject)) {
             seenThisOrganizer.add(built.subject);
@@ -382,14 +384,14 @@ export function extractLabQuads(
         }
 
         quads.push(...buildPanelQuads(
-          organizer, patientUri, sourceSystem, stamp, memberSubjects, memberDates, encounterSubjects,
+          organizer, sourceSystem, stamp, memberSubjects, memberDates, encounterSubjects, warnings,
         ));
       }
     } else if (entry?.observation) {
       // Standalone observation (no organizer): a plain lab result, no panel.
       const obsList = Array.isArray(entry.observation) ? entry.observation : [entry.observation];
       for (const obs of obsList) {
-        const member = extractObservationQuads(obs, patientUri, sourceSystem);
+        const member = extractObservationQuads(obs, sourceSystem, warnings);
         if (member) quads.push(...member.quads);
       }
     }

--- a/src/lib/ccda-converter/sections/medications.ts
+++ b/src/lib/ccda-converter/sections/medications.ts
@@ -2,7 +2,8 @@
  * Extract medications from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.1.1)
  */
 
-import { NS, medicationUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaMedicationRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { lookupRxNormName } from '../rxnorm-lookup.js';
 import { DataFactory } from 'n3';
@@ -78,9 +79,10 @@ function resolveNarrativeName(codeEl: any, narrativeIdMap: Record<string, string
 
 export function extractMedicationQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
   sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const rxNormOid = '2.16.840.1.113883.6.88';
@@ -125,19 +127,27 @@ export function extractMedicationQuads(
     const dose = doseEl?.['@_value'] ?? doseEl?.value ?? '';
     const doseUnit = doseEl?.['@_unit'] ?? doseEl?.unit ?? '';
 
-    const sourceId = (() => {
-      const idEl = Array.isArray(sa?.id) ? sa.id[0] : sa?.id;
-      return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-    })();
+    const sourceId = ccdaSourceId(sa?.id);
 
     if (!displayName && !code) continue;
 
-    const uri = medicationUri({
-      patient: patientUri,
-      rxNormCode: isRxNorm ? code : undefined,
-      medicationName: displayName || undefined,
-      startDate: startDate || undefined,
-    }, sourceId || undefined);
+    // `dose` and `doseUnit` are serialized but deliberately outside the key:
+    // `medicationUri` is the ONE medication identity shared by every importer,
+    // and it treats a dose change as a conflict on the same medication rather
+    // than as a second medication. Changing that would move FHIR IRIs too.
+    const uri = ccdaMedicationRecordUri({
+      sourceId,
+      fields: {
+        rxNormCode: isRxNorm ? code : undefined,
+        medicationName: displayName || undefined,
+        startDate: startDate || undefined,
+      },
+      // The raw entry was NOT passed before, so the last identity tier landed on
+      // the per-type sentinel rather than on a hash of the record.
+      source: entry,
+      warnings,
+      label: 'C-CDA medication',
+    });
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Medication')));

--- a/src/lib/ccda-converter/sections/patient.ts
+++ b/src/lib/ccda-converter/sections/patient.ts
@@ -2,7 +2,8 @@
  * Extract patient demographics from C-CDA recordTarget → cascade:PatientProfile
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS, structuredKey } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -34,11 +35,11 @@ export function extractPatientQuads(
   recordTarget: any,
   sourceSystem: string,
   /**
-   * Collects a tier-4 identity-collapse notice. This is the ONE C-CDA site that
-   * can reach tier 4: every other section keys on `patient: patientUri`, which is
-   * always a non-empty `urn:uuid:` string, so their content tier always fires.
-   * Here the key is the demographics themselves, and a recordTarget can carry
-   * none of them.
+   * Collects a tier-4 identity-collapse notice. This used to be the ONE C-CDA
+   * site that could reach tier 4, because every other section keyed on
+   * `patient: patientUri` — always a non-empty `urn:uuid:` — so their content
+   * tier always fired. That component is gone from the section keys, so the
+   * salvage and loud-collapse tiers are reachable across the whole path now.
    */
   warnings?: string[],
 ): { quads: Quad[]; patientUri: string } {
@@ -91,16 +92,46 @@ export function extractPatientQuads(
     return raw.replace(/^mailto:/, '');
   })();
 
-  // Deterministic URI from identity fields. `patientRole` is passed as the last
-  // tier so that a recordTarget with no name, no birthTime and no gender keys on
-  // whatever else it does carry (ids, address, telecom) instead of on a random
-  // UUID, which is what the un-passed version fell through to.
-  const patientUri = contentHashedUri('Patient', {
-    dob: dob.slice(0, 8),  // YYYYMMDD
-    sex: sex,
-    family: familyStr.toLowerCase(),
-    given: givenStr.toLowerCase(),
-  }, undefined, patientRole, warnings);
+  // IDENTITY.
+  //
+  // Tier 1 is the MRN. `patientRole/id` is where a C-CDA carries the medical
+  // record number — the identifier the EHR itself uses to tell two patients
+  // apart — and this call passed `undefined` where the id belongs, so it did not
+  // even ATTEMPT it. Measured on `main`: two different people, distinct MRNs,
+  // sharing a birth date, a sex, a surname and a first given name minted ONE
+  // profile IRI, and every record of either then hung off it.
+  //
+  // Tier 2 is the demographics, and the four fields it used to be
+  // ({dob, sex, family, given[0]}) are exactly the four the FHIR Patient key was
+  // widened away from in the same release, for the same reason: reading
+  // `given[0]` alone means middle names, suffixes and maiden names contribute
+  // nothing, and everything the converter SERIALIZES but leaves out of the key
+  // is a field two people sharing one IRI can disagree on. So the key now
+  // fingerprints the whole `name` array, the whole `addr` array and the whole
+  // `telecom` array. (`telecom` is excluded on the FHIR path because that
+  // converter does not serialize it; this one emits vcard:hasTelephone and
+  // vcard:hasEmail, so here it must be in the key.)
+  //
+  // THE SAME PERSON FROM TWO EHRs STILL RECONCILES. Two exports carrying two
+  // MRNs now mint two profiles where they previously minted one; they do not
+  // stay two, because `matchPatientProfiles` merges on date of birth plus sex at
+  // 0.95 against a 0.65 threshold — with a merge trail, and with a conflict
+  // raised wherever they disagree. The merge moves out of a hash nobody can
+  // inspect and into the layer built to make it reviewable.
+  const patientUri = ccdaRecordUri({
+    type: 'Patient',
+    sourceId: ccdaSourceId(patientRole?.id),
+    content: {
+      dob: dob.slice(0, 8),  // YYYYMMDD
+      sex: sex,
+      name: structuredKey(patient?.name),
+      address: structuredKey(patientRole?.addr),
+      telecom: structuredKey(patientRole?.telecom),
+    },
+    source: patientRole,
+    warnings,
+    label: 'C-CDA patient (recordTarget)',
+  });
 
   const subj = namedNode(patientUri);
   const quads: Quad[] = [

--- a/src/lib/ccda-converter/sections/problems.ts
+++ b/src/lib/ccda-converter/sections/problems.ts
@@ -2,7 +2,8 @@
  * Extract conditions/problems from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.5.1)
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -14,8 +15,10 @@ export const PROBLEMS_LOINC = '11450-4';
 
 export function extractProblemQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const snomedOid = '2.16.840.1.113883.6.96';
@@ -66,18 +69,22 @@ export function extractProblemQuads(
         ? `${onsetVal.slice(0, 4)}-${onsetVal.slice(4, 6)}-${onsetVal.slice(6, 8)}`
         : onsetVal;
 
-      const sourceId = (() => {
-        const idEl = Array.isArray(observation?.id) ? observation.id[0] : observation?.id;
-        return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-      })();
+      const sourceId = ccdaSourceId(observation?.id);
 
-      const uri = contentHashedUri('Condition', {
-        patient: patientUri,
-        snomedCode: isSnomed ? code : undefined,
-        icd10Code: isIcd10 ? code : undefined,
-        conditionName: displayName || undefined,
-        onsetDate: onsetDate || undefined,
-      }, sourceId || undefined, entry);
+      const uri = ccdaRecordUri({
+        type: 'Condition',
+        sourceId,
+        content: {
+          snomedCode: isSnomed ? code : undefined,
+          icd10Code: isIcd10 ? code : undefined,
+          conditionName: displayName || undefined,
+          onsetDate: onsetDate || undefined,
+          status: status || undefined,
+        },
+        source: entry,
+        warnings,
+        label: 'C-CDA problem',
+      });
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'ConditionRecord')));

--- a/src/lib/ccda-converter/sections/problems.ts
+++ b/src/lib/ccda-converter/sections/problems.ts
@@ -55,10 +55,17 @@ export function extractProblemQuads(
       const isSnomed = codeSystem.includes('6.96') || codeSystem === snomedOid;
       const isIcd10 = codeSystem.includes('6.90') || codeSystem === icd10Oid;
 
-      // Status from entryRelationship
+      // Status from entryRelationship. `statedStatus` and `status` are kept
+      // apart on purpose: `status` carries the 'active' DEFAULT and is what the
+      // record DISPLAYS, while only `statedStatus` — what the source actually
+      // said — may enter the identity key. A placeholder default in a key turns
+      // "we do not know" into "these are the same record", and a content tier
+      // that succeeds with a constant is indistinguishable from one that fails
+      // except that it merges.
       const statusObs = observation?.entryRelationship?.observation;
       const statusValue = (Array.isArray(statusObs) ? statusObs[0] : statusObs)?.value;
-      const status = statusValue?.['@_displayName'] ?? statusValue?.displayName ?? 'active';
+      const statedStatus = statusValue?.['@_displayName'] ?? statusValue?.displayName ?? '';
+      const status = statedStatus || 'active';
 
       // Onset date
       const effectiveTime = observation?.effectiveTime ?? act?.effectiveTime ?? {};
@@ -79,7 +86,11 @@ export function extractProblemQuads(
           icd10Code: isIcd10 ? code : undefined,
           conditionName: displayName || undefined,
           onsetDate: onsetDate || undefined,
-          status: status || undefined,
+          // Serialized as health:status, so it belongs in the key: "active" and
+          // "resolved" are two different claims about a patient, and the FHIR
+          // Condition key includes clinicalStatus for exactly that reason. The
+          // STATED value only — never the default.
+          status: statedStatus ? statedStatus.toLowerCase() : undefined,
         },
         source: entry,
         warnings,

--- a/src/lib/ccda-converter/sections/procedures.ts
+++ b/src/lib/ccda-converter/sections/procedures.ts
@@ -2,7 +2,8 @@
  * Extract procedures from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.7.1)
  */
 
-import { NS, contentHashedUri } from '../../fhir-converter/types.js';
+import { NS } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -14,8 +15,10 @@ export const PROCEDURES_LOINC = '47519-4';
 
 export function extractProcedureQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const snomedOid = '2.16.840.1.113883.6.96';
@@ -37,17 +40,20 @@ export function extractProcedureQuads(
       ? `${dateVal.slice(0, 4)}-${dateVal.slice(4, 6)}-${dateVal.slice(6, 8)}`
       : dateVal;
 
-    const sourceId = (() => {
-      const idEl = Array.isArray(proc?.id) ? proc.id[0] : proc?.id;
-      return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-    })();
+    const sourceId = ccdaSourceId(proc?.id);
 
-    const uri = contentHashedUri('Procedure', {
-      patient: patientUri,
-      code: code || undefined,
-      displayName: displayName || undefined,
-      date: dateStr || undefined,
-    }, sourceId || undefined, entry);
+    const uri = ccdaRecordUri({
+      type: 'Procedure',
+      sourceId,
+      content: {
+        code: code || undefined,
+        displayName: displayName || undefined,
+        date: dateStr || undefined,
+      },
+      source: entry,
+      warnings,
+      label: 'C-CDA procedure',
+    });
 
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Procedure')));

--- a/src/lib/ccda-converter/sections/social-history.ts
+++ b/src/lib/ccda-converter/sections/social-history.ts
@@ -10,7 +10,6 @@ export const SOCIAL_HISTORY_LOINC = '29762-2';
 
 export function extractSocialHistoryQuads(
   _entries: any[],
-  _patientUri: string,
   _sourceSystem: string,
 ): Quad[] {
   // Social history structured extraction is deferred; narrative is preserved separately.

--- a/src/lib/ccda-converter/sections/vitals.ts
+++ b/src/lib/ccda-converter/sections/vitals.ts
@@ -10,7 +10,8 @@
  * converter's convertObservationVital -> convertObservationLab fallback.
  */
 
-import { NS, contentHashedUri, VITAL_LOINC_CODES } from '../../fhir-converter/types.js';
+import { NS, VITAL_LOINC_CODES } from '../../fhir-converter/types.js';
+import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -43,8 +44,10 @@ const VITAL_TYPE_TO_SHACL: Record<string, string> = {
 
 export function extractVitalQuads(
   entries: any[],
-  patientUri: string,
   sourceSystem: string,
+  _sectionText?: any,
+  _importedAt?: string,
+  warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const loincOid = '2.16.840.1.113883.6.1';
@@ -93,10 +96,7 @@ export function extractVitalQuads(
       const value = valueEl?.['@_value'] ?? valueEl?.value ?? valueEl?.['#text'] ?? '';
       const unit = valueEl?.['@_unit'] ?? valueEl?.unit ?? '';
 
-      const sourceId = (() => {
-        const idEl = Array.isArray(obs?.id) ? obs.id[0] : obs?.id;
-        return idEl?.['@_extension'] ? `${idEl['@_root'] ?? ''}:${idEl['@_extension']}` : '';
-      })();
+      const sourceId = ccdaSourceId(obs?.id);
 
       // Resolve a clinical:vitalType the VitalSignShape enum accepts.
       const vitalInfo = isLoinc && loincCode ? VITAL_LOINC_CODES[loincCode] : undefined;
@@ -106,19 +106,28 @@ export function extractVitalQuads(
         // Not a VitalSign per the shape (no LOINC match, or a LOINC outside the
         // canonical enum). Preserve the value as a lab result rather than drop it.
         quads.push(...buildLabFallback({
-          patientUri, sourceSystem, loincCode, isLoinc, loincOid,
-          displayName, dateStr, value, unit, sourceId,
+          sourceSystem, loincCode, isLoinc, loincOid,
+          displayName, dateStr, value, unit, sourceId, source: obs, warnings,
         }));
         continue;
       }
 
-      const uri = contentHashedUri('VitalSign', {
-        patient: patientUri,
-        loincCode: isLoinc ? loincCode : undefined,
-        displayName: displayName || undefined,
-        date: dateStr || undefined,
-        value: value || undefined,
-      }, sourceId || undefined, obs);
+      const uri = ccdaRecordUri({
+        type: 'VitalSign',
+        sourceId,
+        content: {
+          loincCode: isLoinc ? loincCode : undefined,
+          displayName: displayName || undefined,
+          date: dateStr || undefined,
+          value: value || undefined,
+          // Serialized as clinical:unit and was outside the key: a weight of
+          // "70 kg" and one of "70 lb" are different readings.
+          unit: unit || undefined,
+        },
+        source: obs,
+        warnings,
+        label: 'C-CDA vital sign',
+      });
 
       const subj = namedNode(uri);
       quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'VitalSign')));
@@ -145,7 +154,6 @@ export function extractVitalQuads(
  * SHACL target shape, so this validates cleanly while keeping the data.
  */
 function buildLabFallback(args: {
-  patientUri: string;
   sourceSystem: string;
   loincCode: string;
   isLoinc: boolean;
@@ -154,18 +162,29 @@ function buildLabFallback(args: {
   dateStr: string;
   value: string;
   unit: string;
-  sourceId: string;
+  sourceId: string | undefined;
+  /** The raw observation. It was NOT passed before, so the last identity tier
+   *  landed on the per-type sentinel rather than on a hash of the record. */
+  source: unknown;
+  warnings: string[] | undefined;
 }): Quad[] {
-  const { patientUri, sourceSystem, loincCode, isLoinc, loincOid, displayName, dateStr, value, unit, sourceId } = args;
+  const { sourceSystem, loincCode, isLoinc, loincOid, displayName, dateStr, value, unit, sourceId, source, warnings } = args;
   const quads: Quad[] = [];
 
-  const uri = contentHashedUri('LabResult', {
-    patient: patientUri,
-    loincCode: isLoinc ? loincCode : undefined,
-    testName: displayName || undefined,
-    date: dateStr || undefined,
-    value: value || undefined,
-  }, sourceId || undefined);
+  const uri = ccdaRecordUri({
+    type: 'LabResult',
+    sourceId,
+    content: {
+      loincCode: isLoinc ? loincCode : undefined,
+      testName: displayName || undefined,
+      date: dateStr || undefined,
+      value: value || undefined,
+      unit: unit || undefined,
+    },
+    source,
+    warnings,
+    label: 'C-CDA vital-sign observation (recorded as a lab result)',
+  });
 
   const subj = namedNode(uri);
   quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.health + 'LabResultRecord')));

--- a/test-fixtures/ccda-root-only-ids.xml
+++ b/test-fixtures/ccda-root-only-ids.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic C-CDA where EVERY entry identifier is the root-only form:
+
+      <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4a"/>
+
+  with no @extension. HL7 v3 II says the root alone may be the entire instance
+  identifier, and this is what real Epic and Cerner exports emit for a locally
+  minted id — but eight of nine section handlers extracted an id only when
+  @extension was present, so on this shape they discarded it entirely and never
+  emitted cascade:sourceRecordId either.
+
+  The whole conformance C-CDA corpus carries ZERO root-only ids (measured: 41
+  <id> elements across 7 fixtures, all with @extension), which is exactly how a
+  suite passes while the importer ignores the id on the majority of real
+  documents. This fixture is that gap closed.
+
+  Each section carries TWO entries that are identical in every content field and
+  differ ONLY in their root-only id, so a test can assert they are two records.
+  All values are synthetic and PHI-free.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+  <id root="1cb0f0a0-0000-4000-8000-00000000d0c0"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Root-Only Identifier Fixture</title>
+  <effectiveTime value="20260201120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <name>Synthetic Health System</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <recordTarget>
+    <patientRole>
+      <!-- The patient's own identifier is root-only too. -->
+      <id root="7f1e0000-0000-4000-8000-0000000000aa"/>
+      <patient>
+        <name use="L"><given>Jane</given><given>Q</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody>
+
+      <!-- ── Problems ────────────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" displayName="Problem List" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Problems</title>
+          <text>Type 2 diabetes mellitus, recorded twice by two clinicians.</text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="11111111-0000-4000-8000-0000000000a1"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="11111111-0000-4000-8000-0000000000a1"/>
+                  <code code="55607006" displayName="Problem" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20240115"/></effectiveTime>
+                  <value xsi:type="CD" code="44054006" displayName="Type 2 diabetes mellitus" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="11111111-0000-4000-8000-0000000000a2"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="11111111-0000-4000-8000-0000000000a2"/>
+                  <code code="55607006" displayName="Problem" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20240115"/></effectiveTime>
+                  <value xsi:type="CD" code="44054006" displayName="Type 2 diabetes mellitus" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Allergies ───────────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+          <code code="48765-2" displayName="Allergies and Adverse Reactions" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Allergies</title>
+          <text>Penicillin, two concern acts.</text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+              <id root="22222222-0000-4000-8000-0000000000b1"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                  <id root="22222222-0000-4000-8000-0000000000b1"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20200301"/></effectiveTime>
+                  <participant typeCode="CSM">
+                    <participantRole classCode="MANU">
+                      <playingEntity classCode="MMAT">
+                        <code code="7980" displayName="Penicillin" codeSystem="2.16.840.1.113883.6.88"/>
+                      </playingEntity>
+                    </participantRole>
+                  </participant>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+              <id root="22222222-0000-4000-8000-0000000000b2"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                  <id root="22222222-0000-4000-8000-0000000000b2"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20200301"/></effectiveTime>
+                  <participant typeCode="CSM">
+                    <participantRole classCode="MANU">
+                      <playingEntity classCode="MMAT">
+                        <code code="7980" displayName="Penicillin" codeSystem="2.16.840.1.113883.6.88"/>
+                      </playingEntity>
+                    </participantRole>
+                  </participant>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Immunizations ───────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+          <code code="11369-6" displayName="History of Immunizations" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Immunizations</title>
+          <text>Two influenza doses recorded on the same day.</text>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+              <id root="33333333-0000-4000-8000-0000000000c1"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20251015"/>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <manufacturedMaterial>
+                    <code code="140" displayName="Influenza, seasonal, injectable" codeSystem="2.16.840.1.113883.12.292"/>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+              <id root="33333333-0000-4000-8000-0000000000c2"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20251015"/>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <manufacturedMaterial>
+                    <code code="140" displayName="Influenza, seasonal, injectable" codeSystem="2.16.840.1.113883.12.292"/>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Medications ─────────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+          <code code="10160-0" displayName="History of Medication Use" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Medications</title>
+          <text>Metformin, two orders.</text>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+              <id root="44444444-0000-4000-8000-0000000000d1"/>
+              <statusCode code="active"/>
+              <effectiveTime xsi:type="IVL_TS"><low value="20240115"/></effectiveTime>
+              <doseQuantity value="500" unit="mg"/>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <manufacturedMaterial>
+                    <code code="860975" displayName="Metformin hydrochloride 500 MG" codeSystem="2.16.840.1.113883.6.88"/>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+              <id root="44444444-0000-4000-8000-0000000000d2"/>
+              <statusCode code="active"/>
+              <effectiveTime xsi:type="IVL_TS"><low value="20240115"/></effectiveTime>
+              <doseQuantity value="500" unit="mg"/>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <manufacturedMaterial>
+                    <code code="860975" displayName="Metformin hydrochloride 500 MG" codeSystem="2.16.840.1.113883.6.88"/>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Vital signs ─────────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+          <code code="8716-3" displayName="Vital Signs" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Vital Signs</title>
+          <text>Two heart-rate readings recorded as one value.</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+              <id root="55555555-0000-4000-8000-0000000000e0"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20260110"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="55555555-0000-4000-8000-0000000000e1"/>
+                  <code code="8867-4" displayName="Heart rate" codeSystem="2.16.840.1.113883.6.1"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260110"/>
+                  <value xsi:type="PQ" value="72" unit="/min"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="55555555-0000-4000-8000-0000000000e2"/>
+                  <code code="8867-4" displayName="Heart rate" codeSystem="2.16.840.1.113883.6.1"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260110"/>
+                  <value xsi:type="PQ" value="72" unit="/min"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Procedures ──────────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+          <code code="47519-4" displayName="History of Procedures" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Procedures</title>
+          <text>Two colonoscopies on one day.</text>
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+              <id root="66666666-0000-4000-8000-0000000000f1"/>
+              <code code="73761001" displayName="Colonoscopy" codeSystem="2.16.840.1.113883.6.96"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250620"/>
+            </procedure>
+          </entry>
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+              <id root="66666666-0000-4000-8000-0000000000f2"/>
+              <code code="73761001" displayName="Colonoscopy" codeSystem="2.16.840.1.113883.6.96"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250620"/>
+            </procedure>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Encounters ──────────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+          <code code="46240-8" displayName="Encounters" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Encounters</title>
+          <text>Two office visits on one day.</text>
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="77777777-0000-4000-8000-000000000101"/>
+              <code code="185349003" displayName="Encounter for check up" codeSystem="2.16.840.1.113883.6.96"/>
+              <effectiveTime><low value="20260110"/></effectiveTime>
+            </encounter>
+          </entry>
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="77777777-0000-4000-8000-000000000102"/>
+              <code code="185349003" displayName="Encounter for check up" codeSystem="2.16.840.1.113883.6.96"/>
+              <effectiveTime><low value="20260110"/></effectiveTime>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Results (lab) ───────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Results</title>
+          <text>Two glucose draws reported with the same value.</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="88888888-0000-4000-8000-000000000201"/>
+              <code code="24323-8" displayName="Comprehensive metabolic panel" codeSystem="2.16.840.1.113883.6.1"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20260110070000-0500"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="88888888-0000-4000-8000-000000000211"/>
+                  <code code="2339-0" displayName="Glucose [Mass/volume] in Blood" codeSystem="2.16.840.1.113883.6.1"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260110070000-0500"/>
+                  <value xsi:type="PQ" value="95" unit="mg/dL"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="88888888-0000-4000-8000-000000000212"/>
+                  <code code="2339-0" displayName="Glucose [Mass/volume] in Blood" codeSystem="2.16.840.1.113883.6.1"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260110070000-0500"/>
+                  <value xsi:type="PQ" value="95" unit="mg/dL"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="88888888-0000-4000-8000-000000000202"/>
+              <code code="24323-8" displayName="Comprehensive metabolic panel" codeSystem="2.16.840.1.113883.6.1"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20260110070000-0500"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="88888888-0000-4000-8000-000000000221"/>
+                  <code code="2339-0" displayName="Glucose [Mass/volume] in Blood" codeSystem="2.16.840.1.113883.6.1"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260110070000-0500"/>
+                  <value xsi:type="PQ" value="95" unit="mg/dL"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Family history ──────────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+          <code code="10157-6" displayName="History of Family Member Diseases" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Family History</title>
+          <text>Two sisters, both with type 2 diabetes.</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+              <id root="99999999-0000-4000-8000-000000000301"/>
+              <statusCode code="completed"/>
+              <subject>
+                <relatedSubject classCode="PRS">
+                  <code code="27733009" displayName="Sister" codeSystem="2.16.840.1.113883.6.96"/>
+                  <subject>
+                    <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                  </subject>
+                </relatedSubject>
+              </subject>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                  <id root="99999999-0000-4000-8000-000000000311"/>
+                  <code code="64572001" displayName="Condition" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20180101"/></effectiveTime>
+                  <value xsi:type="CD" code="44054006" displayName="Type 2 diabetes mellitus" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+              <id root="99999999-0000-4000-8000-000000000302"/>
+              <statusCode code="completed"/>
+              <subject>
+                <relatedSubject classCode="PRS">
+                  <code code="27733009" displayName="Sister" codeSystem="2.16.840.1.113883.6.96"/>
+                  <subject>
+                    <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                  </subject>
+                </relatedSubject>
+              </subject>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                  <id root="99999999-0000-4000-8000-000000000312"/>
+                  <code code="64572001" displayName="Condition" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20180101"/></effectiveTime>
+                  <value xsi:type="CD" code="44054006" displayName="Type 2 diabetes mellitus" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- ── Implanted devices ───────────────────────────────────────────── -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+          <code code="46264-8" displayName="Medical Equipment" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Medical Equipment</title>
+          <text>Two pacemaker leads implanted on one day.</text>
+          <entry typeCode="DRIV">
+            <supply classCode="SPLY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.50"/>
+              <id root="aaaaaaaa-0000-4000-8000-000000000401"/>
+              <statusCode code="completed"/>
+              <effectiveTime><low value="20230404"/></effectiveTime>
+              <participant typeCode="DEV">
+                <participantRole classCode="MANU">
+                  <playingDevice>
+                    <code code="14106009" displayName="Cardiac pacemaker" codeSystem="2.16.840.1.113883.6.96"/>
+                  </playingDevice>
+                </participantRole>
+              </participant>
+            </supply>
+          </entry>
+          <entry typeCode="DRIV">
+            <supply classCode="SPLY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.50"/>
+              <id root="aaaaaaaa-0000-4000-8000-000000000402"/>
+              <statusCode code="completed"/>
+              <effectiveTime><low value="20230404"/></effectiveTime>
+              <participant typeCode="DEV">
+                <participantRole classCode="MANU">
+                  <playingDevice>
+                    <code code="14106009" displayName="Cardiac pacemaker" codeSystem="2.16.840.1.113883.6.96"/>
+                  </playingDevice>
+                </participantRole>
+              </participant>
+            </supply>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/tests/ccda-identity-chokepoint.test.ts
+++ b/tests/ccda-identity-chokepoint.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The C-CDA importer mints identity through ONE door, and this is the lock on
+ * every other way in.
+ *
+ * WHAT IS BEING PROTECTED, STATED SO THE NEXT READER DOES NOT HAVE TO GUESS
+ * ------------------------------------------------------------------------
+ * Every C-CDA section handler independently wrote the same call:
+ *
+ *     contentHashedUri('X', { patient: patientUri, … }, sourceId || undefined, entry)
+ *
+ * It reads as "identify by content, and fall back to the source's id". It is
+ * not. `contentHashedUri` consults `fallbackId` ONLY when every content field is
+ * empty, and `patient` was always a non-empty `urn:uuid:`, so the id was not a
+ * fallback — it was DEAD, at all ten identity sites, unconditionally. Two
+ * records the source had deliberately kept apart minted one IRI and one of them
+ * was overwritten.
+ *
+ * A comment does not hold that shut. The lab section already carried a "subject
+ * minting is FROZEN" comment, and the freeze is a large part of why the defect
+ * survived long enough to ship in two importers at once; the note left in its
+ * place says that a test states which property is protected instead of asking
+ * the next reader to guess. This is that test.
+ *
+ * THE THREE RULES
+ * ---------------
+ *   1. Nothing under `lib/ccda-converter/` may call `contentHashedUri` or
+ *      `medicationUri` except the door itself. One place decides, so there is
+ *      one place to review when the rule changes.
+ *   2. The door's own calls pass `undefined` in the fallbackId slot. That is the
+ *      dead-`fallbackId` shape, made unrepresentable rather than discouraged.
+ *   3. No C-CDA identity key contains a patient component. It merged records the
+ *      source kept apart and split records that were the same; a field that is
+ *      constant within a pod cannot tell two of that pod's records apart.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT: rules 1 and 2 both FAIL against
+ * `main` at 51a4089 — there is no door there, and ten call sites pass a live
+ * `sourceId` in the third argument. Rule 3 fails there too, on ten `patient:`
+ * key entries.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src');
+const CCDA_DIR = 'lib/ccda-converter/';
+
+/** The one module allowed to mint. */
+const DOOR = 'lib/ccda-converter/record-identity.ts';
+
+/** Identity primitives whose fallbackId slot is the shape being banned. */
+const GUARDED: ReadonlyArray<{ call: string; fallbackArgIndex: number }> = [
+  { call: 'contentHashedUri(', fallbackArgIndex: 2 },
+  { call: 'medicationUri(', fallbackArgIndex: 1 },
+];
+
+function ccdaSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        out.push(path.relative(SRC_DIR, full).split(path.sep).join('/'));
+      }
+    }
+  };
+  walk(path.join(SRC_DIR, 'lib', 'ccda-converter'));
+  return out.sort();
+}
+
+/** Strip line and block comments; keep template literals and strings. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/** The argument text of every `name(…)` call, balancing parens. */
+function callArguments(code: string, callName: string): string[] {
+  const out: string[] = [];
+  let from = 0;
+  for (;;) {
+    const start = code.indexOf(callName, from);
+    if (start === -1) break;
+    let depth = 0;
+    let i = start + callName.length - 1;
+    const open = i;
+    for (; i < code.length; i++) {
+      if (code[i] === '(') depth++;
+      else if (code[i] === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    out.push(code.slice(open + 1, i));
+    from = start + callName.length;
+  }
+  return out;
+}
+
+/** Split an argument list on TOP-LEVEL commas only. */
+function topLevelArgs(argText: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of argText) {
+    if (ch === '(' || ch === '[' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  out.push(current);
+  return out.map((s) => s.trim());
+}
+
+const FILES = ccdaSourceFiles();
+const CODE = new Map(FILES.map((f) => [f, fs.readFileSync(path.join(SRC_DIR, f), 'utf8')]));
+
+describe('C-CDA identity minting has exactly one door', () => {
+  it('the door exists and applies id -> content -> loud collapse', async () => {
+    const mod = await import('../src/lib/ccda-converter/record-identity.js');
+    expect(typeof mod.ccdaRecordUri).toBe('function');
+    expect(typeof mod.ccdaSourceId).toBe('function');
+    expect(typeof mod.ccdaMedicationRecordUri).toBe('function');
+
+    // Tier 1: the id decides, and nothing else is consulted.
+    const withId = (content: Record<string, string | undefined>) =>
+      mod.ccdaRecordUri({ type: 'Condition', sourceId: '1.2.3:A', content });
+    expect(withId({ conditionName: 'diabetes' })).toBe(withId({ conditionName: 'asthma' }));
+
+    // Tier 2: no id, so the content separates.
+    const noId = (content: Record<string, string | undefined>) =>
+      mod.ccdaRecordUri({ type: 'Condition', content });
+    expect(noId({ conditionName: 'diabetes' })).not.toBe(noId({ conditionName: 'asthma' }));
+
+    // Tier 4: nothing at all, and it is not silent.
+    const warnings: string[] = [];
+    mod.ccdaRecordUri({ type: 'Condition', content: {}, source: {}, warnings, label: 'C-CDA problem' });
+    expect(warnings.length, 'an identity collapse must never be silent').toBe(1);
+    expect(warnings[0]).toContain('C-CDA problem');
+  });
+
+  it('nothing in the C-CDA converter mints identity except the door', () => {
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (file === DOOR) continue;
+      const code = stripComments(CODE.get(file)!);
+      for (const { call } of GUARDED) {
+        if (callArguments(code, call).length > 0) {
+          offenders.push(`${file}: calls ${call}…)`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Mint through ccdaRecordUri()/ccdaMedicationRecordUri() in ${DOOR}. A second mint site is ` +
+        'how the id tier came to be dead at ten call sites at once.',
+    ).toEqual([]);
+  });
+
+  it('the door never passes a live fallbackId — the shape that killed the id tier', () => {
+    const code = stripComments(CODE.get(DOOR)!);
+    const offenders: string[] = [];
+    for (const { call, fallbackArgIndex } of GUARDED) {
+      for (const args of callArguments(code, call)) {
+        const parts = topLevelArgs(args);
+        const slot = parts[fallbackArgIndex];
+        if (slot === undefined) continue;   // called with fewer args: no fallbackId at all
+        if (slot !== 'undefined') {
+          offenders.push(`${DOOR}: ${call}…) argument ${fallbackArgIndex + 1} is \`${slot}\`, not \`undefined\``);
+        }
+      }
+    }
+    expect(
+      offenders,
+      'contentHashedUri consults fallbackId ONLY when every content field is empty, so an id ' +
+        'passed there is not a fallback, it is discarded. Route the id through the tier-1 branch.',
+    ).toEqual([]);
+  });
+
+  it('no C-CDA identity key carries a patient component', () => {
+    // The derived patient IRI is gone from every key AND from every section
+    // signature. Both halves matter: while it was a parameter, the next key
+    // written would have reached for it.
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      const code = stripComments(CODE.get(file)!);
+      if (/\bpatientUri\b/.test(code)) {
+        // `patient.ts` legitimately names its own return value.
+        if (file !== 'lib/ccda-converter/sections/patient.ts') {
+          offenders.push(`${file}: mentions patientUri`);
+        }
+      }
+      for (const args of callArguments(code, 'ccdaRecordUri(')) {
+        if (/(^|[^A-Za-z])patient\s*:/.test(args)) {
+          offenders.push(`${file}: an identity key contains a \`patient:\` entry`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      'Within a pod the patient component is either constant — telling no two records apart — or ' +
+        'varying, in which case each variation is a spurious split of the same person. See the ' +
+        `header of ${DOOR}.`,
+    ).toEqual([]);
+  });
+
+  it('every C-CDA section handler routes through the door', () => {
+    // A section that mints nothing (social-history) is fine; a section that
+    // mints without importing the door is not.
+    const sections = FILES.filter((f) => f.startsWith(`${CCDA_DIR}sections/`));
+    expect(sections.length, 'section handlers not found — has the tree moved?').toBeGreaterThan(8);
+
+    const offenders: string[] = [];
+    for (const file of sections) {
+      const code = stripComments(CODE.get(file)!);
+      const mints = /urn:uuid:|namedNode\(uri\)|namedNode\(patientUri\)/.test(code);
+      const takesDoor = /from '\.\.\/record-identity\.js'/.test(code);
+      if (mints && !takesDoor) offenders.push(`${file}: mints a subject without importing the door`);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/ccda-lab-identity.test.ts
+++ b/tests/ccda-lab-identity.test.ts
@@ -49,7 +49,6 @@ import { extractLabQuads } from '../src/lib/ccda-converter/sections/labs.js';
 // Helpers and fixtures — the shapes fast-xml-parser produces from real C-CDA
 // ---------------------------------------------------------------------------
 
-const PATIENT = 'urn:uuid:synthetic-patient-1';
 const SOURCE = 'SyntheticEHR';
 const IMPORTED_AT = '2026-08-03T00:00:00Z';
 
@@ -93,7 +92,7 @@ function panel(opts: { id?: string; code?: string; time?: string; members: any[]
 }
 
 function convert(entries: any[]): any[] {
-  return extractLabQuads(entries, PATIENT, SOURCE, undefined, IMPORTED_AT);
+  return extractLabQuads(entries, SOURCE, undefined, IMPORTED_AT);
 }
 
 /** Every subject carrying an `rdf:type` of the given local name, in emission order. */
@@ -202,24 +201,43 @@ describe('C-CDA lab results that differ are two records', () => {
 /**
  * The panel path did NOT carry the member path's "the id was discarded" defect:
  * `panelId` was already a first-class content field, put there by an earlier fix
- * for a related collision. So an id-bearing organizer was already separated by
- * its id, and its IRI is deliberately left byte-identical by this change.
+ * for a related collision, so an id-bearing organizer was already separated by
+ * its id.
  *
- * What it DID carry is the other half — a day-truncated `clinicalDate` — which
- * bites when the organizer has neither an id nor a code, the combination the
- * code's own comment reports is common in real Epic exports (47 of 55 panels in
- * an acceptance export carry no code).
+ * Its IRI moves anyway, and it is worth being precise about why, because the
+ * previous revision of this file pinned it as deliberately unmoved. The panel
+ * key also carried the document's DERIVED patient IRI, and that component has
+ * left every C-CDA key — it merged records the source kept apart and split
+ * records that were the same. So the panel IRI was going to move whichever way
+ * this was written, and given that, the panel takes the same door as every other
+ * record rather than keeping a hybrid key: the organizer's own `<id>` decides.
+ *
+ * The other half of the original defect stands and is still pinned below: a
+ * day-truncated `clinicalDate`, which bites when the organizer has neither an id
+ * nor a code — the combination the converter's own comment reports is common in
+ * real Epic exports (47 of 55 panels in an acceptance export carry no code).
  */
 describe('C-CDA lab panels', () => {
   const memberA = labObs({ id: 'm-a', value: '95', time: '20260802070000-0500' });
   const memberB = labObs({ id: 'm-b', value: '310', time: '20260802110000-0500' });
 
-  it('an id-bearing panel mints exactly the IRI it always has', () => {
-    // GOLDEN PIN, and it passes with or without this change BY DESIGN — that is
-    // what it is asserting. The value was measured against the previous build.
-    // A drift here means panel IRIs moved in an existing pod for no reason.
-    expect(panelUri(panel({ id: 'org-1', code: '24323-8', time: '20260802070000-0500', members: [memberA] })))
-      .toBe('urn:uuid:f9e45f8f-0927-571b-bee2-e1cf609cda5a');
+  it('an id-bearing panel keys on its id alone', () => {
+    // GOLDEN PIN. The value is `deterministicUuid('LaboratoryReport:1.2.3:org-1')`
+    // and nothing else feeds it, so changing the organizer's code, its time or
+    // its members cannot move it.
+    const withId = (over: Record<string, unknown>) =>
+      panelUri(panel({ id: 'org-1', code: '24323-8', time: '20260802070000-0500', members: [memberA], ...over }));
+
+    expect(withId({})).toBe('urn:uuid:a3ae422f-8cea-51a9-8a2c-61cb10216694');
+    expect(withId({ code: '58410-2' })).toBe(withId({}));
+    expect(withId({ time: '20260802110000-0500' })).toBe(withId({}));
+    expect(withId({ members: [memberB] })).toBe(withId({}));
+  });
+
+  it('two panels with different ids are two records', () => {
+    const p1 = panel({ id: 'org-1', code: '24323-8', time: '20260802070000-0500', members: [memberA] });
+    const p2 = panel({ id: 'org-2', code: '24323-8', time: '20260802070000-0500', members: [memberA] });
+    expect(panelUri(p1)).not.toBe(panelUri(p2));
   });
 
   it('two id-less, code-less panels on one day are two records', () => {
@@ -288,7 +306,7 @@ const { extractLabQuads } = await import(
   pathToFileURL(path.join(dist, 'lib/ccda-converter/sections/labs.js')).href
 );
 const p = JSON.parse(process.env.CASCADE_PAYLOAD);
-const quads = extractLabQuads(p.entries, p.patient, p.source, undefined, p.importedAt);
+const quads = extractLabQuads(p.entries, p.source, undefined, p.importedAt);
 const uris = quads
   .filter((q) => q.predicate.value.endsWith('#type'))
   .map((q) => q.subject.value);
@@ -303,7 +321,7 @@ function mintIn(dir: string, entries: any[]): { cwd: string; uris: string[] } {
     env: {
       ...process.env,
       CASCADE_DIST: DIST,
-      CASCADE_PAYLOAD: JSON.stringify({ entries, patient: PATIENT, source: SOURCE, importedAt: IMPORTED_AT }),
+      CASCADE_PAYLOAD: JSON.stringify({ entries, source: SOURCE, importedAt: IMPORTED_AT }),
     },
     encoding: 'utf8',
   });

--- a/tests/ccda-record-identity.test.ts
+++ b/tests/ccda-record-identity.test.ts
@@ -1,0 +1,435 @@
+/**
+ * The C-CDA importer must honour a source record's own identifier, for every
+ * record type, and it must keep working when that identifier is the root-only
+ * form that real EHR exports actually emit.
+ *
+ * THE DEFECT THESE PIN, MEASURED AGAINST `main` BEFORE THE CHANGE
+ * --------------------------------------------------------------
+ * Every section minted with
+ *
+ *     contentHashedUri('X', { patient: patientUri, … }, sourceId || undefined, entry)
+ *
+ * and `contentHashedUri` reads `fallbackId` ONLY when every content field is
+ * empty. `patient` never is. So two entries identical in every content field and
+ * differing only in their `<id extension>` minted ONE IRI, at all ten identity
+ * sites:
+ *
+ *     problems allergies immunizations vitals devices procedures encounters
+ *     family-history medications patient        -> 10 of 10 MERGED
+ *
+ * And the id most of them would have needed was unreadable anyway: eight of nine
+ * section handlers extracted an id only when `@extension` was present, so
+ * `<id root="9a6d1bac-…"/>` — the canonical C-CDA form for a locally minted
+ * identifier — was discarded outright, along with the `cascade:sourceRecordId`
+ * that would have been emitted from it.
+ *
+ *     problems allergies immunizations vitals devices procedures
+ *     family-history medications labs           -> 9 of 10 DISCARDED a root-only id
+ *
+ * The derived `patientUri` in those keys also failed in the opposite direction:
+ * it is derived from four mutable demographic fields, so one person recorded as
+ * "John" in one document and "Johnny" in another produced two patient IRIs, and
+ * a byte-identical procedure carrying the SAME source id split into two records.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT
+ * ------------------------------------------
+ * Every `it` in the first four describes FAILS against a build of `main` at
+ * 51a4089. That was run, not assumed. The re-import and determinism blocks are
+ * the opposite kind of test — they pass both before and after BY DESIGN, and
+ * they are labelled where they sit: they are the controls that catch this fix
+ * over-correcting into a blunt split.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { ccdaSourceId } from '../src/lib/ccda-converter/record-identity.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const LOCAL_FIXTURES = path.join(REPO, 'test-fixtures');
+const ROOT_ONLY_FIXTURE = path.join(LOCAL_FIXTURES, 'ccda-root-only-ids.xml');
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+
+function readRootOnlyFixture(): string {
+  return fs.readFileSync(ROOT_ONLY_FIXTURE, 'utf8');
+}
+
+/** Convert a C-CDA document and return its parsed quads. */
+async function quadsOf(xml: string): Promise<any[]> {
+  const result = await convertCcda(xml, { sourceSystem: 'SyntheticEHR' });
+  expect(result.errors, `conversion errors: ${result.errors.join(', ')}`).toHaveLength(0);
+  return new Parser({ format: 'Turtle' }).parse(result.output);
+}
+
+/** Every subject carrying an rdf:type whose IRI ends with `localName`. */
+function subjectsOfType(quads: any[], localName: string): string[] {
+  return [
+    ...new Set(
+      quads
+        .filter((q) => q.predicate.value === RDF_TYPE && q.object.value.endsWith(localName))
+        .map((q) => q.subject.value),
+    ),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 1. The id extraction chokepoint
+// ---------------------------------------------------------------------------
+
+describe('ccdaSourceId reads every HL7 II form a real export emits', () => {
+  it('root + extension: the shape every section already handled', () => {
+    expect(ccdaSourceId({ '@_root': '1.2.3', '@_extension': 'A' })).toBe('1.2.3:A');
+  });
+
+  it('ROOT ONLY: the canonical locally-minted identifier, discarded by 9 of 10 sections', () => {
+    expect(ccdaSourceId({ '@_root': '9a6d1bac-17d3-4195-89a4-1121bc809b4a' }))
+      .toBe('9a6d1bac-17d3-4195-89a4-1121bc809b4a');
+  });
+
+  it('extension only, which stays byte-compatible with the old inline readers', () => {
+    expect(ccdaSourceId({ '@_extension': 'A' })).toBe(':A');
+  });
+
+  it('the bare (non-attribute) spelling only immunizations used to handle', () => {
+    expect(ccdaSourceId({ root: '1.2.3', extension: 'A' })).toBe('1.2.3:A');
+    expect(ccdaSourceId({ root: '1.2.3' })).toBe('1.2.3');
+  });
+
+  it('multiple ids: the first USABLE one, so a nullFlavor placeholder does not blind it', () => {
+    // `id[0]`, which every section used, returned nothing here.
+    expect(ccdaSourceId([{ '@_nullFlavor': 'NI' }, { '@_root': '1.2.3', '@_extension': 'B' }]))
+      .toBe('1.2.3:B');
+    // …and with real ids it is document order, which is stable within a
+    // document's bytes. Not a sort: a sort would change which id wins when a
+    // vendor adds a second one.
+    expect(ccdaSourceId([{ '@_root': 'z' }, { '@_root': 'a' }])).toBe('z');
+  });
+
+  it('no usable identifier at all is undefined, not an empty string', () => {
+    expect(ccdaSourceId(undefined)).toBeUndefined();
+    expect(ccdaSourceId(null)).toBeUndefined();
+    expect(ccdaSourceId({})).toBeUndefined();
+    expect(ccdaSourceId({ '@_nullFlavor': 'NI' })).toBeUndefined();
+    expect(ccdaSourceId({ '@_root': '   ' })).toBeUndefined();
+  });
+
+  it('accepts the element OR its id, because a silent undefined is not a chokepoint', () => {
+    // Writing this with an id-value-only signature cost a real defect during the
+    // change that introduced it: `ccdaSourceId(organizer)` returned undefined
+    // with no error and two lab panels with different ids MERGED.
+    const idEl = { '@_root': '1.2.3', '@_extension': 'A' };
+    expect(ccdaSourceId({ id: idEl })).toBe('1.2.3:A');
+    expect(ccdaSourceId(idEl)).toBe('1.2.3:A');
+    expect(ccdaSourceId({ id: [idEl] })).toBe('1.2.3:A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Root-only ids across every section, end to end
+// ---------------------------------------------------------------------------
+
+/**
+ * The fixture carries TWO entries per section, identical in every content field
+ * and differing ONLY in a root-only `<id>`. Before the change, each pair minted
+ * one record; after it, two.
+ *
+ * This is the case §4 of the plan calls out: a suite whose fixtures all carry
+ * `@extension` passes while the importer still ignores the id on the majority of
+ * real documents. The conformance corpus carries zero root-only ids, which is
+ * why this fixture lives here.
+ */
+describe('root-only <id> is honoured in every section, end to end', () => {
+  const CASES: ReadonlyArray<{ type: string; expected: number; why: string }> = [
+    { type: 'ConditionRecord', expected: 2, why: 'two problem acts, one diagnosis' },
+    { type: 'AllergyRecord', expected: 2, why: 'two concern acts, one allergen' },
+    { type: 'ImmunizationRecord', expected: 2, why: 'two doses, same vaccine and day' },
+    { type: 'Medication', expected: 2, why: 'two orders, same drug and start date' },
+    { type: 'VitalSign', expected: 2, why: 'two heart-rate readings, same value' },
+    { type: 'Procedure', expected: 2, why: 'two colonoscopies on one day' },
+    { type: 'Encounter', expected: 2, why: 'two office visits on one day' },
+    // STABILITY PIN, not evidence: the panel key already carried the organizer
+    // id as a first-class CONTENT field, so this one passes on a build without
+    // the change too. It guards the panel path against regressing INTO the
+    // defect the other nine had.
+    { type: 'LaboratoryReport', expected: 2, why: 'two panels, same code and time' },
+    { type: 'FamilyHistoryRecord', expected: 2, why: 'two sisters, one diagnosis' },
+    { type: 'ImplantedDevice', expected: 2, why: 'two pacemaker leads on one day' },
+  ];
+
+  for (const { type, expected, why } of CASES) {
+    it(`${type}: ${why} -> ${expected} records`, async () => {
+      const quads = await quadsOf(readRootOnlyFixture());
+      const subs = subjectsOfType(quads, type);
+      expect(subs.length, `${type} collapsed: ${subs.join(' ')}`).toBe(expected);
+    });
+  }
+
+  it('and every one of them emits cascade:sourceRecordId, which was lost too', async () => {
+    const quads = await quadsOf(readRootOnlyFixture());
+    const withSourceId = new Set(
+      quads
+        .filter((q) => q.predicate.value === `${CASCADE}sourceRecordId`)
+        .map((q) => q.subject.value),
+    );
+    // The root-only ids in the fixture are UUIDs; a section that discarded them
+    // emitted no sourceRecordId at all.
+    expect(withSourceId.size).toBeGreaterThanOrEqual(18);
+    for (const value of quads
+      .filter((q) => q.predicate.value === `${CASCADE}sourceRecordId`)
+      .map((q) => q.object.value)) {
+      expect(value, 'a root-only id must survive verbatim, not as ":ext"').not.toMatch(/^:/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Patient identity: the MRN, and the John / Johnny case
+// ---------------------------------------------------------------------------
+
+/** A minimal C-CDA carrying only a recordTarget. */
+function patientDoc(opts: { mrn?: string | null; given?: string; family?: string; addr?: string }): string {
+  const idEl = opts.mrn === null || opts.mrn === undefined
+    ? ''
+    : `<id root="2.16.840.1.113883.19.5" extension="${opts.mrn}"/>`;
+  const addr = opts.addr
+    ? `<addr use="HP"><streetAddressLine>${opts.addr}</streetAddressLine><city>Springfield</city></addr>`
+    : '';
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5" extension="DOC-1"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1"/>
+  <title>Patient identity fixture</title>
+  <effectiveTime value="20260201120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <recordTarget>
+    <patientRole>
+      ${idEl}
+      ${addr}
+      <patient>
+        <name><given>${opts.given ?? 'John'}</given><family>${opts.family ?? 'Smith'}</family></name>
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19800412"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component><structuredBody></structuredBody></component>
+</ClinicalDocument>`;
+}
+
+async function patientUriOf(xml: string): Promise<string> {
+  const subs = subjectsOfType(await quadsOf(xml), 'PatientProfile');
+  expect(subs.length, 'expected exactly one PatientProfile').toBe(1);
+  return subs[0];
+}
+
+describe('C-CDA patient identity keys on the MRN the source assigned', () => {
+  it('two different people with distinct MRNs are two profiles', async () => {
+    // Previously: the key was {dob, sex, family, given[0]}, so two people
+    // sharing all four merged and every record of either hung off one profile.
+    const a = await patientUriOf(patientDoc({ mrn: 'MRN-000111', given: 'John', family: 'Smith' }));
+    const b = await patientUriOf(patientDoc({ mrn: 'MRN-999888', given: 'John', family: 'Smith' }));
+    expect(a).not.toBe(b);
+  });
+
+  it('one person under two spellings, one MRN, is ONE profile', async () => {
+    const john = await patientUriOf(patientDoc({ mrn: 'MRN-000111', given: 'John' }));
+    const johnny = await patientUriOf(patientDoc({ mrn: 'MRN-000111', given: 'Johnny' }));
+    expect(johnny).toBe(john);
+  });
+
+  // STABILITY PIN, not evidence: `address` was outside the old four-field key
+  // too, so this passes on a build without the change. It guards the widened key
+  // from over-correcting — an address change must not re-identify a person whose
+  // MRN the source stated.
+  it('the MRN decides even when the address differs between two exports', async () => {
+    const home = await patientUriOf(patientDoc({ mrn: 'MRN-000111', addr: '1 Elm St' }));
+    const moved = await patientUriOf(patientDoc({ mrn: 'MRN-000111', addr: '2 Oak Ave' }));
+    expect(moved).toBe(home);
+  });
+
+  it('without an MRN the demographics separate, including beyond given[0]', async () => {
+    const a = await patientUriOf(patientDoc({ mrn: null, given: 'John', family: 'Smith' }));
+    const b = await patientUriOf(patientDoc({ mrn: null, given: 'Jane', family: 'Smith' }));
+    expect(a).not.toBe(b);
+
+    // A field the converter SERIALIZES but the old four-field key left out.
+    const here = await patientUriOf(patientDoc({ mrn: null, addr: '1 Elm St' }));
+    const there = await patientUriOf(patientDoc({ mrn: null, addr: '2 Oak Ave' }));
+    expect(here).not.toBe(there);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The derived patient IRI no longer splits records across documents
+// ---------------------------------------------------------------------------
+
+/** One C-CDA carrying a single procedure with a fixed source id. */
+function procedureDoc(given: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5" extension="DOC-${given}"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1"/>
+  <title>Procedure fixture</title>
+  <effectiveTime value="20260201120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5" extension="MRN-000111"/>
+      <patient>
+        <name><given>${given}</given><family>Smith</family></name>
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19800412"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component><structuredBody>
+    <component><section>
+      <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+      <code code="47519-4" codeSystem="2.16.840.1.113883.6.1"/>
+      <title>Procedures</title>
+      <text>Appendectomy.</text>
+      <entry typeCode="DRIV">
+        <procedure classCode="PROC" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+          <id root="1.2.3.4" extension="PROC-1"/>
+          <code code="80146002" displayName="Appendectomy" codeSystem="2.16.840.1.113883.6.96"/>
+          <statusCode code="completed"/>
+          <effectiveTime value="20260101"/>
+        </procedure>
+      </entry>
+    </section></component>
+  </structuredBody></component>
+</ClinicalDocument>`;
+}
+
+describe('a record does not change identity because the patient changed nickname', () => {
+  it('the same procedure, same source id, in a "John" doc and a "Johnny" doc is ONE record', async () => {
+    // Previously TWO. `patientUri` was derived from {dob, sex, family, given[0]}
+    // and spliced into every section key, so a nickname re-identified every
+    // clinical record in the document.
+    const [john] = subjectsOfType(await quadsOf(procedureDoc('John')), 'Procedure');
+    const [johnny] = subjectsOfType(await quadsOf(procedureDoc('Johnny')), 'Procedure');
+    expect(john).toBeTruthy();
+    expect(johnny).toBe(john);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. CONTROLS. These pass before and after, by design.
+// ---------------------------------------------------------------------------
+
+describe('CONTROL — a true re-import still produces one record set', () => {
+  /** Every record subject in a converted document. */
+  async function recordSubjects(xml: string): Promise<string[]> {
+    return [
+      ...new Set(
+        (await quadsOf(xml))
+          .filter((q) => q.predicate.value === RDF_TYPE)
+          .map((q) => q.subject.value),
+      ),
+    ].sort();
+  }
+
+  it('importing the same document twice mints exactly the same subjects', async () => {
+    // This is what separates a fix from a blunt split. If honouring the source
+    // id had been implemented as "mint something new for each entry", this
+    // fails — and this is the control that caught an over-correction earlier in
+    // this work.
+    const xml = readRootOnlyFixture();
+    const first = await recordSubjects(xml);
+    const second = await recordSubjects(xml);
+
+    expect(first.length, 'the fixture must actually produce records').toBeGreaterThan(18);
+    expect(second).toEqual(first);
+  });
+
+  it('and two documents that differ only in whitespace agree', async () => {
+    // Identity must be a function of what the record SAYS, not of the bytes'
+    // incidental formatting.
+    const xml = readRootOnlyFixture();
+    const reflowed = xml.replace(/>\s+</g, '>\n            <');
+    expect(await recordSubjects(reflowed)).toEqual(await recordSubjects(xml));
+  });
+});
+
+describe('CONTROL — determinism AND distinctness, across processes and directories', () => {
+  /**
+   * Minting twice in one process shares a warm module cache and one
+   * `process.cwd()`. A previous identity defect in this repo was path-dependent
+   * and stayed green for months for exactly that reason.
+   *
+   * The guard keys on a module present in EVERY revision (`sections/labs.js`),
+   * not on anything this change introduces: a guard on a new file SKIPS rather
+   * than FAILS against a pre-fix build, which is how a determinism suite looks
+   * green while proving nothing.
+   */
+  const DIST = path.join(REPO, 'dist');
+  const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'ccda-converter', 'sections', 'labs.js'));
+
+  const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+const dist = process.env.CASCADE_DIST;
+const { convertCcda } = await import(
+  pathToFileURL(path.join(dist, 'lib/ccda-converter/index.js')).href
+);
+const xml = fs.readFileSync(process.env.CASCADE_FIXTURE, 'utf8');
+const result = await convertCcda(xml, { sourceSystem: 'SyntheticEHR' });
+const uris = [...new Set(
+  (result.output.match(/<urn:uuid:[0-9a-f-]{36}>/g) ?? []).map((s) => s.slice(1, -1)),
+)].sort();
+process.stdout.write(JSON.stringify({ cwd: process.cwd(), uris }));
+`;
+
+  function mintIn(dir: string): { cwd: string; uris: string[] } {
+    const scriptPath = path.join(dir, 'mint-ccda-identity.mjs');
+    fs.writeFileSync(scriptPath, SCRIPT, 'utf8');
+    const stdout = execFileSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      env: { ...process.env, CASCADE_DIST: DIST, CASCADE_FIXTURE: ROOT_ONLY_FIXTURE },
+      encoding: 'utf8',
+    });
+    return JSON.parse(stdout);
+  }
+
+  it.skipIf(!HAVE_DIST)('two processes in two directories agree, and still tell the records apart', () => {
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-ccda-id-a-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-ccda-id-b-'));
+    try {
+      const a = mintIn(dirA);
+      const b = mintIn(dirB);
+
+      expect(a.cwd, 'the two runs must not share a working directory').not.toBe(b.cwd);
+      // Determinism.
+      expect(a.uris).toEqual(b.uris);
+      // Distinctness. Determinism alone is satisfied by a constant, which is
+      // precisely what the previous key set was.
+      expect(new Set(a.uris).size).toBe(a.uris.length);
+      expect(a.uris.length).toBeGreaterThan(18);
+    } finally {
+      fs.rmSync(dirA, { recursive: true, force: true });
+      fs.rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('the guard is not silently skipping', () => {
+    // `dist/` is built by `npm run build`, which the test script runs. If this
+    // fails, the determinism test above did NOT run and its green is meaningless.
+    expect(HAVE_DIST, 'run `npm run build` — the cross-process check needs dist/').toBe(true);
+  });
+});

--- a/tests/ccda-record-identity.test.ts
+++ b/tests/ccda-record-identity.test.ts
@@ -329,7 +329,67 @@ describe('a record does not change identity because the patient changed nickname
 });
 
 // ---------------------------------------------------------------------------
-// 5. CONTROLS. These pass before and after, by design.
+// 5. Identity falls through to the record itself when the key has nothing
+// ---------------------------------------------------------------------------
+
+describe('a record with no usable key fields is identified by its own content', () => {
+  /** A problem entry with nothing codeable: no code, no name, no onset. */
+  const bare = (note: string) => ({
+    act: { entryRelationship: { observation: { value: { '@_nullFlavor': 'NI' }, text: note } } },
+  });
+
+  it('two key-less problems with different content are two records', async () => {
+    // Previously ONE. While `patient` was in the key it could never be empty, so
+    // `contentHashedUri` never fell through to the shared identity door and
+    // every such entry landed on the same IRI. A problem noted "left knee" and
+    // one noted "right shoulder" are plainly two problems to any reader.
+    const { extractProblemQuads } = await import('../src/lib/ccda-converter/sections/problems.js');
+    const subjectOf = (entry: any) => {
+      const q = extractProblemQuads([entry], 'SyntheticEHR');
+      const typed = q.filter((x) => x.predicate.value === RDF_TYPE);
+      return typed.length > 0 ? typed[0].subject.value : null;
+    };
+    const a = subjectOf(bare('left knee'));
+    const b = subjectOf(bare('right shoulder'));
+    expect(a).toBeTruthy();
+    expect(b).not.toBe(a);
+  });
+
+  it('a DEFAULTED field is not in the key, or the fall-through never happens', async () => {
+    // `status` is defaulted to the literal 'active' by the converter. The first
+    // draft of this change put it in the key, which made the key a non-empty
+    // CONSTANT and silently restored the merge above. A content tier that
+    // succeeds with a constant is indistinguishable from one that fails, except
+    // that it merges.
+    const src = fs.readFileSync(path.join(REPO, 'src/lib/ccda-converter/sections/problems.ts'), 'utf8');
+    const key = src.slice(src.indexOf('content: {'), src.indexOf('source: entry'));
+    expect(key, 'the problems key must use the STATED status, never the default').not.toMatch(
+      /status:\s*status\b/,
+    );
+    expect(key).toMatch(/statedStatus/);
+  });
+
+  it('but a stated status still separates an active problem from a resolved one', async () => {
+    const { extractProblemQuads } = await import('../src/lib/ccda-converter/sections/problems.js');
+    const withStatus = (state: string) => ({
+      act: {
+        entryRelationship: {
+          observation: {
+            value: { '@_code': '44054006', '@_codeSystem': '2.16.840.1.113883.6.96', '@_displayName': 'Diabetes' },
+            effectiveTime: { low: { '@_value': '20240115' } },
+            entryRelationship: { observation: { value: { '@_displayName': state } } },
+          },
+        },
+      },
+    });
+    const subjectOf = (entry: any) =>
+      extractProblemQuads([entry], 'SyntheticEHR').filter((x) => x.predicate.value === RDF_TYPE)[0].subject.value;
+    expect(subjectOf(withStatus('Active'))).not.toBe(subjectOf(withStatus('Resolved')));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. CONTROLS. These pass before and after, by design.
 // ---------------------------------------------------------------------------
 
 describe('CONTROL — a true re-import still produces one record set', () => {

--- a/tests/pod-import-integration.test.ts
+++ b/tests/pod-import-integration.test.ts
@@ -27,9 +27,22 @@ import { convertCcda } from '../src/lib/ccda-converter/index.js';
 function makeSyntheticCcda(options: {
   patientGiven?: string;
   patientFamily?: string;
+  /**
+   * The MRN in `patientRole/id`. Two different PEOPLE carry two different MRNs;
+   * two renderings of one person carry the same one. It is parameterized because
+   * patient identity now reads it, and a fixture that hard-codes one MRN for
+   * everybody cannot express the difference.
+   */
+  patientMrn?: string | null;
 } = {}): string {
   const given = options.patientGiven ?? 'TestGiven';
   const family = options.patientFamily ?? 'TestFamily';
+  // `null` omits the <id> element entirely — a recordTarget with no identifier
+  // at all, which is what forces the demographics tier to do the separating.
+  const mrn = options.patientMrn === undefined ? 'FAKE-PAT-001' : options.patientMrn;
+  const patientIdEl = mrn === null
+    ? ''
+    : `<id root="2.16.840.1.113883.19.5" extension="${mrn}"/>`;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <ClinicalDocument xmlns="urn:hl7-org:v3"
@@ -48,7 +61,7 @@ function makeSyntheticCcda(options: {
   <!-- Patient demographics (fake) -->
   <recordTarget>
     <patientRole>
-      <id root="2.16.840.1.113883.19.5" extension="FAKE-PAT-001"/>
+      ${patientIdEl}
       <patient>
         <name>
           <given>${given}</given>
@@ -301,26 +314,56 @@ describe('C-CDA import pipeline (integration)', () => {
 
   // ─── Test 3: Different patients → different record URIs ────────────────────
 
-  it('should produce different patient URIs for different patient demographics', async () => {
-    const xmlA = makeSyntheticCcda({ patientGiven: 'AliceGiven', patientFamily: 'AlphaFamily' });
-    const xmlB = makeSyntheticCcda({ patientGiven: 'BobGiven', patientFamily: 'BetaFamily' });
+  // Patient URIs appear as subjects in lines like:
+  //   <urn:uuid:...> a cascade:PatientProfile
+  const PATIENT_URI_REGEX = /<(urn:uuid:[0-9a-f-]{36})>\s+a\s+cascade:PatientProfile/g;
 
-    const resultA = await convertCcda(xmlA, { sourceSystem: 'TestSystem' });
-    const resultB = await convertCcda(xmlB, { sourceSystem: 'TestSystem' });
+  async function patientUriOf(xml: string): Promise<string> {
+    const result = await convertCcda(xml, { sourceSystem: 'TestSystem' });
+    const matches = [...result.output.matchAll(PATIENT_URI_REGEX)].map((m) => m[1]);
+    expect(matches.length, 'document produced no cascade:PatientProfile').toBeGreaterThan(0);
+    return matches[0];
+  }
 
-    // Extract URIs following cascade:PatientProfile type assertion
-    // Patient URIs appear as subjects in lines like: <urn:uuid:...> a cascade:PatientProfile
-    const patientUriRegex = /<(urn:uuid:[0-9a-f-]{36})>\s+a\s+cascade:PatientProfile/g;
+  it('should produce different patient URIs for two different people', async () => {
+    // Two different people, so two different MRNs — which is what an EHR
+    // assigns and what `patientRole/id` carries.
+    const a = await patientUriOf(makeSyntheticCcda({
+      patientGiven: 'AliceGiven', patientFamily: 'AlphaFamily', patientMrn: 'FAKE-PAT-001',
+    }));
+    const b = await patientUriOf(makeSyntheticCcda({
+      patientGiven: 'BobGiven', patientFamily: 'BetaFamily', patientMrn: 'FAKE-PAT-002',
+    }));
 
-    const matchesA = [...resultA.output.matchAll(patientUriRegex)].map(m => m[1]);
-    const matchesB = [...resultB.output.matchAll(patientUriRegex)].map(m => m[1]);
+    expect(a).not.toBe(b);
+  });
 
-    // Both documents must have produced a patient URI
-    expect(matchesA.length).toBeGreaterThan(0);
-    expect(matchesB.length).toBeGreaterThan(0);
+  it('should produce ONE patient URI for one person recorded under two names', async () => {
+    // The other half, and the half that was broken: one person, one MRN, two
+    // documents spelling the given name differently ("John" / "Johnny" in the
+    // real report of this). The demographics-derived key made these two people,
+    // and then split every clinical record in both documents along with them.
+    const john = await patientUriOf(makeSyntheticCcda({
+      patientGiven: 'John', patientFamily: 'Smith', patientMrn: 'FAKE-PAT-777',
+    }));
+    const johnny = await patientUriOf(makeSyntheticCcda({
+      patientGiven: 'Johnny', patientFamily: 'Smith', patientMrn: 'FAKE-PAT-777',
+    }));
 
-    // The URIs must differ (different demographics → different content hash)
-    expect(matchesA[0]).not.toBe(matchesB[0]);
+    expect(johnny).toBe(john);
+  });
+
+  it('should produce different patient URIs for two id-less people', async () => {
+    // With no MRN the demographics are all there is, so the content tier has to
+    // do the separating. It must still separate.
+    const a = await patientUriOf(makeSyntheticCcda({
+      patientGiven: 'AliceGiven', patientFamily: 'AlphaFamily', patientMrn: null,
+    }));
+    const b = await patientUriOf(makeSyntheticCcda({
+      patientGiven: 'BobGiven', patientFamily: 'BetaFamily', patientMrn: null,
+    }));
+
+    expect(a).not.toBe(b);
   });
 
   // ─── Test 4: CVX codes are preserved in immunization output ────────────────

--- a/tests/pod-import-reimport-idempotence.test.ts
+++ b/tests/pod-import-reimport-idempotence.test.ts
@@ -295,3 +295,97 @@ describe('pod import: --report under --dry-run (root 3.52)', () => {
     expect(real.edgeResolution.totalInPod).toBe(preflight.edgeResolution.totalInPod);
   });
 });
+
+// ---------------------------------------------------------------------------
+// C-CDA: the same acceptance, on the import path a portal download takes
+// ---------------------------------------------------------------------------
+
+/**
+ * CONTROL for the C-CDA record-identity change, and the reason it is here rather
+ * than in that change's own suite: this file already owns "a re-import must not
+ * grow the pod", and a fix that makes the source's `<id>` decide identity is
+ * exactly the kind of change that can over-correct into a blunt split.
+ *
+ * It passes before AND after by design. Its job is to fail if identity ever
+ * becomes a function of anything but the record.
+ */
+const CCDA_ROOT_ONLY_FIXTURE = resolve(__dirname, '../test-fixtures/ccda-root-only-ids.xml');
+
+describe('pod import: an identical C-CDA re-import leaves the pod unchanged', () => {
+  it('imports twice, adds no records the second time, and stays byte-identical', () => {
+    const podDir = newPod('cascade-reimport-ccda-');
+
+    const first = importOnce(podDir, CCDA_ROOT_ONLY_FIXTURE);
+    const second = importOnce(podDir, CCDA_ROOT_ONLY_FIXTURE);
+    // A single-FILE import does not reconcile until there is existing pod
+    // content to reconcile against, and `profile/card.ttl` is populated from the
+    // reconciled `clinical/patient-profile.ttl` on the import AFTER that. So the
+    // pod reaches its steady state on import 3, and byte-identity is asserted
+    // from there. Deduplication (`recordsNew === 0`) holds from import 2, and is
+    // asserted from import 2.
+    const third = importOnce(podDir, CCDA_ROOT_ONLY_FIXTURE);
+    const afterThird = podSnapshot(podDir);
+    const fourth = importOnce(podDir, CCDA_ROOT_ONLY_FIXTURE);
+    const afterFourth = podSnapshot(podDir);
+
+    // The document actually carries records, so a green here is not vacuous.
+    expect(first.totalRecordsImported).toBeGreaterThan(0);
+    expect(first.recordsNew).toBeGreaterThan(0);
+
+    // Every later import recognizes every record as already present. THIS is
+    // what separates a fix from a blunt split: if honouring the source `<id>`
+    // had been implemented as "mint something new per entry", recordsNew would
+    // equal totalRecordsImported here, forever, on every re-sync.
+    for (const report of [second, third, fourth]) {
+      expect(report.recordsNew).toBe(0);
+      expect(report.recordsAlreadyPresent).toBe(report.totalRecordsImported);
+    }
+
+    // And the RECORD files did not move.
+    //
+    // TWO files are excluded, and the exclusions are statements rather than
+    // conveniences. Both grow without bound on every C-CDA re-import, both grow
+    // BYTE-FOR-BYTE IDENTICALLY on a build without this change, and both are the
+    // same family as the stated-edge duplication above — filed, not fixed here,
+    // and not hidden either:
+    //
+    //   clinical/documents.ttl  the section-narrative node accumulates a fresh
+    //                           prov:generatedAtTime per import. Measured over
+    //                           four imports: 8050 -> 8720 -> 9140 -> 9560
+    //                           bytes, +420 each. The document SUBJECT count is
+    //                           stable at 10, so this is unbounded property
+    //                           growth, not duplicate records.
+    //   profile/card.ttl        the identity-name block is APPENDED rather than
+    //                           replaced, so foaf:name is stated once per
+    //                           import: 1237 -> 1320 -> 1403 -> 1486 -> 1569
+    //                           bytes, +83 each. The FHIR import path does NOT
+    //                           do this (stable at 1247 bytes across three
+    //                           imports), so it is specific to this path.
+    const KNOWN_UNBOUNDED = new Set([
+      path.join('clinical', 'documents.ttl'),
+      path.join('profile', 'card.ttl'),
+    ]);
+    const recordFiles = (snap: Map<string, string>) =>
+      [...snap.keys()].filter((k) => !KNOWN_UNBOUNDED.has(k));
+    expect(recordFiles(afterFourth)).toEqual(recordFiles(afterThird));
+    for (const rel of recordFiles(afterThird)) {
+      expect(afterFourth.get(rel), rel).toBe(afterThird.get(rel));
+    }
+  });
+
+  it('keeps entries the source kept apart apart, in the pod and not just in a hash', () => {
+    // The other half. A pod that dedupes perfectly by collapsing everything into
+    // one record would pass the test above.
+    const podDir = newPod('cascade-ccda-distinct-');
+    importOnce(podDir, CCDA_ROOT_ONLY_FIXTURE);
+
+    const typed = podQuads(podDir).filter(
+      (q) => q.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+    );
+    const subjects = new Set(typed.map((q) => q.subject.value));
+
+    // The fixture pairs every section: two entries per section, identical except
+    // for a root-only <id>. All ten pairs must survive as pairs.
+    expect(subjects.size).toBeGreaterThan(18);
+  });
+});


### PR DESCRIPTION
## The defect

Every C-CDA section minted its subject IRI with the same call:

```ts
contentHashedUri('X', { patient: patientUri, … }, sourceId || undefined, entry)
```

That reads as "identify by content, fall back to the source's id". It is not.
`contentHashedUri` consults `fallbackId` **only when every content field is empty**, and
`patient` is always a non-empty `urn:uuid:`. So on this path the source's own identifier was
not usually ignored — it was **unconditionally dead**, at every one of the ten places a C-CDA
record gets an identity.

Measured against a build of `main` at `51a4089`, two entries identical in every content field
and differing only in their `<id extension>`:

```
problems      allergies      immunizations  vitals    devices
procedures    encounters     family-history medications
patient (two different people, distinct MRNs)

10 of 10 minted ONE IRI — the source id was discarded
```

The same field also failed in the **opposite** direction, from one cause. `patientUri` is
derived from four mutable demographic fields (`dob`, `sex`, `family`, `given[0]`), so the same
person recorded as "John" in one document and "Johnny" in another — same MRN — derived two
different patient values:

```
patientUri John vs Johnny (same MRN)         : DIFFERENT
identical procedure, same source id, two docs: SPLIT INTO TWO
```

So one design both **merged** records the source kept apart and **split** records that were
the same.

And on most real documents there was no id left to read anyway. C-CDA's canonical form for a
locally minted identifier is `<id root="9a6d1bac-…"/>` with no `@extension`, which is what
Epic and Cerner emit, and nine of ten sections extracted an id only when `@extension` was
present:

```
problems allergies immunizations vitals devices procedures
family-history medications labs      -> root-only <id> DISCARDED
encounters                           -> kept

9 of 10
```

`cascade:sourceRecordId` was therefore missing from those records too, so the loss was already
visible in pod output and not only in identity.

## Should the derived patient value stay in the keys, widened, or leave?

It leaves. The evidence, all measured on `51a4089`:

- **It is never an edge.** No C-CDA quad has the patient IRI as its object; it exists only as
  an ingredient of other records' keys. Removing it severs nothing `pod query --neighbors` can
  traverse.
- **Nothing downstream is patient-scoped.** `pod import` populates the profile from the FIRST
  `cascade:PatientProfile` subject it finds and stops; `PodReader.readPatientProfile` reads
  "the pod owner's" fields first-wins across two files. Both are written for one person.
- **A pod holds one person.** `pod init` takes a single `--owner-name`; `cascade:ProxyAgent`
  (core v3.3) models a caregiver operating a pod as an agent acting for the patient,
  *"Distinct from the patient (cascade:PatientProfile)"* — the second person in the room is
  explicitly not a second profile. The FHIR converter states it outright: *"a store whose whole
  premise is that the record is about one person"*.
- **Family history, the case most likely to break, does not.** Two sisters with the same
  diagnosis already collided on `main` at every id level, because a component that is constant
  within a pod cannot tell two of that pod's records apart. Removing it changes none of those
  cases; honouring the observation's own `<id>` fixes two of the three.

Within a pod the component is either constant — contributing nothing — or varying, and every
variation is one of the splits above. Removing it also makes the shared identity door's salvage
and **loud-collapse** tiers reachable on this path for the first time; they were documented as
unreachable precisely because of this field.

## The fix

Two chokepoints, because one shape repeated ten times is what this class is.

1. **`ccdaRecordUri` / `ccdaMedicationRecordUri`** — the identity door. `id` → content →
   salvage → loud collapse. Tier 1 is `{type}:{id}`: the same template `mintSubjectUri` applies
   to `resource.id` on the FHIR path, and byte-identical to the `contentHashedUri(type, {}, id)`
   the C-CDA lab path already ships, so **no id-bearing lab IRI moves**.
2. **`ccdaSourceId`** — one `<id>` reader. Handles root+extension, extension alone, root alone,
   the bare non-attribute spelling, and multiple `<id>` elements (the first *usable* one, so a
   `nullFlavor` placeholder does not blind it). Generalized from `encounters.ts`, the one
   section that already handled root-only.

`tests/ccda-identity-chokepoint.test.ts` is the lock, in the manner of the existing chokepoint
tests: nothing under `src/lib/ccda-converter/` may call `contentHashedUri` or `medicationUri`
except the door; the door's own calls must pass `undefined` in the fallbackId slot — the
dead-`fallbackId` shape, made unrepresentable rather than discouraged; and no key may carry a
patient component. A comment does not hold this. The lab section's "subject minting is FROZEN"
comment is a large part of why the defect shipped in two importers at once.

**Patient identity** now reads the MRN in `patientRole/id`, which the previous call did not
even attempt — it passed `undefined`. Without an MRN the key fingerprints the whole `name`
array, the whole `addr` array and `telecom`, replacing `{dob, sex, family, given[0]}`. That is
the same widening the FHIR Patient key received, plus `telecom`, which this converter
serializes and that one does not.

## Fixed in passing

All three measured on `51a4089`, all pre-existing:

- **A C-CDA allergy in its standard nesting produced NO record at all.** `act` →
  `entryRelationship` → `observation` is what Epic and Cerner emit; only the looser
  `act` → `observation` shape was walked, and `entryRelationship` is always an array from the
  parser's `isArray` config, so `act?.entryRelationship?.observation` was always `undefined`.
- **Family history produced NO record at all**, for the same class of reason: component
  observations were read as an object where the parser always yields a list. The conformance
  corpus has no family history section, so the handler was never exercised.
- **`vitals` (the lab re-route) and `medications` passed no source object** to the last identity
  tier, so a contentless record landed on a shared per-type sentinel rather than a hash of
  itself.

## Blast radius

Across the nine C-CDA documents in the conformance corpus and this repo's fixtures, which
convert to **56 records: 28 move, 28 do not.**

| | |
|---|---|
| unchanged | 19 section-narrative document nodes, 9 id-bearing lab results |
| moved | 9 patient profiles, 5 allergies, 5 lab panels, 3 conditions, 3 immunizations, 2 medications, 1 encounter |

Counted as distinct IRIs rather than per document: **17 of 44 move.**

**The FHIR import path is untouched**: 266 distinct IRIs across the same fixtures, **0 moved**.

The reference pod holds no C-CDA-imported records — its 177 `urn:uuid` subjects are
hand-authored placeholders with zero overlap against any C-CDA-minted IRI — so its blast radius
is 0 of 177.

## Verification

Run against **both** a build of `51a4089` and this branch, both results reported.

Per-claim negative control, identical script against both builds:

```
main @ 51a4089    4 pass / 15 fail
this branch      19 pass /  0 fail
```

The 4 that pass on both are labelled **STABILITY PIN** in place and each states what it guards
rather than being counted as evidence: the lab-panel case (the panel key already carried the
organizer id as a content field), the address case (address was outside the old key too), and
the two re-import controls.

**One of those 19 claims caught a defect I had introduced**, and it is worth naming because the
claim only existed because the plan said to verify rather than assert. The first draft added
`status` to the Condition key on the completeness rule — but the converter DEFAULTS status to
the literal `'active'`, so the key was a non-empty CONSTANT, the fall-through this change exists
to unlock never happened, and two plainly different key-less problems still merged onto one IRI,
exactly as on `main`. Only the STATED status is in the key now, and a test reads the key back
out of the source so that re-adding a defaulted field fails the suite.

**A correction to one claim in the plan, measured.** Removing the patient component does NOT
make the tier-4 loud-collapse warning fire in practice. Every section passes its raw source
element, and a parsed C-CDA element is essentially never empty, so tier 2 answers: a problem
entry whose only `<value>` is `nullFlavor="NI"` emits **zero** collapse warnings on this branch.
Tier 4 is reachable *through* the door and the chokepoint test exercises it, but from a real
document it stays as unreached as `src/lib/identity.ts` says. What removing the component really
buys is the fall-through: two key-less entries with different content mint two IRIs where they
minted one.

- **Determinism AND distinctness**, in two processes from two working directories through
  `dist/`. Determinism alone is satisfied by a constant, which is what the previous key set
  effectively was. The skip guard keys on a module present in every revision, plus an explicit
  assertion that the guard is not skipping — a guard on a new file would SKIP against a pre-fix
  build rather than fail.
- **A true re-import still dedupes.** The same document imported four times reports
  `recordsNew: 0` from the second import on, and the record files are byte-identical from the
  third. Two files are excluded from that byte check and the exclusion is stated in the test
  rather than hidden: `clinical/documents.ttl` (+420 bytes per re-import, unbounded) and
  `profile/card.ttl` (+83 bytes per re-import, unbounded) both grow **byte-for-byte identically
  on a build without this change**, so they are separate pre-existing defects; the FHIR import
  path does not exhibit the `card.ttl` one.
- **Real fixtures.** `test-fixtures/ccda-root-only-ids.xml` carries the root-only `<id>` form in
  every section, two entries per section identical but for the id. The conformance corpus
  contains **zero** root-only ids across its 41 `<id>` elements, so a suite written without this
  would pass while the importer still ignored the id on the majority of real documents.

```
Suite: 1499 -> 1536 passed, 0 failed, 0 skipped (109 -> 111 files)
Lint:  11 errors on this branch, 11 on 51a4089 — all pre-existing, none in changed files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

