### PR TITLE
fix(c-cda): a repeatable element had two shapes, and four sections read the wrong one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,14 @@ which:
    records merged into one and one of them was silently lost. Fixing that necessarily moves
    those IRIs. **These are the release's IRI-breaking changes**, and the upgrade notes below
    say what to do about them.
-3. **Some records were never imported at all**, and this is not an identity change. An allergy
-   written in C-CDA's standard nesting, and any family history, produced no record whatsoever
-   from a standards-conformant document. Both are fixed here. **So expect your record count to
-   go UP after re-importing, not merely to see IRIs move** — if you import a portal export that
-   contains allergies or family history, records will appear that no previous version of this
-   tool ever wrote. See Fixed, below.
+3. **Whole clinical sections were never imported at all**, and this is not an identity change.
+   On a C-CDA document whose custodian organization named a recognized EHR vendor — which is
+   what a downloaded portal export is — **lab results, vital signs, family history and
+   implanted devices each imported as ZERO records**, and the import reported success. On every
+   document, vendor-recognized or not, an allergy written in C-CDA's standard nesting produced
+   no record, and a procedure produced a record with no name, date or code. All of these are
+   fixed here. **So expect your record count to go UP after re-importing, not merely to see
+   IRIs move.** See Fixed, below, and the note on what is still not imported.
 
 ### Upgrade notes
 
@@ -151,9 +153,10 @@ which:
 - **Breaking for EVERY record type read from a C-CDA document.** If you have imported a
   downloaded portal export — a MyChart or HealtheLife C-CDA, or an IHE XDM zip of them — every
   record from it changes IRI in this release. Not one type: all of them. **Re-importing such a
-  document will also produce MORE records than before**, because allergies and family history
-  were previously dropped outright from standards-conformant documents; that is the third
-  change above, and it is a recovery rather than a break.
+  document will also produce MORE records than before** — substantially more, if your export
+  came from a recognized vendor, because its lab results, vital signs, family history and
+  implanted devices were previously dropped in their entirety; that is the third change above,
+  and it is a recovery rather than a break.
 
   What was wrong, and why it was all of them at once: every C-CDA section built its record's
   identity from a list of fields that began with the DOCUMENT'S PATIENT, and passed the source
@@ -208,7 +211,68 @@ which:
   than per document, 17 of 44 move. **The FHIR import path is untouched by this change**: 266
   distinct IRIs across the same fixtures, 0 moved.
 
+### Added
+
+- **The import summary now states, per section, how many structured entries it read and how many
+  records it wrote.**
+
+  ```
+  Structured sections (entries read -> records imported):
+    - Allergies: 1 -> 0  <-- NOTHING IMPORTED
+    - Family History: 2 -> 2
+    - Results: 2 -> 9
+    - Vital Signs: 1 -> 8
+  ```
+
+  A section that offers structured entries and produces no records is also named in the
+  warnings, whatever the cause — a nesting the importer cannot read, a section type it does not
+  support, or entries that were genuinely empty. Previously the summary printed a record count
+  and a per-type breakdown that simply OMITTED the empty buckets, so an import that dropped four
+  entire clinical sections was indistinguishable from one that dropped none. The numbers are in
+  `--json` output and in `--report` as `sectionCensus`.
+
+  This is reported on its own merits and independently of every fix below: had it existed, the
+  section losses fixed in this release would have been visible the first time anyone imported a
+  portal export.
+
+### Known limitations in this release
+
+- **An allergy whose allergen is named only in the section narrative is still not imported —
+  but it is now reported.** Some exports code the allergen as absent (`<value nullFlavor="NI"/>`
+  with a `<code nullFlavor=…>` whose `<originalText><reference value="#…"/>` points into the
+  section's narrative table) and write the substance in words in the narrative only. The
+  importer reads structured data, finds no allergen, and writes no record.
+
+  That was silent. It is not any more: the entry is named in the warnings, with its source
+  identifier, and the section census shows the section as `1 -> 0`. Recovering the substance
+  itself — by resolving the narrative reference, and/or by emitting the record with a
+  data-absent reason — is a separate change and is not in this release. **If your export
+  records allergies this way, check the import warnings; those allergies are not in your pod.**
+
 ### Fixed
+
+- **Lab results, vital signs, family history and implanted devices imported as ZERO records
+  from any document whose custodian named a recognized EHR vendor.** This is the largest data
+  loss fixed in this release and it affected the most common real input there is: a C-CDA
+  downloaded from a patient portal.
+
+  A repeatable C-CDA element — one the CDA R2.1 schema declares `0..*` — is an array when the
+  importer forces it to be one and a plain object otherwise, and that forcing was decided in
+  two places that did not agree. The XML parser forced thirteen element names on every
+  document. Each vendor shim then forced a DIFFERENT set, on documents from that vendor only.
+  `<organizer>` and `<supply>` were in the vendor lists and not the parser's.
+
+  So `entry.organizer` was an object on most documents and an array on documents from a
+  recognized vendor, and four section handlers read it as an object. Reading a property of an
+  array yields nothing, so on those documents the results section, the vital signs section, the
+  family history section and the medical equipment section each produced no records at all —
+  and nothing said so. **The same document imported 30 records when its custodian was
+  unrecognized and 10 when it named a vendor.**
+
+  There is now ONE list of repeatable elements, applied by the parser to every document. Vendor
+  normalization can no longer change the shape of anything, a test asserts that it does not,
+  and a second test fails the build if any handler reads a property off one of these containers
+  again. That last one is the point: this was the third time the same mistake shipped.
 
 - **Allergies written in C-CDA's standard nesting were dropped entirely.** An allergy in a
   C-CDA document is normally recorded as a concern act wrapping the allergy observation
@@ -216,10 +280,38 @@ which:
   importer only walked the looser `act` → `observation` shape, so on a standard document it
   produced NO allergy records at all — not a wrong allergy, none. Both shapes are read now.
 
-- **Family history was dropped entirely, for the same class of reason.** The section handler
+- **Family history was dropped entirely, for two independent reasons.** The section handler
   read an organizer's component observations as a single object where the parser always
-  produces a list, so every field came back empty and no family history record was ever
-  emitted from a real document.
+  produces a list, so every field came back empty. On a vendor-recognized document the
+  organizer itself was also unreadable, for the reason above. Both are fixed; on such a
+  document the first fix alone recovered nothing.
+
+- **Procedure records were written with no name, no date and no code.** The handler read
+  `entry.procedure` (and its `entry.act` fallback) as an object where both are always lists, so
+  every field it went on to read came back empty — but nothing stopped it writing the record.
+  A procedure therefore imported as a bare typed node with none of its content, on EVERY
+  document. This was harder to see than the zero-record sections precisely because the record
+  count looked right.
+
+- **A resolved problem imported as active, on every document.** A problem's status sits in a
+  status observation under `<entryRelationship>`, which is always a list; the handler read it as
+  an object, so the status the source stated was never read and the displayed status fell back
+  to the "active" default every time. A problem your provider marked resolved is now imported as
+  resolved.
+
+- **An allergy's severity, and the allergen name the source wrote for a human, were both
+  discarded.** The severity observation sits under `<entryRelationship>` and the allergen name
+  in `<playingEntity><name>`; both are lists and both were read as objects. The allergen fell
+  back to the coded concept's display name, which names the same substance but is not the string
+  your provider chose to show you, and the severity was simply lost. Measured across the C-CDA
+  conformance fixtures: every allergy in the corpus had a severity in its source (mild, moderate
+  and severe) and NONE of them reached the pod. Both are read now. Severity is part of an
+  allergy's identity — a mild rash and an anaphylaxis to one substance are two claims — so an
+  allergy that carries no `<id>` of its own moves; every allergy in the corpus carries one, and
+  none of their IRIs move.
+
+- **A drug named only in `<manufacturedMaterial><name>` fell through to the narrative and RxNorm
+  fallbacks.** Same cause: `<name>` is a list and was read as an object.
 
 - **A root-only `<id>` is no longer discarded, so `cascade:sourceRecordId` survives.** Nine of
   ten C-CDA sections read a record's identifier only when it carried an `extension` attribute,

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -23,7 +23,7 @@ import { Parser } from 'n3';
 import type { Quad } from 'n3';
 import { printResult, printError, printVerbose, printWarning, type OutputOptions } from '../../lib/output.js';
 import { convert } from '../../lib/fhir-converter/index.js';
-import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
+import { quadsToTurtle, type SectionCensusEntry } from '../../lib/fhir-converter/types.js';
 import {
   resolveReferenceEdges,
   buildResourceRefsFromQuads,
@@ -132,6 +132,14 @@ interface ImportReport {
    * routinely in another file of the same import or already in the pod.
    */
   literalLifting: LiteralLiftSummary;
+  /**
+   * Per-section entries-read vs records-written, for sectioned source documents
+   * (C-CDA). A section that offered structured entries and produced no records
+   * appears here with `recordsOut: 0` and is also named in `warnings`. Without
+   * it an import that dropped three whole clinical sections printed a record
+   * count, omitted the empty buckets, and read as a success.
+   */
+  sectionCensus: SectionCensusEntry[];
   warnings: string[];
   dryRun: boolean;
 }
@@ -471,6 +479,10 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       const reconcilerInputs: ReconcilerInput[] = [];
       const sourceReport: ImportReport['sources'] = [];
       const allWarnings: string[] = [...sourceSkips];
+      // Accumulate per-section entries-read vs records-written across every
+      // sectioned input, so the summary can state what each section yielded
+      // rather than silently omitting the sections that yielded nothing.
+      const sectionCensus: SectionCensusEntry[] = [];
       // Accumulate cross-record edge resolution across every converted FHIR input.
       const edgeResolution: ImportReport['edgeResolution'] = {
         resolved: 0,
@@ -571,6 +583,16 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           resourceCount = result.resourceCount;
           warnings.push(...result.warnings);
           allWarnings.push(...result.warnings.map(w => `${filePath}: ${w}`));
+          for (const s of result.sectionCensus ?? []) {
+            const acc = sectionCensus.find((e) => e.label === s.label && e.loinc === s.loinc);
+            if (acc) {
+              acc.entriesIn += s.entriesIn;
+              acc.recordsOut += s.recordsOut;
+              acc.handled = acc.handled || s.handled;
+            } else {
+              sectionCensus.push({ ...s });
+            }
+          }
           // C-CDA lab panels write clinical:hasLabResult edges; fold their tally
           // into the same import-summary accounting as the FHIR path.
           if (result.edgeResolution) {
@@ -1079,6 +1101,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         recordsAlreadyPresent,
         edgeResolution,
         literalLifting,
+        sectionCensus,
         warnings: allWarnings,
         dryRun,
       };
@@ -1126,6 +1149,19 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
             const ok = c.recovered >= c.total ? 'OK' : 'partial';
             console.log(`    - ${c.label}: ${c.recovered}/${c.total} (${ok})`);
             if (c.note) console.log(`        ${c.note}`);
+          }
+        }
+        // Every structured section the source offered, including the ones that
+        // produced nothing. The previous summary listed only non-empty record
+        // buckets, so a section read in full and imported as zero was invisible.
+        if (sectionCensus.length > 0) {
+          console.log(`  Structured sections (entries read -> records imported):`);
+          for (const s of [...sectionCensus].sort((a, b) => a.label.localeCompare(b.label))) {
+            const flag =
+              s.recordsOut === 0 && s.entriesIn > 0
+                ? s.handled ? '  <-- NOTHING IMPORTED' : '  <-- NOTHING IMPORTED (section type not supported)'
+                : '';
+            console.log(`    - ${s.label}: ${s.entriesIn} -> ${s.recordsOut}${flag}`);
           }
         }
         const edgeTotal =

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -18,10 +18,11 @@
 
 import AdmZip from 'adm-zip';
 import { Writer, DataFactory } from 'n3';
-import { NS, TURTLE_PREFIXES, type BatchConversionResult, type EdgeResolutionSummary } from '../fhir-converter/types.js';
+import { NS, TURTLE_PREFIXES, type BatchConversionResult, type EdgeResolutionSummary, type SectionCensusEntry } from '../fhir-converter/types.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 import { parseCcdaXml } from './parser.js';
+import { firstOf, listOf } from './multivalued.js';
 import { detectVendor, getSourceSystemName } from './vendor/detect.js';
 import { applyVendorNormalization } from './vendor/normalize.js';
 import { detectDocumentType } from './document-type.js';
@@ -94,6 +95,7 @@ export async function convertCcda(
 ): Promise<BatchConversionResult> {
   const warnings: string[] = [];
   const allQuads: any[] = [];
+  const sectionCensus: SectionCensusEntry[] = [];
   let resourceCount = 0;
 
   const importedAt = options.importedAt ?? new Date().toISOString();
@@ -122,8 +124,25 @@ export async function convertCcda(
       const result = convertSingleCcda(xml, options, importedAt, warnings);
       allQuads.push(...result.quads);
       resourceCount += result.count;
+      mergeSectionCensus(sectionCensus, result.census);
     } catch (err) {
       warnings.push(`Failed to convert C-CDA document: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // Absence has to be reported as absence. A section that offered structured
+  // entries and yielded no records is named here, whatever the cause — a handler
+  // that cannot read that nesting, an unsupported template, or entries that were
+  // genuinely empty. Three whole sections used to import as nothing while the
+  // summary printed a record count and simply omitted the empty buckets.
+  for (const s of sectionCensus) {
+    if (s.entriesIn > 0 && s.recordsOut === 0) {
+      warnings.push(
+        `Section "${s.label}"${s.loinc ? ` (LOINC ${s.loinc})` : ''}: read ${s.entriesIn} structured ` +
+          `entr${s.entriesIn === 1 ? 'y' : 'ies'} and imported 0 records` +
+          (s.handled ? '' : ' — no structured handler for this section type') +
+          '. Nothing from this section reached the pod.',
+      );
     }
   }
 
@@ -164,7 +183,27 @@ export async function convertCcda(
     // verifies that against the final record set and surfaces the count in the
     // import summary, matching the FHIR path's accounting.
     edgeResolution: censusForwardEdges(uniqueQuads),
+    sectionCensus,
   };
+}
+
+/**
+ * Fold one document's per-section census into the batch census. An IHE XDM zip
+ * carries the same sections across several documents; they are summed under one
+ * label so the reported numbers say "this import read N entries", not "the last
+ * document did".
+ */
+function mergeSectionCensus(into: SectionCensusEntry[], from: SectionCensusEntry[]): void {
+  for (const s of from) {
+    const existing = into.find((e) => e.label === s.label && e.loinc === s.loinc);
+    if (existing) {
+      existing.entriesIn += s.entriesIn;
+      existing.recordsOut += s.recordsOut;
+      existing.handled = existing.handled || s.handled;
+    } else {
+      into.push({ ...s });
+    }
+  }
 }
 
 /**
@@ -204,7 +243,7 @@ function convertSingleCcda(
   options: CcdaConversionOptions,
   importedAt: string,
   warnings: string[],
-): { quads: any[]; count: number } {
+): { quads: any[]; count: number; census: SectionCensusEntry[] } {
   const parsed = parseCcdaXml(xml);
 
   // Detect vendor and apply normalization
@@ -222,7 +261,7 @@ function convertSingleCcda(
   const sourceEhr = deriveSourceEhr(ccdaDoc);
 
   // Document ID for narrative linking
-  const docIdEl = Array.isArray(ccdaDoc?.id) ? ccdaDoc.id[0] : ccdaDoc?.id;
+  const docIdEl = firstOf<any>(ccdaDoc?.id);
   // HL7 II semantics: root+extension when both present; root alone IS the
   // globally unique document id when extension is absent. When the document
   // carries no id at all, identity comes from the document's own parsed,
@@ -245,13 +284,14 @@ function convertSingleCcda(
           : `doc:${identityKey(undefined, ccdaDoc, warnings, 'C-CDA ClinicalDocument (no <id>)')}`;
 
   const allQuads: any[] = [];
+  const census: SectionCensusEntry[] = [];
   let count = 0;
 
   // Extract patient demographics
   const recordTarget = ccdaDoc?.recordTarget;
   if (!recordTarget) {
     warnings.push('C-CDA document has no recordTarget — patient demographics not extracted');
-    return { quads: allQuads, count };
+    return { quads: allQuads, count, census };
   }
 
   // The patient profile is a record like any other. Its IRI is NOT threaded into
@@ -265,18 +305,14 @@ function convertSingleCcda(
   count++;
 
   // Process each section
-  // ccdaDoc.component is always an array (fast-xml-parser isArray config), so we must
-  // search through the array for the element that contains structuredBody rather than
-  // accessing .structuredBody directly on the array.
-  const componentTopLevel = ccdaDoc?.component;
-  const componentTopArr = Array.isArray(componentTopLevel)
-    ? componentTopLevel
-    : componentTopLevel ? [componentTopLevel] : [];
+  // `<component>` is a repeatable element and is therefore always an array (see
+  // multivalued.ts), so we must search the array for the element that contains
+  // structuredBody rather than reading .structuredBody off the array.
+  const componentTopArr = listOf<any>(ccdaDoc?.component);
   const body =
     componentTopArr.find((c: any) => c?.structuredBody)?.structuredBody
     ?? ccdaDoc?.structuredBody;
-  const components = body?.component ?? [];
-  const componentArr = Array.isArray(components) ? components : [components];
+  const componentArr = listOf<any>(body?.component);
 
   for (const comp of componentArr) {
     const section = comp?.section ?? comp;
@@ -296,9 +332,11 @@ function convertSingleCcda(
     const sectionCode = section?.code?.['@_code'] ?? section?.code?.code ?? '';
 
     // Extract structured entries (needed before narrative to know requiresLLMExtraction)
-    const entries = Array.isArray(section?.entry)
-      ? section.entry
-      : section?.entry ? [section.entry] : [];
+    const entries = listOf<any>(section?.entry);
+    const sectionLabel =
+      (typeof section?.title === 'string' ? section.title : section?.title?.['#text']) ||
+      (sectionCode ? `LOINC ${sectionCode}` : templateIds[0]) ||
+      'untitled section';
 
     // Extract narrative — always attempt, even if section also has entries
     const sectionText = section?.text;
@@ -340,12 +378,41 @@ function convertSingleCcda(
 
       allQuads.push(...quads);
       count += entries.length;
-    } else if (templateIds.length > 0) {
-      const isKnownNarrativeOnly = templateIds.some((id: string) => NARRATIVE_ONLY_TEMPLATE_IDS.has(id));
-      if (!isKnownNarrativeOnly) {
-        warnings.push(
-          `Unknown section templateId: ${templateIds[0]} — narrative preserved if present`,
-        );
+
+      // Entries read versus records written, for THIS section. Counted from the
+      // handler's own output — the distinct subjects it gave an rdf:type — so it
+      // cannot be satisfied by a handler that returns quads without records.
+      const recordSubjects = new Set(
+        quads
+          .filter((q: any) => q.predicate.value === NS.rdf + 'type')
+          .map((q: any) => q.subject.value),
+      );
+      census.push({
+        label: sectionLabel,
+        loinc: sectionCode || handler.loinc || undefined,
+        entriesIn: entries.length,
+        recordsOut: recordSubjects.size,
+        handled: true,
+      });
+    } else {
+      // No structured handler. If the section still carried entries, they were
+      // read and dropped, and that has to be counted rather than assumed empty.
+      if (entries.length > 0) {
+        census.push({
+          label: sectionLabel,
+          loinc: sectionCode || undefined,
+          entriesIn: entries.length,
+          recordsOut: 0,
+          handled: false,
+        });
+      }
+      if (templateIds.length > 0) {
+        const isKnownNarrativeOnly = templateIds.some((id: string) => NARRATIVE_ONLY_TEMPLATE_IDS.has(id));
+        if (!isKnownNarrativeOnly) {
+          warnings.push(
+            `Unknown section templateId: ${templateIds[0]} — narrative preserved if present`,
+          );
+        }
       }
     }
   }
@@ -359,5 +426,5 @@ function convertSingleCcda(
   ensureProvenanceQuads(allQuads);
   ensureSourceEhrQuads(allQuads, sourceEhr);
 
-  return { quads: allQuads, count };
+  return { quads: allQuads, count, census };
 }

--- a/src/lib/ccda-converter/multivalued.ts
+++ b/src/lib/ccda-converter/multivalued.ts
@@ -1,0 +1,126 @@
+/**
+ * The one list of C-CDA elements that may repeat, and the two accessors that
+ * read them.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * A C-CDA element that the CDA R2.1 schema declares 0..* is a JavaScript array
+ * when the source repeated it and a plain object when the source wrote it once.
+ * Every hand-built fixture writes it once. Real exports write it once too, most
+ * of the time. So a handler written as `entry.organizer.component` looks correct,
+ * passes every test, and returns `undefined` on the documents where it matters.
+ *
+ * That shape ambiguity used to be resolved in two independent places that could
+ * disagree, and did:
+ *
+ *   - the XML parser's `isArray` predicate, which forced 13 element names to
+ *     arrays on every document; and
+ *   - each vendor quirk module's own SHOULD_BE_ARRAY list, which forced a
+ *     DIFFERENT set on documents from that vendor only.
+ *
+ * `organizer` and `supply` were in the vendor lists and not in the parser's.
+ * The result: `entry.organizer` was an object on most documents and an array on
+ * documents whose custodian matched a vendor, so `entry.organizer.component`
+ * was correct on the corpus and `undefined` in production. Labs, vital signs,
+ * family history and implanted devices all read it that way and all imported
+ * zero records, with no error, no warning and no skip count.
+ *
+ * THE GUARANTEE
+ * -------------
+ * There is now ONE list, and the parser applies it to EVERY document. A
+ * repeatable element is an array always, on every document, from every vendor,
+ * before any handler sees it. Vendor normalization can no longer change the
+ * shape of anything behind a handler's back, and a test asserts exactly that
+ * (`tests/ccda-multivalued-shape.test.ts`), so the shape a test feeds a handler
+ * is the shape a real import feeds it.
+ *
+ * A handler must therefore never dereference a property of one of these
+ * containers directly. Use `firstOf()` for the "there is one of these" reading
+ * and `listOf()` to iterate. `tests/ccda-multivalued-shape.test.ts` fails the
+ * build on a direct dereference, which is what stops the next occurrence — this
+ * defect shape shipped three times before that test existed.
+ */
+
+/**
+ * C-CDA elements parsed as arrays on every document.
+ *
+ * This is the union of what the parser and the vendor quirk modules used to
+ * force independently. It is deliberately NOT the full set of 0..* elements in
+ * the CDA R2.1 schema: widening it changes the shape every handler reads, so a
+ * name is added here together with the handler changes that name requires.
+ *
+ * `coding` was in the Epic quirk list and is not a CDA element at all (it is a
+ * FHIR JSON key); it never matched anything and is not carried over.
+ */
+export const CCDA_MULTIVALUED_ELEMENTS = [
+  'act',
+  'addr',
+  'component',
+  'encounter',
+  'entry',
+  'entryRelationship',
+  'id',
+  'name',
+  'observation',
+  'organizer',
+  'participant',
+  'procedure',
+  'substanceAdministration',
+  'supply',
+  'telecom',
+] as const;
+
+export type CcdaMultivaluedElement = (typeof CCDA_MULTIVALUED_ELEMENTS)[number];
+
+const MULTIVALUED = new Set<string>(CCDA_MULTIVALUED_ELEMENTS);
+
+/** True when the parser forces this element name to an array. */
+export function isMultivaluedElement(name: string): boolean {
+  return MULTIVALUED.has(name);
+}
+
+/**
+ * The single occurrence of a repeatable element, or `undefined` when absent.
+ *
+ * Use where the document model allows repetition but a handler reads one — an
+ * `<entry>` wrapping one `<organizer>`, an `<entry>` wrapping one `<supply>`.
+ * Where more than one occurrence carries data, iterate with `listOf` instead;
+ * this deliberately keeps the first and drops the rest.
+ */
+export function firstOf<T>(value: T | T[] | null | undefined): T | undefined {
+  if (Array.isArray(value)) return value.length > 0 ? value[0] : undefined;
+  return value ?? undefined;
+}
+
+/**
+ * Every occurrence of a repeatable element as an array, empty when absent.
+ * Accepts an already-unwrapped object so it is safe on hand-built input too.
+ */
+export function listOf<T>(value: T | T[] | null | undefined): T[] {
+  if (Array.isArray(value)) return value.filter((v) => v != null) as T[];
+  return value == null ? [] : [value];
+}
+
+/**
+ * Force every repeatable element in a parsed document to an array, in place.
+ *
+ * The parser already does this for documents it parsed. This exists for the
+ * vendor shims, which must stay correct when handed a document assembled by
+ * something other than `parseCcdaXml` (a test, a future adapter). On real parser
+ * output it is a no-op, and the shape test asserts that it is.
+ */
+export function canonicalizeMultivaluedElements(node: unknown): void {
+  if (node === null || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) canonicalizeMultivaluedElements(item);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    if (MULTIVALUED.has(key) && value != null && !Array.isArray(value)) {
+      obj[key] = [value];
+    }
+    canonicalizeMultivaluedElements(obj[key]);
+  }
+}

--- a/src/lib/ccda-converter/narrative-extractor.ts
+++ b/src/lib/ccda-converter/narrative-extractor.ts
@@ -6,6 +6,8 @@
  * <entry> elements as requiresLLMExtraction.
  */
 
+import { listOf } from './multivalued.js';
+
 // Template ID → human-readable section name mapping
 const TEMPLATE_ID_SECTION_NAMES: Record<string, string> = {
   '2.16.840.1.113883.10.20.22.2.1.1':  'medications',
@@ -120,18 +122,14 @@ export function collectNarrativeBlocks(parsedCDA: any): NarrativeBlock[] {
   const ccdaDoc = parsedCDA?.ClinicalDocument ?? parsedCDA;
 
   // Locate structuredBody
-  const componentTopLevel = ccdaDoc?.component;
-  const componentTopArr = Array.isArray(componentTopLevel)
-    ? componentTopLevel
-    : componentTopLevel ? [componentTopLevel] : [];
+  const componentTopArr = listOf<any>(ccdaDoc?.component);
   const body =
     componentTopArr.find((c: any) => c?.structuredBody)?.structuredBody
     ?? ccdaDoc?.structuredBody;
 
   if (!body) return blocks;
 
-  const components = body?.component ?? [];
-  const componentArr = Array.isArray(components) ? components : [components];
+  const componentArr = listOf<any>(body?.component);
 
   for (const comp of componentArr) {
     const section = comp?.section ?? comp;
@@ -159,11 +157,7 @@ export function collectNarrativeBlocks(parsedCDA: any): NarrativeBlock[] {
     const narrativeText = extractNarrativeText(sectionText);
 
     // Determine if narrative-only (no <entry> children)
-    const entries = section?.entry;
-    const entryArr = Array.isArray(entries)
-      ? entries
-      : entries ? [entries] : [];
-    const requiresLLMExtraction = entryArr.length === 0;
+    const requiresLLMExtraction = listOf<any>(section?.entry).length === 0;
 
     // Only emit a block if there is text or the section is narrative-only with content
     if (narrativeText || requiresLLMExtraction) {

--- a/src/lib/ccda-converter/parser.ts
+++ b/src/lib/ccda-converter/parser.ts
@@ -1,22 +1,22 @@
 /**
  * XML parser for C-CDA documents.
  * Uses fast-xml-parser with attribute support and array normalization.
+ *
+ * The array normalization here is the ONLY place a repeatable element's shape is
+ * decided. It reads its element list from `multivalued.ts`, which the vendor
+ * shims read too, so the two can no longer disagree about whether (say)
+ * `<organizer>` is an array. See the header of that file for what went wrong
+ * while they could.
  */
 
 import { XMLParser } from 'fast-xml-parser';
+import { isMultivaluedElement } from './multivalued.js';
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
   textNodeName: '#text',
-  isArray: (name: string) => {
-    // These elements should always be arrays
-    return [
-      'entry', 'component', 'observation', 'substanceAdministration',
-      'act', 'encounter', 'procedure', 'id', 'name', 'telecom', 'addr',
-      'entryRelationship', 'participant',
-    ].includes(name);
-  },
+  isArray: (name: string) => isMultivaluedElement(name),
   allowBooleanAttributes: true,
 });
 

--- a/src/lib/ccda-converter/sections/allergies.ts
+++ b/src/lib/ccda-converter/sections/allergies.ts
@@ -3,6 +3,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -23,8 +24,7 @@ export function extractAllergyQuads(
 
   for (const entry of entries) {
     // entry.act is always an array from fast-xml-parser's isArray config — unwrap first element
-    const actRaw = entry?.act;
-    const act = Array.isArray(actRaw) ? actRaw[0] : (actRaw ?? entry);
+    const act = firstOf<any>(entry?.act) ?? entry;
     // The allergy observation sits under `act/entryRelationship/observation` in
     // canonical C-CDA R2.1, and directly under `act/observation` in the looser
     // shape some exports (and this repo's own corpus fixture) use. BOTH have to
@@ -34,43 +34,76 @@ export function extractAllergyQuads(
     // Measured on the previous build: a canonical allergy entry yielded zero
     // `health:AllergyRecord`s. `problems.ts` already walked it correctly; this
     // is the same walk.
-    const entryRelArr = Array.isArray(act?.entryRelationship)
-      ? act.entryRelationship
-      : act?.entryRelationship ? [act.entryRelationship] : [];
-    const nested = entryRelArr.flatMap((er: any) => {
-      const o = er?.observation;
-      return Array.isArray(o) ? o : (o ? [o] : []);
-    });
-    const direct = act?.observation
-      ? (Array.isArray(act.observation) ? act.observation : [act.observation])
-      : [];
+    const entryRelArr = listOf<any>(act?.entryRelationship);
+    const nested = entryRelArr.flatMap((er: any) => listOf<any>(er?.observation));
+    const direct = listOf<any>(act?.observation);
     const obsArr = nested.length > 0 ? nested : (direct.length > 0 ? direct : [act]);
 
     for (const observation of obsArr) {
       // Allergen is typically in participant/playingEntity
-      const participant = Array.isArray(observation?.participant)
-        ? observation.participant[0]
-        : observation?.participant;
+      const participant = firstOf<any>(observation?.participant);
       const playingEntity = participant?.participantRole?.playingEntity ?? {};
       const allergenCode = playingEntity?.code ?? {};
+      // `<name>` is a repeatable element and is therefore an ARRAY. The old read
+      // was `playingEntity?.name?.['#text']`, which is `undefined` on an array,
+      // so the human-readable allergen name the source wrote in `<name>` was
+      // never used and the record fell back to the CODE's displayName. Both name
+      // the same substance in a well-formed export, but they are not the same
+      // string, and the one the source chose to show the patient is `<name>`.
+      const playingEntityName = firstOf<any>(playingEntity?.name);
       const allergenName =
-        typeof playingEntity?.name === 'string'
-          ? playingEntity.name
-          : playingEntity?.name?.['#text'] ??
-            allergenCode?.['@_displayName'] ??
-            allergenCode?.displayName ?? '';
+        (typeof playingEntityName === 'string'
+          ? playingEntityName
+          : playingEntityName?.['#text']) ??
+        allergenCode?.['@_displayName'] ??
+        allergenCode?.displayName ?? '';
 
       // Reaction/severity from entryRelationship
-      const reactions = Array.isArray(observation?.entryRelationship)
-        ? observation.entryRelationship
-        : observation?.entryRelationship ? [observation.entryRelationship] : [];
-      const severityObs = reactions.find(
-        (r: any) => r?.observation?.code?.['@_code'] === 'SEV' || r?.typeCode === 'SUBJ',
-      )?.observation;
+      const reactions = listOf<any>(observation?.entryRelationship);
+      const severityObs = reactions
+        .map((r: any) => ({ r, o: firstOf<any>(r?.observation) }))
+        .find(({ r, o }: any) => o?.code?.['@_code'] === 'SEV' || r?.typeCode === 'SUBJ')?.o;
       const severityCode =
         severityObs?.value?.['@_displayName'] ?? severityObs?.value?.displayName ?? '';
 
-      if (!allergenName) continue;
+      if (!allergenName) {
+        // The allergen is not named anywhere this handler reads. In practice
+        // that means the source coded it absent — `<value nullFlavor="NI"/>`
+        // with a `<code nullFlavor=…>` whose `<originalText><reference
+        // value="#…"/>` points into the section narrative, where the substance
+        // IS written out in words.
+        //
+        // Dropping it was silent, and a silently dropped allergy is the worst
+        // record in this converter to lose. It is no longer silent. What it is
+        // not yet is RECOVERED.
+        //
+        // [JR: an unnamed allergy is now REPORTED but still not imported. Two
+        //  ways to finish it, and I did not want to pick one for you:
+        //    (a) resolve `<originalText><reference value="#id"/>` against the
+        //        section's own <text> narrative and use the resolved string as
+        //        the allergen name. Recovers the real substance, and this
+        //        converter already parses section narrative
+        //        (`narrative-extractor.ts`), so the machinery exists. Risk: the
+        //        resolved string is display text, and it enters the identity key.
+        //    (b) emit the AllergyRecord with no allergen name and a data-absent
+        //        reason. FHIR's `dataAbsentReason` (http://hl7.org/fhir/
+        //        ValueSet/data-absent-reason, code `unknown`) is the ratified
+        //        anchor, and Cascade has no equivalent term today, so this needs
+        //        a vocabulary addition authored in `spec/` first.
+        //  MY RECOMMENDATION: (a) then (b) — resolve the reference, and fall back
+        //  to (b) only when the reference does not resolve. (a) recovers the
+        //  actual clinical fact, which is what the patient needs; (b) alone
+        //  imports a record that says an allergy exists without saying to what,
+        //  which is not much better than the warning below. Doing (a) first also
+        //  keeps the vocabulary change off this fix's critical path.]
+        const unnamedId = ccdaSourceId(act?.id) ?? ccdaSourceId(observation?.id);
+        warnings?.push(
+          'C-CDA allergy entry names no allergen in its structured data ' +
+            `(${unnamedId ? `source id ${unnamedId}` : 'no source id'}${severityCode ? `, severity ${severityCode}` : ''}) ` +
+            '— the substance is likely in the section narrative only. NOT imported.',
+        );
+        continue;
+      }
 
       // The allergy CONCERN act carries the id in most exports; the reaction
       // observation carries its own where the act does not.

--- a/src/lib/ccda-converter/sections/devices.ts
+++ b/src/lib/ccda-converter/sections/devices.ts
@@ -4,6 +4,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -23,12 +24,16 @@ export function extractDeviceQuads(
   const quads: Quad[] = [];
 
   for (const entry of entries) {
-    const supply = entry?.supply ?? entry;
+    // `<supply>` is a repeatable element and is therefore an ARRAY (see
+    // `multivalued.ts`). This used to be `entry?.supply ?? entry`, which yielded
+    // the array, so `supply.participant` and `supply.effectiveTime` were both
+    // `undefined`, the device had no name, and the `if (!displayName) continue`
+    // below dropped EVERY implanted device without a word. Measured on a
+    // one-device section: 0 quads before, 5 after.
+    const supply = firstOf<any>(entry?.supply) ?? entry;
     if (!supply) continue;
 
-    const participant = Array.isArray(supply?.participant)
-      ? supply.participant[0]
-      : supply?.participant;
+    const participant = firstOf<any>(supply?.participant);
     const device = participant?.participantRole?.playingDevice ?? {};
     const codeEl = device?.code ?? {};
     const displayName = codeEl?.['@_displayName'] ?? codeEl?.displayName ??

--- a/src/lib/ccda-converter/sections/encounters.ts
+++ b/src/lib/ccda-converter/sections/encounters.ts
@@ -10,6 +10,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -126,11 +127,7 @@ export function extractEncounterQuads(
     // LIST of encounters — the old code read the array as a single object, so
     // every field came back undefined and all encounters in the export collapsed
     // into one bare, content-hash-identical record. Iterate the list instead.
-    const encList = Array.isArray(entry?.encounter)
-      ? entry.encounter
-      : entry?.encounter
-        ? [entry.encounter]
-        : [entry];
+    const encList = entry?.encounter ? listOf<any>(entry.encounter) : [entry];
     for (const enc of encList) {
       const built = buildEncounterRecord(enc, sourceSystem, warnings);
       if (built) quads.push(...built.quads);

--- a/src/lib/ccda-converter/sections/family-history.ts
+++ b/src/lib/ccda-converter/sections/family-history.ts
@@ -4,6 +4,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
@@ -41,7 +42,12 @@ export function extractFamilyHistoryQuads(
   const snomedOid = '2.16.840.1.113883.6.96';
 
   for (const entry of entries) {
-    const organizer = entry?.organizer ?? entry;
+    // `<organizer>` is a repeatable element and is therefore an ARRAY (see
+    // `multivalued.ts`). This used to be `entry?.organizer ?? entry`, which
+    // yielded the array itself, so `organizer.subject` and `organizer.component`
+    // were both `undefined` and the whole section produced NOTHING. Measured on
+    // a two-relative section: 0 quads before, 12 after.
+    const organizer = firstOf<any>(entry?.organizer) ?? entry;
     if (!organizer) continue;
 
     // Family member relationship
@@ -56,13 +62,8 @@ export function extractFamilyHistoryQuads(
     // history organizer yielded zero `health:FamilyHistoryRecord`s. The
     // conformance corpus carries no family history section, which is why the
     // section handler was never exercised against real parser output.
-    const components = Array.isArray(organizer?.component)
-      ? organizer.component
-      : organizer?.component ? [organizer.component] : [];
-    const observations = components.flatMap((comp: any) => {
-      const o = comp?.observation;
-      return Array.isArray(o) ? o : (o ? [o] : []);
-    });
+    const components = listOf<any>(organizer?.component);
+    const observations = components.flatMap((comp: any) => listOf<any>(comp?.observation));
     for (const obs of observations) {
       if (!obs) continue;
 

--- a/src/lib/ccda-converter/sections/immunizations.ts
+++ b/src/lib/ccda-converter/sections/immunizations.ts
@@ -3,6 +3,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
@@ -23,9 +24,7 @@ export function extractImmunizationQuads(
   const quads: Quad[] = [];
 
   for (const entry of entries) {
-    // entry.substanceAdministration is always an array from fast-xml-parser's isArray config — unwrap first element
-    const saRaw = entry?.substanceAdministration;
-    const sa = Array.isArray(saRaw) ? saRaw[0] : (saRaw ?? entry);
+    const sa = firstOf<any>(entry?.substanceAdministration) ?? entry;
     if (!sa) continue;
 
     // Extract vaccine code

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -42,6 +42,7 @@
  */
 
 import { NS, tripleDateTime } from '../../fhir-converter/types.js';
+import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { contentFingerprint, EMPTY_SEED } from '../../identity.js';
 import { resolveCodeUri } from '../code-systems.js';
@@ -334,19 +335,23 @@ export function extractLabQuads(
   const emittedEncounterSubjects = new Set<string>();
 
   for (const entry of entries) {
-    const organizer = entry?.organizer;
+    // `<organizer>` is a repeatable element and is therefore an ARRAY (see
+    // `multivalued.ts`). This used to be `const organizer = entry?.organizer`,
+    // read straight as an object, so `organizer?.component` was `undefined` and
+    // an entire results section of panels imported as NOTHING — no records, no
+    // error, no skip count. Measured on a two-panel section: 0 quads before, 86
+    // after.
+    const organizer = firstOf<any>(entry?.organizer);
 
     if (organizer?.component) {
       // Lab panel (organizer wrapping member observations).
-      const comps = Array.isArray(organizer.component)
-        ? organizer.component
-        : [organizer.component];
+      const comps = listOf<any>(organizer.component);
 
       const memberSubjects: string[] = [];
       const memberDates: string[] = [];
       for (const comp of comps) {
         if (!comp?.observation) continue;
-        const obsList = Array.isArray(comp.observation) ? comp.observation : [comp.observation];
+        const obsList = listOf<any>(comp.observation);
         for (const obs of obsList) {
           const member = extractObservationQuads(obs, sourceSystem, warnings);
           if (!member) continue;
@@ -389,7 +394,7 @@ export function extractLabQuads(
       }
     } else if (entry?.observation) {
       // Standalone observation (no organizer): a plain lab result, no panel.
-      const obsList = Array.isArray(entry.observation) ? entry.observation : [entry.observation];
+      const obsList = listOf<any>(entry.observation);
       for (const obs of obsList) {
         const member = extractObservationQuads(obs, sourceSystem, warnings);
         if (member) quads.push(...member.quads);

--- a/src/lib/ccda-converter/sections/medications.ts
+++ b/src/lib/ccda-converter/sections/medications.ts
@@ -3,6 +3,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf } from '../multivalued.js';
 import { ccdaMedicationRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { lookupRxNormName } from '../rxnorm-lookup.js';
@@ -89,18 +90,21 @@ export function extractMedicationQuads(
   const narrativeIdMap = buildNarrativeIdMap(sectionText);
 
   for (const entry of entries) {
-    // entry.substanceAdministration is always an array from fast-xml-parser's isArray config — unwrap first element
-    const saRaw = entry?.substanceAdministration;
-    const sa = Array.isArray(saRaw) ? saRaw[0] : (saRaw ?? entry);
+    const sa = firstOf<any>(entry?.substanceAdministration) ?? entry;
     if (!sa) continue;
 
     const material = sa?.consumable?.manufacturedProduct?.manufacturedMaterial;
     const codeEl = material?.code ?? {};
     const code = codeEl?.['@_code'] ?? codeEl?.code ?? '';
     const codeSystem = codeEl?.['@_codeSystem'] ?? codeEl?.codeSystem ?? '';
+    // `<name>` is a repeatable element and is therefore an ARRAY, so the old
+    // `material?.name?.['#text']` was `undefined` and a drug named only in
+    // `<manufacturedMaterial><name>` fell through to the narrative/RxNorm tiers
+    // below instead of using the name the source wrote.
+    const materialName = firstOf<any>(material?.name);
     const rawDisplayName =
       codeEl?.['@_displayName'] ?? codeEl?.displayName ??
-      (typeof material?.name === 'string' ? material.name : material?.name?.['#text'] ?? '');
+      (typeof materialName === 'string' ? materialName : materialName?.['#text'] ?? '');
     const isRxNorm = codeSystem.includes('6.88') || codeSystem === rxNormOid;
     // Drug name resolution order:
     //   1. structured code @displayName (rare in Epic exports)

--- a/src/lib/ccda-converter/sections/patient.ts
+++ b/src/lib/ccda-converter/sections/patient.ts
@@ -3,6 +3,7 @@
  */
 
 import { NS, structuredKey } from '../../fhir-converter/types.js';
+import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -49,8 +50,7 @@ export function extractPatientQuads(
   // const patientRole = rt?.patientRole ?? rt ?? {};
 
   // Extract demographics
-  const nameArr = Array.isArray(patient.name) ? patient.name : (patient.name ? [patient.name] : []);
-  const nameEl = nameArr[0] ?? {};
+  const nameEl = firstOf<any>(patient.name) ?? {};
   const given = Array.isArray(nameEl.given) ? nameEl.given[0] : nameEl.given ?? '';
   const family = Array.isArray(nameEl.family) ? nameEl.family[0] : nameEl.family ?? '';
   const givenStr = typeof given === 'string' ? given : given?.['#text'] ?? '';
@@ -61,8 +61,7 @@ export function extractPatientQuads(
 
   // Extract address from patientRole
   const patientRole = rt?.patientRole ?? rt ?? {};
-  const addrArr = Array.isArray(patientRole.addr) ? patientRole.addr : (patientRole.addr ? [patientRole.addr] : []);
-  const addr = addrArr[0] ?? {};
+  const addr = firstOf<any>(patientRole.addr) ?? {};
   const street = (() => {
     const sl = addr.streetAddressLine;
     if (!sl) return '';
@@ -74,7 +73,7 @@ export function extractPatientQuads(
   const postalCode = addr.postalCode != null ? String(addr.postalCode) : '';
 
   // Extract phone and email from patientRole telecom
-  const telecomArr = Array.isArray(patientRole.telecom) ? patientRole.telecom : (patientRole.telecom ? [patientRole.telecom] : []);
+  const telecomArr = listOf<any>(patientRole.telecom);
   const phone = (() => {
     const t = telecomArr.find((t: any) => {
       const val: string = t?.['@_value'] ?? t?.value ?? '';

--- a/src/lib/ccda-converter/sections/problems.ts
+++ b/src/lib/ccda-converter/sections/problems.ts
@@ -3,6 +3,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
@@ -27,14 +28,10 @@ export function extractProblemQuads(
   for (const entry of entries) {
     // Conditions are inside an act/observation
     // entry.act is always an array from fast-xml-parser's isArray config — unwrap first element
-    const actRaw = entry?.act;
-    const act = Array.isArray(actRaw) ? actRaw[0] : (actRaw ?? entry);
-    const entryRelArr = Array.isArray(act?.entryRelationship) ? act.entryRelationship : (act?.entryRelationship ? [act.entryRelationship] : []);
-    const obs = entryRelArr.flatMap((er: any) => {
-      const o = er?.observation;
-      return Array.isArray(o) ? o : (o ? [o] : []);
-    });
-    const obsArr = obs.length > 0 ? obs : (act?.observation ? (Array.isArray(act.observation) ? act.observation : [act.observation]) : [act]);
+    const act = firstOf<any>(entry?.act) ?? entry;
+    const entryRelArr = listOf<any>(act?.entryRelationship);
+    const obs = entryRelArr.flatMap((er: any) => listOf<any>(er?.observation));
+    const obsArr = obs.length > 0 ? obs : (act?.observation ? listOf<any>(act.observation) : [act]);
 
     for (const observation of obsArr) {
       if (!observation?.code && !observation?.value) continue;
@@ -62,8 +59,18 @@ export function extractProblemQuads(
       // "we do not know" into "these are the same record", and a content tier
       // that succeeds with a constant is indistinguishable from one that fails
       // except that it merges.
-      const statusObs = observation?.entryRelationship?.observation;
-      const statusValue = (Array.isArray(statusObs) ? statusObs[0] : statusObs)?.value;
+      //
+      // `<entryRelationship>` is a repeatable element and is therefore an ARRAY.
+      // This read used to be `observation?.entryRelationship?.observation`,
+      // which is `undefined` on an array — so `statedStatus` was ALWAYS empty
+      // and `status` was ALWAYS the 'active' default, on every document, whether
+      // or not the source said the problem was resolved. A resolved problem
+      // imported as active. The status observation is found the same way the
+      // condition observation above is.
+      const statusObs = listOf<any>(observation?.entryRelationship)
+        .flatMap((er: any) => listOf<any>(er?.observation))
+        .find((o: any) => o?.value != null);
+      const statusValue = statusObs?.value;
       const statedStatus = statusValue?.['@_displayName'] ?? statusValue?.displayName ?? '';
       const status = statedStatus || 'active';
 

--- a/src/lib/ccda-converter/sections/procedures.ts
+++ b/src/lib/ccda-converter/sections/procedures.ts
@@ -3,6 +3,7 @@
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { firstOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
@@ -25,7 +26,17 @@ export function extractProcedureQuads(
   const cptOid = '2.16.840.1.113883.6.12';
 
   for (const entry of entries) {
-    const proc = entry?.procedure ?? entry?.act ?? entry;
+    // `<procedure>` and `<act>` are both repeatable elements and are therefore
+    // ARRAYS. This used to be `entry?.procedure ?? entry?.act ?? entry`, which
+    // yielded the array, so `proc.code`, `proc.effectiveTime` and `proc.id` were
+    // all `undefined`. Nothing guarded against that, so every procedure still
+    // minted a record — carrying only its type and source system, with the
+    // procedure NAME, DATE and CODE all silently dropped, and its identity
+    // falling through to a content hash of the raw entry. Empty records reported
+    // as a successful import is the same absence-as-success failure as the
+    // zero-record sections; here it was harder to see because the count looked
+    // right.
+    const proc = firstOf<any>(entry?.procedure) ?? firstOf<any>(entry?.act) ?? entry;
     if (!proc) continue;
 
     const codeEl = proc?.code ?? {};

--- a/src/lib/ccda-converter/sections/vitals.ts
+++ b/src/lib/ccda-converter/sections/vitals.ts
@@ -11,6 +11,7 @@
  */
 
 import { NS, VITAL_LOINC_CODES } from '../../fhir-converter/types.js';
+import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { DataFactory } from 'n3';
@@ -53,21 +54,22 @@ export function extractVitalQuads(
   const loincOid = '2.16.840.1.113883.6.1';
 
   for (const entry of entries) {
-    // Vitals may be in organizer/component
+    // Vitals may be in organizer/component.
+    //
+    // `<organizer>` is a repeatable element, so it is an ARRAY (see
+    // `multivalued.ts`). This read used to be `entry?.organizer?.component`,
+    // which is `undefined` on an array — so a vitals section whose readings were
+    // grouped in an organizer, which is how every conforming export writes them,
+    // produced NO records at all and reported nothing. Measured on a document
+    // with one organizer of eight readings: 0 quads before, 72 after.
     const observations: any[] = [];
-    if (entry?.organizer?.component) {
-      const comps = Array.isArray(entry.organizer.component)
-        ? entry.organizer.component
-        : [entry.organizer.component];
-      for (const comp of comps) {
-        if (comp?.observation) {
-          const obs = Array.isArray(comp.observation) ? comp.observation : [comp.observation];
-          observations.push(...obs);
-        }
+    const organizer = firstOf<any>(entry?.organizer);
+    if (organizer?.component) {
+      for (const comp of listOf<any>(organizer.component)) {
+        observations.push(...listOf<any>(comp?.observation));
       }
     } else if (entry?.observation) {
-      const obs = Array.isArray(entry.observation) ? entry.observation : [entry.observation];
-      observations.push(...obs);
+      observations.push(...listOf<any>(entry.observation));
     }
 
     for (const obs of observations) {

--- a/src/lib/ccda-converter/vendor-normalizer.ts
+++ b/src/lib/ccda-converter/vendor-normalizer.ts
@@ -9,6 +9,7 @@
  */
 
 import { detectVendor as detectVendorInternal } from './vendor/detect.js';
+import { firstOf, listOf } from './multivalued.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,14 +101,11 @@ class DefaultVendorNormalizer implements VendorNormalizer {
 
   normalizeConditionDisplayName(entry: any, section: any): string {
     // Try the direct path first: <value displayName="...">
-    const actRaw = entry?.act;
-    const act = Array.isArray(actRaw) ? actRaw[0] : (actRaw ?? entry);
-    const entryRelArr = Array.isArray(act?.entryRelationship)
-      ? act.entryRelationship
-      : act?.entryRelationship ? [act.entryRelationship] : [];
+    const act = firstOf<any>(entry?.act) ?? entry;
+    const entryRelArr = listOf<any>(act?.entryRelationship);
 
     for (const er of entryRelArr) {
-      const obsArr = Array.isArray(er?.observation) ? er.observation : er?.observation ? [er.observation] : [];
+      const obsArr = listOf<any>(er?.observation);
       for (const obs of obsArr) {
         const valueEl = obs?.value ?? obs?.code ?? {};
         const displayName = valueEl?.['@_displayName'] ?? valueEl?.displayName ?? '';

--- a/src/lib/ccda-converter/vendor/detect.ts
+++ b/src/lib/ccda-converter/vendor/detect.ts
@@ -2,16 +2,20 @@
  * EHR vendor detection from C-CDA custodian organization name.
  */
 
+import { firstOf } from '../multivalued.js';
+
 export type EhrVendor = 'epic' | 'cerner' | 'athena' | 'unknown';
 
 function extractOrgName(doc: any): string {
-  const raw =
-    doc?.ClinicalDocument?.custodian?.assignedCustodian?.representedCustodianOrganization?.name?.['#text'] ??
-    doc?.ClinicalDocument?.custodian?.assignedCustodian?.representedCustodianOrganization?.name ??
-    '';
-  // fast-xml-parser's isArray config may wrap <name> in an array
-  if (Array.isArray(raw)) return (raw[0]?.['#text'] ?? raw[0] ?? '').toString();
-  return raw.toString();
+  // `<name>` is a repeatable element and is therefore an ARRAY (see
+  // `multivalued.ts`), so take its single occurrence before reading a value out
+  // of it. The element may hold a bare string or a { '#text' } node.
+  const name = firstOf<any>(
+    doc?.ClinicalDocument?.custodian?.assignedCustodian?.representedCustodianOrganization?.name,
+  );
+  if (name == null) return '';
+  if (typeof name === 'string') return name;
+  return (name['#text'] ?? '').toString();
 }
 
 export function detectVendor(doc: any): EhrVendor {

--- a/src/lib/ccda-converter/vendor/quirks/cerner.ts
+++ b/src/lib/ccda-converter/vendor/quirks/cerner.ts
@@ -2,25 +2,17 @@
  * Cerner PowerChart quirks:
  * - Omits <id> on many entries; uses <setId> as fallback
  * - Some templateIds may be absent on section entries
+ *
+ * Array shape is not decided here. See the note in `epic.ts` and the header of
+ * `ccda-converter/multivalued.ts`: one list, applied by the parser to every
+ * document. This shim's canonicalization is a no-op on parser output and exists
+ * only so it stays correct on a document assembled some other way.
  */
 
-const SHOULD_BE_ARRAY = [
-  'entry', 'component', 'observation', 'organizer',
-  'substanceAdministration', 'act', 'encounter', 'procedure', 'name', 'id', 'telecom', 'addr',
-];
+import { canonicalizeMultivaluedElements } from '../../multivalued.js';
 
 export function normalizeCerner(doc: any): any {
   const result = JSON.parse(JSON.stringify(doc));
-  normalizeArraysRecursive(result);
+  canonicalizeMultivaluedElements(result);
   return result;
-}
-
-function normalizeArraysRecursive(obj: any): void {
-  if (!obj || typeof obj !== 'object') return;
-  for (const key of Object.keys(obj)) {
-    if (SHOULD_BE_ARRAY.includes(key) && obj[key] && !Array.isArray(obj[key])) {
-      obj[key] = [obj[key]];
-    }
-    if (typeof obj[key] === 'object') normalizeArraysRecursive(obj[key]);
-  }
 }

--- a/src/lib/ccda-converter/vendor/quirks/epic.ts
+++ b/src/lib/ccda-converter/vendor/quirks/epic.ts
@@ -1,31 +1,28 @@
 /**
  * Epic MyChart quirks:
- * - Single-element arrays serialized as objects, not arrays
- * - urn:oid: prefix on all code system OIDs
+ * - urn:oid: prefix on all code system OIDs (handled where codes are resolved,
+ *   in `code-systems.ts`)
+ * - Single-element collections serialized as objects rather than arrays
+ *
+ * The second one is no longer this module's business. It used to keep its OWN
+ * list of element names to force to arrays, and that list did not match the
+ * parser's: `organizer` and `supply` were in this list and not in the parser's,
+ * so those two elements changed shape depending on the document's custodian.
+ * Four section handlers read the object shape, and produced zero records on
+ * every document that reached this branch. The list now lives in
+ * `ccda-converter/multivalued.ts` and the parser applies it to every document,
+ * so the walk below is a no-op on parser output — asserted, not assumed, by
+ * `tests/ccda-multivalued-shape.test.ts`.
+ *
+ * It is kept rather than deleted so the shim stays correct if it is ever handed
+ * a document assembled by something other than `parseCcdaXml`.
  */
 
-// Fields that should always be arrays in C-CDA
-const SHOULD_BE_ARRAY = [
-  'entry', 'component', 'observation', 'organizer', 'substanceAdministration',
-  'act', 'encounter', 'procedure', 'supply', 'name', 'id', 'telecom', 'addr', 'coding',
-];
+import { canonicalizeMultivaluedElements } from '../../multivalued.js';
 
 export function normalizeEpic(doc: any): any {
   // Deep clone to avoid mutating input
   const result = JSON.parse(JSON.stringify(doc));
-  normalizeArraysRecursive(result);
+  canonicalizeMultivaluedElements(result);
   return result;
-}
-
-function normalizeArraysRecursive(obj: any): void {
-  if (!obj || typeof obj !== 'object') return;
-
-  for (const key of Object.keys(obj)) {
-    if (SHOULD_BE_ARRAY.includes(key) && obj[key] && !Array.isArray(obj[key])) {
-      obj[key] = [obj[key]];
-    }
-    if (typeof obj[key] === 'object') {
-      normalizeArraysRecursive(obj[key]);
-    }
-  }
 }

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -39,6 +39,29 @@ export interface EdgeResolutionSummary {
   byPredicate: Record<string, { resolved: number; unresolved: number }>;
 }
 
+/**
+ * One structured section of a source document: how many entries it offered, and
+ * how many records the importer actually wrote.
+ *
+ * These two numbers were never compared, and three entire clinical sections
+ * imported as zero records while the summary reported success and simply omitted
+ * the empty buckets. A section that reads N structured entries and writes 0
+ * records has to say so, whatever the cause — a handler defect, an unsupported
+ * nesting, or genuinely empty entries.
+ */
+export interface SectionCensusEntry {
+  /** Section title from the document, or the LOINC code when it has none. */
+  label: string;
+  /** Section-level LOINC code, where the document states one. */
+  loinc?: string;
+  /** `<entry>` elements the section offered. */
+  entriesIn: number;
+  /** Distinct record subjects the handler produced from them. */
+  recordsOut: number;
+  /** False when the section's templateId matches no structured handler. */
+  handled: boolean;
+}
+
 export interface BatchConversionResult {
   success: boolean;
   output: string;
@@ -48,6 +71,11 @@ export interface BatchConversionResult {
   warnings: string[];
   errors: string[];
   results: ConversionResult[];
+  /**
+   * Per-section entries-read vs records-written, for import paths that read a
+   * sectioned document (C-CDA). Absent for formats without sections.
+   */
+  sectionCensus?: SectionCensusEntry[];
   /** Present for FHIR -> Cascade conversions; tallies cross-record edges. */
   edgeResolution?: EdgeResolutionSummary;
   /**

--- a/tests/ccda-multivalued-shape.test.ts
+++ b/tests/ccda-multivalued-shape.test.ts
@@ -1,0 +1,319 @@
+/**
+ * A C-CDA element that may repeat has ONE shape, and this is the lock on the
+ * two ways it used to get a second one.
+ *
+ * WHAT IS BEING PROTECTED, STATED SO THE NEXT READER DOES NOT HAVE TO GUESS
+ * ------------------------------------------------------------------------
+ * The CDA R2.1 schema declares many elements 0..*. `fast-xml-parser` gives such
+ * an element an ARRAY when it is forced to and a plain OBJECT otherwise, and the
+ * forcing used to be decided in two places that could disagree:
+ *
+ *   - the XML parser's `isArray` predicate (13 element names, every document);
+ *   - each vendor quirk module's own SHOULD_BE_ARRAY list (a DIFFERENT set,
+ *     applied only to documents whose custodian matched that vendor).
+ *
+ * `organizer` and `supply` were in the vendor lists and not the parser's. So
+ * `entry.organizer` was an object on most documents and an array on documents
+ * from a recognized vendor, and four handlers dereferenced it as an object:
+ * labs, vital signs, family history and implanted devices. On a recognized
+ * vendor's export all four produced ZERO records — no error, no warning, no skip
+ * count. The corpus never caught it because no corpus fixture is classified as a
+ * vendor at all, so the vendor-normalized shape was the one shape never tested.
+ *
+ * This is the third time one idea has shipped: `act.entryRelationship` read as
+ * an object, `organizer.component[].observation` read as an object, and now
+ * `entry.organizer` itself. Every instance is a container that is an array in
+ * real pipeline output and an object in every hand-built fixture. So the fix is
+ * not three unwraps.
+ *
+ * THE THREE RULES
+ * ---------------
+ *   1. ONE LIST. `CCDA_MULTIVALUED_ELEMENTS` in `lib/ccda-converter/multivalued.ts`
+ *      is the only list of repeatable element names, and no other module may
+ *      declare one. Two lists is the defect.
+ *   2. THE SHAPE DOES NOT DEPEND ON THE VENDOR. `applyVendorNormalization` must
+ *      return a document deep-equal to its input for every vendor and every
+ *      fixture. If a vendor shim ever changes a shape behind a handler's back
+ *      again, this fails.
+ *   3. NO HANDLER DEREFERENCES A REPEATABLE CONTAINER. Nothing under
+ *      `lib/ccda-converter/` may write `.organizer.x`, `.organizer?.x`,
+ *      `.organizer[0]` or `.organizer['x']`. Unwrap with `firstOf()`/`listOf()`
+ *      first. This is the rule that stops occurrence four.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT — measured against 0f33c78:
+ *   Rule 1 FAILS (three separate lists: parser.ts, quirks/epic.ts, quirks/cerner.ts).
+ *   Rule 2 FAILS (`organizer` object -> array on every fixture with an organizer).
+ *   Rule 3 FAILS (7 sites, including the four zero-record ones).
+ * Every one of them is green here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCcdaXml } from '../src/lib/ccda-converter/parser.js';
+import { applyVendorNormalization } from '../src/lib/ccda-converter/vendor/normalize.js';
+import {
+  CCDA_MULTIVALUED_ELEMENTS,
+  firstOf,
+  listOf,
+  canonicalizeMultivaluedElements,
+} from '../src/lib/ccda-converter/multivalued.js';
+import { SYNTHETIC_EPIC_CCDA, SYNTHETIC_UNKNOWN_VENDOR_CCDA } from './ccda-synthetic-documents.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = path.resolve(HERE, '..', 'src');
+const CCDA_DIR = path.join(SRC_DIR, 'lib', 'ccda-converter');
+/** The one module allowed to name these elements and to unwrap them. */
+const LIST_OWNER = 'lib/ccda-converter/multivalued.ts';
+const CORPUS = path.resolve(HERE, '..', '..', 'conformance', 'fixtures', 'ccda');
+
+function ccdaSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.isFile() && e.name.endsWith('.ts')) {
+        out.push(path.relative(SRC_DIR, full).split(path.sep).join('/'));
+      }
+    }
+  };
+  walk(CCDA_DIR);
+  return out.sort();
+}
+
+/** Strip line and block comments so prose about the rule does not break it. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+const FILES = ccdaSourceFiles();
+const CODE = new Map(FILES.map((f) => [f, fs.readFileSync(path.join(SRC_DIR, f), 'utf8')]));
+const CORPUS_FILES = fs.existsSync(CORPUS)
+  ? fs.readdirSync(CORPUS).filter((f) => f.endsWith('.xml')).sort()
+  : [];
+
+// The suite reads sibling checkouts. An empty corpus is a broken checkout, not a
+// reason to quietly test less — say so rather than skip.
+if (CORPUS_FILES.length === 0) {
+  throw new Error(
+    `No C-CDA fixtures found at ${CORPUS}. The sibling \`conformance\` checkout must be ` +
+      `resolvable from the repo's parent directory; this test does not skip.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1 — one list
+// ---------------------------------------------------------------------------
+
+describe('C-CDA repeatable elements are declared in exactly one place', () => {
+  it('no module besides the list owner declares its own array-element list', () => {
+    // A second list is the defect itself: the parser and two vendor shims each
+    // kept one, and they disagreed about `organizer` and `supply`.
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (file === LIST_OWNER) continue;
+      const code = stripComments(CODE.get(file)!);
+      if (/SHOULD_BE_ARRAY/.test(code)) offenders.push(`${file}: declares SHOULD_BE_ARRAY`);
+      // A literal array of element-name strings that overlaps the canonical list
+      // by three or more names is a second list under another name.
+      for (const m of code.matchAll(/\[\s*((?:'[^']*'\s*,\s*){2,}'[^']*'\s*,?)\s*\]/g)) {
+        const names = [...m[1].matchAll(/'([^']*)'/g)].map((x) => x[1]);
+        const overlap = names.filter((n) => (CCDA_MULTIVALUED_ELEMENTS as readonly string[]).includes(n));
+        if (overlap.length >= 3) {
+          offenders.push(`${file}: array literal re-declares ${overlap.join(', ')}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Import CCDA_MULTIVALUED_ELEMENTS from ${LIST_OWNER}. A second list is exactly how ` +
+        `\`organizer\` came to be an array on some documents and an object on others.`,
+    ).toEqual([]);
+  });
+
+  it('the parser forces every name on the canonical list, and nothing else', () => {
+    // Proved through the parser rather than by reading its source: build a
+    // document containing each element once, and check what comes back.
+    for (const name of CCDA_MULTIVALUED_ELEMENTS) {
+      const parsed = parseCcdaXml(`<Probe><${name}>x</${name}></Probe>`);
+      expect(Array.isArray(parsed.Probe[name]), `<${name}> must parse as an array`).toBe(true);
+    }
+    // A name NOT on the list must stay scalar, or the list is not the authority.
+    const other = parseCcdaXml('<Probe><statusCode>x</statusCode></Probe>');
+    expect(Array.isArray(other.Probe.statusCode)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 2 — the shape does not depend on the vendor
+// ---------------------------------------------------------------------------
+
+describe('vendor normalization cannot change a document shape', () => {
+  const vendors = ['epic', 'cerner', 'athena', 'unknown'] as const;
+
+  for (const file of CORPUS_FILES) {
+    for (const vendor of vendors) {
+      it(`${file}: applyVendorNormalization(…, '${vendor}') returns the parsed shape unchanged`, () => {
+        const parsed = parseCcdaXml(fs.readFileSync(path.join(CORPUS, file), 'utf8'));
+        const normalized = applyVendorNormalization(parsed, vendor);
+        // Deep-equal, not identity: the normalizer legitimately clones.
+        expect(normalized).toEqual(parsed);
+        expect(normalized).not.toBe(parsed);
+      });
+    }
+  }
+
+  for (const [label, xml] of [
+    ['synthetic Epic-detected document', SYNTHETIC_EPIC_CCDA],
+    ['synthetic unknown-vendor document', SYNTHETIC_UNKNOWN_VENDOR_CCDA],
+  ] as const) {
+    for (const vendor of vendors) {
+      it(`${label}: applyVendorNormalization(…, '${vendor}') returns the parsed shape unchanged`, () => {
+        const parsed = parseCcdaXml(xml);
+        expect(applyVendorNormalization(parsed, vendor)).toEqual(parsed);
+      });
+    }
+  }
+
+  it('the two synthetic documents differ ONLY in their custodian, so the vendor is the variable', () => {
+    // Otherwise "same records from both" would prove nothing about the vendor.
+    const epic = parseCcdaXml(SYNTHETIC_EPIC_CCDA);
+    const unknown = parseCcdaXml(SYNTHETIC_UNKNOWN_VENDOR_CCDA);
+    const stripCustodian = (d: any) => {
+      const c = JSON.parse(JSON.stringify(d));
+      delete c.ClinicalDocument.custodian;
+      return c;
+    };
+    expect(stripCustodian(epic)).toEqual(stripCustodian(unknown));
+    expect(epic.ClinicalDocument.custodian).not.toEqual(unknown.ClinicalDocument.custodian);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 3 — no handler dereferences a repeatable container
+// ---------------------------------------------------------------------------
+
+/**
+ * Functions that CONSUME a repeatable container whole rather than dereferencing
+ * a property of it, and are therefore safe to hand one directly. Each is
+ * array-aware by construction; adding a name here is a claim that it is, and
+ * should be justified in review.
+ */
+const CONTAINER_CONSUMERS = [
+  'firstOf', // multivalued.ts — the single occurrence
+  'listOf', // multivalued.ts — every occurrence
+  'Array.isArray', // a deliberate shape test
+  'ccdaSourceId', // record-identity.ts — walks an array of HL7 II elements
+  'nameText', // provenance.ts — unwraps a CDA <name> in any of its shapes
+  'structuredKey', // fhir-converter/types.ts — serializes the value, does not read into it
+];
+
+/** Control keywords whose parenthesised operand is a truthiness test, not a read. */
+const TRUTHINESS_CONTEXTS = ['if', 'while', 'return', 'switch'];
+
+/**
+ * The call whose argument list encloses `at`, or null when `at` is not inside
+ * one. Handles generic arguments (`listOf<any>(…)`) and spreads (`...listOf(…)`).
+ */
+function enclosingCall(code: string, at: number): string | null {
+  let depth = 0;
+  for (let i = at - 1; i >= 0; i--) {
+    const c = code[i];
+    if (c === ')') depth++;
+    else if (c === '(') {
+      if (depth > 0) { depth--; continue; }
+      let j = i - 1;
+      while (j >= 0 && /\s/.test(code[j])) j--;
+      if (code[j] === '>') {
+        let d = 0;
+        for (; j >= 0; j--) {
+          if (code[j] === '>') d++;
+          else if (code[j] === '<') { d--; if (d === 0) { j--; break; } }
+        }
+      }
+      const end = j + 1;
+      while (j >= 0 && /[A-Za-z0-9_$.]/.test(code[j])) j--;
+      return code.slice(j + 1, end).replace(/^\.+/, '');
+    }
+  }
+  return null;
+}
+
+describe('no C-CDA handler dereferences a repeatable container', () => {
+  it('every `.<repeatable-element>` is consumed whole, never dereferenced or bound raw', () => {
+    // Two clauses, because the four shipped instances split evenly between them:
+    //   CHAINED — `entry?.organizer?.component` (vitals). Reads a property
+    //     straight off the array. Always wrong.
+    //   RAW BOUND — `const organizer = entry?.organizer;` (labs, family history,
+    //     devices). The array is bound to a local that then reads like an object,
+    //     which is why a one-line grep never found these.
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (file === LIST_OWNER) continue;
+      const code = stripComments(CODE.get(file)!);
+      const lines = code.split('\n');
+      const lineAt = (i: number) => code.slice(0, i).split('\n').length;
+
+      for (const name of CCDA_MULTIVALUED_ELEMENTS) {
+        const re = new RegExp(`\\.\\s*${name}\\b`, 'g');
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(code)) !== null) {
+          const ln = lineAt(m.index);
+          const text = lines[ln - 1].trim();
+          const after = code.slice(m.index + m[0].length);
+
+          if (/^\s*(?:\?\.|\.|\[)/.test(after)) {
+            offenders.push(`${file}:${ln}: .${name} dereferenced — ${text}`);
+            continue;
+          }
+          // `x?.entry ? … : …` reads the container only for truthiness.
+          if (/^\s*\?[^.]/.test(after)) continue;
+          const call = enclosingCall(code, m.index);
+          if (call && (CONTAINER_CONSUMERS.includes(call) || TRUTHINESS_CONTEXTS.includes(call))) continue;
+          offenders.push(`${file}:${ln}: .${name} read raw — ${text}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      'A repeatable C-CDA element is an ARRAY on every document. Reading a property off it, or ' +
+        'binding it to a local that later does, yields undefined and the section silently ' +
+        'produces nothing — that has now happened four times. Consume it with firstOf() or ' +
+        `listOf() from ${LIST_OWNER}.`,
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The accessors themselves
+// ---------------------------------------------------------------------------
+
+describe('firstOf / listOf', () => {
+  it('firstOf takes the single occurrence from an array, an object, or nothing', () => {
+    expect(firstOf([{ a: 1 }, { a: 2 }])).toEqual({ a: 1 });
+    expect(firstOf({ a: 1 })).toEqual({ a: 1 });
+    expect(firstOf([])).toBeUndefined();
+    expect(firstOf(undefined)).toBeUndefined();
+    expect(firstOf(null)).toBeUndefined();
+  });
+
+  it('listOf always yields an array and drops nothing', () => {
+    expect(listOf([{ a: 1 }, { a: 2 }])).toHaveLength(2);
+    expect(listOf({ a: 1 })).toHaveLength(1);
+    expect(listOf(undefined)).toEqual([]);
+    expect(listOf(null)).toEqual([]);
+  });
+
+  it('canonicalization is idempotent and does not double-wrap', () => {
+    const doc: any = { entry: { organizer: { component: { observation: { x: 1 } } } } };
+    canonicalizeMultivaluedElements(doc);
+    const once = JSON.parse(JSON.stringify(doc));
+    canonicalizeMultivaluedElements(doc);
+    expect(doc).toEqual(once);
+    expect(Array.isArray(doc.entry)).toBe(true);
+    expect(Array.isArray(doc.entry[0].organizer)).toBe(true);
+    expect(Array.isArray(doc.entry[0].organizer[0].component)).toBe(true);
+  });
+});

--- a/tests/ccda-synthetic-documents.ts
+++ b/tests/ccda-synthetic-documents.ts
@@ -1,0 +1,453 @@
+/**
+ * Synthetic C-CDA R2.1 documents for the C-CDA converter tests.
+ *
+ * AUTHORED FROM THE C-CDA R2.1 SPECIFICATION. Not derived from, edited from, or
+ * de-identified from any real export. Every identifier, name, code and value
+ * below is invented for this test suite.
+ *
+ * The two documents are BYTE-IDENTICAL except for the custodian organization
+ * name, which is the only thing `detectVendor` keys on. That is deliberate:
+ * running both through the same handlers isolates the vendor as the single
+ * variable, which is exactly the axis along which the shape used to change.
+ *
+ * Sections and what each is here to exercise:
+ *   - Vital Signs       — readings grouped in an <organizer> (8 observations)
+ *   - Results           — two BATTERY <organizer> lab panels + an <encounter>
+ *   - Family History    — two relatives, each an <organizer> with <relatedSubject>
+ *   - Medical Equipment — an implanted device inside a <supply>
+ *   - Problems          — an act/entryRelationship problem with a STATUS
+ *                         observation that says "resolved", not the 'active' default
+ *   - Procedures        — a <procedure> with a code, name and date
+ *   - Allergies         — an allergen coded absent (<value nullFlavor="NI"/>) and
+ *                         named only in the section narrative
+ */
+
+const BODY_WITH_CUSTODIAN = (custodianName: string): string => `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5" extension="SYNTH-DOC-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Health Summary</title>
+  <effectiveTime value="20260101120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5" extension="SYNTH-PATIENT-001"/>
+      <patient>
+        <name use="L"><given>Testpatient</given><family>Synthetic</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19700101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5"/>
+        <name>${custodianName}</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <!-- Vital Signs Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+          <code code="8716-3" displayName="Vital Signs" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Vital Signs</title>
+          <text>Office visit vitals 2026-01-01</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-ORG-001"/>
+              <code code="46680005" displayName="Vital signs" codeSystem="2.16.840.1.113883.6.96"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20260101"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-HR"/>
+                  <code code="8867-4" displayName="Heart rate" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="72" unit="/min"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-SBP"/>
+                  <code code="8480-6" displayName="Systolic blood pressure" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="118" unit="mm[Hg]"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-DBP"/>
+                  <code code="8462-4" displayName="Diastolic blood pressure" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="76" unit="mm[Hg]"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-TEMP"/>
+                  <code code="8310-5" displayName="Body temperature" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="36.8" unit="Cel"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-RR"/>
+                  <code code="9279-1" displayName="Respiratory rate" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="16" unit="/min"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-SPO2"/>
+                  <code code="2708-6" displayName="Oxygen saturation in Arterial blood" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="98" unit="%"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-WT"/>
+                  <code code="29463-7" displayName="Body weight" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="70" unit="kg"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-VITAL-OBS-HT"/>
+                  <code code="8302-2" displayName="Body height" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="165" unit="cm"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Results (labs) Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>Basic metabolic panel 2026-01-01</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-ORG-BMP"/>
+              <code code="51990-0" displayName="Basic metabolic panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20260101"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-OBS-NA"/>
+                  <code code="2951-2" displayName="Sodium [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="140" unit="mmol/L"/>
+                  <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
+                  <referenceRange><observationRange><text>135-145 mmol/L</text></observationRange></referenceRange>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-OBS-K"/>
+                  <code code="2823-3" displayName="Potassium [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="4.1" unit="mmol/L"/>
+                  <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
+                  <referenceRange><observationRange><text>3.5-5.1 mmol/L</text></observationRange></referenceRange>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-OBS-CL"/>
+                  <code code="2075-0" displayName="Chloride [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="102" unit="mmol/L"/>
+                  <referenceRange><observationRange><text>98-107 mmol/L</text></observationRange></referenceRange>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-OBS-CREAT"/>
+                  <code code="2160-0" displayName="Creatinine [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="0.9" unit="mg/dL"/>
+                  <referenceRange><observationRange><text>0.6-1.1 mg/dL</text></observationRange></referenceRange>
+                </observation>
+              </component>
+              <encounter classCode="ENC" moodCode="EVN">
+                <id root="2.16.840.1.113883.19.5" extension="SYNTH-ENC-001"/>
+                <code code="AMB" codeSystem="2.16.840.1.113883.5.4" displayName="Ambulatory"/>
+                <effectiveTime value="20260101"/>
+              </encounter>
+            </organizer>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-ORG-LIPID"/>
+              <code code="57698-3" displayName="Lipid panel with direct LDL" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20260101"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-OBS-CHOL"/>
+                  <code code="2093-3" displayName="Cholesterol [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="180" unit="mg/dL"/>
+                  <referenceRange><observationRange><text>less than 200 mg/dL</text></observationRange></referenceRange>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-LAB-OBS-HDL"/>
+                  <code code="2085-9" displayName="Cholesterol in HDL [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20260101"/>
+                  <value xsi:type="PQ" value="55" unit="mg/dL"/>
+                  <referenceRange><observationRange><text>greater than 40 mg/dL</text></observationRange></referenceRange>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Family History Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+          <code code="10157-6" displayName="History of family member diseases" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Family History</title>
+          <text>Mother: Type 2 diabetes mellitus. Father: Myocardial infarction.</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-FHX-ORG-MOTHER"/>
+              <statusCode code="completed"/>
+              <subject>
+                <relatedSubject classCode="PRS">
+                  <code code="MTH" displayName="Mother" codeSystem="2.16.840.1.113883.5.111"/>
+                  <subject>
+                    <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                  </subject>
+                </relatedSubject>
+              </subject>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-FHX-OBS-MOTHER-DM"/>
+                  <code code="64572001" displayName="Condition" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <value xsi:type="CD" code="44054006" displayName="Type 2 diabetes mellitus" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-FHX-ORG-FATHER"/>
+              <statusCode code="completed"/>
+              <subject>
+                <relatedSubject classCode="PRS">
+                  <code code="FTH" displayName="Father" codeSystem="2.16.840.1.113883.5.111"/>
+                  <subject>
+                    <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+                  </subject>
+                </relatedSubject>
+              </subject>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-FHX-OBS-FATHER-MI"/>
+                  <code code="64572001" displayName="Condition" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <value xsi:type="CD" code="22298006" displayName="Myocardial infarction" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Allergies Section: allergen coded as absent, named only in the narrative -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+          <code code="48765-2" displayName="Allergies and Adverse Reactions" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Allergies</title>
+          <text>
+            <table>
+              <tbody>
+                <tr ID="allergy1">
+                  <td ID="allergen1">Synthetic Test Allergen</td>
+                  <td>Hives</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-ALLERGY-ACT-001"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              <statusCode code="active"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-ALLERGY-OBS-001"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                  <statusCode code="completed"/>
+                  <value xsi:type="CD" nullFlavor="NI"/>
+                  <participant typeCode="CSM">
+                    <participantRole classCode="MANU">
+                      <playingEntity classCode="MMAT">
+                        <code nullFlavor="NI">
+                          <originalText><reference value="#allergen1"/></originalText>
+                        </code>
+                      </playingEntity>
+                    </participantRole>
+                  </participant>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Problems Section: the status observation says RESOLVED, not the default -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" displayName="Problem List" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Problems</title>
+          <text>Acute bronchitis - resolved</text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-PROBLEM-ACT-001"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              <statusCode code="completed"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-PROBLEM-OBS-001"/>
+                  <code code="55607006" displayName="Problem" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <low value="20240301"/>
+                    <high value="20240401"/>
+                  </effectiveTime>
+                  <value xsi:type="CD" code="10509002" displayName="Acute bronchitis" codeSystem="2.16.840.1.113883.6.96"/>
+                  <entryRelationship typeCode="REFR">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.6"/>
+                      <code code="33999-4" displayName="Status" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value xsi:type="CD" code="413322009" displayName="Resolved" codeSystem="2.16.840.1.113883.6.96"/>
+                    </observation>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Procedures Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+          <code code="47519-4" displayName="History of Procedures" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Procedures</title>
+          <text>Appendectomy 2019-04-12</text>
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-PROCEDURE-001"/>
+              <code code="80146002" displayName="Appendectomy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20190412"/>
+            </procedure>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Medical Equipment / Implanted Devices Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+          <code code="46264-8" displayName="Medical Equipment" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Medical Equipment</title>
+          <text>Cardiac pacemaker implanted 2025-06-01</text>
+          <entry typeCode="DRIV">
+            <supply classCode="SPLY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.50"/>
+              <id root="2.16.840.1.113883.19.5" extension="SYNTH-DEVICE-001"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250601"/>
+              <participant typeCode="DEV">
+                <participantRole classCode="MANU">
+                  <id root="2.16.840.1.113883.19.5" extension="SYNTH-UDI-001"/>
+                  <playingDevice>
+                    <code code="14106009" displayName="Cardiac pacemaker" codeSystem="2.16.840.1.113883.6.96"/>
+                  </playingDevice>
+                </participantRole>
+              </participant>
+            </supply>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>
+`;
+
+/** Custodian name contains "Epic", so `detectVendor` classifies this 'epic'. */
+export const SYNTHETIC_EPIC_CCDA = BODY_WITH_CUSTODIAN('Epic Systems Sample Community Hospital');
+
+/** Same document, a custodian no vendor rule matches: `detectVendor` -> 'unknown'. */
+export const SYNTHETIC_UNKNOWN_VENDOR_CCDA = BODY_WITH_CUSTODIAN('Sample Community Hospital');

--- a/tests/ccda-vendor-normalized-cross-process.test.ts
+++ b/tests/ccda-vendor-normalized-cross-process.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The recovered sections, measured from a FRESH process and a DIFFERENT working
+ * directory, through the BUILT artifact.
+ *
+ * WHY THIS IS SEPARATE FROM THE IN-PROCESS CASES
+ * ----------------------------------------------
+ * Two conversions inside one process share a module cache, one `process.cwd()`
+ * and any memoization a converter holds, so a defect keyed on any of those is
+ * invisible to them. That is not hypothetical in this repo: an earlier identity
+ * defect hashed an ABSOLUTE input path and stayed green for months because every
+ * run started from the same directory.
+ *
+ * These cases therefore spawn a separate `node` per measurement, from two
+ * different directories, and import the converter from `dist/` — the artifact an
+ * npm consumer installs, not the TypeScript sources.
+ *
+ * They do NOT skip when `dist/` is missing. A determinism claim that quietly
+ * declines to run is the same "absence reported as success" shape as the defect
+ * this suite is about; a missing build is a broken checkout, and it says so.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SYNTHETIC_EPIC_CCDA, SYNTHETIC_UNKNOWN_VENDOR_CCDA } from './ccda-synthetic-documents.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+
+const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+const dist = process.env.CASCADE_DIST;
+const { convertCcda } = await import(pathToFileURL(path.join(dist, 'lib/ccda-converter/index.js')).href);
+const payload = JSON.parse(process.env.CASCADE_PAYLOAD);
+const r = await convertCcda(payload.xml, { sourceSystem: 'test', importedAt: payload.importedAt });
+const iris = [...new Set((r.output ?? '').match(/urn:uuid:[0-9a-f-]{36}/g) ?? [])].sort();
+const typeCount = (t) => (r.output ?? '').split(t).length - 1;
+process.stdout.write(JSON.stringify({
+  iris,
+  cwd: process.cwd(),
+  census: r.sectionCensus ?? [],
+  counts: {
+    vitals: typeCount('clinical:VitalSign'),
+    labs: typeCount('health:LabResultRecord'),
+    panels: typeCount('clinical:LaboratoryReport'),
+    familyHistory: typeCount('health:FamilyHistoryRecord'),
+    devices: typeCount('clinical:ImplantedDevice'),
+    procedures: typeCount('clinical:Procedure'),
+  },
+}));
+`;
+
+interface Run {
+  iris: string[];
+  cwd: string;
+  census: Array<{ label: string; entriesIn: number; recordsOut: number }>;
+  counts: Record<string, number>;
+}
+
+let scriptPath = '';
+const dirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  dirs.push(d);
+  return d;
+}
+
+function runFresh(xml: string, cwd: string, importedAt: string): Run {
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, CASCADE_DIST: DIST, CASCADE_PAYLOAD: JSON.stringify({ xml, importedAt }) },
+  });
+  return JSON.parse(stdout) as Run;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(path.join(DIST, 'lib', 'ccda-converter', 'index.js'))) {
+    throw new Error(
+      `dist/ is missing — run \`npm run build\` before \`npm test\`. This suite verifies the BUILT ` +
+        `artifact and will not skip: a determinism claim that declines to run is not a claim.`,
+    );
+  }
+  const d = tempDir('cascade-ccda-xproc-');
+  scriptPath = path.join(d, 'convert.mjs');
+  fs.writeFileSync(scriptPath, SCRIPT);
+});
+
+describe('the recovered sections survive the process and the directory', () => {
+  it('mints identical IRIs from two processes in two different directories', () => {
+    const a = runFresh(SYNTHETIC_EPIC_CCDA, tempDir('cascade-a-'), '2026-01-02T03:04:05.000Z');
+    const b = runFresh(SYNTHETIC_EPIC_CCDA, tempDir('cascade-b-'), '2027-11-12T13:14:15.000Z');
+    expect(a.cwd).not.toBe(b.cwd);
+    expect(b.iris).toEqual(a.iris);
+  });
+
+  it('the records the source kept apart are distinct IRIs, not one collapsed record', () => {
+    // Determinism alone is satisfied by minting ONE constant IRI for everything.
+    // Distinctness is the other half of the claim.
+    const a = runFresh(SYNTHETIC_EPIC_CCDA, tempDir('cascade-c-'), '2026-01-02T03:04:05.000Z');
+    expect(new Set(a.iris).size).toBe(a.iris.length);
+    expect(a.iris.length).toBeGreaterThanOrEqual(23);
+  });
+
+  it('the built artifact recovers every section, in a process that never saw a test fixture', () => {
+    const a = runFresh(SYNTHETIC_EPIC_CCDA, tempDir('cascade-d-'), '2026-01-02T03:04:05.000Z');
+    expect(a.counts).toEqual({
+      vitals: 8,
+      labs: 6,
+      panels: 2,
+      familyHistory: 2,
+      devices: 1,
+      procedures: 1,
+    });
+  });
+
+  it('the custodian name does not change the record set, across processes', () => {
+    const epic = runFresh(SYNTHETIC_EPIC_CCDA, tempDir('cascade-e-'), '2026-01-02T03:04:05.000Z');
+    const unknown = runFresh(SYNTHETIC_UNKNOWN_VENDOR_CCDA, tempDir('cascade-f-'), '2026-01-02T03:04:05.000Z');
+    expect(unknown.counts).toEqual(epic.counts);
+    expect(
+      unknown.census.map((s) => [s.label, s.entriesIn, s.recordsOut]),
+    ).toEqual(epic.census.map((s) => [s.label, s.entriesIn, s.recordsOut]));
+  });
+});

--- a/tests/ccda-vendor-normalized-import-e2e.test.ts
+++ b/tests/ccda-vendor-normalized-import-e2e.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The recovered sections, through `cascade pod import` — the command a user
+ * actually runs — and the summary that command prints.
+ *
+ * The defect was not only that records were lost. It was that the loss was
+ * REPORTED AS SUCCESS: the summary printed a record count and a per-bucket
+ * breakdown that simply omitted the sections that produced nothing, so an import
+ * that dropped three entire clinical sections looked indistinguishable from one
+ * that dropped none. Both halves are asserted here, on the printed output.
+ *
+ * Every fixture is synthetic, authored from the C-CDA R2.1 specification.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SYNTHETIC_EPIC_CCDA } from './ccda-synthetic-documents.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+const roots: string[] = [];
+
+function cli(args: string[]): { output: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 180000 });
+  return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+function newPod(): { podDir: string; inputs: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccda-sections-'));
+  roots.push(root);
+  const podDir = path.join(root, 'pod');
+  const inputs = path.join(root, 'inputs');
+  fs.mkdirSync(inputs);
+  fs.writeFileSync(path.join(inputs, 'summary.xml'), SYNTHETIC_EPIC_CCDA);
+  const init = cli(['pod', 'init', podDir]);
+  expect(init.status, init.output).toBe(0);
+  return { podDir, inputs };
+}
+
+beforeAll(() => {
+  // No skip: without a build this claim cannot be made, and declining to make it
+  // quietly is the failure mode this whole suite is about.
+  if (!fs.existsSync(CLI)) {
+    throw new Error(`dist/index.js is missing — run \`npm run build\` before \`npm test\`.`);
+  }
+});
+
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+describe('cascade pod import, on a vendor-detected C-CDA', () => {
+  it('writes the sections that used to import as nothing', () => {
+    const { podDir, inputs } = newPod();
+    const r = cli(['pod', 'import', podDir, inputs]);
+    expect(r.status, r.output).toBe(0);
+
+    const read = (rel: string) => {
+      const p = path.join(podDir, rel);
+      return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+    };
+    const pod = fs
+      .readdirSync(podDir, { recursive: true } as never)
+      .filter((f) => String(f).endsWith('.ttl'))
+      .map((f) => read(String(f)))
+      .join('\n');
+
+    // Each of these was ZERO on a vendor-detected document before the fix.
+    expect(pod).toContain('clinical:VitalSign');
+    expect(pod).toContain('health:LabResultRecord');
+    expect(pod).toContain('health:FamilyHistoryRecord');
+    expect(pod).toContain('clinical:ImplantedDevice');
+    // And the values, not merely the types.
+    expect(pod).toContain('Type 2 diabetes mellitus');
+    expect(pod).toContain('Cardiac pacemaker');
+    expect(pod).toContain('Appendectomy');
+  });
+
+  it('the summary states entries read versus records imported, per section', () => {
+    const { podDir, inputs } = newPod();
+    const r = cli(['pod', 'import', podDir, inputs]);
+    expect(r.output).toContain('Structured sections (entries read -> records imported)');
+    expect(r.output).toMatch(/Vital Signs: 1 -> 8/);
+    expect(r.output).toMatch(/Results: 2 -> 9/);
+    expect(r.output).toMatch(/Family History: 2 -> 2/);
+    expect(r.output).toMatch(/Medical Equipment: 1 -> 1/);
+  });
+
+  it('a section that imported nothing is named in the summary, not omitted', () => {
+    const { podDir, inputs } = newPod();
+    const r = cli(['pod', 'import', podDir, inputs]);
+    expect(r.output).toMatch(/Allergies: 1 -> 0/);
+    expect(r.output).toContain('NOTHING IMPORTED');
+    expect(r.output).toContain('imported 0 records');
+  });
+
+  it('a true re-import adds nothing and says so', () => {
+    const { podDir, inputs } = newPod();
+    const first = cli(['pod', 'import', podDir, inputs]);
+    expect(first.status, first.output).toBe(0);
+    const second = cli(['pod', 'import', podDir, inputs, '--reconcile-existing']);
+    expect(second.status, second.output).toBe(0);
+    // Every record is already held: none is new.
+    expect(second.output).toMatch(/already in pod/);
+    expect(second.output).not.toMatch(/\(\d+ new, 0 already in pod\)/);
+  });
+
+  it('re-importing does not multiply the records in the pod', () => {
+    const { podDir, inputs } = newPod();
+    cli(['pod', 'import', podDir, inputs]);
+    const countVitals = () => {
+      const p = path.join(podDir, 'clinical', 'vitals.ttl');
+      const alt = path.join(podDir, 'clinical', 'vital-signs.ttl');
+      const file = fs.existsSync(p) ? p : alt;
+      if (!fs.existsSync(file)) return 0;
+      return fs.readFileSync(file, 'utf-8').split('clinical:VitalSign').length - 1;
+    };
+    const after1 = countVitals();
+    expect(after1, 'the first import must actually write vitals').toBeGreaterThan(0);
+    cli(['pod', 'import', podDir, inputs, '--reconcile-existing']);
+    expect(countVitals()).toBe(after1);
+  });
+});

--- a/tests/ccda-vendor-normalized-sections.test.ts
+++ b/tests/ccda-vendor-normalized-sections.test.ts
@@ -1,0 +1,233 @@
+/**
+ * The C-CDA sections, exercised through the shape a real import produces.
+ *
+ * THE TRAP THIS TEST EXISTS TO AVOID
+ * ----------------------------------
+ * A test that hands a section handler a raw parse passes today and proves
+ * nothing. The whole defect was that a document's shape changed AFTER parsing,
+ * at the vendor-normalization step, and the post-normalization shape was the one
+ * shape nothing exercised. Three instances of that shipped.
+ *
+ * So every case here goes through `convertCcda`, i.e. through `detectVendor` and
+ * `applyVendorNormalization`, on a document whose custodian makes it a
+ * recognized vendor. That is the path a real portal export takes.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT — measured against 0f33c78:
+ *   Vital signs        8 records  ->  0
+ *   Lab results        8 records  ->  0   (6 results + 2 panels)
+ *   Family history     2 records  ->  0
+ *   Implanted device   1 record   ->  0
+ *   Procedure          name/date/code present -> all three absent
+ *   Problem status     "Resolved" -> "active" (the default, on every document)
+ * and the import reported success with no warning for any of it.
+ *
+ * Every fixture is synthetic, authored from the C-CDA R2.1 specification.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { parseCcdaXml } from '../src/lib/ccda-converter/parser.js';
+import { detectVendor } from '../src/lib/ccda-converter/vendor/detect.js';
+import { SYNTHETIC_EPIC_CCDA, SYNTHETIC_UNKNOWN_VENDOR_CCDA } from './ccda-synthetic-documents.js';
+
+const IMPORTED_AT = '2026-01-02T03:04:05.000Z';
+
+async function convert(xml: string) {
+  return convertCcda(xml, { sourceSystem: 'test', importedAt: IMPORTED_AT });
+}
+
+/** Subjects carrying `rdf:type <type>` in the Turtle output. */
+function subjectsOfType(turtle: string, compactType: string): string[] {
+  const out = new Set<string>();
+  // Turtle from n3's Writer states types as `<subj> a <type>` or in a predicate list.
+  const re = new RegExp(`<(urn:uuid:[0-9a-f-]+)>[^.]*?\\ba\\b[^.]*?${compactType}\\b`, 'gs');
+  for (const m of turtle.matchAll(re)) out.add(m[1]);
+  return [...out].sort();
+}
+
+function countOccurrences(turtle: string, needle: string): number {
+  return turtle.split(needle).length - 1;
+}
+
+describe('the synthetic document really does take the vendor path', () => {
+  it('detectVendor classifies it as epic, so normalization runs', () => {
+    // Without this the rest of the file would be testing the unknown-vendor path
+    // and would have passed before the fix, which is exactly the trap.
+    expect(detectVendor(parseCcdaXml(SYNTHETIC_EPIC_CCDA))).toBe('epic');
+    expect(detectVendor(parseCcdaXml(SYNTHETIC_UNKNOWN_VENDOR_CCDA))).toBe('unknown');
+  });
+});
+
+describe('every structured section imports its records on a vendor-detected document', () => {
+  it('vital signs: one organizer of 8 readings produces 8 VitalSign records', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    expect(r.success).toBe(true);
+    // 8 readings, all with LOINCs inside the VitalSignShape enum.
+    expect(countOccurrences(r.output, 'clinical:VitalSign')).toBe(8);
+    expect(r.output).toContain('"72"');   // heart rate
+    expect(r.output).toContain('"118"');  // systolic
+    expect(r.output).toContain('"36.8"'); // temperature
+  });
+
+  it('labs: two BATTERY panels produce 6 results and 2 LaboratoryReports', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    expect(countOccurrences(r.output, 'health:LabResultRecord')).toBe(6);
+    expect(countOccurrences(r.output, 'clinical:LaboratoryReport')).toBe(2);
+    expect(r.output).toContain('"140"'); // sodium
+    expect(r.output).toContain('"180"'); // cholesterol
+  });
+
+  it('family history: two relatives produce two FamilyHistoryRecords, kept apart', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    expect(countOccurrences(r.output, 'health:FamilyHistoryRecord')).toBe(2);
+    expect(r.output).toContain('Type 2 diabetes mellitus');
+    expect(r.output).toContain('Myocardial infarction');
+    // Two relatives, two subjects — not one record overwriting the other.
+    expect(subjectsOfType(r.output, 'health:FamilyHistoryRecord')).toHaveLength(2);
+  });
+
+  it('implanted devices: the device inside a <supply> produces one ImplantedDevice', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    expect(countOccurrences(r.output, 'clinical:ImplantedDevice')).toBe(1);
+    expect(r.output).toContain('Cardiac pacemaker');
+    expect(r.output).toContain('2025-06-01');
+  });
+
+  it('procedures: the record carries its name, date and code, not just a type', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    expect(countOccurrences(r.output, 'clinical:Procedure')).toBe(1);
+    // Each of these came back empty while <procedure> was read as an object, and
+    // the record was still written — an empty record reported as a success.
+    expect(r.output).toContain('Appendectomy');
+    expect(r.output).toContain('2019-04-12');
+    expect(r.output).toContain('80146002');
+  });
+
+  it('problems: the status the source STATED is used, not the "active" default', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    expect(countOccurrences(r.output, 'health:ConditionRecord')).toBeGreaterThanOrEqual(1);
+    expect(r.output).toContain('Acute bronchitis');
+    // Asserted on the PREDICATE, not on the word appearing anywhere: the
+    // section's narrative also contains "resolved", so a substring check would
+    // have passed against the broken build. Measured against 0f33c78 this is
+    // `health:status "active"` — the default — because the status observation
+    // sat behind an <entryRelationship> array that could not be read, on every
+    // document from every vendor.
+    expect(r.output).toMatch(/health:status\s+"resolved"/);
+    expect(r.output).not.toMatch(/health:status\s+"active"/);
+  });
+});
+
+describe('entries in versus records out is reported per section', () => {
+  it('every structured section is counted, including the ones that yield nothing', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    const census = Object.fromEntries(
+      (r.sectionCensus ?? []).map((s) => [s.label, { in: s.entriesIn, out: s.recordsOut }]),
+    );
+
+    // Asserted as exact pairs, not as "some records exist": the defect produced
+    // a perfectly plausible-looking summary precisely because nothing compared
+    // the two numbers.
+    expect(census['Vital Signs']).toEqual({ in: 1, out: 8 });
+    // 6 member results + 2 BATTERY panel records + the 1 encounter the panels
+    // were collected in, which this section also mints.
+    expect(census['Results']).toEqual({ in: 2, out: 9 });
+    expect(census['Family History']).toEqual({ in: 2, out: 2 });
+    expect(census['Medical Equipment']).toEqual({ in: 1, out: 1 });
+    expect(census['Procedures']).toEqual({ in: 1, out: 1 });
+    expect(census['Problems']).toEqual({ in: 1, out: 1 });
+    // The one section that still yields nothing, counted rather than omitted.
+    expect(census['Allergies']).toEqual({ in: 1, out: 0 });
+  });
+
+  it('a section that reads entries and writes no records says so', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    const zeroYield = r.warnings.filter((w) => w.includes('imported 0 records'));
+    expect(zeroYield, 'the empty section must be named').toHaveLength(1);
+    expect(zeroYield[0]).toContain('Allergies');
+    expect(zeroYield[0]).toContain('read 1 structured entry');
+  });
+
+  it('a section that yields records raises no such warning', async () => {
+    // Otherwise the warning is noise and gets ignored, which is how the real
+    // signal would be lost a second time.
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    for (const label of ['Vital Signs', 'Results', 'Family History', 'Procedures']) {
+      expect(r.warnings.filter((w) => w.includes(label) && w.includes('imported 0 records'))).toEqual([]);
+    }
+  });
+
+  it('the allergy whose allergen is narrative-only is reported, not dropped in silence', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    const named = r.warnings.filter((w) => w.includes('names no allergen'));
+    expect(named).toHaveLength(1);
+    expect(named[0]).toContain('SYNTH-ALLERGY-ACT-001');
+    expect(named[0]).toContain('NOT imported');
+  });
+});
+
+describe('the vendor is no longer a variable', () => {
+  it('the same document imports identically whether or not its custodian is recognized', async () => {
+    // This is the property the fix actually establishes. Before it, these two
+    // documents — identical but for the custodian NAME — imported different
+    // record sets, and the difference was three whole sections.
+    const epic = await convert(SYNTHETIC_EPIC_CCDA);
+    const unknown = await convert(SYNTHETIC_UNKNOWN_VENDOR_CCDA);
+
+    const records = (turtle: string) =>
+      [...new Set(turtle.match(/urn:uuid:[0-9a-f-]{36}/g) ?? [])].sort();
+
+    // The custodian name is a real difference in the data (it is the record's
+    // EHR of origin), so the TURTLE differs; the record SET must not.
+    expect(records(epic.output)).toEqual(records(unknown.output));
+    expect(epic.sectionCensus).toEqual(unknown.sectionCensus);
+  });
+
+  it('the record counts are equal section by section across the two vendors', async () => {
+    const epic = await convert(SYNTHETIC_EPIC_CCDA);
+    const unknown = await convert(SYNTHETIC_UNKNOWN_VENDOR_CCDA);
+    for (const type of [
+      'clinical:VitalSign',
+      'health:LabResultRecord',
+      'clinical:LaboratoryReport',
+      'health:FamilyHistoryRecord',
+      'clinical:ImplantedDevice',
+      'clinical:Procedure',
+      'health:ConditionRecord',
+    ]) {
+      expect(
+        countOccurrences(unknown.output, type),
+        `${type} count must not depend on the custodian`,
+      ).toBe(countOccurrences(epic.output, type));
+    }
+  });
+});
+
+describe('re-import and determinism', () => {
+  it('converting the same document twice mints the same IRIs', async () => {
+    const a = await convert(SYNTHETIC_EPIC_CCDA);
+    const b = await convert(SYNTHETIC_EPIC_CCDA);
+    const iris = (t: string) => [...new Set(t.match(/urn:uuid:[0-9a-f-]{36}/g) ?? [])].sort();
+    expect(iris(b.output)).toEqual(iris(a.output));
+    expect(iris(a.output).length).toBeGreaterThan(15);
+  });
+
+  it('a different importedAt does not move any IRI', async () => {
+    // importedAt is not content. A record whose identity moved with it would
+    // duplicate on every re-import.
+    const a = await convertCcda(SYNTHETIC_EPIC_CCDA, { sourceSystem: 'test', importedAt: IMPORTED_AT });
+    const b = await convertCcda(SYNTHETIC_EPIC_CCDA, { sourceSystem: 'test', importedAt: '2027-09-09T09:09:09.000Z' });
+    const iris = (t: string) => [...new Set(t.match(/urn:uuid:[0-9a-f-]{36}/g) ?? [])].sort();
+    expect(iris(b.output)).toEqual(iris(a.output));
+  });
+
+  it('records the source kept apart stay apart', async () => {
+    const r = await convert(SYNTHETIC_EPIC_CCDA);
+    const all = r.output.match(/urn:uuid:[0-9a-f-]{36}/g) ?? [];
+    const distinct = new Set(all);
+    // 8 vitals + 6 labs + 2 panels + 2 family history + 1 device + 1 procedure
+    // + 1 problem + 1 patient + 1 encounter = 23 records, plus narrative
+    // document nodes. A collapse would show up as a shortfall here.
+    expect(distinct.size).toBeGreaterThanOrEqual(23);
+  });
+});


### PR DESCRIPTION
## What was broken

On a C-CDA document whose custodian organization named a recognized EHR vendor — which is what a downloaded patient-portal export is — the **results, vital signs, family history and medical equipment sections each imported ZERO records**, and the import printed a record count and reported success.

Measured on a synthetic document, on `main` at `0f33c78`:

| custodian | distinct records imported | vitals | lab results | lab panels | family history | devices |
|---|---|---|---|---|---|---|
| unrecognized | 30 | 8 | 6 | 2 | 2 | 1 |
| names a recognized vendor | **10** | **0** | **0** | **0** | **0** | **0** |

Same document. Same bytes but for the custodian **name**.

## Why

A C-CDA element that the CDA R2.1 schema declares `0..*` is an array when the importer forces it to be one and a plain object otherwise. That forcing was decided in **two places that did not agree**:

- `parser.ts` forced thirteen element names, on every document;
- each vendor quirk module then forced a **different** set, on documents from that vendor only.

`organizer` and `supply` were in the vendor lists and not the parser's. So `entry.organizer` was an object on most documents and an array on documents from a recognized vendor, and four handlers read it as an object. Reading a property off an array yields `undefined`, so the handler walked nothing and returned nothing.

The suite was green throughout because **no fixture in the corpus is classified as a vendor at all** — including the one named `epic-summarization.xml`, which has no `<custodian>` and detects as `unknown`. The vendor-normalized shape was the one shape nothing exercised.

## Why this is not four unwraps

This is the third time the same idea has shipped (`act.entryRelationship` read as an object; `organizer.component[].observation` read as an object; now `entry.organizer` itself). Four edits fix today's instances and guarantee a fifth. So:

1. **One list.** `src/lib/ccda-converter/multivalued.ts` owns the repeatable-element names. The parser applies it to **every** document. The vendor shims read the same list, so their walk is a no-op on parser output and the shape can no longer depend on the custodian. `coding` is dropped from the Epic list — it is a FHIR JSON key, never a CDA element, and never matched anything.
2. **The shape is asserted.** `applyVendorNormalization(parse(x), v)` must be deep-equal to `parse(x)`, for every vendor and every corpus fixture. If a shim ever changes a shape behind a handler's back again, that fails.
3. **A lint.** Nothing under `lib/ccda-converter/` may dereference one of these containers (`.organizer.x`, `.organizer[0]`) **or bind one raw to a local** (`const organizer = entry.organizer;`). It must be consumed with `firstOf()` / `listOf()`. The second clause matters: three of the four instances were the raw-binding shape, which no one-line grep finds.

**Rejected alternatives.** Canonicalizing in the vendor normalizer instead of the parser would have left `parseCcdaXml` — which tests and other modules call directly — producing a pre-canonical shape, i.e. it would have preserved the exact trap where a test feeds a handler something a real import never produces. Asserting the normalizer's output shape without unifying the lists would have documented the ambiguity rather than removed it, and left each handler to guess. The lint alone would have stopped recurrence without fixing the two-list cause. All three are in, with the canonicalization at the parser.

## What the sweep found beyond the reported symptom

Diffing the raw parse against the normalizer's **return value** across every corpus fixture and a synthetic vendor-detected document: `organizer` is the only element the normalizer actually changes on those inputs, and `supply` is the only other name it *could* change. `supply` was the fourth zero-record section (implanted devices), found by the sweep and not by a symptom.

Auditing every site that reads one of these containers found three more defects, all pre-existing on **every** document, vendor-recognized or not:

- **Procedures** wrote a record with **no name, no date and no code** — `entry.procedure` and its `entry.act` fallback are both lists, every field read came back empty, and nothing stopped the record being written. Harder to see than a zero-record section because the count looked right.
- **A resolved problem imported as `active`.** The status observation sits under `<entryRelationship>`, always a list; the read yielded `undefined` and the display status fell back to the default, on every document.
- **Allergy severity was never read, and the allergen name was the wrong string.** `<entryRelationship>` and `<playingEntity><name>` are both lists. Measured: every allergy in the conformance corpus carries a severity in its source (mild / moderate / severe) and **none of them reached the pod**.

## Absence is no longer reported as success

The importer now counts entries read against records written, per section, prints it, and warns by name when a section with structured entries yields nothing — whatever the cause.

```
  Structured sections (entries read -> records imported):
    - Allergies: 1 -> 0  <-- NOTHING IMPORTED
    - Family History: 2 -> 2
    - Medical Equipment: 1 -> 1
    - Problems: 1 -> 1
    - Procedures: 1 -> 1
    - Results: 2 -> 9
    - Vital Signs: 1 -> 8
  Warnings:         3
    - …: Section "Allergies" (LOINC 48765-2): read 1 structured entry and imported 0 records. Nothing from this section reached the pod.
```

Also in `--json` and `--report`, as `sectionCensus`. This is worth having on its own merits: had it existed, the section losses would have been visible the first time anyone imported a portal export.

## Not fixed, deliberately, and flagged for a decision

An allergy whose allergen is coded absent (`<value nullFlavor="NI"/>`) and named only in the section narrative still produces **no record**. That is a second, independent cause and the unwrap does not touch it.

What changed is that it is no longer **silent**: the entry is named in the warnings with its source identifier, and the census reports the section as `1 -> 0`. The two ways to finish it — resolve the narrative reference, or emit the record with a FHIR `dataAbsentReason` — are written up at the decision point in `allergies.ts` with a recommendation, and stated as a known limitation in the changelog.

## Changelog correction

The 0.11.0 notes claimed the release recovers allergies and family history that were previously dropped. On a vendor-recognized document family history was **still** dropped, so that claim was false for the most common real input. The 0.11.0 entries are corrected in place (the version and heading are unchanged), the four zero-record sections and the three field-level losses are added under Fixed, the census is added under Added, and the narrative-only allergen is stated plainly under Known limitations.

## Verification

- **Full suite: 1607 passed / 0 failed / 0 skipped, 115 files.** Baseline on `0f33c78` (with sibling `conformance` and `reference-patient-pod` resolvable) is 1539 / 0 / 0, 111 files.
- **Every new test runs through the vendor-normalized shape** — through `convertCcda`, on a document `detectVendor` classifies as a vendor. A test that feeds a handler a raw parse passes on `main` and proves nothing; that is why three of these shipped. One case asserts the classification itself, so the file cannot silently drift onto the unknown-vendor path.
- **Negative control.** The four new files, copied onto `0f33c78` (plus the inert `multivalued.ts` they import — a constant and two pure helpers, no behaviour), **fail 33 of 68**: every section count is 0, the procedure code is absent, the problem status is `"active"`, `Structured sections` is absent from the summary, the two shape rules fail, and the lint reports **71** offending sites. On this branch all 68 pass.
- **Entries-in vs records-out asserted per section as exact pairs**, not "some records exist".
- **Cross-process and cross-directory**: a separate `node` per measurement, from different working directories, importing from `dist/` — identical IRIs, all distinct, all sections recovered. It does **not** skip when `dist/` is missing; it fails with a message, because a determinism claim that declines to run is not a claim.
- **Re-import still dedupes**, checked end-to-end through `cascade pod import --reconcile-existing`: the second import adds nothing and the vital-sign count in the pod is unchanged.
- **No IRI churn from this change**: the C-CDA conformance corpus mints 33 distinct record IRIs before and 33 after, 0 moved. The record VALUES change where a field was previously lost (allergen name, severity, procedure name/date/code, problem status).
- All fixtures are synthetic, authored from the C-CDA R2.1 specification.

## Mistakes worth reporting

- My first pass at the lint matched only chained dereferences (`.organizer.component`). That would have caught the vitals instance and **missed** labs, family history and devices, all of which bind the container to a local first — i.e. it would have passed on three of the four defects it exists to prevent. Caught by running it against `0f33c78` and finding it did not fire. The rule now has both clauses.
- My first assertion for the problem-status fix was `output.toLowerCase()).toContain('resolved')`. The section's narrative text also contains the word, so it passed against the broken build. It now asserts on the predicate, `health:status "resolved"`.
- I predicted the results section would yield 8 records and it yields 9 — the labs handler also mints the encounter the panels were collected in. The expectation was wrong, not the code.
