### PR TITLE
feat(cli): report how many subjects `validate` actually checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+**`cascade validate` now reports how many subjects it actually checked.** Before this change it
+returned PASS on records it had no constraints for, and there was no way to tell the difference
+from the output. A file whose subjects match no `sh:targetClass` runs zero constraints, and a
+SHACL report over zero constraints conforms — so "PASS" meant "nothing was found wrong", which
+is not the same as "this was checked".
+
+Every result line now carries a count:
+
+```
+PASS clinical/medications.ttl (192 triples; 8 of 8 subjects checked)
+PASS clinical/lab-results.ttl (187 triples; 0 of 11 subjects checked; 11 subjects of type
+     health:LabResultRecord had no applicable shape)
+```
+
+and a directory validation ends with a pod-wide `Coverage:` line naming every type no loaded
+shape applies to. The same figures are available under `coverage` in `--json` output.
+
+**If your validation output changes after upgrading, the validator got more accurate — your data
+did not get worse.** Nothing that passed before now fails: unshaped subjects are counted and
+named, but they do not affect the exit code, because a class with no shape is a gap in the
+vocabulary rather than a defect in your data. On a 19-file reference pod this surfaces 292
+previously unreported subjects (122 of them carrying Cascade-namespace types) that were being
+reported as passing while nothing ran against them.
+
+### Fixed
+
+- **`Shapes:` no longer names shape files that ran nothing.** The reported shapes were derived
+  from which vocabulary prefixes a file declared, so a file using `health:` predicates printed
+  `Shapes: health.shapes.ttl` even when no shape in it targeted any subject present. Reporting is
+  now derived from the shapes that actually selected a focus node. A conditions file that
+  previously listed three shape files now correctly lists none, and `--json` gains `shapesFired`
+  naming the individual shapes that ran.
+- **Class targets now honour `rdfs:subClassOf`.** Shape applicability is resolved per
+  [SHACL 2.1.3.1](https://www.w3.org/TR/shacl/#targetClass), so a shape targeting a superclass is
+  correctly reported as covering subclass-typed subjects, transitively. Nodes reached through a
+  parent shape's `sh:node` are counted as checked rather than reported as unconstrained.
+
 ## [0.11.0] - 2026-08-03
 
 **This release is about record identity — the IRI each record gets, which decides whether a

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -12,6 +12,13 @@
  *   0 = all files pass validation
  *   1 = one or more validation failures
  *   2 = errors (file not found, malformed Turtle, etc.)
+ *
+ * Subjects that no loaded shape applies to are counted and named in the output
+ * but do NOT affect the exit code. An unshaped subject means the vocabulary has
+ * no constraints for that class yet, which is a gap in the shapes rather than a
+ * defect in the data being validated, and failing on it would break every
+ * existing caller on upgrade for something they cannot fix in their own data.
+ * The count is reported on every file so the gap cannot pass unnoticed.
  */
 
 import fs from 'node:fs';
@@ -24,6 +31,7 @@ import {
   findTurtleFiles,
   type ValidationResult,
 } from '../lib/shacl-validator.js';
+import { shortenIRI } from '../lib/turtle-parser.js';
 import { isPodEncrypted, resolveDek, PodDecryptError } from '../lib/pod-encryption.js';
 import { obtainPassphrase } from '../lib/passphrase.js';
 
@@ -47,14 +55,61 @@ const severityIcons: Record<string, string> = {
 };
 
 /**
+ * Describe how much of a file the loaded shapes actually reached.
+ *
+ * Rendered on every result line, passing or failing, because a file with no
+ * applicable shape produces a conforming SHACL report while running zero
+ * constraints, and the count is the only thing that distinguishes "checked and
+ * correct" from "not checked".
+ */
+function formatCoverage(result: ValidationResult): { summary: string; detail?: string } {
+  const { totalSubjects, checkedSubjects, unshapedTypes } = result.coverage;
+
+  if (totalSubjects === 0) {
+    return { summary: 'no typed subjects' };
+  }
+
+  const unshapedCount = totalSubjects - checkedSubjects;
+  const checked = `${checkedSubjects} of ${totalSubjects} subject${totalSubjects !== 1 ? 's' : ''} checked`;
+
+  if (unshapedCount === 0) {
+    return { summary: checked };
+  }
+
+  const plural = unshapedCount !== 1 ? 's' : '';
+
+  // A single unshaped type fits on the result line; several need their own.
+  if (unshapedTypes.length === 1) {
+    const type = shortenIRI(unshapedTypes[0].type);
+    return {
+      summary: `${checked}; ${unshapedCount} subject${plural} of type ${type} had no applicable shape`,
+    };
+  }
+
+  const breakdown = unshapedTypes
+    .map((t) => `${shortenIRI(t.type)} (${t.count})`)
+    .join(', ');
+  return {
+    summary: `${checked}; ${unshapedCount} subject${plural} had no applicable shape`,
+    detail: `     No shape applies to: ${breakdown}`,
+  };
+}
+
+/**
  * Format a single validation result for human-readable output.
  */
 function formatResultHuman(result: ValidationResult, verbose: boolean): string {
   const lines: string[] = [];
   const relPath = result.file;
+  const coverage = formatCoverage(result);
 
   if (result.valid) {
-    lines.push(`${colors.green}PASS${colors.reset} ${relPath} (${result.quadCount} triples)`);
+    lines.push(
+      `${colors.green}PASS${colors.reset} ${relPath} (${result.quadCount} triples; ${coverage.summary})`,
+    );
+    if (coverage.detail) {
+      lines.push(coverage.detail);
+    }
     if (verbose && result.shapesUsed.length > 0) {
       lines.push(`     Shapes: ${result.shapesUsed.join(', ')}`);
     }
@@ -78,7 +133,13 @@ function formatResultHuman(result: ValidationResult, verbose: boolean): string {
       ? `${colors.red}FAIL${colors.reset}`
       : `${colors.yellow}WARN${colors.reset}`;
 
-    lines.push(`${statusIcon} ${relPath} (${result.quadCount} triples, ${countParts.join(', ')})`);
+    lines.push(
+      `${statusIcon} ${relPath} (${result.quadCount} triples, ${countParts.join(', ')}; ${coverage.summary})`,
+    );
+
+    if (coverage.detail) {
+      lines.push(coverage.detail);
+    }
 
     if (result.shapesUsed.length > 0) {
       lines.push(`     Shapes: ${result.shapesUsed.join(', ')}`);
@@ -153,6 +214,32 @@ function printSummary(
   if (totalInfos > 0) parts.push(`${colors.blue}${totalInfos} info${colors.reset}`);
   if (parts.length > 0) {
     console.log(`  Issues: ${parts.join(', ')}`);
+  }
+
+  const totalSubjects = results.reduce((sum, r) => sum + r.coverage.totalSubjects, 0);
+  const checkedSubjects = results.reduce((sum, r) => sum + r.coverage.checkedSubjects, 0);
+  const unshaped = totalSubjects - checkedSubjects;
+
+  if (totalSubjects > 0) {
+    const coverageLine = `  Coverage: ${checkedSubjects} of ${totalSubjects} subjects checked`;
+    if (unshaped === 0) {
+      console.log(coverageLine);
+    } else {
+      console.log(`${coverageLine}, ${colors.yellow}${unshaped} with no applicable shape${colors.reset}`);
+
+      // Roll the per-file breakdowns into one list so a repeated gap reads as
+      // one vocabulary hole rather than N unrelated file problems.
+      const byType = new Map<string, number>();
+      for (const r of results) {
+        for (const t of r.coverage.unshapedTypes) {
+          byType.set(t.type, (byType.get(t.type) ?? 0) + t.count);
+        }
+      }
+      const ranked = Array.from(byType.entries())
+        .sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]))
+        .map(([type, count]) => `${shortenIRI(type)} (${count})`);
+      console.log(`  No shape applies to: ${ranked.join(', ')}`);
+    }
   }
 }
 
@@ -294,8 +381,15 @@ export function registerValidateCommand(program: Command): void {
               message: `Error processing file: ${msg}`,
             }],
             shapesUsed: [],
+            shapesFired: [],
             quadCount: 0,
             subjects: [],
+            coverage: {
+              totalSubjects: 0,
+              checkedSubjects: 0,
+              unshapedSubjects: [],
+              unshapedTypes: [],
+            },
           };
           results.push(errorResult);
           if (!globalOpts.json) {

--- a/src/lib/shacl-validator.ts
+++ b/src/lib/shacl-validator.ts
@@ -8,19 +8,58 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Parser, Store } from 'n3';
+import { Parser, Store, DataFactory } from 'n3';
+import type { Term } from '@rdfjs/types';
 import SHACLValidator from 'rdf-validate-shacl';
-import { parseTurtle, detectVocabularies, CASCADE_NAMESPACES } from './turtle-parser.js';
+import {
+  parseTurtle,
+  collectSubClassOfEdges,
+  expandToSuperClasses,
+  CASCADE_NAMESPACES,
+  RDF_TYPE_IRI,
+} from './turtle-parser.js';
 import type { ParseResult } from './turtle-parser.js';
 import { readResource } from './pod-encryption.js';
+
+const { namedNode } = DataFactory;
 
 export interface ValidationResult {
   valid: boolean;
   file: string;
   results: ValidationIssue[];
+  /**
+   * Shape *files* that contributed at least one shape which selected a focus
+   * node in this data graph. This is derived from actual target resolution, not
+   * from which prefixes the file happens to declare.
+   */
   shapesUsed: string[];
+  /** Local names of the individual shapes that selected at least one focus node. */
+  shapesFired: string[];
   quadCount: number;
   subjects: Array<{ uri: string; types: string[] }>;
+  /** How much of the data graph any loaded shape actually applied to. */
+  coverage: ShapeCoverage;
+}
+
+/**
+ * How much of a data graph the loaded shapes actually reached.
+ *
+ * A file whose subjects match no `sh:targetClass` runs zero constraints, so a
+ * conforming SHACL report on it means "nothing was checked", not "everything is
+ * correct". Reporting that difference is the point of this structure.
+ */
+export interface ShapeCoverage {
+  /** Subjects in the data graph carrying at least one `rdf:type`. */
+  totalSubjects: number;
+  /** Of those, the number selected as a focus node by at least one shape. */
+  checkedSubjects: number;
+  /** The typed subjects no loaded shape applies to. */
+  unshapedSubjects: Array<{ uri: string; types: string[] }>;
+  /**
+   * Counts of the `rdf:type` values carried by unshaped subjects, sorted by
+   * descending count then by type IRI so the output is deterministic.
+   */
+  unshapedTypes: Array<{ type: string; count: number }>;
 }
 
 export interface ValidationIssue {
@@ -64,6 +103,303 @@ function getShapesDir(): string {
   return shapesDir;
 }
 
+/** SHACL and RDF terms needed to resolve targets without re-running the engine. */
+const SH = 'http://www.w3.org/ns/shacl#';
+const SH_TARGET_CLASS = `${SH}targetClass`;
+const SH_TARGET_NODE = `${SH}targetNode`;
+const SH_TARGET_SUBJECTS_OF = `${SH}targetSubjectsOf`;
+const SH_TARGET_OBJECTS_OF = `${SH}targetObjectsOf`;
+const SH_NODE_SHAPE = `${SH}NodeShape`;
+const SH_PROPERTY = `${SH}property`;
+const SH_NODE = `${SH}node`;
+const SH_PATH = `${SH}path`;
+/** Logical constraint components whose members are themselves shapes. */
+const SH_LOGICAL = [`${SH}or`, `${SH}and`, `${SH}xone`, `${SH}not`];
+const RDF_FIRST = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first';
+const RDF_REST = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest';
+const RDF_NIL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil';
+
+/**
+ * The `sh:target*` declarations of a loaded shapes graph, inverted so a data
+ * node can be resolved to the shapes that select it.
+ */
+interface ShapeIndex {
+  /** target class IRI -> shape IRIs declaring `sh:targetClass` on it */
+  byClass: Map<string, string[]>;
+  /** `sh:targetNode` node IRI -> shape IRIs */
+  byNode: Map<string, string[]>;
+  /** `sh:targetSubjectsOf` predicate IRI -> shape IRIs */
+  bySubjectsOf: Map<string, string[]>;
+  /** `sh:targetObjectsOf` predicate IRI -> shape IRIs */
+  byObjectsOf: Map<string, string[]>;
+  /** shape IRI -> the `*.shapes.ttl` that declares it, when known */
+  fileOfShape: Map<string, string>;
+}
+
+/**
+ * Shape indexes are derived once per loaded shapes graph and reused across every
+ * file in a run. Keyed weakly on the store so callers keep their existing
+ * `loadShapes()` / `validateFile()` signatures.
+ */
+const shapeIndexCache = new WeakMap<Store, ShapeIndex>();
+/** Shape-IRI to shape-file attribution, recorded by `loadShapes`. */
+const shapeFileAttribution = new WeakMap<Store, Map<string, string>>();
+
+function pushInto(map: Map<string, string[]>, key: string, value: string): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.push(value);
+  } else {
+    map.set(key, [value]);
+  }
+}
+
+/**
+ * Invert the `sh:target*` declarations of a shapes graph.
+ */
+function buildShapeIndex(shapesStore: Store): ShapeIndex {
+  const index: ShapeIndex = {
+    byClass: new Map(),
+    byNode: new Map(),
+    bySubjectsOf: new Map(),
+    byObjectsOf: new Map(),
+    fileOfShape: shapeFileAttribution.get(shapesStore) ?? new Map(),
+  };
+
+  const targetPredicates: Array<[string, Map<string, string[]>]> = [
+    [SH_TARGET_CLASS, index.byClass],
+    [SH_TARGET_NODE, index.byNode],
+    [SH_TARGET_SUBJECTS_OF, index.bySubjectsOf],
+    [SH_TARGET_OBJECTS_OF, index.byObjectsOf],
+  ];
+
+  for (const [predicate, target] of targetPredicates) {
+    for (const quad of shapesStore.getQuads(null, namedNode(predicate), null, null)) {
+      pushInto(target, quad.object.value, quad.subject.value);
+    }
+  }
+
+  return index;
+}
+
+function getShapeIndex(shapesStore: Store): ShapeIndex {
+  let index = shapeIndexCache.get(shapesStore);
+  if (!index) {
+    index = buildShapeIndex(shapesStore);
+    shapeIndexCache.set(shapesStore, index);
+  }
+  return index;
+}
+
+/**
+ * Read an RDF collection (`rdf:first`/`rdf:rest` chain) into an array of terms.
+ * Returns an empty array for a node that is not a list head.
+ *
+ * Terms are carried rather than IRI strings throughout target resolution: SHACL
+ * property shapes and logical-constraint members are overwhelmingly blank
+ * nodes, and rebuilding a blank node as a named node silently matches nothing.
+ */
+function readRdfList(store: Store, head: Term): Term[] {
+  const items: Term[] = [];
+  const seen = new Set<string>();
+  let current: Term | undefined = head;
+
+  while (current && current.value !== RDF_NIL && !seen.has(current.value)) {
+    seen.add(current.value);
+    const first = store.getObjects(current, namedNode(RDF_FIRST), null);
+    if (first.length === 0) break;
+    items.push(first[0]);
+    const rest = store.getObjects(current, namedNode(RDF_REST), null);
+    if (rest.length === 0) break;
+    current = rest[0];
+  }
+  return items;
+}
+
+/**
+ * Resolve the values of a SHACL property path from a focus node.
+ *
+ * Supports the two path forms the Cascade shapes use: a plain predicate IRI and
+ * a sequence path (an RDF list of predicate IRIs). Other SHACL path forms
+ * (inverse, alternative, zeroOrMore, ...) are not currently authored in any
+ * Cascade vocabulary; they resolve to no values here, which can only ever make
+ * coverage reporting more conservative (a node reported as unshaped), never
+ * less.
+ */
+function resolvePathValues(dataStore: Store, focus: Term, pathNode: Term): Term[] {
+  const sequence = readRdfList(dataStore, pathNode);
+  const steps = sequence.length > 0 ? sequence : [pathNode];
+
+  let current: Term[] = [focus];
+  for (const step of steps) {
+    const next: Term[] = [];
+    for (const node of current) {
+      for (const obj of dataStore.getObjects(node, step, null)) {
+        next.push(obj);
+      }
+    }
+    if (next.length === 0) return [];
+    current = next;
+  }
+  return current;
+}
+
+/**
+ * Given a shape that has fired on a focus node, find the shapes it hands work
+ * off to via `sh:node`, together with the focus nodes they receive.
+ *
+ * Traverses `sh:property` (applying `sh:path` to reach new focus nodes), direct
+ * `sh:node` on the shape itself, and the members of `sh:or`/`sh:and`/`sh:xone`/
+ * `sh:not`. This matters because a node reached only through a parent shape's
+ * `sh:node` *is* validated, and reporting it as having "no applicable shape"
+ * would be the same false report this module exists to remove.
+ */
+function expandShape(
+  shapesStore: Store,
+  dataStore: Store,
+  shape: Term,
+  focus: Term,
+): Array<[Term, Term]> {
+  const out: Array<[Term, Term]> = [];
+  // Nested shape structure reachable without changing the focus node.
+  const sameFocus = new Set<string>([shape.value]);
+  const stack: Term[] = [shape];
+
+  while (stack.length > 0) {
+    const current = stack.pop() as Term;
+
+    // sh:node directly on this shape keeps the focus node.
+    for (const child of shapesStore.getObjects(current, namedNode(SH_NODE), null)) {
+      out.push([child, focus]);
+    }
+
+    // Logical constraint members are shapes over the same focus node.
+    for (const predicate of SH_LOGICAL) {
+      for (const member of shapesStore.getObjects(current, namedNode(predicate), null)) {
+        const listed = readRdfList(shapesStore, member);
+        const members = listed.length > 0 ? listed : [member];
+        for (const m of members) {
+          if (!sameFocus.has(m.value)) {
+            sameFocus.add(m.value);
+            stack.push(m);
+          }
+        }
+      }
+    }
+
+    // Property shapes move the focus along sh:path.
+    for (const prop of shapesStore.getObjects(current, namedNode(SH_PROPERTY), null)) {
+      const paths = shapesStore.getObjects(prop, namedNode(SH_PATH), null);
+      if (paths.length === 0) continue;
+      const children = shapesStore.getObjects(prop, namedNode(SH_NODE), null);
+      if (children.length === 0) continue;
+      const values = resolvePathValues(dataStore, focus, paths[0]);
+      for (const child of children) {
+        for (const value of values) {
+          out.push([child, value]);
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Determine which subjects of a data graph any loaded shape actually applies to.
+ *
+ * Class targets are resolved per SHACL 2.1.3.1: a node is targeted by
+ * `sh:targetClass C` when its `rdf:type` is `C` or any class reaching `C`
+ * through `rdfs:subClassOf*`. The subclass hierarchy is read from the **data
+ * graph**, which is what the SHACL specification says ("SHACL instance ... in
+ * that graph") and what the underlying engine does. An `rdfs:subClassOf` axiom
+ * that exists only in the ontology therefore does not activate a superclass
+ * shape, and this function deliberately reports that state of affairs rather
+ * than papering over it.
+ *
+ * https://www.w3.org/TR/shacl/#targetClass
+ */
+export function computeShapeCoverage(
+  parseResult: ParseResult,
+  shapesStore: Store,
+): { coverage: ShapeCoverage; firedShapes: Set<string> } {
+  const index = getShapeIndex(shapesStore);
+  const dataStore = parseResult.store;
+  const subClassEdges = collectSubClassOfEdges(dataStore);
+
+  const firedShapes = new Set<string>();
+  const checkedNodes = new Set<string>();
+  const visited = new Set<string>();
+  const queue: Array<[Term, Term]> = [];
+
+  // sh:targetClass, honouring rdfs:subClassOf*.
+  for (const quad of dataStore.getQuads(null, namedNode(RDF_TYPE_IRI), null, null)) {
+    for (const cls of expandToSuperClasses(quad.object.value, subClassEdges)) {
+      for (const shape of index.byClass.get(cls) ?? []) {
+        queue.push([namedNode(shape), quad.subject]);
+      }
+    }
+  }
+
+  // sh:targetNode.
+  for (const [node, shapes] of index.byNode) {
+    const term = namedNode(node);
+    if (dataStore.countQuads(term, null, null, null) > 0) {
+      for (const shape of shapes) queue.push([namedNode(shape), term]);
+    }
+  }
+
+  // sh:targetSubjectsOf / sh:targetObjectsOf.
+  if (index.bySubjectsOf.size > 0 || index.byObjectsOf.size > 0) {
+    for (const quad of dataStore.getQuads(null, null, null, null)) {
+      for (const shape of index.bySubjectsOf.get(quad.predicate.value) ?? []) {
+        queue.push([namedNode(shape), quad.subject]);
+      }
+      for (const shape of index.byObjectsOf.get(quad.predicate.value) ?? []) {
+        queue.push([namedNode(shape), quad.object]);
+      }
+    }
+  }
+
+  // Propagate through sh:node so nodes validated via a parent shape count as
+  // checked.
+  while (queue.length > 0) {
+    const [shape, focus] = queue.pop() as [Term, Term];
+    const key = `${shape.value} ${focus.value}`;
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    firedShapes.add(shape.value);
+    checkedNodes.add(focus.value);
+
+    for (const next of expandShape(shapesStore, dataStore, shape, focus)) {
+      queue.push(next);
+    }
+  }
+
+  const unshapedSubjects = parseResult.subjects.filter((s) => !checkedNodes.has(s.uri));
+
+  const typeCounts = new Map<string, number>();
+  for (const subject of unshapedSubjects) {
+    for (const type of subject.types) {
+      typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1);
+    }
+  }
+  const unshapedTypes = Array.from(typeCounts.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => (b.count - a.count) || a.type.localeCompare(b.type));
+
+  return {
+    coverage: {
+      totalSubjects: parseResult.subjects.length,
+      checkedSubjects: parseResult.subjects.length - unshapedSubjects.length,
+      unshapedSubjects,
+      unshapedTypes,
+    },
+    firedShapes,
+  };
+}
+
 /**
  * Load and parse a Turtle file into an N3 Store.
  */
@@ -74,6 +410,36 @@ function loadTurtleFile(filePath: string): Store {
   const quads = parser.parse(content);
   store.addQuads(quads);
   return store;
+}
+
+/**
+ * Collect the IRIs of the shapes a single shapes file declares: anything typed
+ * `sh:NodeShape`, plus anything carrying a `sh:target*` declaration.
+ */
+function collectDeclaredShapes(fileStore: Store): string[] {
+  const shapes = new Set<string>();
+
+  for (const quad of fileStore.getQuads(
+    null,
+    namedNode(RDF_TYPE_IRI),
+    namedNode(SH_NODE_SHAPE),
+    null,
+  )) {
+    if (quad.subject.termType === 'NamedNode') shapes.add(quad.subject.value);
+  }
+
+  for (const predicate of [
+    SH_TARGET_CLASS,
+    SH_TARGET_NODE,
+    SH_TARGET_SUBJECTS_OF,
+    SH_TARGET_OBJECTS_OF,
+  ]) {
+    for (const quad of fileStore.getQuads(null, namedNode(predicate), null, null)) {
+      if (quad.subject.termType === 'NamedNode') shapes.add(quad.subject.value);
+    }
+  }
+
+  return Array.from(shapes);
 }
 
 /**
@@ -95,14 +461,23 @@ export function loadShapes(customShapesPath?: string): { store: Store; shapeFile
     throw new Error(`No SHACL shape files (*.shapes.ttl) found in ${shapesDir}`);
   }
 
+  // Which file declares which shape. Merging every file into one store loses
+  // that, and it is what lets a run report the shape files that actually fired.
+  const fileOfShape = new Map<string, string>();
+
   for (const file of files) {
     const filePath = path.join(shapesDir, file);
     const fileStore = loadTurtleFile(filePath);
+    for (const shape of collectDeclaredShapes(fileStore)) {
+      if (!fileOfShape.has(shape)) fileOfShape.set(shape, file);
+    }
     for (const quad of fileStore) {
       store.addQuad(quad);
     }
     shapeFiles.push(file);
   }
+
+  shapeFileAttribution.set(store, fileOfShape);
 
   // Also load vocabulary/ontology files so the validator knows about class hierarchies
   const vocabFiles = fs.readdirSync(shapesDir).filter(
@@ -171,6 +546,11 @@ function uriToName(uri: string): string {
   return uri.split('/').pop() ?? uri;
 }
 
+/** Coverage placeholder for results produced without a parsed data graph. */
+function emptyCoverage(): ShapeCoverage {
+  return { totalSubjects: 0, checkedSubjects: 0, unshapedSubjects: [], unshapedTypes: [] };
+}
+
 /**
  * Validate an already-parsed Turtle file against SHACL shapes.
  */
@@ -191,17 +571,26 @@ export function validateParsed(
         message: `Parse error: ${err}`,
       })),
       shapesUsed: [],
+      shapesFired: [],
       quadCount: 0,
       subjects: [],
+      coverage: emptyCoverage(),
     };
   }
 
-  // Detect vocabularies used so we can report which shapes apply
-  const vocabsUsed = detectVocabularies(parseResult);
-  const shapesUsed = shapeFiles.filter((f) => {
-    const vocabName = f.replace('.shapes.ttl', '');
-    return vocabsUsed.includes(vocabName);
-  });
+  // Work out which shapes actually select a focus node in this data graph. Only
+  // those ran constraints; naming any other shape would claim work that never
+  // happened.
+  const { coverage, firedShapes } = computeShapeCoverage(parseResult, shapesStore);
+  const index = getShapeIndex(shapesStore);
+
+  const firedFiles = new Set<string>();
+  for (const shape of firedShapes) {
+    const file = index.fileOfShape.get(shape);
+    if (file) firedFiles.add(file);
+  }
+  const shapesUsed = shapeFiles.filter((f) => firedFiles.has(f));
+  const shapesFired = Array.from(firedShapes, uriToName).sort((a, b) => a.localeCompare(b));
 
   // Run SHACL validation
   const validator = new SHACLValidator(shapesStore, { allowNamedNodeInList: true });
@@ -243,8 +632,10 @@ export function validateParsed(
     file: filePath,
     results: issues,
     shapesUsed,
+    shapesFired,
     quadCount: parseResult.quadCount,
     subjects: parseResult.subjects,
+    coverage,
   };
 }
 
@@ -284,8 +675,10 @@ export function validateFile(
         message: `File not found: ${filePath}`,
       }],
       shapesUsed: [],
+      shapesFired: [],
       quadCount: 0,
       subjects: [],
+      coverage: emptyCoverage(),
     };
   }
 

--- a/src/lib/turtle-parser.ts
+++ b/src/lib/turtle-parser.ts
@@ -12,7 +12,10 @@ import * as fs from 'fs/promises';
 const { namedNode } = DataFactory;
 
 /** Well-known RDF predicates */
-const RDF_TYPE_IRI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+export const RDF_TYPE_IRI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/** `rdfs:subClassOf`, used for SHACL class-target resolution. */
+export const RDFS_SUBCLASS_OF_IRI = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
 
 /** Known Cascade Protocol namespace prefixes */
 export const CASCADE_NAMESPACES: Record<string, string> = {
@@ -121,8 +124,20 @@ function extractSubjectsWithTypes(store: Store): SubjectInfo[] {
 }
 
 /**
- * Detect which Cascade Protocol vocabularies are used in a parsed Turtle file
- * based on prefixes and type URIs.
+ * Detect which Cascade Protocol vocabularies are *mentioned* in a parsed Turtle
+ * file, based on prefix declarations and on namespaces appearing in type URIs,
+ * predicates and objects.
+ *
+ * IMPORTANT: this answers "which vocabularies does this file reference?" and
+ * nothing more. It must NOT be used to report which SHACL shapes apply to, or
+ * were run against, a file. A file can declare the `health:` prefix, or use a
+ * single `health:` predicate, while no shape in `health.shapes.ttl` targets any
+ * of its subjects — in which case reporting `Shapes: health.shapes.ttl` claims
+ * constraints ran that never ran.
+ *
+ * For shape applicability use {@link computeShapeCoverage} in `shacl-validator.ts`,
+ * which resolves `sh:targetClass` (and the other `sh:target*` forms) against the
+ * subjects actually present in the data graph.
  */
 export function detectVocabularies(result: ParseResult): string[] {
   const vocabs = new Set<string>();
@@ -227,6 +242,51 @@ export function getAllTypes(store: Store): string[] {
     types.add(obj.value);
   }
   return Array.from(types);
+}
+
+/**
+ * Collect the direct `rdfs:subClassOf` edges present in a store, as a map from
+ * a class IRI to the set of classes it is *directly* declared a subclass of.
+ *
+ * Used to resolve SHACL class targets: per SHACL 2.1.3.1 a node is targeted by
+ * `sh:targetClass C` when it is a SHACL instance of `C`, meaning its `rdf:type`
+ * is `C` or any subclass of `C` reachable by `rdfs:subClassOf*`.
+ * https://www.w3.org/TR/shacl/#targetClass
+ */
+export function collectSubClassOfEdges(store: Store): Map<string, Set<string>> {
+  const edges = new Map<string, Set<string>>();
+  for (const quad of store.getQuads(null, namedNode(RDFS_SUBCLASS_OF_IRI), null, null)) {
+    const sub = quad.subject.value;
+    let supers = edges.get(sub);
+    if (!supers) {
+      supers = new Set<string>();
+      edges.set(sub, supers);
+    }
+    supers.add(quad.object.value);
+  }
+  return edges;
+}
+
+/**
+ * Expand a class IRI to itself plus every class reachable from it by following
+ * `rdfs:subClassOf` transitively (`rdfs:subClassOf*`). Cycle-safe.
+ */
+export function expandToSuperClasses(
+  cls: string,
+  edges: Map<string, Set<string>>,
+): Set<string> {
+  const seen = new Set<string>([cls]);
+  const stack = [cls];
+  while (stack.length > 0) {
+    const current = stack.pop() as string;
+    for (const parent of edges.get(current) ?? []) {
+      if (!seen.has(parent)) {
+        seen.add(parent);
+        stack.push(parent);
+      }
+    }
+  }
+  return seen;
 }
 
 /**

--- a/tests/validate-coverage-reference-pod.test.ts
+++ b/tests/validate-coverage-reference-pod.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Shape coverage measured against the reference patient pod.
+ *
+ * This file records the coverage of the bundled shapes over the reference pod
+ * AS MEASURED WHEN THE REPORTING WAS BUILT, before SHACL shapes existed for
+ * several health record classes. At that point `cascade validate` reported
+ * 19 of 19 files passing and exit code 0 on a pod where most subjects matched
+ * no shape at all, because a conforming report over zero constraints is
+ * indistinguishable from a conforming report over many.
+ *
+ * The numbers below are therefore a deliberate high-water mark of a gap, not a
+ * target. Authoring shapes for the unshaped classes SHOULD move them down, and
+ * this file is expected to be updated in the same change that moves them. What
+ * must not happen is the numbers moving without anyone noticing.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadShapes, validateFile, findTurtleFiles } from '../src/lib/shacl-validator.js';
+
+const CLI_PATH = resolve(__dirname, '../dist/index.js');
+const REFERENCE_POD = resolve(__dirname, '../../reference-patient-pod');
+const skipIfNoPod = !existsSync(REFERENCE_POD);
+
+const CASCADE_NS = 'https://ns.cascadeprotocol.org/';
+
+/**
+ * Coverage of the bundled shapes over the reference pod at the commit that
+ * introduced this reporting.
+ *
+ * Two denominators are recorded because both are meaningful and they differ a
+ * lot. `totalSubjects` counts every subject carrying an rdf:type, including
+ * those typed only in non-Cascade vocabularies (prov:, foaf:, ldp:, solid:,
+ * fhir:) that the Cascade shapes were never written to constrain.
+ * `cascadeTypedSubjects` counts only subjects carrying at least one type in the
+ * Cascade namespace, which is the population the protocol is responsible for
+ * constraining.
+ */
+const PRE_SHAPE_COVERAGE = {
+  files: 19,
+  totalSubjects: 448,
+  checkedSubjects: 156,
+  unshapedSubjects: 292,
+  cascadeTypedSubjects: 278,
+  unshapedCascadeTypedSubjects: 122,
+} as const;
+
+/** Per-file totals, so a shift can be attributed rather than just noticed. */
+const PRE_SHAPE_BY_FILE: Record<string, { total: number; checked: number }> = {
+  'clinical/allergies.ttl': { total: 3, checked: 0 },
+  'clinical/conditions.ttl': { total: 5, checked: 0 },
+  'clinical/immunizations.ttl': { total: 4, checked: 0 },
+  'clinical/insurance.ttl': { total: 1, checked: 0 },
+  'clinical/lab-results.ttl': { total: 11, checked: 0 },
+  'clinical/medications.ttl': { total: 8, checked: 8 },
+  'clinical/patient-profile.ttl': { total: 4, checked: 4 },
+  'clinical/vital-signs.ttl': { total: 141, checked: 141 },
+  'index.ttl': { total: 1, checked: 0 },
+  'manifest.ttl': { total: 8, checked: 0 },
+  'profile/card.ttl': { total: 2, checked: 0 },
+  'profile/extended.ttl': { total: 0, checked: 0 },
+  'settings/privateTypeIndex.ttl': { total: 5, checked: 0 },
+  'settings/publicTypeIndex.ttl': { total: 8, checked: 0 },
+  'wellness/activity.ttl': { total: 61, checked: 0 },
+  'wellness/blood-pressure.ttl': { total: 61, checked: 0 },
+  'wellness/heart-rate.ttl': { total: 61, checked: 0 },
+  'wellness/sleep.ttl': { total: 61, checked: 0 },
+  'wellness/supplements.ttl': { total: 3, checked: 3 },
+};
+
+/**
+ * The health record classes carrying real clinical content that no shape
+ * constrained at this commit. Each count is a number of subjects that
+ * `cascade validate` reported PASS on while running nothing against them.
+ */
+const UNSHAPED_CLINICAL_CLASSES: Record<string, number> = {
+  'https://ns.cascadeprotocol.org/health/v1#LabResultRecord': 11,
+  'https://ns.cascadeprotocol.org/health/v1#ConditionRecord': 5,
+  'https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord': 4,
+  'https://ns.cascadeprotocol.org/health/v1#AllergyRecord': 3,
+};
+
+describe.skipIf(skipIfNoPod)('shape coverage over the reference patient pod', () => {
+  let results: ReturnType<typeof validateFile>[];
+
+  beforeAll(() => {
+    const { store, shapeFiles } = loadShapes();
+    results = findTurtleFiles(REFERENCE_POD).map((f) => validateFile(f, store, shapeFiles));
+  });
+
+  it('measures the pod at the recorded pre-shape coverage', () => {
+    const totalSubjects = results.reduce((n, r) => n + r.coverage.totalSubjects, 0);
+    const checkedSubjects = results.reduce((n, r) => n + r.coverage.checkedSubjects, 0);
+
+    expect(results).toHaveLength(PRE_SHAPE_COVERAGE.files);
+    expect(totalSubjects).toBe(PRE_SHAPE_COVERAGE.totalSubjects);
+    expect(checkedSubjects).toBe(PRE_SHAPE_COVERAGE.checkedSubjects);
+    expect(totalSubjects - checkedSubjects).toBe(PRE_SHAPE_COVERAGE.unshapedSubjects);
+  });
+
+  it('measures the Cascade-typed population at the recorded pre-shape coverage', () => {
+    const isCascadeTyped = (s: { types: string[] }) =>
+      s.types.some((t) => t.startsWith(CASCADE_NS));
+
+    const cascadeTyped = results.reduce(
+      (n, r) => n + r.subjects.filter(isCascadeTyped).length,
+      0,
+    );
+    const unshapedCascadeTyped = results.reduce(
+      (n, r) => n + r.coverage.unshapedSubjects.filter(isCascadeTyped).length,
+      0,
+    );
+
+    expect(cascadeTyped).toBe(PRE_SHAPE_COVERAGE.cascadeTypedSubjects);
+    expect(unshapedCascadeTyped).toBe(PRE_SHAPE_COVERAGE.unshapedCascadeTypedSubjects);
+  });
+
+  it('attributes the coverage to specific files', () => {
+    const actual: Record<string, { total: number; checked: number }> = {};
+    for (const r of results) {
+      const rel = r.file.slice(REFERENCE_POD.length + 1);
+      actual[rel] = {
+        total: r.coverage.totalSubjects,
+        checked: r.coverage.checkedSubjects,
+      };
+    }
+    expect(actual).toEqual(PRE_SHAPE_BY_FILE);
+  });
+
+  it('names the clinical record classes no shape constrains', () => {
+    const counts = new Map<string, number>();
+    for (const r of results) {
+      for (const t of r.coverage.unshapedTypes) {
+        counts.set(t.type, (counts.get(t.type) ?? 0) + t.count);
+      }
+    }
+    for (const [type, expected] of Object.entries(UNSHAPED_CLINICAL_CLASSES)) {
+      expect(counts.get(type), `unshaped count for ${type}`).toBe(expected);
+    }
+  });
+
+  it('reports files that pass while running zero constraints', () => {
+    // The defect in one assertion: files the validator called PASS having
+    // selected no focus node at all.
+    const passedWithNothingChecked = results.filter(
+      (r) => r.valid && r.coverage.totalSubjects > 0 && r.coverage.checkedSubjects === 0,
+    );
+    expect(passedWithNothingChecked.length).toBeGreaterThan(0);
+    for (const r of passedWithNothingChecked) {
+      expect(r.shapesUsed).toEqual([]);
+      expect(r.shapesFired).toEqual([]);
+    }
+  });
+
+  it('does not name a shape file for a file whose subjects match no target', () => {
+    // conditions.ttl declares the health: prefix and uses health: predicates,
+    // so prefix-based reporting named health.shapes.ttl and claimed constraints
+    // that never ran.
+    const conditions = results.find((r) => r.file.endsWith('clinical/conditions.ttl'));
+    expect(conditions).toBeDefined();
+    expect(conditions?.valid).toBe(true);
+    expect(conditions?.coverage.totalSubjects).toBe(5);
+    expect(conditions?.coverage.checkedSubjects).toBe(0);
+    expect(conditions?.shapesUsed).toEqual([]);
+  });
+
+  it('names the shape files that did fire on a file with real coverage', () => {
+    const medications = results.find((r) => r.file.endsWith('clinical/medications.ttl'));
+    expect(medications?.coverage.checkedSubjects).toBe(8);
+    expect(medications?.shapesUsed.length).toBeGreaterThan(0);
+    expect(medications?.shapesFired.length).toBeGreaterThan(0);
+  });
+});
+
+describe.skipIf(skipIfNoPod)('cascade validate output over the reference pod', () => {
+  const runCli = (args: string[], cwd: string): string =>
+    execFileSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      cwd,
+      timeout: 120000,
+      // Keep colour codes out of the assertions.
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+    });
+
+  // Strip ANSI so assertions match the text, not the styling.
+  const plain = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+
+  it('states how many subjects were checked on a passing file', () => {
+    const out = plain(
+      runCli(['validate', resolve(REFERENCE_POD, 'clinical/conditions.ttl')], '/'),
+    );
+    expect(out).toContain(
+      '0 of 5 subjects checked; 5 subjects of type health:ConditionRecord had no applicable shape',
+    );
+    expect(out).toContain('PASS');
+  });
+
+  it('does not print a Shapes: line when no shape fired', () => {
+    const out = plain(
+      runCli(
+        ['--verbose', 'validate', resolve(REFERENCE_POD, 'clinical/conditions.ttl')],
+        '/',
+      ),
+    );
+    // Match the exact indented output line rather than the bare word, which
+    // also occurs in the verbose "Loaded N shape files" preamble.
+    expect(out).not.toMatch(/^ {5}Shapes: /m);
+  });
+
+  it('prints a pod-wide coverage summary', () => {
+    const out = plain(runCli(['validate', REFERENCE_POD], '/'));
+    expect(out).toContain(
+      `Coverage: ${PRE_SHAPE_COVERAGE.checkedSubjects} of ${PRE_SHAPE_COVERAGE.totalSubjects} subjects checked, ${PRE_SHAPE_COVERAGE.unshapedSubjects} with no applicable shape`,
+    );
+  });
+
+  it('keeps exit code 0: unshaped subjects are reported, not failed', () => {
+    // Deliberate. An unshaped subject is a gap in the vocabulary, not a defect
+    // in the data, and failing on it would break every existing caller on
+    // upgrade for something they cannot fix in their own pod.
+    const out = plain(runCli(['validate', REFERENCE_POD], '/'));
+    expect(out).toContain('19 passed');
+    expect(out).toContain('with no applicable shape');
+  });
+
+  it('is deterministic across processes and working directories', () => {
+    const a = plain(runCli(['validate', REFERENCE_POD], '/'));
+    const b = plain(runCli(['validate', REFERENCE_POD], resolve(__dirname, '..')));
+    expect(a).toBe(b);
+    expect(a).toContain('Coverage:');
+  });
+
+  it('reports different coverage for genuinely different inputs', () => {
+    const labs = plain(
+      runCli(['--json', 'validate', resolve(REFERENCE_POD, 'clinical/lab-results.ttl')], '/'),
+    );
+    const meds = plain(
+      runCli(['--json', 'validate', resolve(REFERENCE_POD, 'clinical/medications.ttl')], '/'),
+    );
+
+    const labsCoverage = JSON.parse(labs)[0].coverage;
+    const medsCoverage = JSON.parse(meds)[0].coverage;
+
+    expect(labsCoverage).not.toEqual(medsCoverage);
+    expect(labsCoverage.checkedSubjects).toBe(0);
+    expect(labsCoverage.totalSubjects).toBe(11);
+    expect(medsCoverage.checkedSubjects).toBe(8);
+    expect(medsCoverage.totalSubjects).toBe(8);
+  });
+
+  it('exposes coverage in the JSON output', () => {
+    const out = runCli(
+      ['--json', 'validate', resolve(REFERENCE_POD, 'clinical/allergies.ttl')],
+      '/',
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed[0].coverage).toEqual({
+      totalSubjects: 3,
+      checkedSubjects: 0,
+      unshapedSubjects: expect.any(Array),
+      unshapedTypes: [
+        { type: 'https://ns.cascadeprotocol.org/health/v1#AllergyRecord', count: 3 },
+      ],
+    });
+    expect(parsed[0].coverage.unshapedSubjects).toHaveLength(3);
+    expect(parsed[0].shapesUsed).toEqual([]);
+  });
+});

--- a/tests/validate-coverage.test.ts
+++ b/tests/validate-coverage.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Shape-coverage reporting.
+ *
+ * `cascade validate` used to return PASS on a file no shape targeted, and to
+ * print a `Shapes:` line naming shape files that ran nothing, because shape
+ * reporting matched the prefixes a file declared rather than the shapes that
+ * actually selected a focus node. These tests pin both halves: the count of
+ * subjects no shape applies to, and the requirement that a named shape fired.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+
+const PREFIXES = `
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://example.org/> .
+`;
+
+/** Write a throwaway shapes directory and load it. */
+function withShapes(files: Record<string, string>): ReturnType<typeof loadShapes> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-coverage-'));
+  tempDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), PREFIXES + content, 'utf-8');
+  }
+  return loadShapes(dir);
+}
+
+const tempDirs: string[] = [];
+afterAll(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** A shape requiring ex:required on every instance of ex:Super. */
+const SUPER_SHAPE = `
+ex:SuperShape a sh:NodeShape ;
+    sh:targetClass ex:Super ;
+    sh:property [ sh:path ex:required ; sh:minCount 1 ; sh:message "ex:required is missing" ] .
+`;
+
+describe('shape coverage: class targeting', () => {
+  let shapes: ReturnType<typeof loadShapes>;
+  beforeAll(() => {
+    shapes = withShapes({ 'example.shapes.ttl': SUPER_SHAPE });
+  });
+
+  const validate = (data: string) =>
+    validateTurtle(PREFIXES + data, shapes.store, shapes.shapeFiles, 'test.ttl');
+
+  it('counts a subject of the exact target class as checked', () => {
+    const result = validate('ex:a a ex:Super ; ex:required "x" .');
+    expect(result.coverage.totalSubjects).toBe(1);
+    expect(result.coverage.checkedSubjects).toBe(1);
+    expect(result.coverage.unshapedSubjects).toHaveLength(0);
+  });
+
+  it('counts a subject of an unrelated type as unshaped, and names the type', () => {
+    const result = validate('ex:b a ex:Unrelated ; ex:whatever "x" .');
+    expect(result.coverage.totalSubjects).toBe(1);
+    expect(result.coverage.checkedSubjects).toBe(0);
+    expect(result.coverage.unshapedSubjects.map((s) => s.uri)).toEqual([
+      'http://example.org/b',
+    ]);
+    expect(result.coverage.unshapedTypes).toEqual([
+      { type: 'http://example.org/Unrelated', count: 1 },
+    ]);
+    // The engine agrees nothing ran: a conforming report over zero constraints.
+    expect(result.valid).toBe(true);
+    expect(result.results).toHaveLength(0);
+  });
+
+  it('counts a subclass-typed subject as checked (SHACL 2.1.3.1)', () => {
+    // A shape targeting ex:Super must cover a subject typed ex:Sub. Exact-type
+    // matching would report this subject as unshaped.
+    const result = validate(`
+      ex:Sub rdfs:subClassOf ex:Super .
+      ex:c a ex:Sub ; ex:required "x" .
+    `);
+    const cSubject = result.coverage.unshapedSubjects.find(
+      (s) => s.uri === 'http://example.org/c',
+    );
+    expect(cSubject).toBeUndefined();
+    expect(result.coverage.checkedSubjects).toBeGreaterThanOrEqual(1);
+  });
+
+  it('follows rdfs:subClassOf transitively, not one hop', () => {
+    const result = validate(`
+      ex:Mid rdfs:subClassOf ex:Super .
+      ex:Leaf rdfs:subClassOf ex:Mid .
+      ex:d a ex:Leaf .
+    `);
+    // Two hops from ex:Leaf to ex:Super. A single-hop implementation reports
+    // ex:d as unshaped; a transitive one runs the shape and reports the
+    // missing ex:required.
+    expect(result.coverage.unshapedSubjects.map((s) => s.uri)).not.toContain(
+      'http://example.org/d',
+    );
+    expect(result.valid).toBe(false);
+    expect(result.results.map((r) => r.message)).toContain('ex:required is missing');
+  });
+
+  it('terminates on a subClassOf cycle and reports the subject as unshaped', () => {
+    const result = validate(`
+      ex:Ring rdfs:subClassOf ex:Loop .
+      ex:Loop rdfs:subClassOf ex:Ring .
+      ex:e a ex:Ring .
+    `);
+    expect(result.coverage.unshapedSubjects.map((s) => s.uri)).toContain(
+      'http://example.org/e',
+    );
+  });
+
+  it('reports every subject as unshaped when no shape targets anything present', () => {
+    const result = validate(`
+      ex:f a ex:Unrelated .
+      ex:g a ex:AlsoUnrelated .
+      ex:h a ex:Unrelated .
+    `);
+    expect(result.coverage.totalSubjects).toBe(3);
+    expect(result.coverage.checkedSubjects).toBe(0);
+    // Sorted by descending count, then IRI, so output is stable.
+    expect(result.coverage.unshapedTypes).toEqual([
+      { type: 'http://example.org/Unrelated', count: 2 },
+      { type: 'http://example.org/AlsoUnrelated', count: 1 },
+    ]);
+  });
+});
+
+describe('shape coverage: subclass axioms that live only in the ontology', () => {
+  // The SHACL specification defines a class target over SHACL instances "in the
+  // data graph", so an rdfs:subClassOf axiom present only in the ontology does
+  // NOT activate a superclass shape. The engine behaves that way; coverage
+  // reporting must agree with the engine rather than with the ontology, or it
+  // would report constraints as having run when they did not.
+  it('does not count the subject as checked, matching engine behaviour', () => {
+    const shapes = withShapes({
+      'example.shapes.ttl': SUPER_SHAPE,
+      // Loaded as a vocabulary file into the shapes graph, not the data graph.
+      'example.ttl': 'ex:OntoSub rdfs:subClassOf ex:Super .\n',
+    });
+    const result = validateTurtle(
+      `${PREFIXES}ex:i a ex:OntoSub .`,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+
+    // The engine ran no constraint: ex:required is absent yet nothing failed.
+    expect(result.valid).toBe(true);
+    expect(result.results).toHaveLength(0);
+    // Coverage reports that honestly.
+    expect(result.coverage.checkedSubjects).toBe(0);
+    expect(result.coverage.unshapedSubjects.map((s) => s.uri)).toEqual([
+      'http://example.org/i',
+    ]);
+  });
+});
+
+describe('shape coverage: nodes reached through sh:node', () => {
+  it('counts a node validated via a parent shape as checked', () => {
+    const shapes = withShapes({
+      'example.shapes.ttl': `
+ex:ParentShape a sh:NodeShape ;
+    sh:targetClass ex:Parent ;
+    sh:property [ sh:path ex:child ; sh:node ex:ChildShape ] .
+
+ex:ChildShape a sh:NodeShape ;
+    sh:property [ sh:path ex:childRequired ; sh:minCount 1 ; sh:message "child field missing" ] .
+`,
+    });
+
+    const result = validateTurtle(
+      `${PREFIXES}
+      ex:parent a ex:Parent ; ex:child ex:kid .
+      ex:kid a ex:ChildType .
+      `,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+
+    // ex:kid's own type is targeted by nothing, but the parent shape hands it
+    // to ex:ChildShape, so it genuinely is validated. Proof: the engine could
+    // only have decided ex:kid fails ex:ChildShape by evaluating it. (The
+    // engine surfaces sh:node failures against the parent focus node, naming
+    // the offending value, rather than reporting the inner message.)
+    expect(result.valid).toBe(false);
+    const nodeFailure = result.results.find((r) => r.value === 'http://example.org/kid');
+    expect(nodeFailure).toBeDefined();
+    expect(nodeFailure?.message).toContain('ChildShape');
+    expect(nodeFailure?.focusNode).toBe('http://example.org/parent');
+
+    // Therefore reporting ex:kid as having "no applicable shape" would be false.
+    expect(result.coverage.unshapedSubjects.map((s) => s.uri)).not.toContain(
+      'http://example.org/kid',
+    );
+    expect(result.coverage.checkedSubjects).toBe(2);
+    expect(result.coverage.totalSubjects).toBe(2);
+  });
+
+  it('still reports a node the parent shape never reaches', () => {
+    const shapes = withShapes({
+      'example.shapes.ttl': `
+ex:ParentShape a sh:NodeShape ;
+    sh:targetClass ex:Parent ;
+    sh:property [ sh:path ex:child ; sh:node ex:ChildShape ] .
+
+ex:ChildShape a sh:NodeShape ;
+    sh:property [ sh:path ex:childRequired ; sh:minCount 1 ] .
+`,
+    });
+
+    const result = validateTurtle(
+      `${PREFIXES}
+      ex:parent a ex:Parent .
+      ex:orphan a ex:ChildType .
+      `,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+
+    // ex:orphan is not the object of ex:child, so nothing hands it to a shape.
+    expect(result.coverage.unshapedSubjects.map((s) => s.uri)).toEqual([
+      'http://example.org/orphan',
+    ]);
+  });
+});
+
+describe('shape coverage: sh:targetSubjectsOf and sh:targetObjectsOf', () => {
+  it('counts nodes selected by predicate-based targets as checked', () => {
+    const shapes = withShapes({
+      'example.shapes.ttl': `
+ex:SubjShape a sh:NodeShape ;
+    sh:targetSubjectsOf ex:emits ;
+    sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+
+ex:ObjShape a sh:NodeShape ;
+    sh:targetObjectsOf ex:emits ;
+    sh:property [ sh:path ex:alsoRequired ; sh:minCount 1 ] .
+`,
+    });
+
+    const result = validateTurtle(
+      `${PREFIXES}
+      ex:src a ex:AnyType ; ex:emits ex:dst .
+      ex:dst a ex:OtherType .
+      `,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+
+    // Neither type is a sh:targetClass anywhere; both are still validated.
+    expect(result.coverage.checkedSubjects).toBe(2);
+    expect(result.coverage.unshapedSubjects).toHaveLength(0);
+  });
+});
+
+describe('shapesUsed reports shapes that fired, not prefixes present', () => {
+  const TWO_FILES = {
+    'alpha.shapes.ttl': `
+ex:AlphaShape a sh:NodeShape ;
+    sh:targetClass ex:Alpha ;
+    sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+`,
+    'beta.shapes.ttl': `
+ex:BetaShape a sh:NodeShape ;
+    sh:targetClass ex:Beta ;
+    sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+`,
+  };
+
+  it('names only the shape file whose shape selected a node', () => {
+    const shapes = withShapes(TWO_FILES);
+    const result = validateTurtle(
+      `${PREFIXES}ex:a a ex:Alpha ; ex:required "x" .`,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+    expect(result.shapesUsed).toEqual(['alpha.shapes.ttl']);
+    expect(result.shapesFired).toEqual(['AlphaShape']);
+  });
+
+  it('names no shape file when a file uses a vocabulary but matches no target', () => {
+    const shapes = withShapes(TWO_FILES);
+    // Every term here is in the ex: namespace the shapes are written in, and
+    // the ex: prefix is declared. Prefix-based reporting names both files; only
+    // target-based reporting correctly names none.
+    const result = validateTurtle(
+      `${PREFIXES}ex:c a ex:Gamma ; ex:required "x" .`,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+    expect(result.shapesUsed).toEqual([]);
+    expect(result.shapesFired).toEqual([]);
+    expect(result.coverage.checkedSubjects).toBe(0);
+    expect(result.coverage.totalSubjects).toBe(1);
+  });
+
+  it('names both shape files when both fire', () => {
+    const shapes = withShapes(TWO_FILES);
+    const result = validateTurtle(
+      `${PREFIXES}
+      ex:a a ex:Alpha ; ex:required "x" .
+      ex:b a ex:Beta ; ex:required "y" .
+      `,
+      shapes.store,
+      shapes.shapeFiles,
+      'test.ttl',
+    );
+    expect(result.shapesUsed.sort()).toEqual(['alpha.shapes.ttl', 'beta.shapes.ttl']);
+    expect(result.shapesFired).toEqual(['AlphaShape', 'BetaShape']);
+  });
+});
+
+describe('shape coverage is deterministic and input-sensitive', () => {
+  const shapes = () => withShapes({ 'example.shapes.ttl': SUPER_SHAPE });
+
+  it('produces identical coverage for the same input across separate loads', () => {
+    const data = `${PREFIXES}
+      ex:a a ex:Super ; ex:required "x" .
+      ex:b a ex:Unrelated .
+      ex:c a ex:AlsoUnrelated .
+    `;
+    const first = shapes();
+    const second = shapes();
+    const a = validateTurtle(data, first.store, first.shapeFiles, 'test.ttl');
+    const b = validateTurtle(data, second.store, second.shapeFiles, 'test.ttl');
+
+    // Pin the content before comparing. Two absent values compare equal, so a
+    // bare a-equals-b assertion would pass just as happily with no coverage
+    // computed at all.
+    expect(a.coverage.totalSubjects).toBe(3);
+    expect(a.coverage.checkedSubjects).toBe(1);
+    expect(a.coverage.unshapedTypes).toHaveLength(2);
+    expect(a.shapesUsed).toEqual(['example.shapes.ttl']);
+
+    expect(JSON.stringify(a.coverage)).toBe(JSON.stringify(b.coverage));
+    expect(a.shapesUsed).toEqual(b.shapesUsed);
+  });
+
+  it('produces different coverage for genuinely different inputs', () => {
+    const loaded = shapes();
+    const one = validateTurtle(
+      `${PREFIXES}ex:a a ex:Super ; ex:required "x" .`,
+      loaded.store,
+      loaded.shapeFiles,
+      'test.ttl',
+    );
+    const two = validateTurtle(
+      `${PREFIXES}ex:b a ex:Unrelated . ex:c a ex:Unrelated .`,
+      loaded.store,
+      loaded.shapeFiles,
+      'test.ttl',
+    );
+    expect(one.coverage).not.toEqual(two.coverage);
+    expect(one.coverage.checkedSubjects).toBe(1);
+    expect(two.coverage.checkedSubjects).toBe(0);
+    expect(two.coverage.totalSubjects).toBe(2);
+  });
+});


### PR DESCRIPTION
## The problem

`cascade validate` returned PASS on records it had no constraints for.

SHACL only constrains a node whose `rdf:type` matches a shape's `sh:targetClass`. A file whose
subjects match no target therefore runs **zero** constraints, and a SHACL report over zero
constraints conforms. Nothing in the output distinguished that from a file that was checked
thoroughly and found correct.

The `Shapes:` line made it worse rather than better, because it was derived from the vocabulary
prefixes a file declared rather than from anything that ran. On the reference pod:

```
$ cascade validate --verbose reference-patient-pod/clinical/conditions.ttl
PASS reference-patient-pod/clinical/conditions.ttl (64 triples)
     Shapes: clinical.shapes.ttl, core.shapes.ttl, health.shapes.ttl
     Types: ConditionRecord
```

Three shape files named. Zero constraints run against any of the five subjects.

Across the whole 19-file reference pod, the command reported **19 of 19 files passing, exit 0**,
on a pod where 292 of 448 typed subjects (122 of them carrying Cascade-namespace types) matched
no shape at all.

## What changed

Every result line now states how much of the file was actually checked:

```
PASS reference-patient-pod/clinical/medications.ttl (192 triples; 8 of 8 subjects checked)
PASS reference-patient-pod/clinical/conditions.ttl (64 triples; 0 of 5 subjects checked;
     5 subjects of type health:ConditionRecord had no applicable shape)
PASS reference-patient-pod/manifest.ttl (73 triples; 0 of 8 subjects checked;
     8 subjects had no applicable shape)
     No shape applies to: prov:Agent (2), core:RecordSummary (2), prov:Activity (1),
     prov:SoftwareAgent (1), core:ExportManifest (1), core:InteractionScenario (1)

Validation Summary
  Files: 19 total, 19 passed, 0 failed
  Coverage: 156 of 448 subjects checked, 292 with no applicable shape
  No shape applies to: prov:Activity (121), fhir:Observation (30), ...
```

- **`src/lib/shacl-validator.ts`** — resolves which shapes actually select a focus node.
  Class targets honour `rdfs:subClassOf*` per [SHACL 2.1.3.1](https://www.w3.org/TR/shacl/#targetClass),
  alongside `sh:targetNode`, `sh:targetSubjectsOf` and `sh:targetObjectsOf`. Nodes reached
  through a parent shape's `sh:node` count as checked, since they genuinely are validated.
- **`src/lib/turtle-parser.ts`** — `detectVocabularies` keeps its (accurate) job of reporting
  which vocabularies a file mentions, and now documents that it must not be used for shape
  applicability. Adds `rdfs:subClassOf` edge collection and transitive expansion.
- **`src/commands/validate.ts`** — output format, per file and pod-wide.
- `coverage` and `shapesFired` are exposed in `--json`.

## Exit code is deliberately unchanged

Unshaped subjects are counted and named but do not fail the run. A class with no shape is a gap
in the vocabulary, not a defect in the data being validated; failing on it would break every
existing caller on upgrade for something they cannot fix in their own pod. The count appears on
every result line and in the summary so it cannot pass unnoticed. If a stricter mode is wanted
later it can be added as an opt-in flag without a breaking change.

## Subclass targeting resolves against the data graph

Worth flagging for anyone authoring shapes against this: the SHACL specification defines a class
target over SHACL instances *in the data graph*, so an `rdfs:subClassOf` axiom that exists only
in the ontology does **not** activate a superclass shape. The underlying engine behaves that way,
and this reporting agrees with the engine rather than with the ontology — otherwise it would
claim constraints ran when they did not. `tests/validate-coverage.test.ts` pins both directions.

## Verification

**Negative control.** All 29 new tests fail against `2543667`, the commit this branches from:

```
 Test Files  2 failed (2)
      Tests  29 failed (29)
```

They fail for the right reasons — the coverage figures are absent, and the CLI output assertions
fail against output that reports no coverage at all. One determinism test initially passed on
the baseline by comparing two absent values, and was rewritten to pin the content before
comparing.

**Suite.** Before (`2543667`): 115 files, 1607 passed / 0 failed / 0 skipped.
After: **117 files, 1636 passed / 0 failed / 0 skipped.** Sibling `reference-patient-pod` and
`conformance` checkouts resolved, so no test silently skipped. No existing test changed behaviour.

**Determinism and distinctness.** Identical output for the same pod across separate processes
and different working directories; different coverage for different inputs, asserted on pinned
values rather than on equality alone.

**Subclass targeting** is tested as such: a shape targeting a superclass is shown to cover a
subclass-typed subject and a two-hop subclass-typed subject, while an unrelated type is shown to
remain uncovered, and a `subClassOf` cycle terminates.

The reference-pod measurement is committed as a fixture, per file and per type. It is a
high-water mark of a gap, not a target: authoring shapes for the unshaped classes should move it
down, and the fixture is expected to be updated by whatever change moves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
