### PR TITLE
Sync vocabulary to core v3.4 / health v2.5 / clinical v1.13, and fix the sync script that let it drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+**Vocabulary and shapes synced to core v3.4, health v2.5 and clinical v1.13.** health v2.5 defines
+five record classes the CLI has been emitting for a long time without any definition or constraint
+behind them — `health:LabResultRecord`, `health:AllergyRecord`, `health:ConditionRecord`,
+`health:ImmunizationRecord`, `health:FamilyHistoryRecord` — and gives each a SHACL shape. clinical
+v1.13 deprecates the four duplicated `clinical:*` equivalents (they are not removed, and nothing
+stops emitting them) and adds a shape for consultation notes, which were the one document subtype
+validating against nothing. core v3.4 models the pod export manifest on
+[DCAT 3](https://www.w3.org/TR/vocab-dcat-3/) and [VoID](https://www.w3.org/TR/void/).
+
+**Records that used to validate against nothing are now actually validated, and some of them will
+report findings. That means the validator improved, not that your data degraded.** These records
+have not changed. Before this release, `cascade validate` had no constraints for them, and a SHACL
+report over zero constraints conforms — so they were reported as passing without being examined.
+Concretely, on the 19-file reference pod the number of Cascade-typed subjects that no shape applied
+to falls from **122 to 1**, and subjects actually checked rises from **156 to 277** of 448. The
+reference pod reports zero violations after the change; a pod carrying data the new shapes disagree
+with will report violations it did not report before, and those findings were always true.
+
+A worked example of what this buys, because it is not paperwork: a single bundle carrying two
+same-day glucose readings — a fasting 95 and a post-prandial 310, an entirely routine pairing —
+produced ONE subject asserting both `health:resultValue "95"` and `health:resultValue "310"`.
+`cascade validate` returned PASS on that, because nothing constrained the cardinality, and reading
+it back gave `"health:resultValue": "95, 310"`, a single string no consumer can interpret. The
+`sh:maxCount 1` on the new lab shape catches it at write time.
+
+**Known finding after upgrading: three date properties.** The C-CDA converter reads
+`<effectiveTime value="20250311"/>` and writes `2025-03-11` as a plain string literal on
+`health:performedDate`, `health:onsetDate` and `health:administrationDate`. All three are declared
+`rdfs:range xsd:dateTime` and are now constrained with `sh:datatype xsd:dateTime`, so C-CDA imports
+will report violations on them. The constraint is not new and not an overreach — it is the same one
+`clinical:onsetDate` has always carried — but the emitters have disagreed with it for as long as
+they have existed and nothing was checking. It is deliberately not patched in this release: the
+source carries DAY precision, and typing it as `xsd:dateTime` means appending `T00:00:00`, which
+invents a time that downstream date arithmetic will treat as real. FHIR R4's `dateTime` primitive
+accepts `YYYY-MM-DD` precisely to avoid that, so the correct fix is a vocabulary change first and
+an emitter change second, in a release of its own.
+
 **`cascade validate` now reports how many subjects it actually checked.** Before this change it
 returned PASS on records it had no constraints for, and there was no way to tell the difference
 from the output. A file whose subjects match no `sh:targetClass` runs zero constraints, and a
@@ -31,9 +68,12 @@ shape applies to. The same figures are available under `coverage` in `--json` ou
 **If your validation output changes after upgrading, the validator got more accurate — your data
 did not get worse.** Nothing that passed before now fails: unshaped subjects are counted and
 named, but they do not affect the exit code, because a class with no shape is a gap in the
-vocabulary rather than a defect in your data. On a 19-file reference pod this surfaces 292
-previously unreported subjects (122 of them carrying Cascade-namespace types) that were being
-reported as passing while nothing ran against them.
+vocabulary rather than a defect in your data. On a 19-file reference pod this surfaced 292
+previously unreported subjects, 122 of them carrying Cascade-namespace types, that were being
+reported as passing while nothing ran against them. The vocabulary sync in this same release then
+closes 121 of those 122; what remains unshaped is almost entirely subjects typed only in foreign
+vocabularies (`prov:`, `fhir:`, `solid:`, `foaf:`, `ldp:`), which Cascade shapes are not written to
+constrain.
 
 ### Fixed
 
@@ -47,6 +87,35 @@ reported as passing while nothing ran against them.
   [SHACL 2.1.3.1](https://www.w3.org/TR/shacl/#targetClass), so a shape targeting a superclass is
   correctly reported as covering subclass-typed subjects, transitively. Nodes reached through a
   parent shape's `sh:node` are counted as checked rather than reported as unconstrained.
+- **A file whose only findings are advisories is no longer counted as failed.** `sh:conforms` is
+  false whenever a SHACL report carries any result at all, including `sh:Info`, and the summary was
+  reading it directly — so a file with zero violations and one Info advisory printed `WARN` and was
+  tallied under **failed**, while the exit code (computed from violations alone) said 0. On a pod
+  with no defects the summary read `19 total, 15 passed, 4 failed` and the process exited 0, so one
+  of the two was always lying. A file now fails if and only if it carries at least one
+  `sh:Violation`; warnings and info are printed per file and counted on the `Issues:` line but do
+  not move the pass/fail column, which is what makes the tally and the exit code agree. The same pod
+  now reports `19 total, 19 passed, 0 failed` with `4 info`.
+- **The vocabulary sync script only ever copied half of what it should have.** It kept two separate
+  lists: one naming the vocabularies whose `.shapes.ttl` to copy, and one naming the vocabularies
+  whose ontology to copy. The second list had three entries and never grew. `health.ttl` had
+  therefore never been synced at all — 928 lines against the 1489 it should have been — and
+  `checkup`, `pots` and all four draft vocabularies had no ontology bundled either. The measured
+  consequence: **52 of 89 `sh:targetClass` values in Cascade namespaces resolved to a class that the
+  CLI's own loaded vocabulary did not define**, meaning the validator was loading shapes that could
+  select nothing and report nothing, silently. The script now drives both files from one list per
+  maturity tier and exits non-zero if any expected file is missing, and `tests/shapes-sync.test.ts`
+  asserts the invariant directly: every Cascade-namespace `sh:targetClass` in the bundled shapes
+  must resolve to a class defined in the bundled vocabulary, every shapes file must have a matching
+  ontology, each `VOCAB_VERSIONS` row must equal the `owl:versionInfo` of the ontology actually
+  bundled, and `dist/shapes` must match `src/shapes` byte for byte.
+- **Family-history records no longer land in the FHIR passthrough bucket.**
+  `health:FamilyHistoryRecord` was registered in no data-type entry, so import routing fell through
+  to its unmapped-type branch and every family-history record a C-CDA import produced was written to
+  `clinical/fhir-passthrough.ttl` instead of `clinical/family-history.ttl`. Nothing looked wrong:
+  the import succeeded and the section summary counted the records. They were simply filed under
+  "type we could not map", which is the one bucket a reader is entitled to skip — and the class now
+  has a ratified shape whose consumers look for the file that did not exist.
 
 ## [0.11.0] - 2026-08-03
 

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -41,9 +41,22 @@
 #   (2) removed the sh:class constraints from HasEncounterEdgeShape +
 #   LinkedConditionEdgeShape (unenforceable + false-positive under per-file
 #   validation; sh:nodeKind sh:IRI kept). spec tag vocab/clinical-v1.11; slice R3.
-core=3.3
-health=2.4
-clinical=1.12
+# Updated 2026-08-03: core v3.4 + health v2.5 + clinical v1.13.
+#   health v2.5 defines five record classes that were emitted but undefined
+#   (LabResultRecord, AllergyRecord, ConditionRecord, ImmunizationRecord,
+#   FamilyHistoryRecord) and shapes them; clinical v1.13 deprecates the four
+#   duplicated clinical:* equivalents and adds ConsultationNoteShape; core v3.4
+#   models the export manifest on DCAT and VoID.
+#   Synced in the same pass that fixed scripts/sync-shapes-from-spec.sh: it
+#   copied a shapes file for every vocabulary but an ontology for only three of
+#   them, so src/shapes/health.ttl had never been synced at all (928 lines
+#   against spec's 1489) and checkup/pots plus all four drafts had no ontology
+#   here. tests/shapes-sync.test.ts now pins these rows to the owl:versionInfo
+#   of the synced ontology, so a bump without a sync (or a sync without a bump)
+#   fails the suite.
+core=3.4
+health=2.5
+clinical=1.13
 coverage=1.3
 checkup=3.2
 pots=1.4

--- a/scripts/sync-shapes-from-spec.sh
+++ b/scripts/sync-shapes-from-spec.sh
@@ -30,11 +30,14 @@ if [[ "${1:-}" == "--dry-run" ]]; then
   echo "[dry-run] No files will be written."
 fi
 
+MISSING_COUNT=0
+
 copy_file() {
   local src="$1"
   local dst="$2"
   if [[ ! -f "$src" ]]; then
-    echo "  MISSING: $src"
+    echo "  MISSING: $src" >&2
+    MISSING_COUNT=$((MISSING_COUNT + 1))
     return
   fi
   if $DRY_RUN; then
@@ -45,38 +48,57 @@ copy_file() {
   fi
 }
 
-VOCABS=(core health clinical coverage checkup pots)
+# Sync BOTH the ontology and its shapes for every vocabulary, driven by a single
+# list per maturity tier.
+#
+# These used to be two independent lists — every vocabulary got its
+# `.shapes.ttl`, but only `core clinical coverage` got the ontology itself. The
+# validator loads both (`loadShapes` reads every `*.shapes.ttl` for constraints
+# and every other `*.ttl` for the vocabulary), so the split meant it could load a
+# shape whose target class its own loaded vocabulary did not define. Measured
+# before this change: 52 of 89 `sh:targetClass` values in Cascade namespaces
+# resolved to no loaded class definition, and `src/shapes/health.ttl` had never
+# been synced at all. Keeping one list per tier makes that drift impossible to
+# reintroduce by omission; `tests/shapes-sync.test.ts` asserts the invariant.
+STABLE_VOCABS=(core health clinical coverage checkup pots)
+
+# Draft vocabularies (per D-PATH, NOT registered in VOCAB_VERSIONS).
+# Mirrored so `cascade validate` can target the new classes while the
+# vocabularies are still pre-stable. They land in VOCAB_VERSIONS at v1.0.
+DRAFT_VOCABS=(genomics advisory evidence workbench)
 
 echo ""
-echo "=== Syncing SHACL shapes to src/shapes/ ==="
-for vocab in "${VOCABS[@]}"; do
+echo "=== Syncing stable vocabularies to src/shapes/ ==="
+for vocab in "${STABLE_VOCABS[@]}"; do
+  copy_file "$SPEC_ROOT/ontologies/$vocab/v1/$vocab.ttl" \
+            "$CLI_ROOT/src/shapes/$vocab.ttl"
   copy_file "$SPEC_ROOT/ontologies/$vocab/v1/$vocab.shapes.ttl" \
             "$CLI_ROOT/src/shapes/$vocab.shapes.ttl"
 done
 
-# Also sync full ontologies if CLI uses them for validation
 echo ""
-echo "=== Syncing ontologies to src/shapes/ ==="
-for vocab in core clinical coverage; do
-  copy_file "$SPEC_ROOT/ontologies/$vocab/v1/$vocab.ttl" \
-            "$CLI_ROOT/src/shapes/$vocab.ttl"
-done
-
-# Draft vocabularies (per D-PATH, NOT registered in VOCAB_VERSIONS).
-# Mirror the shapes file so cascade validate can target the new classes
-# while drafts are still pre-stable.
-echo ""
-echo "=== Syncing draft shapes to src/shapes/ ==="
-DRAFT_VOCABS=(genomics advisory evidence workbench)
+echo "=== Syncing draft vocabularies to src/shapes/ ==="
 for vocab in "${DRAFT_VOCABS[@]}"; do
+  copy_file "$SPEC_ROOT/ontologies/$vocab/v1-draft/$vocab.ttl" \
+            "$CLI_ROOT/src/shapes/$vocab.ttl"
   copy_file "$SPEC_ROOT/ontologies/$vocab/v1-draft/$vocab.shapes.ttl" \
             "$CLI_ROOT/src/shapes/$vocab.shapes.ttl"
 done
+
+if (( MISSING_COUNT > 0 )); then
+  echo "" >&2
+  echo "FAILED: $MISSING_COUNT expected file(s) not found in $SPEC_ROOT." >&2
+  echo "Every vocabulary listed above must ship both an ontology and a shapes" >&2
+  echo "file. Fix spec/ or correct the vocabulary lists in this script; do not" >&2
+  echo "leave a vocabulary half-synced." >&2
+  exit 1
+fi
 
 echo ""
 echo "Done. Next steps:"
 echo "  1. Review diffs: git diff src/shapes/"
 echo "  2. Update VOCAB_VERSIONS file"
-echo "  3. Verify: cascade validate passes all conformance fixtures"
-echo "  4. Update CHANGELOG.md"
-echo "  5. Bump version in package.json"
+echo "  3. npm run build && npm test  (tests/shapes-sync.test.ts checks the sync)"
+echo "  4. Verify: cascade validate passes all conformance fixtures"
+echo "  5. Update CHANGELOG.md"
+echo "  6. Bump version in package.json"

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -29,6 +29,7 @@ import {
   loadShapes,
   validateFile,
   findTurtleFiles,
+  failsValidation,
   type ValidationResult,
 } from '../lib/shacl-validator.js';
 import { shortenIRI } from '../lib/turtle-parser.js';
@@ -103,7 +104,7 @@ function formatResultHuman(result: ValidationResult, verbose: boolean): string {
   const relPath = result.file;
   const coverage = formatCoverage(result);
 
-  if (result.valid) {
+  if (result.results.length === 0) {
     lines.push(
       `${colors.green}PASS${colors.reset} ${relPath} (${result.quadCount} triples; ${coverage.summary})`,
     );
@@ -129,9 +130,15 @@ function formatResultHuman(result: ValidationResult, verbose: boolean): string {
     if (warnings.length > 0) countParts.push(`${warnings.length} warning${warnings.length !== 1 ? 's' : ''}`);
     if (infos.length > 0) countParts.push(`${infos.length} info`);
 
+    // Status tracks severity, not `sh:conforms`. An Info-only file conforms to
+    // nothing in the SHACL sense (`sh:conforms` is false the moment any result
+    // exists) but has no defect to report, so it reads PASS and lists its
+    // advisories underneath. See `failsValidation`.
     const statusIcon = violations.length > 0
       ? `${colors.red}FAIL${colors.reset}`
-      : `${colors.yellow}WARN${colors.reset}`;
+      : warnings.length > 0
+        ? `${colors.yellow}WARN${colors.reset}`
+        : `${colors.green}PASS${colors.reset}`;
 
     lines.push(
       `${statusIcon} ${relPath} (${result.quadCount} triples, ${countParts.join(', ')}; ${coverage.summary})`,
@@ -188,8 +195,10 @@ function printSummary(
   if (opts.json) return; // JSON mode outputs the full array
 
   const total = results.length;
-  const passed = results.filter((r) => r.valid).length;
-  const failed = total - passed;
+  // Keyed on severity, not on `sh:conforms`, so this column agrees with the
+  // process exit code. Both say "failure" only for `sh:Violation`.
+  const failed = results.filter(failsValidation).length;
+  const passed = total - failed;
 
   const totalViolations = results.reduce(
     (sum, r) => sum + r.results.filter((i) => i.severity === 'violation').length,
@@ -357,11 +366,8 @@ export function registerValidateCommand(program: Command): void {
           const result = validateFile(file, shapesStore, shapeFiles, dek);
           results.push(result);
 
-          if (!result.valid) {
-            const violations = result.results.filter((r) => r.severity === 'violation');
-            if (violations.length > 0) {
-              hasViolations = true;
-            }
+          if (failsValidation(result)) {
+            hasViolations = true;
           }
 
           // Print result immediately in human-readable mode

--- a/src/lib/pod-data-types.ts
+++ b/src/lib/pod-data-types.ts
@@ -170,6 +170,18 @@ export const DATA_TYPES: Record<string, DataTypeInfo> = {
     directory: 'clinical',
     filename: 'social-history.ttl',
   },
+  // The C-CDA Family History section emits `health:FamilyHistoryRecord`. Without
+  // this entry `routeTypeKey` matched no registered type and fell through to the
+  // FHIR passthrough bucket, so every family-history record a C-CDA import
+  // produced landed in `clinical/fhir-passthrough.ttl` — not the
+  // `clinical/family-history.ttl` the pod structure documents, and not anywhere
+  // the read verbs present as family history.
+  'family-history': {
+    label: 'Family History',
+    rdfTypes: [CASCADE_NAMESPACES.health + 'FamilyHistoryRecord'],
+    directory: 'clinical',
+    filename: 'family-history.ttl',
+  },
   'ai-extraction-activities': {
     label: 'AI Extraction Activities',
     rdfTypes: [CASCADE_NAMESPACES.cascade + 'AIExtractionActivity'],

--- a/src/lib/shacl-validator.ts
+++ b/src/lib/shacl-validator.ts
@@ -24,6 +24,15 @@ import { readResource } from './pod-encryption.js';
 const { namedNode } = DataFactory;
 
 export interface ValidationResult {
+  /**
+   * The SHACL `sh:conforms` value, verbatim.
+   *
+   * Per [SHACL 3.2](https://www.w3.org/TR/shacl/#validation-report) this is
+   * `false` whenever the report carries ANY result, regardless of severity — so
+   * a file whose only finding is an `sh:Info` advisory reports `valid: false`.
+   * That is correct SHACL and wrong English. Do not use this field to decide
+   * whether a file passed; use {@link failsValidation}.
+   */
   valid: boolean;
   file: string;
   results: ValidationIssue[];
@@ -70,6 +79,26 @@ export interface ValidationIssue {
   focusNode?: string;
   value?: string;
   specLink?: string;
+}
+
+/**
+ * Whether a result counts as a validation FAILURE.
+ *
+ * A file fails if and only if it carries at least one `sh:Violation`. Parse
+ * errors, unreadable files and processing errors are all synthesised as
+ * violations, so they fail through this same rule.
+ *
+ * **Warnings and Info deliberately do not fail.** The rule is fixed by the exit
+ * code, which has always been driven by violations alone: `cascade validate`
+ * exits 0 on a warning-only or info-only run. Counting those files as failures
+ * in the summary made the tally and the exit code assert opposite things about
+ * the same run, so a caller who trusted one was misled by the other. Advisories
+ * still print per file and are still counted on the `Issues:` line; they just do
+ * not move the pass/fail column. Tightening a constraint from Info or Warning to
+ * Violation is the supported way to make something fail.
+ */
+export function failsValidation(result: ValidationResult): boolean {
+  return result.results.some((issue) => issue.severity === 'violation');
 }
 
 /** Mapping from shape file prefixes to their documentation base URLs */

--- a/src/shapes/advisory.ttl
+++ b/src/shapes/advisory.ttl
@@ -1,0 +1,369 @@
+@prefix advisory: <https://ns.cascadeprotocol.org/advisory/v1#> .
+@prefix genomics: <https://ns.cascadeprotocol.org/genomics/v1#> .
+@prefix cascade:  <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix prov:     <http://www.w3.org/ns/prov#> .
+
+# ============================================================================
+# Changelog
+# ============================================================================
+# v1.0-draft.0.1 (2026-05-05) — Initial draft.
+#   Defines the Cascade Advisory Patch (CAP) profile envelope, the six
+#   AdvisoryClass named individuals, the Cadence enum, the per-pod
+#   TrustedIssuer class with TrustSourceEnum provenance, the AutoApplyPolicy
+#   class with AutoApplyScope, and the detached-JWS signature property
+#   (per D-Q4). References cascade:AdvisoryApplicationActivity from core
+#   v3.1; does not redeclare it.
+# ============================================================================
+
+# ============================================================================
+# Ontology Metadata
+# ============================================================================
+
+<https://ns.cascadeprotocol.org/advisory/v1#> a owl:Ontology ;
+    owl:imports <https://ns.cascadeprotocol.org/core/v1#> ;
+    dct:title "Cascade Protocol Advisory Vocabulary"@en ;
+    dct:description "Vocabulary for the Cascade Advisory Patch (CAP) profile — a constrained subset of W3C LDPatch carrying clinical knowledge updates (variant reclassifications, PGx dosing changes, surveillance guideline updates, etc.) into a Cascade pod with author-readable, statically-auditable, bounded-execution semantics."@en ;
+    dct:creator "Cascade Agentic Labs" ;
+    dct:created "2026-05-05"^^xsd:date ;
+    dct:modified "2026-05-05"^^xsd:date ;
+    owl:versionInfo "1.0-draft" ;
+    rdfs:comment "DRAFT — vocabulary is under development and subject to change before v1.0 stable release. Architecture: (1) constrained-LDPatch envelope (advisory:CascadeAdvisoryPatch) with required human-readable summary, advisory class, issuer, and issuance time; (2) tiered cadence — SafetyCritical advisories check on every app open, VariantReclassification monthly, SurveillanceGuidelineUpdate quarterly-to-annual (advisory:Cadence enum); (3) per-pod trust — each pod chooses which issuers to trust via advisory:TrustedIssuer records (advisory:TrustSourceEnum tracks how each was added: cascade-cli starter list vs user-added vs imported-from-registry vs verified-via-DID); (4) detached JWS Ed25519 signatures (RFC 7515) for issuer authentication (advisory:signature plus issuer claims); (5) opt-in auto-apply scoped per (issuer x advisoryClass) pair via advisory:AutoApplyPolicy. The application of an advisory to a pod is recorded using cascade:AdvisoryApplicationActivity (declared in core v3.1, not redeclared here)."@en ;
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/advisory/v1.0-draft/> .
+
+# ============================================================================
+# Profile envelope: CascadeAdvisoryPatch
+# ============================================================================
+
+advisory:CascadeAdvisoryPatch a owl:Class ;
+    rdfs:label "Cascade Advisory Patch"@en ;
+    rdfs:comment "The envelope of a CAP file — a constrained-LDPatch document delivering a clinical knowledge update to a Cascade pod. Subclass of prov:Entity so applications can be linked via prov:used / prov:wasGeneratedBy. The application of a CAP to a pod is recorded as a cascade:AdvisoryApplicationActivity (defined in core v3.1) which uses prov:used to point at both the patch and the matched record. Every CascadeAdvisoryPatch MUST carry advisory:humanSummary, advisory:advisoryClass, advisory:issuer, and advisory:issuedAt; SHOULD carry advisory:signature; MAY carry advisory:supersedes, advisory:applicableUntil, advisory:advisoryId, advisory:issuerName, advisory:evidenceUrl, advisory:profileVersion, and advisory:appliesToActiveOnly."@en ;
+    rdfs:subClassOf prov:Entity .
+
+# ----------------------------------------------------------------------------
+# Required envelope properties
+# ----------------------------------------------------------------------------
+
+advisory:humanSummary a owl:DatatypeProperty ;
+    rdfs:label "Human Summary"@en ;
+    rdfs:comment "Plain-text, one-paragraph, patient-readable summary of what this advisory means and what (if anything) the user should do. REQUIRED on every advisory — the applier MUST reject patches without it. This is the string the queue UI shows the user when prompting for approval."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:string .
+
+advisory:advisoryClass a owl:ObjectProperty ;
+    rdfs:label "Advisory Class"@en ;
+    rdfs:comment "The taxonomic category of this advisory, drawn from the six published advisory:AdvisoryClass named individuals. Drives the cadence with which the pod checks for new advisories of this class and the default queue-vs-auto-apply behaviour."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range advisory:AdvisoryClass .
+
+advisory:issuer a owl:ObjectProperty ;
+    rdfs:label "Issuer"@en ;
+    rdfs:comment "The IRI (or DID) identifying the entity that signed this advisory. The pod compares this to its local advisory:TrustedIssuer graph to decide whether to honour the patch silently, queue it for explicit user trust review, or reject it. Range is advisory:TrustedIssuer when the issuer record has been resolved into the pod; xsd:anyURI when the patch is being parsed before resolution."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch .
+
+advisory:issuedAt a owl:DatatypeProperty ;
+    rdfs:label "Issued At"@en ;
+    rdfs:comment "ISO 8601 dateTime when the issuer signed this advisory. REQUIRED. Used both for ordering (later issuance supersedes earlier in a chain) and for signature freshness checks."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:dateTime .
+
+# ----------------------------------------------------------------------------
+# Optional envelope properties
+# ----------------------------------------------------------------------------
+
+advisory:advisoryId a owl:ObjectProperty ;
+    rdfs:label "Advisory Identifier"@en ;
+    rdfs:comment "Stable identifier IRI for this specific advisory. Used as the target of advisory:supersedes in later advisories that revise or replace this one. Optional but strongly recommended for any advisory that may be superseded later."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch .
+
+advisory:supersedes a owl:ObjectProperty ;
+    rdfs:label "Supersedes"@en ;
+    rdfs:comment "IRI of a prior advisory:CascadeAdvisoryPatch that this one revises or replaces. Forms a supersession chain. The pod MAY mark records produced by the prior advisory as superseded but MUST NOT delete them — supersession is monotonic and roll-forward auditable per CAP profile constraint C1."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range advisory:CascadeAdvisoryPatch .
+
+advisory:applicableUntil a owl:DatatypeProperty ;
+    rdfs:label "Applicable Until"@en ;
+    rdfs:comment "ISO 8601 dateTime after which this advisory should no longer be applied to new matches. The pod SHOULD still honour applications that occurred before this time. Used by both worked examples (BRCA2 reclassification, CPIC CYP2C19/warfarin) — the canonical name."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:dateTime .
+
+advisory:profileVersion a owl:DatatypeProperty ;
+    rdfs:label "Profile Version"@en ;
+    rdfs:comment "Version of the Cascade Advisory Patch profile this advisory conforms to (e.g. \"0.1\"). Lets the applier reject patches written against a profile version it does not implement."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:string .
+
+advisory:issuerName a owl:DatatypeProperty ;
+    rdfs:label "Issuer Display Name"@en ;
+    rdfs:comment "Human-readable display name for the issuer (e.g. \"ClinGen HBOP-VCEP\", \"CPIC\"). Convenience field for UI; the authoritative identity is advisory:issuer."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:string .
+
+advisory:evidenceUrl a owl:ObjectProperty ;
+    rdfs:label "Evidence URL"@en ;
+    rdfs:comment "IRI of the publicly-citable evidence supporting this advisory (a ClinVar evidence-repo entry, a CPIC guideline page, a published VCEP statement, etc.). Shown to the user in the queue UI as a 'learn more' link."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch .
+
+advisory:appliesToActiveOnly a owl:DatatypeProperty ;
+    rdfs:label "Applies To Active Records Only"@en ;
+    rdfs:comment "If true, the advisory should only fire when the matched record is currently 'active' according to the pod's domain semantics (e.g. a medication still on the active list, a condition not marked resolved). Used in PGx dosing advisories so the pod does not re-surface guidance for drugs the user discontinued."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:boolean .
+
+advisory:cadence a owl:ObjectProperty ;
+    rdfs:label "Cadence"@en ;
+    rdfs:comment "Optional override of the default check-cadence for this advisory class. If absent, the pod uses the cadence implied by advisory:advisoryClass."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range advisory:Cadence .
+
+# ============================================================================
+# Signature (per D-Q4: detached JWS Ed25519, RFC 7515)
+# ============================================================================
+
+advisory:signature a owl:DatatypeProperty ;
+    rdfs:label "Signature"@en ;
+    rdfs:comment "Detached JWS in RFC 7515 compact serialization carrying an Ed25519 signature over the canonicalized patch body. The protected header MUST include the JWS claims advisory:signatureIssuer (iss), advisory:signatureIssuedAt (iat), and advisory:signatureContentType (cty, fixed to 'application/x-cascade-advisory-patch'); MAY include advisory:signatureExpiresAt (exp). The signature is verified against the public key on the matching advisory:TrustedIssuer record. Per D-Q4, W3C VC 2.0 envelope wrapping is deferred to a later profile version."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:string .
+
+advisory:signatureIssuer a owl:DatatypeProperty ;
+    rdfs:label "Signature Issuer (iss)"@en ;
+    rdfs:comment "JWS 'iss' claim — the issuer URI asserted inside the signed envelope. The applier MUST verify this matches advisory:issuer on the unsigned envelope."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:string .
+
+advisory:signatureIssuedAt a owl:DatatypeProperty ;
+    rdfs:label "Signature Issued At (iat)"@en ;
+    rdfs:comment "JWS 'iat' claim — Unix epoch seconds at which the signature was produced. The applier MUST verify this is consistent with advisory:issuedAt within an implementation-defined skew tolerance."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:long .
+
+advisory:signatureExpiresAt a owl:DatatypeProperty ;
+    rdfs:label "Signature Expires At (exp)"@en ;
+    rdfs:comment "JWS 'exp' claim — Unix epoch seconds after which the signature itself is no longer valid (independent of advisory:applicableUntil, which scopes the clinical applicability)."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:long .
+
+advisory:signatureContentType a owl:DatatypeProperty ;
+    rdfs:label "Signature Content Type (cty)"@en ;
+    rdfs:comment "JWS 'cty' claim — fixed to 'application/x-cascade-advisory-patch' for v0.1. Lets generic JWS verifiers reject signatures intended for other media types."@en ;
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# AdvisoryClass taxonomy (six named individuals)
+# ============================================================================
+# The cadence comments below reference the tiered-cadence guidance in
+# drafts/REPORT-genomics-and-advisory.md (Mersch et al. 2018 ~25% of VUSes
+# reclassify within 9 years, lumpy with VCEP batches; SafetyCritical must
+# fire fast or it isn't safety-critical; carrier-frequency updates are
+# slow-moving population-genetics deltas).
+# ============================================================================
+
+advisory:AdvisoryClass a owl:Class ;
+    rdfs:label "Advisory Class"@en ;
+    rdfs:comment "Closed taxonomy of advisory categories. The class drives the recommended check cadence and the default queue-vs-auto-apply UX. v0.1 ships six named individuals; new classes require a vocabulary version bump."@en .
+
+advisory:SafetyCritical a owl:NamedIndividual, advisory:AdvisoryClass ;
+    rdfs:label "Safety-Critical"@en ;
+    rdfs:comment "An advisory that, if not surfaced quickly, may put the user at material clinical risk (e.g. a drug recall, a black-box warning added to a medication the user is taking, an urgent revocation of a prior reclassification). Recommended cadence: every app open. Default UX: surface as an in-app banner immediately on next open; do not silently auto-apply unless the user has explicitly opted in for this issuer."@en .
+
+advisory:VariantReclassification a owl:NamedIndividual, advisory:AdvisoryClass ;
+    rdfs:label "Variant Reclassification"@en ;
+    rdfs:comment "An advisory that updates the ACMG (or comparable) clinical classification of a previously interpreted variant — typically VUS to Likely Pathogenic, Likely Pathogenic to Pathogenic, or downgrade in the opposite direction. Recommended cadence: monthly. Default UX: queue for user review with the prior interpretation shown alongside the proposed new one; encourage re-engagement with a genetic counselor."@en .
+
+advisory:DrugInteraction a owl:NamedIndividual, advisory:AdvisoryClass ;
+    rdfs:label "Drug Interaction / PGx Update"@en ;
+    rdfs:comment "An advisory carrying new or updated pharmacogenetic dosing guidance (e.g. CPIC-style guideline revisions tied to a star allele or diplotype). Recommended cadence: monthly. Default UX: queue for review when the relevant medication is on the user's active list; suppress when not (see advisory:appliesToActiveOnly)."@en .
+
+advisory:LabReferenceRangeUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
+    rdfs:label "Lab Reference Range Update"@en ;
+    rdfs:comment "An advisory that updates the reference range, units, or interpretation thresholds for a lab analyte (e.g. a new age-specific HbA1c band, a unit harmonization). Recommended cadence: quarterly. Default UX: silent auto-apply when the issuer is on the auto-apply policy for this class, since the change is typically a non-clinical re-display."@en .
+
+advisory:SurveillanceGuidelineUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
+    rdfs:label "Surveillance Guideline Update"@en ;
+    rdfs:comment "An advisory carrying changes to recommended surveillance protocols (e.g. NCCN updating screening intervals for BRCA1/2 carriers, ACMG secondary-finding actionability list edits). Recommended cadence: quarterly to annual. Default UX: queue for review and link to the published guideline."@en .
+
+advisory:CarrierFrequencyUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
+    rdfs:label "Carrier Frequency Update"@en ;
+    rdfs:comment "An advisory updating population carrier-frequency or allele-frequency estimates used in residual-risk calculations (e.g. gnomAD release deltas, ancestry-specific frequency revisions). Recommended cadence: annual. Default UX: silent auto-apply when the issuer is on the auto-apply policy, since these are population-level reference-data refreshes."@en .
+
+# ============================================================================
+# Cadence enum
+# ============================================================================
+
+advisory:Cadence a owl:Class ;
+    rdfs:label "Cadence"@en ;
+    rdfs:comment "Closed enumeration of recommended check-cadence values for advisories. Used as the range of advisory:cadence on a CascadeAdvisoryPatch (per-advisory override) and as the implied cadence of each advisory:AdvisoryClass."@en .
+
+advisory:EveryAppOpen a owl:NamedIndividual, advisory:Cadence ;
+    rdfs:label "Every App Open"@en ;
+    rdfs:comment "Pod checks for new advisories of this class on every foregrounding of the app. Reserved for SafetyCritical."@en .
+
+advisory:Daily a owl:NamedIndividual, advisory:Cadence ;
+    rdfs:label "Daily"@en ;
+    rdfs:comment "Pod checks at most once per calendar day."@en .
+
+advisory:Weekly a owl:NamedIndividual, advisory:Cadence ;
+    rdfs:label "Weekly"@en ;
+    rdfs:comment "Pod checks at most once per calendar week."@en .
+
+advisory:Monthly a owl:NamedIndividual, advisory:Cadence ;
+    rdfs:label "Monthly"@en ;
+    rdfs:comment "Pod checks at most once per calendar month. Default cadence for VariantReclassification and DrugInteraction."@en .
+
+advisory:Quarterly a owl:NamedIndividual, advisory:Cadence ;
+    rdfs:label "Quarterly"@en ;
+    rdfs:comment "Pod checks at most once per calendar quarter. Default cadence for LabReferenceRangeUpdate and the lower bound for SurveillanceGuidelineUpdate."@en .
+
+advisory:Annually a owl:NamedIndividual, advisory:Cadence ;
+    rdfs:label "Annually"@en ;
+    rdfs:comment "Pod checks at most once per calendar year. Default cadence for CarrierFrequencyUpdate and the upper bound for SurveillanceGuidelineUpdate."@en .
+
+# ============================================================================
+# TrustedIssuer (per D-Q3: per-pod, lives in <pod>/trust/issuers.ttl)
+# ============================================================================
+
+advisory:TrustedIssuer a owl:Class ;
+    rdfs:label "Trusted Issuer"@en ;
+    rdfs:comment "An issuer the pod has chosen to trust. Lives per-pod (typically at <pod>/trust/issuers.ttl) — the protocol does NOT define a centralized registry. How the pod populates this graph (cascade-cli starter list, user-added in-app, imported from a community-driven registry URL, or verified via DID) is operational and is captured per-record by advisory:trustSource. Per D-Q3 the protocol is positioned as an extensible framework rather than a gatekeeper; community-driven issuer evaluation and certification is a separate, parallel workstream."@en .
+
+advisory:trustedIssuerId a owl:DatatypeProperty ;
+    rdfs:label "Trusted Issuer Identifier"@en ;
+    rdfs:comment "The IRI (HTTPS URL or DID) that uniquely identifies this issuer. MUST equal the value of advisory:issuer on any patch this issuer signs."@en ;
+    rdfs:domain advisory:TrustedIssuer ;
+    rdfs:range xsd:anyURI .
+
+advisory:trustedIssuerName a owl:DatatypeProperty ;
+    rdfs:label "Trusted Issuer Display Name"@en ;
+    rdfs:comment "Human-readable name shown in pod UI when describing this issuer (e.g. 'ClinGen HBOP-VCEP', 'CPIC')."@en ;
+    rdfs:domain advisory:TrustedIssuer ;
+    rdfs:range xsd:string .
+
+advisory:trustedIssuerPublicKey a owl:DatatypeProperty ;
+    rdfs:label "Trusted Issuer Public Key"@en ;
+    rdfs:comment "The Ed25519 public key (per D-Q4) used to verify advisory:signature on patches issued by this issuer. Encoded as a JWK (RFC 7517) JSON string or as multibase-encoded raw key bytes; SHACL shapes constrain the exact form."@en ;
+    rdfs:domain advisory:TrustedIssuer ;
+    rdfs:range xsd:string .
+
+advisory:trustSource a owl:ObjectProperty ;
+    rdfs:label "Trust Source"@en ;
+    rdfs:comment "Provenance flag indicating how this issuer was added to the pod's trust graph. Used by UI to differentiate cascade-recommended starters from user-curated additions and to surface 'imported from community registry' provenance."@en ;
+    rdfs:domain advisory:TrustedIssuer ;
+    rdfs:range advisory:TrustSourceEnum .
+
+advisory:trustAddedAt a owl:DatatypeProperty ;
+    rdfs:label "Trust Added At"@en ;
+    rdfs:comment "ISO 8601 dateTime when this issuer was added to the pod's trust graph."@en ;
+    rdfs:domain advisory:TrustedIssuer ;
+    rdfs:range xsd:dateTime .
+
+advisory:TrustSourceEnum a owl:Class ;
+    rdfs:label "Trust Source Enumeration"@en ;
+    rdfs:comment "Closed enumeration of the ways an advisory:TrustedIssuer record may have entered the pod's trust graph."@en .
+
+advisory:RecommendedStarterList a owl:NamedIndividual, advisory:TrustSourceEnum ;
+    rdfs:label "Recommended Starter List"@en ;
+    rdfs:comment "Issuer was seeded by `cascade-cli init` from the cascade-recommended starter list (e.g. ClinGen, CPIC, NCCN). The list is a non-binding suggestion; the user retains authority to remove any of these issuers."@en .
+
+advisory:UserAdded a owl:NamedIndividual, advisory:TrustSourceEnum ;
+    rdfs:label "User Added"@en ;
+    rdfs:comment "Issuer was explicitly added by the user in-app, typically by pasting an issuer URI or scanning a QR code provided by the issuer."@en .
+
+advisory:ImportedFromRegistry a owl:NamedIndividual, advisory:TrustSourceEnum ;
+    rdfs:label "Imported From Registry"@en ;
+    rdfs:comment "Issuer was imported from a community-driven issuer registry URL the user chose to consult. Forward-compatibility hook for the parallel issuer-certification workstream."@en .
+
+advisory:VerifiedViaDID a owl:NamedIndividual, advisory:TrustSourceEnum ;
+    rdfs:label "Verified Via DID"@en ;
+    rdfs:comment "Issuer identifier was resolved as a Decentralized Identifier and the DID document chain was verified at trust-add time. Forward-compatibility hook for DID-based issuer identity."@en .
+
+# ============================================================================
+# AutoApplyPolicy
+# ============================================================================
+
+advisory:AutoApplyPolicy a owl:Class ;
+    rdfs:label "Auto-Apply Policy"@en ;
+    rdfs:comment "A per-pod policy declaring which (issuer x advisoryClass) pairs the pod will apply silently rather than queueing for explicit user approval. Auto-apply is opt-in by default; the user adds policy records explicitly. Each record points at one or more advisory:AutoApplyScope tuples."@en .
+
+advisory:appliesTo a owl:ObjectProperty ;
+    rdfs:label "Applies To (Auto-Apply Scope)"@en ;
+    rdfs:comment "Links a policy to one or more advisory:AutoApplyScope records, each pairing an issuer with an advisory class. A patch matches the policy when its (advisory:issuer, advisory:advisoryClass) tuple equals at least one of the linked scopes."@en ;
+    rdfs:domain advisory:AutoApplyPolicy ;
+    rdfs:range advisory:AutoApplyScope .
+
+advisory:effectiveFrom a owl:DatatypeProperty ;
+    rdfs:label "Effective From"@en ;
+    rdfs:comment "ISO 8601 dateTime from which the policy is active. Patches issued or applied before this time fall back to queue-for-approval."@en ;
+    rdfs:domain advisory:AutoApplyPolicy ;
+    rdfs:range xsd:dateTime .
+
+advisory:effectiveUntil a owl:DatatypeProperty ;
+    rdfs:label "Effective Until"@en ;
+    rdfs:comment "ISO 8601 dateTime after which the policy is no longer active. Optional — absence means the policy stays active until the user revokes it."@en ;
+    rdfs:domain advisory:AutoApplyPolicy ;
+    rdfs:range xsd:dateTime .
+
+advisory:requiresQuorum a owl:DatatypeProperty ;
+    rdfs:label "Requires Quorum"@en ;
+    rdfs:comment "Forward-compatibility flag for v1.0 counter-signing. When true, the policy will only auto-apply if the patch carries signatures from a quorum of trusted issuers (rather than just one). Declared in v0.1 for forward compatibility but unused — the v0.1 applier MUST treat this as if absent and ignore counter-signatures."@en ;
+    rdfs:domain advisory:AutoApplyPolicy ;
+    rdfs:range xsd:boolean .
+
+advisory:AutoApplyScope a owl:Class ;
+    rdfs:label "Auto-Apply Scope"@en ;
+    rdfs:comment "One (issuer, advisoryClass) tuple authorizing silent auto-application. Reusable across multiple AutoApplyPolicy records."@en .
+
+advisory:scopeIssuer a owl:ObjectProperty ;
+    rdfs:label "Scope Issuer"@en ;
+    rdfs:comment "The trusted issuer this scope authorizes."@en ;
+    rdfs:domain advisory:AutoApplyScope ;
+    rdfs:range advisory:TrustedIssuer .
+
+advisory:scopeAdvisoryClass a owl:ObjectProperty ;
+    rdfs:label "Scope Advisory Class"@en ;
+    rdfs:comment "The advisory class this scope authorizes for the paired issuer. Use one of the six published advisory:AdvisoryClass named individuals."@en ;
+    rdfs:domain advisory:AutoApplyScope ;
+    rdfs:range advisory:AdvisoryClass .
+
+# ============================================================================
+# Cross-references (declared in core v3.1, NOT redeclared here)
+# ============================================================================
+# - cascade:AdvisoryApplicationActivity (rdfs:subClassOf prov:Activity) records
+#   the application of a CAP to a pod. Use:
+#     <activity> a cascade:AdvisoryApplicationActivity ;
+#                prov:used <patch-iri> ;
+#                prov:used <matched-record-iri> ;
+#                prov:startedAtTime <when-applied>^^xsd:dateTime .
+#   Records produced by the patch carry prov:wasGeneratedBy <activity>.
+
+# ============================================================================
+# Pod Storage Paths (Recommended)
+# ============================================================================
+# /trust/issuers.ttl                 - advisory:TrustedIssuer graph (per D-Q3)
+# /trust/auto-apply.ttl              - advisory:AutoApplyPolicy + Scope graph
+# /advisories/queued/<id>.ldpatch    - patches awaiting user approval
+# /advisories/applied/<id>.ldpatch   - patches that have been applied
+# /advisories/inapplicable/<id>.ldpatch - patches with zero Bind matches
+# /provenance/advisory-applications/<id>.ttl
+#                                   - cascade:AdvisoryApplicationActivity
+#                                     records, one per application
+
+# ============================================================================
+# Notes
+# ============================================================================
+# Data Classification: Clinical knowledge updates (issuer-curated)
+# Underlying syntax: W3C LDPatch (Recommendation, 2015), constrained per
+#                    drafts/advisory-v1/PROFILE.md
+# Signing: Detached JWS Ed25519 (RFC 7515) per D-Q4; W3C VC 2.0 wrapping
+#          deferred to a later profile version.
+# Trust model: Per-pod (D-Q3). The protocol ships a recommended starter list
+#              via cascade-cli but does not operate a centralized registry.
+
+# DRAFT STATUS: This vocabulary is under active development. Property names,
+# ranges, and structure may change before v1.0 stable release.

--- a/src/shapes/checkup.ttl
+++ b/src/shapes/checkup.ttl
@@ -1,0 +1,1983 @@
+@prefix checkup: <https://ns.cascadeprotocol.org/checkup/v1#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix fhir: <http://hl7.org/fhir/> .
+@prefix sct: <http://snomed.info/sct/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+# ============================================================================
+# Ontology Metadata
+# ============================================================================
+
+<https://ns.cascadeprotocol.org/checkup/v1#> a owl:Ontology ;
+    dct:title "Cascade Checkup Vocabulary"@en ;
+    dct:description "Structured health data for patient intake forms and pre-visit preparation. Enables aggregation of EHR, HealthKit, and manually entered health data."@en ;
+    dct:creator "Cascade Agentic Labs" ;
+    dct:created "2026-01-03"^^xsd:date ;
+    dct:modified "2026-02-26"^^xsd:date ;
+    owl:versionInfo "3.2" ;
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/checkup/v1/> .
+
+# ============================================================================
+# CORE CLASSES (27 active, 0 deprecated)
+# ============================================================================
+
+checkup:IntakeFormData a owl:Class ;
+    rdfs:label "Intake Form Data" ;
+    rdfs:comment "Aggregated patient data formatted for healthcare intake forms. Contains all sections needed for a complete pre-visit profile including demographics, medications, allergies, conditions, and visit concerns." ;
+    cascade:subConcern "intake" .
+
+checkup:InsuranceInfo a owl:Class ;
+    rdfs:label "Insurance Information" ;
+    rdfs:comment "Patient-reported insurance information for visit preparation. Uses coverage: namespace for standardized insurance properties (providerName, memberId, groupNumber, coverageType, effectiveStart/End, subscriberName/Relationship, rxBin/rxPcn/rxGroup); adds checkup-specific PCP information (primaryCareProvider, pcpPhone). See coverage.ttl for property definitions." ;
+    cascade:subConcern "financial" .
+
+checkup:MedicationSummary a owl:Class ;
+    rdfs:label "Medication Summary" ;
+    rdfs:comment "Current medication with enriched adherence and tolerability data. Links to clinical:Medication source records and tracks self-reported adherence barriers and side effects." ;
+    cascade:subConcern "summary" .
+
+checkup:AllergySummary a owl:Class ;
+    rdfs:label "Allergy Summary" ;
+    rdfs:comment "Known allergen with reaction type and severity. Tracks data provenance (EHR verified, self-reported) and links to clinical:AllergyIntolerance source records." ;
+    cascade:subConcern "summary" .
+
+checkup:ConditionSummary a owl:Class ;
+    rdfs:label "Condition Summary" ;
+    rdfs:comment "Active or resolved health condition with ICD-10 coding. Includes onset information and current status for clinical context." ;
+    cascade:subConcern "summary" .
+
+checkup:FamilyHistoryEntry a owl:Class ;
+    rdfs:label "Family History Entry" ;
+    rdfs:comment "Single family member health condition for risk assessment. Captures relative type, condition, and age at diagnosis for inherited condition screening." ;
+    cascade:subConcern "summary" .
+
+checkup:ScreeningStatus a owl:Class ;
+    rdfs:label "Screening Status" ;
+    rdfs:comment "Patient status for recommended preventive screening. Tracks last completed date, next due date, and applicable USPSTF/ACS guidelines." ;
+    cascade:subConcern "structural" .
+
+checkup:VisitIssue a owl:Class ;
+    rdfs:label "Visit Issue" ;
+    rdfs:comment "Health issue or symptom the patient wants to discuss at their visit (chief complaint). Includes severity, duration, and user-assigned priority for visit planning." ;
+    cascade:subConcern "intake" .
+
+checkup:SuggestedQuestion a owl:Class ;
+    rdfs:label "Suggested Question" ;
+    rdfs:comment "AI-generated or template question for the patient to ask their provider. Based on conditions, medications, symptoms, or health trends identified in their profile." ;
+    cascade:subConcern "analytics" .
+
+checkup:DiagnosticTestResult a owl:Class ;
+    rdfs:label "Diagnostic Test Result" ;
+    rdfs:comment "Reference to a diagnostic test from an external Cascade app (e.g., POTS Check, glucose monitoring). Provides summary for intake forms and links to detailed results in pod." ;
+    cascade:subConcern "intake" .
+
+checkup:SupplementSummary a owl:Class ;
+    rdfs:label "Supplement Summary" ;
+    rdfs:comment "Dietary supplement, OTC product, or herbal remedy with regulatory classification and evidence strength. Separate from MedicationSummary to reflect different regulatory status and data requirements. Links to clinical:Supplement source records." ;
+    cascade:subConcern "summary" .
+
+
+# --- Clinical Summary Classes (v1.7) ---
+
+checkup:ImmunizationSummary a owl:Class ;
+    rdfs:label "Immunization Summary" ;
+    rdfs:comment "Patient-facing immunization record for intake forms. Uses mixed namespace pattern: checkup: properties for app-layer enrichment (vaccineCategory) alongside clinical data fields." ;
+    cascade:subConcern "summary" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:LabResultSummary a owl:Class ;
+    rdfs:label "Lab Result Summary" ;
+    rdfs:comment "Patient-facing lab result summary for intake forms. Uses mixed namespace pattern: checkup:labCategory for app-layer categorization, clinical: properties for standardized lab data." ;
+    cascade:subConcern "summary" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:ProcedureSummary a owl:Class ;
+    rdfs:label "Procedure Summary" ;
+    rdfs:comment "Patient-facing procedure record for intake forms. Uses mixed namespace pattern: checkup: properties for app-layer fields (procedureName, procedureCategory, procedureLocation), clinical: properties for standardized clinical data (procedureStatus, performedDate, bodySite, performer, outcome, snomedCode, cptCode)." ;
+    cascade:subConcern "summary" ;
+    rdfs:subClassOf prov:Entity .
+
+# --- Reference Classes (v1.7) ---
+
+checkup:WellnessProfileReference a owl:Class ;
+    rdfs:label "Wellness Profile Reference" ;
+    rdfs:comment "Lightweight pointer to the patient's full wellness profile stored in the SDK HealthProfile. Uses rdfs:seeAlso to link to the wellness data file." ;
+    cascade:subConcern "structural" ;
+    rdfs:subClassOf prov:Entity .
+# ============================================================================
+# INSURANCE INFORMATION PROPERTIES
+# ============================================================================
+
+checkup:insuranceProvider a rdf:Property ;
+    rdfs:label "Insurance Provider" ;
+    rdfs:comment "Name of insurance company: Aetna, Blue Cross, Medicare, Medicaid, etc." ;
+    rdfs:domain checkup:InsuranceInfo ;
+    rdfs:range xsd:string .
+
+checkup:memberId a rdf:Property ;
+    rdfs:label "Member ID" ;
+    rdfs:comment "Insurance policy member/subscriber ID number." ;
+    rdfs:domain checkup:InsuranceInfo ;
+    rdfs:range xsd:string .
+
+checkup:groupNumber a rdf:Property ;
+    rdfs:label "Group Number" ;
+    rdfs:comment "Employer group number for employer-sponsored plans." ;
+    rdfs:domain checkup:InsuranceInfo ;
+    rdfs:range xsd:string .
+
+checkup:coverageType a rdf:Property ;
+    rdfs:label "Coverage Type" ;
+    rdfs:comment "Type of coverage: hmo, ppo, epo, pos, medicare, medicaid, tricare, self_pay." ;
+    rdfs:domain checkup:InsuranceInfo ;
+    rdfs:range xsd:string .
+
+checkup:primaryCareProvider a rdf:Property ;
+    rdfs:label "Primary Care Provider" ;
+    rdfs:comment "Name of assigned primary care provider on file with insurance." ;
+    rdfs:domain checkup:InsuranceInfo ;
+    rdfs:range xsd:string .
+
+checkup:pcpPhone a rdf:Property ;
+    rdfs:label "PCP Phone" ;
+    rdfs:comment "Primary care provider office phone for referral verification." ;
+    rdfs:domain checkup:InsuranceInfo ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# MEDICATION SUMMARY PROPERTIES
+# ============================================================================
+
+checkup:medicationName a rdf:Property ;
+    rdfs:label "Medication Name" ;
+    rdfs:comment "Name of the medication (generic or brand)." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:dose a rdf:Property ;
+    rdfs:label "Dose" ;
+    rdfs:comment "Medication dose with units (e.g., '10mg', '500mg')." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:frequency a rdf:Property ;
+    rdfs:label "Frequency" ;
+    rdfs:comment "How often medication is taken: once_daily, twice_daily, three_times_daily, as_needed, weekly, monthly." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:adherenceStatus a rdf:Property ;
+    rdfs:label "Adherence Status" ;
+    rdfs:comment "Self-reported adherence: taking_as_prescribed, usually_take, sometimes_miss, often_miss, stopped." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:adherenceBarrier a rdf:Property ;
+    rdfs:label "Adherence Barrier" ;
+    rdfs:comment "Reason for non-adherence if applicable: cost, side_effects, forgetfulness, access, complexity, other." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:sideEffects a rdf:Property ;
+    rdfs:label "Side Effects" ;
+    rdfs:comment "List of reported side effects as comma-separated string." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:perceivedEffectiveness a rdf:Property ;
+    rdfs:label "Perceived Effectiveness" ;
+    rdfs:comment "Patient assessment of medication effectiveness: very_effective, somewhat_effective, not_sure, not_effective." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:lastRefillDate a rdf:Property ;
+    rdfs:label "Last Refill Date" ;
+    rdfs:comment "Date of most recent prescription refill." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:date .
+
+checkup:prescriber a rdf:Property ;
+    rdfs:label "Prescriber" ;
+    rdfs:comment "Name of prescribing provider." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:sourceRecord a rdf:Property ;
+    rdfs:label "Source Record" ;
+    rdfs:comment "Link to clinical:Medication source record in pod." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:anyURI .
+
+# ============================================================================
+# MEDICATION SUMMARY PROPERTIES - Phase 3 Extensions (v1.2)
+# ============================================================================
+
+checkup:episodeId a rdf:Property ;
+    rdfs:label "Episode ID" ;
+    rdfs:comment "Link to canonical MedicationUseEpisode in CascadeSDK. Enables longitudinal tracking." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:startDate a rdf:Property ;
+    rdfs:label "Start Date" ;
+    rdfs:comment "Date when patient started taking this medication." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:date .
+
+checkup:indication a rdf:Property ;
+    rdfs:label "Indication" ;
+    rdfs:comment "Why the patient takes this medication (patient's understanding of the reason)." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:patientCost a rdf:Property ;
+    rdfs:label "Patient Cost" ;
+    rdfs:comment "Patient's out-of-pocket cost for medication or supplement." ;
+    rdfs:range xsd:decimal .
+
+checkup:costFrequency a rdf:Property ;
+    rdfs:label "Cost Frequency" ;
+    rdfs:comment "Frequency of cost: per_month, per_refill, per_dose, per_bottle, annual." ;
+    rdfs:range xsd:string .
+
+checkup:functionalImpact a rdf:Property ;
+    rdfs:label "Functional Impact" ;
+    rdfs:comment "How this medication helps the patient functionally (e.g., 'helps me sleep')." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:concernsForDoctor a rdf:Property ;
+    rdfs:label "Concerns For Doctor" ;
+    rdfs:comment "Concerns the patient wants to discuss with their healthcare provider." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:needsVerification a owl:DatatypeProperty ;
+    rdfs:label "Needs Verification" ;
+    rdfs:comment "Whether this medication needs patient verification." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:boolean .
+
+checkup:verificationReason a owl:DatatypeProperty ;
+    rdfs:label "Verification Reason" ;
+    rdfs:comment "Why verification is needed: historical, duplicate, conflicting_sources." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:lastVerifiedDate a owl:DatatypeProperty ;
+    rdfs:label "Last Verified Date" ;
+    rdfs:comment "When the patient last verified this medication." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:dateTime .
+
+checkup:importSessionId a owl:ObjectProperty ;
+    rdfs:label "Import Session ID" ;
+    rdfs:comment "Link to the import session that created this medication record." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:anyURI .
+
+# ============================================================================
+# SUPPLEMENT SUMMARY PROPERTIES (v1.1)
+# ============================================================================
+
+checkup:supplementName a rdf:Property ;
+    rdfs:label "Supplement Name" ;
+    rdfs:comment "Name of the supplement or OTC product." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:supplementDose a rdf:Property ;
+    rdfs:label "Supplement Dose" ;
+    rdfs:comment "Dose with units (e.g., '2000 IU', '500mg')." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:supplementFrequency a rdf:Property ;
+    rdfs:label "Supplement Frequency" ;
+    rdfs:comment "How often supplement is taken: once_daily, twice_daily, as_needed, weekly." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:supplementBrand a rdf:Property ;
+    rdfs:label "Supplement Brand" ;
+    rdfs:comment "Brand name if known (e.g., 'Nature Made', 'Garden of Life')." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:supplementForm a rdf:Property ;
+    rdfs:label "Supplement Form" ;
+    rdfs:comment "Physical form: capsule, tablet, softgel, liquid, powder, gummy, spray, patch, tea, tincture, other." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:regulatoryStatus a rdf:Property ;
+    rdfs:label "Regulatory Status" ;
+    rdfs:comment "Regulatory classification distinguishing from FDA-approved medications: dietarySupplement (DSHEA), otcDrug (FDA OTC monograph), homeopathic, herbalRemedy, unknown." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:evidenceStrength a rdf:Property ;
+    rdfs:label "Evidence Strength" ;
+    rdfs:comment "Level of clinical evidence: strongEvidence, moderateEvidence, limitedEvidence, traditionalUse, noEvidence, unknown." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:reasonForUse a rdf:Property ;
+    rdfs:label "Reason For Use" ;
+    rdfs:comment "User-provided reason for taking supplement (e.g., 'bone health', 'sleep support')." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:supplementStartDate a rdf:Property ;
+    rdfs:label "Supplement Start Date" ;
+    rdfs:comment "Date when patient started taking the supplement." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:date .
+
+checkup:supplementIsActive a rdf:Property ;
+    rdfs:label "Supplement Is Active" ;
+    rdfs:comment "Whether patient is currently taking the supplement." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:boolean .
+
+checkup:dsldId a rdf:Property ;
+    rdfs:label "DSLD ID" ;
+    rdfs:comment "NIH Dietary Supplement Label Database identifier for lookup." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+checkup:supplementSourceRecord a rdf:Property ;
+    rdfs:label "Supplement Source Record" ;
+    rdfs:comment "Link to clinical:Supplement source record in pod." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:anyURI .
+
+checkup:doctorAware a rdf:Property ;
+    rdfs:label "Doctor Aware" ;
+    rdfs:comment "Whether the patient's healthcare provider knows about this supplement. Used to identify supplements that should be discussed at visits." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:boolean .
+
+
+# ============================================================================
+# IMMUNIZATION SUMMARY PROPERTIES (v1.7)
+# ============================================================================
+
+checkup:vaccineName a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Name" ;
+    rdfs:comment "Name of the vaccine administered." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:administrationDate a owl:DatatypeProperty ;
+    rdfs:label "Administration Date" ;
+    rdfs:comment "Date the vaccine was administered." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:dateTime .
+
+checkup:immunizationStatus a owl:DatatypeProperty ;
+    rdfs:label "Immunization Status" ;
+    rdfs:comment "Status: completed, entered-in-error, not-done." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:vaccineCode a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Code" ;
+    rdfs:comment "CVX vaccine code for standardized identification." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:vaccineCategory a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Category" ;
+    rdfs:comment "Categorization for intake form display: routine, travel, occupational, other." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:manufacturer a owl:DatatypeProperty ;
+    rdfs:label "Manufacturer" ;
+    rdfs:comment "Vaccine manufacturer name." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:lotNumber a owl:DatatypeProperty ;
+    rdfs:label "Lot Number" ;
+    rdfs:comment "Vaccine lot number." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:expirationDate a owl:DatatypeProperty ;
+    rdfs:label "Expiration Date" ;
+    rdfs:comment "Vaccine expiration date." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:date .
+
+checkup:doseNumber a owl:DatatypeProperty ;
+    rdfs:label "Dose Number" ;
+    rdfs:comment "Dose sequence number in multi-dose series." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:integer .
+
+checkup:doseQuantity a owl:DatatypeProperty ;
+    rdfs:label "Dose Quantity" ;
+    rdfs:comment "Dose quantity administered." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:administrationRoute a owl:DatatypeProperty ;
+    rdfs:label "Administration Route" ;
+    rdfs:comment "Route of vaccine administration: intramuscular, subcutaneous, oral, etc." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:administrationSite a owl:DatatypeProperty ;
+    rdfs:label "Administration Site" ;
+    rdfs:comment "Body site where vaccine was administered: left arm, right arm, etc." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:administeringProvider a owl:DatatypeProperty ;
+    rdfs:label "Administering Provider" ;
+    rdfs:comment "Name of the provider who administered the vaccine." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:administeringLocation a owl:DatatypeProperty ;
+    rdfs:label "Administering Location" ;
+    rdfs:comment "Location where vaccine was administered." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:immunizationNotes a owl:DatatypeProperty ;
+    rdfs:label "Notes" ;
+    rdfs:comment "Additional notes about the immunization." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+checkup:immunizationSourceRecord a owl:ObjectProperty ;
+    rdfs:label "Source Record" ;
+    rdfs:comment "Link to the source clinical:Immunization record." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:anyURI .
+
+# ============================================================================
+# LAB RESULT SUMMARY PROPERTIES (v1.7)
+# ============================================================================
+
+checkup:labCategory a owl:DatatypeProperty ;
+    rdfs:label "Lab Category" ;
+    rdfs:comment "Intake form display category: metabolic, hematology, lipid, thyroid, vitamin, other." ;
+    rdfs:domain checkup:LabResultSummary ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# PROCEDURE SUMMARY PROPERTIES (v1.8)
+# ============================================================================
+# Mixed namespace pattern: checkup: for app-layer fields, clinical: for
+# standardized clinical data fields.
+
+checkup:procedureName a owl:DatatypeProperty ;
+    rdfs:label "Procedure Name" ;
+    rdfs:comment "Name of the medical procedure." ;
+    rdfs:domain checkup:ProcedureSummary ;
+    rdfs:range xsd:string .
+
+checkup:procedureCategory a owl:DatatypeProperty ;
+    rdfs:label "Procedure Category" ;
+    rdfs:comment "Categorization for intake form display: surgical, diagnostic, therapeutic, other." ;
+    rdfs:domain checkup:ProcedureSummary ;
+    rdfs:range xsd:string .
+
+checkup:procedureLocation a owl:DatatypeProperty ;
+    rdfs:label "Procedure Location" ;
+    rdfs:comment "Facility or location where the procedure was performed." ;
+    rdfs:domain checkup:ProcedureSummary ;
+    rdfs:range xsd:string .
+
+checkup:procedureSourceRecord a owl:ObjectProperty ;
+    rdfs:label "Source Record" ;
+    rdfs:comment "Link to the source clinical:Procedure record." ;
+    rdfs:domain checkup:ProcedureSummary ;
+    rdfs:range xsd:anyURI .
+
+# The following clinical: properties are used by ProcedureSummary via the
+# mixed namespace pattern (defined in clinical.ttl):
+# - clinical:procedureStatus (string)
+# - clinical:performedDate (dateTime)
+# - clinical:bodySite (string)
+# - clinical:performer (string)
+# - clinical:outcome (string)
+# - clinical:snomedCode (string)
+# - clinical:cptCode (string)
+
+# ============================================================================
+# ALLERGY SUMMARY PROPERTIES
+# ============================================================================
+
+checkup:allergen a rdf:Property ;
+    rdfs:label "Allergen" ;
+    rdfs:comment "Name of the allergenic substance (drug, food, environmental)." ;
+    rdfs:domain checkup:AllergySummary ;
+    rdfs:range xsd:string .
+
+checkup:reaction a rdf:Property ;
+    rdfs:label "Reaction" ;
+    rdfs:comment "Type of allergic reaction: hives, rash, swelling, difficulty_breathing, anaphylaxis, nausea, other." ;
+    rdfs:domain checkup:AllergySummary ;
+    rdfs:range xsd:string .
+
+checkup:allergySeverity a rdf:Property ;
+    rdfs:label "Allergy Severity" ;
+    rdfs:comment "Severity of allergic reaction: mild, moderate, severe, life_threatening." ;
+    rdfs:domain checkup:AllergySummary ;
+    rdfs:range xsd:string .
+
+checkup:allergyCategory a rdf:Property ;
+    rdfs:label "Allergy Category" ;
+    rdfs:comment "Category of allergen: medication, food, environmental, latex, contrast, other." ;
+    rdfs:domain checkup:AllergySummary ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# CONDITION SUMMARY PROPERTIES
+# ============================================================================
+
+checkup:conditionName a rdf:Property ;
+    rdfs:label "Condition Name" ;
+    rdfs:comment "Name of the health condition or diagnosis." ;
+    rdfs:domain checkup:ConditionSummary ;
+    rdfs:range xsd:string .
+
+checkup:icd10Code a rdf:Property ;
+    rdfs:label "ICD-10 Code" ;
+    rdfs:comment "ICD-10-CM diagnosis code if available." ;
+    rdfs:domain checkup:ConditionSummary ;
+    rdfs:range xsd:string .
+
+checkup:snomedCode a rdf:Property ;
+    rdfs:label "SNOMED Code" ;
+    rdfs:comment "SNOMED CT concept ID if available." ;
+    rdfs:domain checkup:ConditionSummary ;
+    rdfs:range xsd:string .
+
+checkup:onsetDate a rdf:Property ;
+    rdfs:label "Onset Date" ;
+    rdfs:comment "Date when condition was first diagnosed or symptoms began." ;
+    rdfs:domain checkup:ConditionSummary ;
+    rdfs:range xsd:date .
+
+checkup:onsetYear a rdf:Property ;
+    rdfs:label "Onset Year" ;
+    rdfs:comment "Year of condition onset if exact date unknown." ;
+    rdfs:domain checkup:ConditionSummary ;
+    rdfs:range xsd:gYear .
+
+checkup:conditionStatus a rdf:Property ;
+    rdfs:label "Condition Status" ;
+    rdfs:comment "Current status: active, resolved, remission, recurrence, inactive." ;
+    rdfs:domain checkup:ConditionSummary ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# FAMILY HISTORY PROPERTIES
+# ============================================================================
+
+checkup:relativeType a rdf:Property ;
+    rdfs:label "Relative Type" ;
+    rdfs:comment "Relationship to patient: mother, father, sibling, maternal_grandmother, maternal_grandfather, paternal_grandmother, paternal_grandfather, aunt, uncle, child." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:string .
+
+checkup:relativeSex a rdf:Property ;
+    rdfs:label "Relative Sex" ;
+    rdfs:comment "Biological sex of relative: male, female." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:string .
+
+checkup:familyCondition a rdf:Property ;
+    rdfs:label "Family Condition" ;
+    rdfs:comment "Name of health condition the relative has/had." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:string .
+
+checkup:familyConditionCode a rdf:Property ;
+    rdfs:label "Family Condition Code" ;
+    rdfs:comment "ICD-10 or SNOMED code for the family condition." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:string .
+
+checkup:ageAtDiagnosis a rdf:Property ;
+    rdfs:label "Age at Diagnosis" ;
+    rdfs:comment "Relative's age when condition was diagnosed (if known)." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:integer .
+
+checkup:ageAtDeath a rdf:Property ;
+    rdfs:label "Age at Death" ;
+    rdfs:comment "Relative's age at death if deceased." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:integer .
+
+checkup:isDeceased a rdf:Property ;
+    rdfs:label "Is Deceased" ;
+    rdfs:comment "Whether the relative is deceased." ;
+    rdfs:domain checkup:FamilyHistoryEntry ;
+    rdfs:range xsd:boolean .
+
+# ============================================================================
+# SCREENING STATUS PROPERTIES
+# ============================================================================
+
+checkup:screeningType a rdf:Property ;
+    rdfs:label "Screening Type" ;
+    rdfs:comment "Type of preventive screening: mammogram, colonoscopy, pap_smear, psa, bone_density, aaa_ultrasound, lung_ct, diabetes_a1c, lipid_panel, colorectal." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:string .
+
+checkup:screeningStatus a rdf:Property ;
+    rdfs:label "Screening Status" ;
+    rdfs:comment "Current status: not_due, due, overdue, completed, declined, not_applicable." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:string .
+
+checkup:lastCompletedDate a rdf:Property ;
+    rdfs:label "Last Completed Date" ;
+    rdfs:comment "Date when screening was last completed." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:date .
+
+checkup:nextDueDate a rdf:Property ;
+    rdfs:label "Next Due Date" ;
+    rdfs:comment "Date when screening is next due." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:date .
+
+checkup:guidelineSource a rdf:Property ;
+    rdfs:label "Guideline Source" ;
+    rdfs:comment "Source of recommendation: USPSTF, ACS, AAP, ACOG, ADA." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:string .
+
+checkup:gradeLevel a rdf:Property ;
+    rdfs:label "Grade Level" ;
+    rdfs:comment "USPSTF grade if applicable: A, B, C, D, I." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:string .
+
+checkup:applicableAgeMin a rdf:Property ;
+    rdfs:label "Applicable Age Min" ;
+    rdfs:comment "Minimum age for this screening recommendation." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:integer .
+
+checkup:applicableAgeMax a rdf:Property ;
+    rdfs:label "Applicable Age Max" ;
+    rdfs:comment "Maximum age for this screening recommendation." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:integer .
+
+checkup:applicableSex a rdf:Property ;
+    rdfs:label "Applicable Sex" ;
+    rdfs:comment "Sex this screening applies to: male, female, all." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:string .
+
+checkup:frequencyMonths a rdf:Property ;
+    rdfs:label "Frequency Months" ;
+    rdfs:comment "Recommended screening frequency in months." ;
+    rdfs:domain checkup:ScreeningStatus ;
+    rdfs:range xsd:integer .
+
+# ============================================================================
+# VISIT ISSUE (CHIEF COMPLAINT) PROPERTIES
+# ============================================================================
+
+checkup:issueCategory a rdf:Property ;
+    rdfs:label "Issue Category" ;
+    rdfs:comment "Category of health issue: pain, skin, digestive, respiratory, cardiovascular, mental_health, neurological, musculoskeletal, urinary, medication, screening, general, other." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:string .
+
+checkup:issueDescription a rdf:Property ;
+    rdfs:label "Issue Description" ;
+    rdfs:comment "Free text description of the health issue." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:string .
+
+checkup:issueDuration a rdf:Property ;
+    rdfs:label "Issue Duration" ;
+    rdfs:comment "How long the issue has been present: days, weeks, months, years." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:string .
+
+checkup:issueSeverity a rdf:Property ;
+    rdfs:label "Issue Severity" ;
+    rdfs:comment "Severity of the issue: mild, moderate, severe." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:string .
+
+checkup:issueFrequency a rdf:Property ;
+    rdfs:label "Issue Frequency" ;
+    rdfs:comment "How often the issue occurs: constant, intermittent, occasional, rare." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:string .
+
+checkup:affectsDaily a rdf:Property ;
+    rdfs:label "Affects Daily Activities" ;
+    rdfs:comment "Whether the issue impacts daily activities." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:boolean .
+
+checkup:relatedConditions a rdf:Property ;
+    rdfs:label "Related Conditions" ;
+    rdfs:comment "Links to existing condition entries that may be related." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range checkup:ConditionSummary .
+
+checkup:issuePriority a rdf:Property ;
+    rdfs:label "Issue Priority" ;
+    rdfs:comment "User-ranked importance (1 = highest priority)." ;
+    rdfs:domain checkup:VisitIssue ;
+    rdfs:range xsd:integer .
+
+# ============================================================================
+# SUGGESTED QUESTION PROPERTIES
+# ============================================================================
+
+checkup:questionText a rdf:Property ;
+    rdfs:label "Question Text" ;
+    rdfs:comment "The suggested question to ask the provider." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range xsd:string .
+
+checkup:questionCategory a rdf:Property ;
+    rdfs:label "Question Category" ;
+    rdfs:comment "Category: treatment_options, side_effects, prevention, lifestyle, referral, diagnosis, prognosis, medication, screening." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range xsd:string .
+
+checkup:basedOnCondition a rdf:Property ;
+    rdfs:label "Based On Condition" ;
+    rdfs:comment "Link to condition that triggered this question." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range checkup:ConditionSummary .
+
+checkup:basedOnMedication a rdf:Property ;
+    rdfs:label "Based On Medication" ;
+    rdfs:comment "Link to medication that triggered this question." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range checkup:MedicationSummary .
+
+checkup:basedOnIssue a rdf:Property ;
+    rdfs:label "Based On Issue" ;
+    rdfs:comment "Link to visit issue that triggered this question." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range checkup:VisitIssue .
+
+checkup:basedOnTrend a rdf:Property ;
+    rdfs:label "Based On Trend" ;
+    rdfs:comment "Link to a health metric trend that triggered this question." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range health:MetricTrend .
+
+checkup:basedOnTemplate a owl:DatatypeProperty ;
+    rdfs:label "Based On Template" ;
+    rdfs:comment "Template name the question was generated from." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range xsd:string .
+
+checkup:basedOnScreening a owl:ObjectProperty ;
+    rdfs:label "Based On Screening" ;
+    rdfs:comment "Link to the screening record the question relates to." ;
+    rdfs:domain checkup:SuggestedQuestion ;
+    rdfs:range xsd:anyURI .
+
+# ============================================================================
+# DIAGNOSTIC TEST RESULT PROPERTIES
+# ============================================================================
+
+checkup:testType a rdf:Property ;
+    rdfs:label "Test Type" ;
+    rdfs:comment "Type of diagnostic test: pots_check, blood_pressure_series, glucose_series, ecg, sleep_analysis, other." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:string .
+
+checkup:testDate a rdf:Property ;
+    rdfs:label "Test Date" ;
+    rdfs:comment "Date and time when the test was performed." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:dateTime .
+
+checkup:sourceApp a rdf:Property ;
+    rdfs:label "Source App" ;
+    rdfs:comment "Name of the app that generated this result: POTS Check, Cascade Checkup, etc." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:string .
+
+checkup:sourceAppVersion a rdf:Property ;
+    rdfs:label "Source App Version" ;
+    rdfs:comment "Version of the source app." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:string .
+
+checkup:resultSummary a rdf:Property ;
+    rdfs:label "Result Summary" ;
+    rdfs:comment "Brief text summary suitable for intake forms." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:string .
+
+checkup:resultDetails a rdf:Property ;
+    rdfs:label "Result Details" ;
+    rdfs:comment "Link to full result in pod (e.g., pots-check-uuid.ttl)." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:anyURI .
+
+checkup:flaggedForDiscussion a rdf:Property ;
+    rdfs:label "Flagged For Discussion" ;
+    rdfs:comment "Whether user wants to discuss this result with provider." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:boolean .
+
+# POTS Check specific properties
+checkup:potsThresholdMet a rdf:Property ;
+    rdfs:label "POTS Threshold Met" ;
+    rdfs:comment "Whether the POTS diagnostic threshold was met (HR increase >= 30 bpm)." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:boolean .
+
+checkup:maxHeartRateDelta a rdf:Property ;
+    rdfs:label "Max Heart Rate Delta" ;
+    rdfs:comment "Maximum heart rate change during standing test (bpm)." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:double .
+
+checkup:orthostaticFlags a rdf:Property ;
+    rdfs:label "Orthostatic Flags" ;
+    rdfs:comment "Orthostatic findings: hypotension_suspected, hypertension_suspected, none." ;
+    rdfs:domain checkup:DiagnosticTestResult ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# INTAKE FORM DATA AGGREGATE PROPERTIES
+# ============================================================================
+
+checkup:generatedAt a rdf:Property ;
+    rdfs:label "Generated At" ;
+    rdfs:comment "Timestamp when intake form data was generated." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range xsd:dateTime .
+
+checkup:schemaVersion a rdf:Property ;
+    rdfs:label "Schema Version" ;
+    rdfs:comment "Version of the checkup vocabulary used." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range xsd:string .
+
+checkup:hasPatientProfile a rdf:Property ;
+    rdfs:label "Has Patient Profile" ;
+    rdfs:comment "DEPRECATED (v3.0): checkup:PatientProfile class removed. Use cascade:PatientProfile from core.ttl for patient demographics." ;
+    owl:deprecated "true"^^xsd:boolean ;
+    rdfs:domain checkup:IntakeFormData .
+
+checkup:hasInsurance a rdf:Property ;
+    rdfs:label "Has Insurance" ;
+    rdfs:comment "Link to insurance information." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:InsuranceInfo .
+
+checkup:hasMedication a rdf:Property ;
+    rdfs:label "Has Medication" ;
+    rdfs:comment "Link to medication summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:MedicationSummary .
+
+checkup:hasSupplement a rdf:Property ;
+    rdfs:label "Has Supplement" ;
+    rdfs:comment "Link to supplement summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:SupplementSummary .
+
+checkup:hasAllergy a rdf:Property ;
+    rdfs:label "Has Allergy" ;
+    rdfs:comment "Link to allergy summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:AllergySummary .
+
+checkup:hasCondition a rdf:Property ;
+    rdfs:label "Has Condition" ;
+    rdfs:comment "Link to condition summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:ConditionSummary .
+
+checkup:hasFamilyHistory a rdf:Property ;
+    rdfs:label "Has Family History" ;
+    rdfs:comment "Link to family history entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:FamilyHistoryEntry .
+
+checkup:hasVitalsTrend a rdf:Property ;
+    rdfs:label "Has Vitals Trend" ;
+    rdfs:comment "DEPRECATED (v3.0): checkup:VitalSignsTrend class removed. Use health:MetricTrend (Layer 2) and checkup:WellnessSummary (Layer 3) instead." ;
+    owl:deprecated "true"^^xsd:boolean ;
+    rdfs:domain checkup:IntakeFormData .
+
+checkup:hasScreening a rdf:Property ;
+    rdfs:label "Has Screening" ;
+    rdfs:comment "Link to screening status entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:ScreeningStatus .
+
+checkup:hasVisitIssue a rdf:Property ;
+    rdfs:label "Has Visit Issue" ;
+    rdfs:comment "Link to visit issue/chief complaint." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:VisitIssue .
+
+checkup:hasSuggestedQuestion a rdf:Property ;
+    rdfs:label "Has Suggested Question" ;
+    rdfs:comment "Link to generated question for provider." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:SuggestedQuestion .
+
+checkup:hasDiagnosticResult a rdf:Property ;
+    rdfs:label "Has Diagnostic Result" ;
+    rdfs:comment "Link to diagnostic test result from external app." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:DiagnosticTestResult .
+
+checkup:hasWellnessSummary a rdf:Property ;
+    rdfs:label "Has Wellness Summary" ;
+    rdfs:comment "Link to wellness summary with trends and baselines." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:WellnessSummary .
+
+checkup:hasTrendInsight a rdf:Property ;
+    rdfs:label "Has Trend Insight" ;
+    rdfs:comment "Link to a patient-readable trend insight." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:TrendInsight .
+
+checkup:hasCorrelationInsight a rdf:Property ;
+    rdfs:label "Has Correlation Insight" ;
+    rdfs:comment "Link to a temporal correlation insight." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:CorrelationInsight .
+
+checkup:hasKeyIndicator a rdf:Property ;
+    rdfs:label "Has Key Indicator" ;
+    rdfs:comment "Link to a key health indicator for dashboard display." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:KeyIndicator .
+
+checkup:hasAttentionItem a rdf:Property ;
+    rdfs:label "Has Attention Item" ;
+    rdfs:comment "Link to an item requiring patient attention." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:AttentionItem .
+
+checkup:hasVisitPrepSummary a rdf:Property ;
+    rdfs:label "Has Visit Prep Summary" ;
+    rdfs:comment "Link to a curated visit preparation summary." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:VisitPrepSummary .
+
+# ============================================================================
+# DATA PROVENANCE PROPERTIES (shared across record types)
+# ============================================================================
+
+checkup:hasProvenance a rdf:Property ;
+    rdfs:label "Has Provenance" ;
+    rdfs:comment "Link to provenance information for any record." ;
+    rdfs:range cascade:DataProvenance .
+
+checkup:provenanceType a rdf:Property ;
+    rdfs:label "Provenance Type" ;
+    rdfs:comment "Source type: ehr_verified, self_reported, scanned, device, ai_extracted, imported." ;
+    rdfs:range xsd:string .
+
+checkup:provenanceSource a rdf:Property ;
+    rdfs:label "Provenance Source" ;
+    rdfs:comment "Specific source identifier: MyChart, Apple Health, manual entry, etc." ;
+    rdfs:range xsd:string .
+
+checkup:provenanceDate a rdf:Property ;
+    rdfs:label "Provenance Date" ;
+    rdfs:comment "Date when data was recorded or verified at source." ;
+    rdfs:range xsd:dateTime .
+
+# ============================================================================
+# EHR PROVENANCE PROPERTIES (v1.3 - Medication Experience Phase A)
+# ============================================================================
+# Extended provenance properties for tracking medication data from EHR systems.
+# These properties enable any Cascade-compatible app to know where medication
+# data originated, supporting data sovereignty across applications.
+
+checkup:ehrSystemName a rdf:Property ;
+    rdfs:label "EHR System Name" ;
+    rdfs:comment "Name of the EHR patient portal or system: MyChart, Swedish Connect, Cerner, etc." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:ehrOrganization a rdf:Property ;
+    rdfs:label "EHR Organization" ;
+    rdfs:comment "Healthcare organization name associated with the EHR record: Virginia Mason, Swedish Medical, etc." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:fhirResourceType a rdf:Property ;
+    rdfs:label "FHIR Resource Type" ;
+    rdfs:comment "FHIR resource type the medication was derived from: MedicationStatement, MedicationDispense, MedicationRequest, MedicationAdministration." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:lastSyncedFromSource a rdf:Property ;
+    rdfs:label "Last Synced From Source" ;
+    rdfs:comment "Timestamp when this medication record was last synchronized from the EHR source." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:dateTime .
+
+# ============================================================================
+# MEDICATION CLASSIFICATION PROPERTIES (v1.3 - Medication Experience Phase A)
+# ============================================================================
+# Properties for classifying medications into relevance tiers and tracking
+# brand/generic name mappings for display purposes.
+
+checkup:relevanceTier a rdf:Property ;
+    rdfs:label "Relevance Tier" ;
+    rdfs:comment "Classification tier for medication relevance. Values: 'current' (actively taking), 'needsVerification' (status unclear), 'historical' (past medication), 'filtered' (procedure/IV meds)." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:brandName a rdf:Property ;
+    rdfs:label "Brand Name" ;
+    rdfs:comment "Common brand name for the medication if different from generic name. Stored in pod for portability across apps." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:commonBrandNames a rdf:Property ;
+    rdfs:label "Common Brand Names" ;
+    rdfs:comment "Comma-separated list of common brand names for reference data." ;
+    rdfs:range xsd:string .
+
+checkup:therapeuticClass a rdf:Property ;
+    rdfs:label "Therapeutic Class" ;
+    rdfs:comment "Therapeutic/pharmacological class: Beta Blocker, ACE Inhibitor, SSRI, etc." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+checkup:tierClassificationReason a rdf:Property ;
+    rdfs:label "Tier Classification Reason" ;
+    rdfs:comment "Human-readable explanation for why a medication was classified into its tier." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# INSIGHT & CORRELATION CLASSES (v1.4)
+# ============================================================================
+# Layer 3 classes that synthesize across data domains to produce patient-facing
+# insights. These enable MVP features F4 (Medication-Metric Timeline),
+# F5 (Health Score), F8 (Attention Items), and F9 (Visit Prep).
+
+checkup:WellnessSummary a owl:Class ;
+    rdfs:label "Wellness Summary" ;
+    rdfs:comment "Layer 3 patient-facing summary of wellness data. Aggregates trends and baselines from health: Layer 2 properties into a patient-readable format." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:TrendInsight a owl:Class ;
+    rdfs:label "Trend Insight" ;
+    rdfs:comment "A patient-readable observation derived from trend data. Example: 'Your resting heart rate has dropped 5 bpm since you started walking 10k steps/day.'" ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:CorrelationInsight a owl:Class ;
+    rdfs:label "Correlation Insight" ;
+    rdfs:comment "Links two data domains with an observed temporal relationship. Example: medication start date correlates with metric change. IMPORTANT: Temporal correlation only — never implies causation." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:KeyIndicator a owl:Class ;
+    rdfs:label "Key Indicator" ;
+    rdfs:comment "A distilled, patient-friendly health metric chosen for its predictive value and simplicity. Used for dashboard summaries and health scores." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:AttentionItem a owl:Class ;
+    rdfs:label "Attention Item" ;
+    rdfs:comment "Flags when a metric deviates significantly from personal baseline, data has gone stale, or a trend crosses a threshold. Rule-based, not clinical advice." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+# --- WellnessSummary Properties ---
+
+checkup:wellnessTrend a owl:ObjectProperty ;
+    rdfs:label "Wellness Trend" ;
+    rdfs:comment "Link to a health:MetricTrend for a wellness metric" ;
+    rdfs:domain checkup:WellnessSummary ;
+    rdfs:range health:MetricTrend .
+
+checkup:wellnessBaselineDate a owl:DatatypeProperty ;
+    rdfs:label "Baseline Date" ;
+    rdfs:comment "Date of the baseline snapshot this summary compares against" ;
+    rdfs:domain checkup:WellnessSummary ;
+    rdfs:range xsd:dateTime .
+
+# --- TrendInsight Properties ---
+
+checkup:insightText a owl:DatatypeProperty ;
+    rdfs:label "Insight Text" ;
+    rdfs:comment "Patient-readable description of the insight" ;
+    rdfs:domain checkup:TrendInsight ;
+    rdfs:range xsd:string .
+
+checkup:insightSourceTrend a owl:ObjectProperty ;
+    rdfs:label "Source Trend" ;
+    rdfs:comment "The health:MetricTrend this insight is derived from" ;
+    rdfs:domain checkup:TrendInsight ;
+    rdfs:range health:MetricTrend .
+
+checkup:insightGeneratedBy a owl:ObjectProperty ;
+    rdfs:label "Generated By" ;
+    rdfs:comment "The agent that produced this insight. Should link to a prov:Agent (e.g., a cascade:DataSource for 'cascade-rule-engine', or a provider agent). Aligns with W3C PROV-O prov:wasGeneratedBy pattern." ;
+    rdfs:domain checkup:TrendInsight ;
+    rdfs:range prov:Agent .
+
+# --- CorrelationInsight Properties ---
+
+checkup:correlationMetric a owl:ObjectProperty ;
+    rdfs:label "Correlated Metric" ;
+    rdfs:comment "The wellness metric involved in the correlation" ;
+    rdfs:domain checkup:CorrelationInsight ;
+    rdfs:range health:MetricTrend .
+
+checkup:correlationEvent a owl:ObjectProperty ;
+    rdfs:label "Correlated Event" ;
+    rdfs:comment "The clinical event (medication start/stop, condition onset) involved in the correlation" ;
+    rdfs:domain checkup:CorrelationInsight .
+
+checkup:correlationText a owl:DatatypeProperty ;
+    rdfs:label "Correlation Text" ;
+    rdfs:comment "Patient-readable description. Must use temporal language only ('started approximately after'), never causal language ('caused by')." ;
+    rdfs:domain checkup:CorrelationInsight ;
+    rdfs:range xsd:string .
+
+checkup:correlationTimeLag a owl:DatatypeProperty ;
+    rdfs:label "Time Lag" ;
+    rdfs:comment "Days between the clinical event and the observed metric change onset" ;
+    rdfs:domain checkup:CorrelationInsight ;
+    rdfs:range xsd:integer .
+
+# --- KeyIndicator Properties ---
+
+checkup:indicatorMetric a owl:DatatypeProperty ;
+    rdfs:label "Indicator Metric Key" ;
+    rdfs:comment "The metric key this indicator represents (e.g., 'restingHeartRate')" ;
+    rdfs:domain checkup:KeyIndicator ;
+    rdfs:range xsd:string .
+
+checkup:indicatorValue a owl:DatatypeProperty ;
+    rdfs:domain checkup:KeyIndicator ;
+    rdfs:range xsd:decimal .
+
+checkup:indicatorUnit a owl:DatatypeProperty ;
+    rdfs:domain checkup:KeyIndicator ;
+    rdfs:range xsd:string .
+
+checkup:indicatorLabel a owl:DatatypeProperty ;
+    rdfs:label "Patient-Friendly Label" ;
+    rdfs:comment "e.g., 'Your resting heart rate' instead of 'RHR'" ;
+    rdfs:domain checkup:KeyIndicator ;
+    rdfs:range xsd:string .
+
+checkup:indicatorStatus a owl:DatatypeProperty ;
+    rdfs:label "Status" ;
+    rdfs:comment "Traffic light: 'good', 'watch', 'attention'" ;
+    rdfs:domain checkup:KeyIndicator ;
+    rdfs:range xsd:string .
+
+# --- AttentionItem Properties ---
+
+checkup:attentionReason a owl:DatatypeProperty ;
+    rdfs:label "Attention Reason" ;
+    rdfs:comment "Why this needs attention: 'baseline_deviation', 'stale_data', 'threshold_crossed'" ;
+    rdfs:domain checkup:AttentionItem ;
+    rdfs:range xsd:string .
+
+checkup:attentionMetric a owl:DatatypeProperty ;
+    rdfs:label "Attention Metric" ;
+    rdfs:domain checkup:AttentionItem ;
+    rdfs:range xsd:string .
+
+checkup:attentionText a owl:DatatypeProperty ;
+    rdfs:label "Attention Text" ;
+    rdfs:comment "Patient-readable explanation: 'Your blood pressure hasn't been recorded in 60 days'" ;
+    rdfs:domain checkup:AttentionItem ;
+    rdfs:range xsd:string .
+
+checkup:attentionSeverity a owl:DatatypeProperty ;
+    rdfs:label "Severity" ;
+    rdfs:comment "'info', 'watch', 'action'" ;
+    rdfs:domain checkup:AttentionItem ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# VISIT PREP SUMMARY (v1.4)
+# ============================================================================
+# A curated clinical summary for appointments. Combines wellness trends,
+# medication context, and patient questions into a one-page document.
+
+checkup:VisitPrepSummary a owl:Class ;
+    rdfs:label "Visit Prep Summary" ;
+    rdfs:comment "A curated, one-page clinical summary designed for a 15-minute appointment. Auto-generated from metric changes, medication context, and patient questions, then user-edited before export." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:visitPrepDate a owl:DatatypeProperty ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range xsd:dateTime .
+
+checkup:visitPrepComparisonDate a owl:DatatypeProperty ;
+    rdfs:comment "Date of the previous snapshot being compared against" ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range xsd:dateTime .
+
+checkup:visitPrepChange a owl:ObjectProperty ;
+    rdfs:comment "A metric change included in this visit prep" ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range health:MetricTrend .
+
+checkup:visitPrepCorrelation a owl:ObjectProperty ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range checkup:CorrelationInsight .
+
+checkup:visitPrepAttention a owl:ObjectProperty ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range checkup:AttentionItem .
+
+checkup:visitPrepUserNotes a owl:DatatypeProperty ;
+    rdfs:comment "Patient-authored questions and concerns for the visit" ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range xsd:string .
+
+checkup:noteContent a owl:DatatypeProperty ;
+    rdfs:label "Note Content" ;
+    rdfs:comment "Free-text notes for visit preparation. Merges previously separate VisitPrepNotes content into VisitPrepSummary." ;
+    rdfs:domain checkup:VisitPrepSummary ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# ADHERENCE & DISCUSSION CLASSES (v1.5)
+# ============================================================================
+# Patient-reported adherence tracking and visit discussion preparation.
+# Supports Bug 6/11 export overhaul Phase 4B serialization.
+
+checkup:DailyCheckIn a owl:Class ;
+    rdfs:label "Daily Check-in" ;
+    rdfs:comment "Patient-reported daily medication adherence check-in capturing response status, missed medications, and optional notes." ;
+    cascade:subConcern "self-report" ;
+    rdfs:subClassOf health:SelfReport .
+
+checkup:DiscussionTopic a owl:Class ;
+    rdfs:label "Discussion Topic" ;
+    rdfs:comment "AI-generated or user-created topic for discussion during a healthcare visit. Topics are derived from medication data, adherence patterns, supplement interactions, or user input." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:CheckInSettings a owl:Class ;
+    rdfs:label "Check-in Settings" ;
+    rdfs:comment "Application configuration for daily check-in notification scheduling and day-of-week preferences." ;
+    cascade:subConcern "app-config" .
+
+# --- DailyCheckIn Properties ---
+
+checkup:checkInDate a owl:DatatypeProperty ;
+    rdfs:label "Check-in Date" ;
+    rdfs:comment "Date of the check-in (normalized to midnight)" ;
+    rdfs:domain checkup:DailyCheckIn ;
+    rdfs:range xsd:dateTime .
+
+checkup:checkInResponse a owl:DatatypeProperty ;
+    rdfs:label "Check-in Response" ;
+    rdfs:comment "Adherence response: allTaken, missedSome, skippedToday" ;
+    rdfs:domain checkup:DailyCheckIn ;
+    rdfs:range xsd:string .
+
+checkup:missedMedicationIds a owl:DatatypeProperty ;
+    rdfs:label "Missed Medication IDs" ;
+    rdfs:comment "Comma-separated UUIDs of missed medications (when response is missedSome)" ;
+    rdfs:domain checkup:DailyCheckIn ;
+    rdfs:range xsd:string .
+
+checkup:checkInNotes a owl:DatatypeProperty ;
+    rdfs:label "Check-in Notes" ;
+    rdfs:comment "Optional patient notes about the day" ;
+    rdfs:domain checkup:DailyCheckIn ;
+    rdfs:range xsd:string .
+
+checkup:submittedAt a owl:DatatypeProperty ;
+    rdfs:label "Submitted At" ;
+    rdfs:comment "Timestamp when the check-in was submitted" ;
+    rdfs:domain checkup:DailyCheckIn ;
+    rdfs:range xsd:dateTime .
+
+# --- DiscussionTopic Properties ---
+
+checkup:topicText a owl:DatatypeProperty ;
+    rdfs:label "Topic Text" ;
+    rdfs:comment "The discussion topic question or statement" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:string .
+
+checkup:topicCategory a owl:DatatypeProperty ;
+    rdfs:label "Topic Category" ;
+    rdfs:comment "Category: durationBased, recentChange, adherenceConcern, sideEffectReport, multipleForSame, supplementDoctor, interactionRisk, refillDue, effectivenessConcern, costConcern, custom" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:string .
+
+checkup:topicSource a owl:DatatypeProperty ;
+    rdfs:label "Topic Source" ;
+    rdfs:comment "Source type: medication, supplement, medicationPair, supplementMedicationPair, adherencePattern, custom" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:string .
+
+checkup:relevanceScore a owl:DatatypeProperty ;
+    rdfs:label "Relevance Score" ;
+    rdfs:comment "AI-computed relevance score (0.0-1.0)" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:double .
+
+checkup:isSelected a owl:DatatypeProperty ;
+    rdfs:label "Is Selected" ;
+    rdfs:comment "Whether the topic is active for the next visit" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:boolean .
+
+checkup:relatedMedicationName a owl:DatatypeProperty ;
+    rdfs:label "Related Medication Name" ;
+    rdfs:comment "Optional medication name providing context" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:string .
+
+checkup:detailText a owl:DatatypeProperty ;
+    rdfs:label "Detail Text" ;
+    rdfs:comment "Optional supplementary detail text" ;
+    rdfs:domain checkup:DiscussionTopic ;
+    rdfs:range xsd:string .
+
+# --- CheckInSettings Properties ---
+
+checkup:checkInEnabled a owl:DatatypeProperty ;
+    rdfs:label "Check-in Enabled" ;
+    rdfs:comment "Whether daily check-ins are active" ;
+    rdfs:domain checkup:CheckInSettings ;
+    rdfs:range xsd:boolean .
+
+checkup:notificationHour a owl:DatatypeProperty ;
+    rdfs:label "Notification Hour" ;
+    rdfs:comment "Notification hour in 24-hour format (0-23)" ;
+    rdfs:domain checkup:CheckInSettings ;
+    rdfs:range xsd:integer .
+
+checkup:notificationMinute a owl:DatatypeProperty ;
+    rdfs:label "Notification Minute" ;
+    rdfs:comment "Notification minute (0-59)" ;
+    rdfs:domain checkup:CheckInSettings ;
+    rdfs:range xsd:integer .
+
+checkup:enabledDays a owl:DatatypeProperty ;
+    rdfs:label "Enabled Days" ;
+    rdfs:comment "Comma-separated enabled days: sunday, monday, tuesday, wednesday, thursday, friday, saturday" ;
+    rdfs:domain checkup:CheckInSettings ;
+    rdfs:range xsd:string .
+
+# --- IntakeFormData aggregate links (v1.5) ---
+
+checkup:hasDailyCheckIn a owl:ObjectProperty ;
+    rdfs:label "Has Daily Check-in" ;
+    rdfs:comment "Link to a daily medication adherence check-in record." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:DailyCheckIn .
+
+checkup:hasDiscussionTopic a owl:ObjectProperty ;
+    rdfs:label "Has Discussion Topic" ;
+    rdfs:comment "Link to a discussion topic for a healthcare visit." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:DiscussionTopic .
+
+checkup:hasCheckInSettings a owl:ObjectProperty ;
+    rdfs:label "Has Check-in Settings" ;
+    rdfs:comment "Link to check-in notification configuration." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:CheckInSettings .
+
+# ============================================================================
+# INTAKE QUESTIONNAIRE CLASSES (v1.6)
+# ============================================================================
+# FHIR-inspired intake questionnaire response model using native Cascade
+# Protocol serialization. Uses LOINC panel codes as questionnaire identifiers
+# and SNOMED CT for coded answers. Supports template-driven intake form
+# expansion (Kaiser eCheck-In gap analysis: surgical history, social history,
+# advanced care planning, pharmacy preference).
+#
+# Design rationale: Full FHIR QuestionnaireResponse was evaluated and
+# rejected — ~5-6x more verbose in RDF/Turtle due to fhir:v blank-node
+# wrapping for every primitive value, creates two incompatible RDF patterns
+# in the same Pod, and no standard FHIR Questionnaires combine surgical +
+# social + safety screening into a single intake form. This hybrid approach
+# uses LOINC/SNOMED as the actual vocabulary with checkup: providing only
+# the minimal container. A mechanical transformation to FHIR
+# QuestionnaireResponse JSON is preserved for clinical system export.
+#
+# See: https://hl7.org/fhir/questionnaireresponse.html
+
+checkup:IntakeQuestionnaireResponse a owl:Class ;
+    rdfs:label "Intake Questionnaire Response" ;
+    rdfs:comment "Response to a standardized intake questionnaire section. Structure inspired by FHIR QuestionnaireResponse but uses native Cascade Protocol serialization. Uses LOINC panel codes as questionnaire identifiers and SNOMED CT codes for standardized answers." ;
+    cascade:subConcern "intake" ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:seeAlso fhir:QuestionnaireResponse .
+
+checkup:ResponseItem a owl:Class ;
+    rdfs:label "Response Item" ;
+    rdfs:comment "A question-answer pair within an intake questionnaire response. Uses LOINC item codes as link identifiers and SNOMED CT codes for coded answers where available. Supports nested sub-items via childItem for hierarchical questionnaire structures." ;
+    cascade:subConcern "intake" ;
+    rdfs:subClassOf prov:Entity .
+
+# --- IntakeQuestionnaireResponse Properties ---
+
+checkup:questionnaireId a owl:DatatypeProperty ;
+    rdfs:label "Questionnaire ID" ;
+    rdfs:comment "LOINC panel code identifying the questionnaire section (e.g., 71421-2 for Social History, 10187-3 for Review of Systems)" ;
+    rdfs:domain checkup:IntakeQuestionnaireResponse ;
+    rdfs:range xsd:string .
+
+checkup:questionnaireTitle a owl:DatatypeProperty ;
+    rdfs:label "Questionnaire Title" ;
+    rdfs:comment "Human-readable title of the questionnaire section" ;
+    rdfs:domain checkup:IntakeQuestionnaireResponse ;
+    rdfs:range xsd:string .
+
+checkup:responseItem a owl:ObjectProperty ;
+    rdfs:label "Response Item" ;
+    rdfs:comment "Link to a ResponseItem containing a question-answer pair" ;
+    rdfs:domain checkup:IntakeQuestionnaireResponse ;
+    rdfs:range checkup:ResponseItem .
+
+checkup:completedAt a owl:DatatypeProperty ;
+    rdfs:label "Completed At" ;
+    rdfs:comment "Timestamp when the questionnaire response was completed" ;
+    rdfs:domain checkup:IntakeQuestionnaireResponse ;
+    rdfs:range xsd:dateTime .
+
+# --- ResponseItem Properties ---
+
+checkup:itemLinkId a owl:DatatypeProperty ;
+    rdfs:label "Item Link ID" ;
+    rdfs:comment "LOINC item code identifying the question (e.g., 72166-2 for Tobacco smoking status, 63512-8 for Alcohol use)" ;
+    rdfs:domain checkup:ResponseItem ;
+    rdfs:range xsd:string .
+
+checkup:itemText a owl:DatatypeProperty ;
+    rdfs:label "Item Text" ;
+    rdfs:comment "Human-readable question display text" ;
+    rdfs:domain checkup:ResponseItem ;
+    rdfs:range xsd:string .
+
+checkup:itemAnswer a owl:DatatypeProperty ;
+    rdfs:label "Item Answer" ;
+    rdfs:comment "Free-text answer value" ;
+    rdfs:domain checkup:ResponseItem ;
+    rdfs:range xsd:string .
+
+checkup:itemAnswerCode a owl:DatatypeProperty ;
+    rdfs:label "Item Answer Code" ;
+    rdfs:comment "Coded answer value from a standard terminology (SNOMED CT or LOINC answer code)" ;
+    rdfs:domain checkup:ResponseItem ;
+    rdfs:range xsd:string .
+
+checkup:itemAnswerCodeSystem a owl:DatatypeProperty ;
+    rdfs:label "Item Answer Code System" ;
+    rdfs:comment "Code system URI for the coded answer (e.g., http://snomed.info/sct/, http://loinc.org/)" ;
+    rdfs:domain checkup:ResponseItem ;
+    rdfs:range xsd:anyURI .
+
+checkup:childItem a owl:ObjectProperty ;
+    rdfs:label "Child Item" ;
+    rdfs:comment "Nested sub-item for hierarchical questionnaire structures (e.g., follow-up questions based on answers)" ;
+    rdfs:domain checkup:ResponseItem ;
+    rdfs:range checkup:ResponseItem .
+
+# --- IntakeFormData aggregate link (v1.6) ---
+
+checkup:hasQuestionnaireResponse a owl:ObjectProperty ;
+    rdfs:label "Has Questionnaire Response" ;
+    rdfs:comment "Link to a completed intake questionnaire response section." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:IntakeQuestionnaireResponse .
+
+# --- IntakeFormData aggregate links (v1.7) ---
+
+checkup:hasImmunization a owl:ObjectProperty ;
+    rdfs:label "Has Immunization" ;
+    rdfs:comment "Link to an immunization summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:ImmunizationSummary .
+
+checkup:hasLabResult a owl:ObjectProperty ;
+    rdfs:label "Has Lab Result" ;
+    rdfs:comment "Link to a lab result summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:LabResultSummary .
+
+checkup:hasWellnessBaseline a owl:ObjectProperty ;
+    rdfs:label "Has Wellness Baseline" ;
+    rdfs:comment "DEPRECATED (v3.0): checkup:WellnessBaseline class removed. Use checkup:WellnessProfileReference to link to SDK HealthProfile." ;
+    owl:deprecated "true"^^xsd:boolean ;
+    rdfs:domain checkup:IntakeFormData .
+
+checkup:hasActivitySummary a owl:ObjectProperty ;
+    rdfs:label "Has Activity Summary" ;
+    rdfs:comment "DEPRECATED (v3.0): checkup:ActivitySummary class removed. Use checkup:WellnessProfileReference to link to SDK HealthProfile." ;
+    owl:deprecated "true"^^xsd:boolean ;
+    rdfs:domain checkup:IntakeFormData .
+
+# --- IntakeFormData aggregate links (v1.8) ---
+
+checkup:hasProcedure a owl:ObjectProperty ;
+    rdfs:label "Has Procedure" ;
+    rdfs:comment "Link to a procedure summary entry." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:ProcedureSummary .
+
+# ============================================================================
+# MEDICATION CHANGE RECORD (v1.9)
+# ============================================================================
+# Tracks changes to medications and supplements between visit snapshots.
+# Consumed by report generators (PlainTextReportGenerator, PatientBriefSections,
+# ProviderViews) for the "Changes Since Last Visit" section.
+
+checkup:MedicationChangeRecord a owl:Class ;
+    rdfs:label "Medication Change Record" ;
+    rdfs:comment "A recorded change to a medication or supplement since the last visit snapshot. Tracked for the Changes Since Last Visit report section." ;
+    cascade:subConcern "analytics" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:changeType a owl:DatatypeProperty ;
+    rdfs:label "Change Type" ;
+    rdfs:comment "Type of change: added, stopped, doseChanged, frequencyChanged, adherenceChanged, statusChanged." ;
+    rdfs:domain checkup:MedicationChangeRecord ;
+    rdfs:range xsd:string .
+
+checkup:changedField a owl:DatatypeProperty ;
+    rdfs:label "Changed Field" ;
+    rdfs:comment "Name of the field that was changed (e.g., dose, frequency)." ;
+    rdfs:domain checkup:MedicationChangeRecord ;
+    rdfs:range xsd:string .
+
+checkup:changeRecordPreviousValue a owl:DatatypeProperty ;
+    rdfs:label "Previous Value" ;
+    rdfs:comment "Value of the field before the change." ;
+    rdfs:domain checkup:MedicationChangeRecord ;
+    rdfs:range xsd:string .
+
+checkup:changeRecordNewValue a owl:DatatypeProperty ;
+    rdfs:label "New Value" ;
+    rdfs:comment "Value of the field after the change." ;
+    rdfs:domain checkup:MedicationChangeRecord ;
+    rdfs:range xsd:string .
+
+checkup:changeDate a owl:DatatypeProperty ;
+    rdfs:label "Change Date" ;
+    rdfs:comment "Date when the change occurred." ;
+    rdfs:domain checkup:MedicationChangeRecord ;
+    rdfs:range xsd:dateTime .
+
+checkup:hasChange a owl:ObjectProperty ;
+    rdfs:label "Has Change" ;
+    rdfs:comment "Link from a MedicationSummary or SupplementSummary to a change record." ;
+    rdfs:range checkup:MedicationChangeRecord .
+
+# --- IntakeFormData aggregate links (v1.9) ---
+# (hasChange is defined on MedicationSummary/SupplementSummary, not IntakeFormData)
+
+# ============================================================================
+# VISIT PREP TRAY (v3.1 — Task A7)
+# ============================================================================
+
+checkup:VisitPrepTray a owl:Class ;
+    rdfs:label "Visit Prep Tray" ;
+    rdfs:comment "Per-appointment visit preparation container grouping issues, discussion topics, questions, and notes. Uses a typed payload wrapper (VisitItemPayload) to preserve existing type richness from VisitIssue, DiscussionTopic, and SuggestedQuestion." ;
+    cascade:subConcern "intake" ;
+    rdfs:subClassOf prov:Entity .
+
+checkup:VisitTrayItem a owl:Class ;
+    rdfs:label "Visit Tray Item" ;
+    rdfs:comment "A typed item within a VisitPrepTray. Wraps VisitIssue, DiscussionTopic, SuggestedQuestion, note, or custom content with intent category and resolution tracking." ;
+    rdfs:subClassOf prov:Entity .
+
+# --- VisitPrepTray Properties ---
+
+checkup:prepTitle a owl:DatatypeProperty ;
+    rdfs:label "Prep Title" ;
+    rdfs:comment "Display title for the visit prep (e.g., 'Rheumatologist - Feb 28')." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range xsd:string .
+
+checkup:appointmentDate a owl:DatatypeProperty ;
+    rdfs:label "Appointment Date" ;
+    rdfs:comment "Scheduled appointment date and time." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range xsd:dateTime .
+
+checkup:prepProviderName a owl:DatatypeProperty ;
+    rdfs:label "Prep Provider Name" ;
+    rdfs:comment "Name of the healthcare provider for this appointment." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range xsd:string .
+
+checkup:specialty a owl:DatatypeProperty ;
+    rdfs:label "Specialty" ;
+    rdfs:comment "Provider specialty (e.g., 'Rheumatology', 'Cardiology')." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range xsd:string .
+
+checkup:visitPrepStatus a owl:DatatypeProperty ;
+    rdfs:label "Visit Prep Status" ;
+    rdfs:comment "Tray status: preparing, ready, completed." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range xsd:string .
+
+checkup:prepCompletedDate a owl:DatatypeProperty ;
+    rdfs:label "Prep Completed Date" ;
+    rdfs:comment "When the visit was marked completed." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range xsd:dateTime .
+
+checkup:hasTrayItem a owl:ObjectProperty ;
+    rdfs:label "Has Tray Item" ;
+    rdfs:comment "Link from a VisitPrepTray to a VisitTrayItem." ;
+    rdfs:domain checkup:VisitPrepTray ;
+    rdfs:range checkup:VisitTrayItem .
+
+# --- VisitTrayItem Properties ---
+
+checkup:payloadType a owl:DatatypeProperty ;
+    rdfs:label "Payload Type" ;
+    rdfs:comment "Payload discriminator: issue, topic, question, note, custom." ;
+    rdfs:domain checkup:VisitTrayItem ;
+    rdfs:range xsd:string .
+
+checkup:intentCategory a owl:DatatypeProperty ;
+    rdfs:label "Intent Category" ;
+    rdfs:comment "Intent of the tray item: discuss, schedule, inform, ask." ;
+    rdfs:domain checkup:VisitTrayItem ;
+    rdfs:range xsd:string .
+
+checkup:isResolved a owl:DatatypeProperty ;
+    rdfs:label "Is Resolved" ;
+    rdfs:comment "Whether the tray item has been addressed or resolved." ;
+    rdfs:domain checkup:VisitTrayItem ;
+    rdfs:range xsd:boolean .
+
+checkup:sourceSection a owl:DatatypeProperty ;
+    rdfs:label "Source Section" ;
+    rdfs:comment "Health Map section this item originated from (e.g., 'medications', 'conditions')." ;
+    rdfs:domain checkup:VisitTrayItem ;
+    rdfs:range xsd:string .
+
+checkup:sourceRecordId a owl:DatatypeProperty ;
+    rdfs:label "Source Record ID" ;
+    rdfs:comment "UUID linking to the source record that prompted this tray item." ;
+    rdfs:domain checkup:VisitTrayItem ;
+    rdfs:range xsd:anyURI .
+
+# --- IntakeFormData aggregate links (v3.1) ---
+
+checkup:hasVisitPrep a owl:ObjectProperty ;
+    rdfs:label "Has Visit Prep" ;
+    rdfs:comment "Link from IntakeFormData to a VisitPrepTray." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:VisitPrepTray .
+
+checkup:activeVisitPrepId a owl:DatatypeProperty ;
+    rdfs:label "Active Visit Prep ID" ;
+    rdfs:comment "UUID of the currently active visit prep tray on IntakeFormData." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# DARK VOCABULARY REMEDIATION (v2.2 — PF1-R)
+# ============================================================================
+# Properties previously emitted by CheckupSerializer but not formally defined.
+# Corrected property names and new definitions added in Schema Refactoring
+# Plan Phase 3, PF1-R.
+
+# --- IntakeFormData aggregate link ---
+
+checkup:hasLabResults a owl:ObjectProperty ;
+    rdfs:label "Has Lab Results" ;
+    rdfs:comment "Link to a lab result summary entry. Replaces dark vocabulary checkup:hasLabResultSummary." ;
+    rdfs:domain checkup:IntakeFormData ;
+    rdfs:range checkup:LabResultSummary .
+
+# --- Structural / reference properties ---
+
+checkup:wellnessProfileRef a owl:ObjectProperty ;
+    rdfs:label "Wellness Profile Reference" ;
+    rdfs:comment "URI reference to the patient's HealthProfile wellness data file." ;
+    rdfs:domain checkup:IntakeFormData .
+
+checkup:lastSnapshotDate a owl:DatatypeProperty ;
+    rdfs:label "Last Snapshot Date" ;
+    rdfs:comment "When the medication or supplement data was last snapshotted from clinical records." ;
+    rdfs:range xsd:dateTime .
+
+# --- Renamed medication property ---
+
+checkup:medicationEndDate a owl:DatatypeProperty ;
+    rdfs:label "Medication End Date" ;
+    rdfs:comment "End date for a medication prescription. Replaces dark vocabulary checkup:endDate (disambiguated from other end-date uses). NOTE: This reflects the administrative EHR order expiry date, which may not match the actual supply exhaustion date. Use checkup:supplyEndDate for the computed supply end date." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:date .
+
+checkup:supplyEndDate a owl:DatatypeProperty ;
+    rdfs:label "Supply End Date" ;
+    rdfs:comment "Computed date when the dispensed medication supply is expected to be exhausted, calculated as startDate + supplyDurationDays. Distinguishes clinical supply exhaustion from administrative EHR order expiry (checkup:medicationEndDate). Consumers should use this property — rather than medicationEndDate — to determine whether a medication is likely still active when adherenceStatus is absent." ;
+    rdfs:domain checkup:MedicationSummary ;
+    rdfs:range xsd:date .
+
+# --- Renamed immunization property ---
+
+checkup:immunizationNotes a owl:DatatypeProperty ;
+    rdfs:label "Immunization Notes" ;
+    rdfs:comment "Free-text notes about an immunization record. Replaces dark vocabulary checkup:notes (disambiguated from clinical:notes used in lab results)." ;
+    rdfs:domain checkup:ImmunizationSummary ;
+    rdfs:range xsd:string .
+
+# --- Renamed supplement properties ---
+
+checkup:supplementIsActive a owl:DatatypeProperty ;
+    rdfs:label "Supplement Is Active" ;
+    rdfs:comment "Whether the patient is currently taking this supplement. Replaces dark vocabulary checkup:isActive (disambiguated from generic boolean use)." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:boolean .
+
+checkup:supplementUPC a owl:DatatypeProperty ;
+    rdfs:label "Supplement UPC" ;
+    rdfs:comment "Universal Product Code for supplement identification. Replaces dark vocabulary checkup:upc (disambiguated with supplement prefix)." ;
+    rdfs:domain checkup:SupplementSummary ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# (Legacy Compatibility section removed in v3.0 — ClinicalSummary, HealthRecord,
+#  ReviewOfSystems, DataProvenance classes deleted per CLN1 cleanup)
+# ============================================================================
+# (Tier 3 PatientProfile properties removed in v3.0 — preferredLanguage,
+#  maritalStatus, raceEthnicity, preferredPharmacy, hasLivingWill,
+#  hasPowerOfAttorney, hasDNR, advanceDirectiveNotes deleted per CLN1 cleanup.
+#  Migrated to cascade:/dct: namespace in core.ttl.)
+
+# (Insurance migration properties removed in v3.0 — subscriberName,
+#  subscriberRelationship, effectiveDate, rxBin, rxPcn, rxGroup deleted per
+#  CLN1 cleanup. Migrated to coverage: namespace.)
+
+# ============================================================================
+# CHANGELOG
+# ============================================================================
+#
+# v3.2 (2026-02-26, BUG-002): Added checkup:supplyEndDate DatatypeProperty on
+# MedicationSummary. Computed as startDate + supplyDurationDays, this field
+# allows consumers to distinguish administrative EHR order expiry
+# (checkup:medicationEndDate) from actual supply exhaustion. Updated
+# checkup:medicationEndDate rdfs:comment to clarify the distinction.
+# Active classes: 28. Properties added: 1.
+#
+# v3.1 (2026-02-22, Task A7): Added VisitPrepTray class (8 properties) and
+# VisitTrayItem class (5 properties) for per-appointment visit preparation
+# containers. VisitPrepTray groups VisitIssue, DiscussionTopic,
+# SuggestedQuestion, and note items with typed payload wrappers and intent
+# categories. Added hasTrayItem ObjectProperty linking tray to items. Added
+# hasVisitPrep and activeVisitPrepId aggregate links on IntakeFormData.
+# Active classes: 28. Part of Health Map v3 Pre-Phase Track A.
+#
+# v3.0 (2026-02-18, Phase 4 CLN1): Removed 8 deprecated classes (PatientProfile,
+# VitalSignsTrend, WellnessBaseline, ActivitySummary, ClinicalSummary, HealthRecord,
+# ReviewOfSystems, DataProvenance) and their associated properties. Removed 9 core
+# PatientProfile properties (patientName, dateOfBirth, computedAge, ageGroup,
+# biologicalSex, genderIdentity, contactPhone, contactEmail, emergencyContact).
+# Removed 8 deprecated Tier 3 PatientProfile properties (migrated to cascade:/dct:
+# namespace). Removed 6 deprecated insurance properties (migrated to coverage:
+# namespace). Removed deprecated checkup:cascadeUri (superseded by cascade:cascadeUri).
+# Removed VitalSignsTrend properties (8), WellnessBaseline properties (8),
+# ActivitySummary properties (8). Deprecated hasPatientProfile, hasVitalsTrend,
+# hasWellnessBaseline, hasActivitySummary aggregate links. Updated basedOnTrend
+# range to health:MetricTrend. Clean break per guiding constraint #1.
+# Active classes: 27. Total properties removed: ~50.
+#
+# v2.3 (2026-02-18): Deprecated checkup:cascadeUri in favor of
+#   cascade:cascadeUri from core.ttl (Phase 3.5 ONT3). The checkup-specific
+#   definition is superseded by the cross-vocabulary property in core.
+#
+# v2.2 (2026-02-17): Dark Vocabulary Remediation (PF1-R)
+# - Added hasLabResults aggregate link (replaces dark hasLabResultSummary)
+# - Added wellnessProfileRef ObjectProperty for intake form -> wellness link
+# - Added lastSnapshotDate DatatypeProperty for medication/supplement snapshot timestamps
+# - Added medicationEndDate (replaces dark checkup:endDate, disambiguated)
+# - Added immunizationNotes (replaces dark checkup:notes in immunization context)
+# - Added supplementIsActive (replaces dark checkup:isActive in supplement context)
+# - Added cascadeUri ObjectProperty for stable supplement identifiers
+# - Added supplementUPC (replaces dark checkup:upc, disambiguated with prefix)
+# - Total new properties: 8 (all previously dark vocabulary)
+#
+# v2.1 (2026-02-17): DailyCheckIn now rdfs:subClassOf health:SelfReport.
+#   Base self-report properties (reportDate, reportType, completionStatus,
+#   reportContext, reportNotes) promoted to health: namespace. (Phase 3, WS7)
+#
+# v2.0 (2026-02-17): Schema Refactoring Phase 3 — PatientProfile Migration
+# - Deprecated checkup:PatientProfile (use cascade:PatientProfile from core.ttl)
+# - Deprecated 8 Tier 3 patient profile properties with cascade:/dct: replacements:
+#   preferredLanguage (-> dct:language), maritalStatus (-> cascade:maritalStatus),
+#   raceEthnicity (-> cascade:raceEthnicity), preferredPharmacy (-> cascade:hasPreferredPharmacy),
+#   hasLivingWill, hasPowerOfAttorney, hasDNR, advanceDirectiveNotes
+#   (-> cascade:AdvanceDirectives class properties)
+# - Total deprecated classes: 8 (PatientProfile + WellnessBaseline + ActivitySummary +
+#   VitalSignsTrend + HealthRecord + ClinicalSummary + ReviewOfSystems + ScreeningStatus-like)
+#
+# v1.11 (2026-02-18): Updated InsuranceInfo class comment to reference coverage:
+#   namespace for mixed namespace pattern. Part of Schema Refactoring Plan
+#   Phase 2 (WS4).
+#
+# v1.10 (2026-02-17): Schema Refactoring Phase 1 — Taxonomy & Dark Vocabulary
+# - Added cascade:subConcern annotations to all 35 classes (31 active + 4
+#   already-deprecated; summary, analytics, intake, self-report, identity,
+#   financial, app-config, structural, deprecated)
+# - Deprecated WellnessBaseline and ActivitySummary (use WellnessProfileReference)
+# - Deprecated ReviewOfSystems (use IntakeQuestionnaireResponse with LOINC 10187-3)
+# - Defined 14 dark vocabulary properties with migration annotations:
+#   - 8 Tier 3 patient profile properties (preferredLanguage, maritalStatus,
+#     raceEthnicity, preferredPharmacy, hasLivingWill, hasPowerOfAttorney,
+#     hasDNR, advanceDirectiveNotes) — migrating to cascade:/dct: in WS6
+#   - 6 insurance properties (subscriberName, subscriberRelationship,
+#     effectiveDate, rxBin, rxPcn, rxGroup) — migrating to coverage: in WS4
+# - Zero dark vocabulary: every serializer-emitted property now defined in TTL
+#
+# v1.9 (2026-02-10): Medication Change Records
+# - Added MedicationChangeRecord class for tracking medication/supplement
+#   changes between visit snapshots (5 properties + hasChange link)
+# - Enables "Changes Since Last Visit" report section persistence
+# - hasChange link defined without domain constraint — used by both
+#   MedicationSummary and SupplementSummary
+# - Property names prefixed to avoid collision with VitalSignsTrend
+#   previousValue/newValue: changeRecordPreviousValue, changeRecordNewValue
+# - Total classes: 17 (was 16) + 2 questionnaire classes
+#
+# v1.8 (2026-02-10): Procedure Summary & Serializer Alignment
+# - Added ProcedureSummary class with mixed namespace pattern
+#   (4 checkup: properties + 7 clinical: cross-references)
+# - Added hasProcedure aggregate link on IntakeFormData
+# - Total classes: 16 (was 15) + 2 questionnaire classes
+#
+# v1.7 (2026-02-10): Wellness Data & Clinical Summary Classes
+# - Added 5 new classes: WellnessBaseline, ActivitySummary,
+#   ImmunizationSummary, LabResultSummary, WellnessProfileReference
+# - WellnessBaseline: aggregated vital sign baseline (8 properties)
+# - ActivitySummary: combined activity/sleep metrics (8 properties)
+# - ImmunizationSummary: patient-facing vaccine record (16 properties)
+#   using mixed namespace pattern
+# - LabResultSummary: patient-facing lab summary with labCategory
+#   (uses clinical: properties for standardized data)
+# - WellnessProfileReference: lightweight pointer to full wellness profile
+# - Added checkup:noteContent to VisitPrepSummary (merges VisitPrepNotes)
+# - Added 4 MedicationSummary verification properties: needsVerification,
+#   verificationReason, lastVerifiedDate, importSessionId
+# - Added 2 SuggestedQuestion properties: basedOnTemplate, basedOnScreening
+# - Added 4 IntakeFormData aggregate links: hasImmunization, hasLabResult,
+#   hasWellnessBaseline, hasActivitySummary
+#
+# v1.6 (2026-02-09) - Intake Questionnaire Data Model
+# - Added 2 new classes: IntakeQuestionnaireResponse, ResponseItem
+# - IntakeQuestionnaireResponse: FHIR-inspired questionnaire container using
+#   LOINC panel codes as identifiers and SNOMED CT for coded answers
+# - ResponseItem: question-answer pair with nested sub-items support
+# - Added 10 new properties: questionnaireId, questionnaireTitle, responseItem,
+#   completedAt, itemLinkId, itemText, itemAnswer, itemAnswerCode,
+#   itemAnswerCodeSystem, childItem
+# - Added hasQuestionnaireResponse link from IntakeFormData
+# - Design follows "established vocabularies first" principle:
+#   LOINC/SNOMED as actual vocabulary, checkup: as minimal container
+# - Mechanical transformation path to FHIR QuestionnaireResponse JSON
+#   preserved for clinical system interoperability
+# - Supports template-driven intake form expansion (Kaiser eCheck-In
+#   gap analysis: surgical history, social history, advanced care planning)
+#
+# v1.5 (2026-02-07) - Adherence & Discussion Classes
+# - Added 3 new classes: DailyCheckIn, DiscussionTopic, CheckInSettings
+# - DailyCheckIn: patient-reported medication adherence with per-medication
+#   tracking (LOINC 79474-4, SNOMED 225390008/418633004)
+# - DiscussionTopic: AI-generated or user-created visit discussion items
+#   with 11 categories, relevance scoring, and medication context
+# - CheckInSettings: application configuration for notification scheduling
+# - Added 17 new properties for check-in, discussion, and settings
+# - Added hasDailyCheckIn, hasDiscussionTopic, hasCheckInSettings links
+#   from IntakeFormData
+# - Supports Bug 6/11 export overhaul Phase 4B serialization
+#
+# v1.4 (2026-02-01) - Insight & Correlation Classes, Visit Prep
+# - Added 5 new Layer 3 classes: WellnessSummary, TrendInsight,
+#   CorrelationInsight, KeyIndicator, AttentionItem
+# - Added VisitPrepSummary class for curated clinical visit preparation
+# - Added aggregate links to IntakeFormData: hasWellnessSummary,
+#   hasTrendInsight, hasCorrelationInsight, hasKeyIndicator,
+#   hasAttentionItem, hasVisitPrepSummary
+# - Deprecated VitalSignsTrend (superseded by health:MetricTrend at
+#   Layer 2 + checkup:WellnessSummary at Layer 3)
+# - CorrelationInsight enforces temporal-only language (no causation)
+# - insightGeneratedBy uses prov:Agent range for both software and
+#   human agent provenance
+# - Added health: prefix import for cross-layer references
+#
+# v1.3 (2026-01-17) - Medication Experience Phase A: EHR Provenance
+# - Added EHR Provenance Properties section:
+#   - ehrSystemName: EHR patient portal identifier
+#   - ehrOrganization: Healthcare org name
+#   - fhirResourceType: FHIR resource type origin
+#   - lastSyncedFromSource: Sync timestamp
+# - Added Medication Classification Properties section:
+#   - relevanceTier: current, needsVerification, historical, filtered
+#   - brandName: Brand name mapping for display
+#   - commonBrandNames: Comma-separated brand names for reference
+#   - therapeuticClass: Pharmacological class
+#   - tierClassificationReason: Human-readable classification explanation
+# - These properties enable cross-app medication data portability
+#
+# v1.2 (2026-01-15) - Phase 7: SHACL Shapes + Validation
+# - Added Phase 3 MedicationSummary properties (episodeId, indication, cost, functionalImpact)
+# - Added doctorAware property for SupplementSummary
+# - Updated to align with checkup.shapes.ttl v1.2
+# - SHACL shapes now validate:
+#   - MedicationSummary with episode linkage
+#   - SupplementSummary with required regulatoryStatus
+#
+# v1.1 (2026-01-15)
+# - Added SupplementSummary class for dietary supplements and OTC products
+# - Added 12 supplement-specific properties (regulatoryStatus, evidenceStrength, etc.)
+# - Added hasSupplement property to IntakeFormData
+# - Supplements explicitly separated from medications due to different regulatory status
+#
+# v1.0 (2026-01-03)
+# - Initial release with 12 core classes
+# - IntakeFormData, PatientProfile, InsuranceInfo, MedicationSummary,
+#   AllergySummary, ConditionSummary, FamilyHistoryEntry, VitalSignsTrend,
+#   ScreeningStatus, VisitIssue, SuggestedQuestion, DiagnosticTestResult
+# - POTS Check integration via DiagnosticTestResult
+# - Data provenance properties for source tracking
+#
+
+# End of Cascade Checkup Vocabulary v3.1

--- a/src/shapes/clinical.shapes.ttl
+++ b/src/shapes/clinical.shapes.ttl
@@ -245,6 +245,36 @@ clinical:DischargeSummaryShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Consultation Note (v1.13)
+# ============================================================================
+#
+# clinical:ConsultationNote is rdfs:subClassOf clinical:ClinicalDocument, and
+# its five sibling subclasses (ProgressNote, DischargeSummary,
+# LaboratoryReport, ImagingReport, VisitSummary) each carry an explicit
+# sh:targetClass. This one did not, and a subclass axiom alone does not
+# inherit a shape: SHACL resolves sh:targetClass over SHACL-instances in the
+# DATA graph, so an axiom that lives only in clinical.ttl does not expand the
+# target set. Consultation notes were therefore validating vacuously while
+# every other document type was checked, and nothing reported the difference.
+
+clinical:ConsultationNoteShape a sh:NodeShape ;
+    sh:targetClass clinical:ConsultationNote ;
+    rdfs:label "Consultation Note Shape"@en ;
+    rdfs:comment "Additional constraints for specialist consultation notes"@en ;
+
+    # Inherits ClinicalDocument constraints
+    sh:node clinical:ClinicalDocumentShape ;
+
+    # Consultation notes should record when the consultation happened
+    sh:property [
+        sh:path clinical:encounterDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Date"@en ;
+        sh:message "Consultation note must not carry more than one encounter date"@en
+    ] .
+
+# ============================================================================
 # Shape: Laboratory Report
 # ============================================================================
 

--- a/src/shapes/clinical.ttl
+++ b/src/shapes/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-07-20"^^xsd:date ;
-    owl:versionInfo "1.12" ;
+    dct:modified "2026-08-03"^^xsd:date ;
+    owl:versionInfo "1.13" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -101,27 +101,39 @@ clinical:Medication a owl:Class ;
 
 clinical:Allergy a owl:Class ;
     rdfs:label "Allergy"@en ;
-    rdfs:comment "Allergy or intolerance record from EHR AllergyIntolerance resource"@en ;
+    rdfs:comment "Allergy or intolerance record from EHR AllergyIntolerance resource. DEPRECATED in clinical v1.13: use health:AllergyRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:AllergyIntolerance ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#AllergyRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:AllergyRecord" .
 
 clinical:LabResult a owl:Class ;
     rdfs:label "Lab Result"@en ;
-    rdfs:comment "Laboratory test result from EHR Observation resource"@en ;
+    rdfs:comment "Laboratory test result from EHR Observation resource. DEPRECATED in clinical v1.13: use health:LabResultRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#LabResultRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:LabResultRecord" .
 
 clinical:Condition a owl:Class ;
     rdfs:label "Condition"@en ;
-    rdfs:comment "Medical condition or diagnosis from EHR Condition resource"@en ;
+    rdfs:comment "Medical condition or diagnosis from EHR Condition resource. DEPRECATED in clinical v1.13: use health:ConditionRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:Condition ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#ConditionRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:ConditionRecord" .
 
 clinical:Immunization a owl:Class ;
     rdfs:label "Immunization"@en ;
-    rdfs:comment "Vaccination record from EHR Immunization resource"@en ;
+    rdfs:comment "Vaccination record from EHR Immunization resource. DEPRECATED in clinical v1.13: use health:ImmunizationRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:Immunization ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:ImmunizationRecord" .
 
 clinical:Procedure a owl:Class ;
     rdfs:label "Procedure"@en ;
@@ -496,7 +508,20 @@ clinical:recordDate a owl:DatatypeProperty ;
 
 clinical:status a owl:DatatypeProperty ;
     rdfs:label "Status"@en ;
-    rdfs:comment "FHIR status of the record (active, completed, etc.)"@en ;
+    rdfs:comment """Lifecycle status of the record. Permitted values depend on the record class and are constrained per-shape, not on this property.
+
+INTENDED VALUE SETS (FHIR R4). Recorded here in v1.13 because they are only partly enforced, and the gap should be visible in the vocabulary rather than only in the shapes:
+
+  clinical:Immunization   ImmunizationStatusCodes    completed | entered-in-error | not-done
+                          -- ENFORCED by clinical:ImmunizationShape
+  clinical:Procedure      EventStatus
+                          -- ENFORCED by clinical:ProcedureShape
+  clinical:Medication     MedicationRequest.status   active | on-hold | cancelled | completed |
+                                                     entered-in-error | stopped | draft | unknown
+                          -- NOT ENFORCED by clinical:MedicationShape
+
+The omission on medications is deliberate as of v1.13, not an oversight. Emitted data uses at least one value outside the FHIR set ("discontinued"; the FHIR equivalents are "stopped" and "ended"), so adding sh:in would be a BREAKING change for existing pods, not a clarification: records that validate today would start failing without any emitter having been corrected first. The ordered fix is to map emitters onto the FHIR value set, then add the constraint in a release explicitly flagged as tightening."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-medicationrequest-status.html> ;
     rdfs:range xsd:string .
 
 clinical:loincCode a owl:DatatypeProperty ;
@@ -702,7 +727,12 @@ clinical:referenceRange a owl:DatatypeProperty ;
 
 clinical:interpretation a owl:DatatypeProperty ;
     rdfs:label "Interpretation"@en ;
-    rdfs:comment "Interpretation flag (normal, high, low, abnormal)"@en ;
+    rdfs:comment """Categorical reading of an observation against its reference range.
+
+clinical:LabResultShape constrains this property with sh:in to normal | high | low | abnormal | critical (and capitalized forms). clinical:VitalSignShape deliberately does NOT, and as of v1.13 the inconsistency is intentional rather than an oversight: emitted vital-sign data uses "elevated", which is outside the lab set, so applying the lab constraint to vital signs would be a BREAKING change for existing pods rather than a clarification.
+
+Note also that neither set is the FHIR set. FHIR R4 Observation.interpretation binds to v3-ObservationInterpretation, whose codes are symbolic (N, H, L, A, HH, LL, AA), not English words. Both Cascade sets are local vocabulary. Reconciling the two spellings and then aligning them onto the FHIR codes is the ordered fix; doing either half on its own breaks readers."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
     rdfs:range xsd:string .
 
 clinical:specimenType a owl:DatatypeProperty ;
@@ -1300,6 +1330,33 @@ clinical:isActive a owl:DatatypeProperty ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.13 (2026-08-03)
+# - Deprecated 4 classes: clinical:LabResult, clinical:Condition,
+#   clinical:Allergy, clinical:Immunization. Each carries owl:deprecated true
+#   and rdfs:seeAlso pointing at its health: equivalent, which is the type
+#   every import path already emits and which health v2.5 now defines and
+#   shapes. NOT removed: the pod export path remains the sole emitter of these
+#   four classes, and existing pods contain them. Readers must accept both
+#   spellings; writers should prefer the health: forms. No emitter changed in
+#   this release.
+# - Documented the intended FHIR R4 value sets on clinical:status and
+#   clinical:interpretation, and recorded WHY two of them are not enforced.
+#   clinical:MedicationShape has no sh:in on status and clinical:VitalSignShape
+#   has none on interpretation, while the sibling shapes do. Emitted data uses
+#   "discontinued" for medication status and "elevated" for vital-sign
+#   interpretation, neither of which is in the corresponding constrained set,
+#   so adding the constraints would be breaking for existing pods rather than
+#   clarifying. The gap is now stated in the vocabulary instead of being
+#   visible only as an absence in the shapes.
+# - Added clinical:ConsultationNoteShape. clinical:ConsultationNote is one of
+#   six rdfs:subClassOf clinical:ClinicalDocument; the other five each carry an
+#   explicit sh:targetClass and this one did not. A subclass axiom does not
+#   inherit a shape (SHACL resolves sh:targetClass over SHACL-instances in the
+#   DATA graph, so an axiom in this file does not expand the target set), so
+#   consultation notes were validating vacuously while every sibling document
+#   type was checked. Consequence: a consultation note missing importedAt,
+#   sourceEHR or fhirResourceId passed before and fails now.
 #
 # Version 1.12 (2026-07-20)
 # - Added clinical:parsedIndicationReference ObjectProperty, a

--- a/src/shapes/core.shapes.ttl
+++ b/src/shapes/core.shapes.ttl
@@ -2,13 +2,16 @@
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
 # ============================================================================
 # Cascade Protocol -- Core Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.0 (Phase 4, 2026-02-18)
+# Version: 1.1 (2026-08-03)
 # Validates: cascade:PatientProfile, cascade:Address, cascade:EmergencyContact,
-#            cascade:PharmacyInfo, cascade:AdvanceDirectives
+#            cascade:PharmacyInfo, cascade:AdvanceDirectives, cascade:ProxyAgent,
+#            cascade:ExportManifest, cascade:RecordSummary,
+#            cascade:InteractionScenario
 #
 # Severity levels:
 #   sh:Violation -- Must fix (blocks operations)
@@ -656,3 +659,168 @@ cascade:ProxyAgentShape a sh:NodeShape ;
                   sh:message "A ProxyAgent must declare the patient it acts for (cascade:actsForPatient)." ] ;
     sh:property [ sh:path cascade:proxyRelationship ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path cascade:proxyGrantedAt ; sh:minCount 1 ; sh:datatype xsd:dateTime ] .
+
+# ============================================================================
+# Pod Export Manifest Shapes (v1.1 -- core v3.4)
+# ============================================================================
+#
+# The manifest is the first thing a consuming agent reads and the thing it
+# trusts to decide whether an export is complete. Until core v3.4 none of its
+# classes was defined, so nothing targeted them and validating a manifest
+# checked nothing at all.
+
+cascade:ExportManifestShape a sh:NodeShape ;
+    sh:targetClass cascade:ExportManifest ;
+    rdfs:label "Export Manifest Shape"@en ;
+    rdfs:comment "Validation constraints for a pod export manifest. cascade:ExportManifest is a dcat:Dataset, so the DCAT-standard descriptive terms are the required ones."@en ;
+
+    # REQUIRED: a title. An untitled dataset cannot be presented to a user.
+    sh:property [
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Title"@en ;
+        sh:message "Export manifest must carry exactly one non-empty dct:title"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: creation timestamp. Without it a consumer cannot tell whether
+    # the export is current, which is the manifest's main job.
+    sh:property [
+        sh:path dct:created ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Created"@en ;
+        sh:message "Export manifest must carry exactly one dct:created timestamp"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: schema version, so a consumer can refuse an export it cannot read
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Export manifest must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:patientProfileVersion ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Patient Profile Version"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:clinicalSummary ;
+        sh:maxCount 1 ;
+        sh:name "Clinical Summary"@en ;
+        sh:message "Export manifest must not carry more than one clinical summary"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:wellnessSummary ;
+        sh:maxCount 1 ;
+        sh:name "Wellness Summary"@en ;
+        sh:message "Export manifest must not carry more than one wellness summary"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path dct:description ;
+        sh:maxCount 1 ;
+        sh:name "Description"@en ;
+        sh:severity sh:Violation
+    ] .
+
+cascade:RecordSummaryShape a sh:NodeShape ;
+    sh:targetClass cascade:RecordSummary ;
+    rdfs:label "Record Summary Shape"@en ;
+    rdfs:comment "Validation constraints for per-domain record counts. Every count must be a single non-negative integer: a negative or repeated count silently corrupts any completeness check built on it."@en ;
+
+    sh:property [
+        sh:path cascade:domain ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Domain"@en ;
+        sh:message "Record summary must name exactly one domain"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [ sh:path cascade:conditionCount ;     sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Condition Count"@en ;      sh:message "conditionCount must be a single non-negative integer"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:medicationCount ;    sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Medication Count"@en ;     sh:message "medicationCount must be a single non-negative integer"@en ;     sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:allergyCount ;       sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Allergy Count"@en ;        sh:message "allergyCount must be a single non-negative integer"@en ;        sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:labResultCount ;     sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Lab Result Count"@en ;     sh:message "labResultCount must be a single non-negative integer"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:immunizationCount ;  sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Immunization Count"@en ;   sh:message "immunizationCount must be a single non-negative integer"@en ;   sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:coverageCount ;      sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Coverage Count"@en ;       sh:message "coverageCount must be a single non-negative integer"@en ;       sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:supplementCount ;    sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Supplement Count"@en ;     sh:message "supplementCount must be a single non-negative integer"@en ;     sh:severity sh:Violation ] ;
+
+    # Day counts are bounded above as well: a "days covered" figure larger than
+    # a decade of daily readings is a unit error, not a long history.
+    sh:property [ sh:path cascade:vitalSignDays ;      sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Vital Sign Days"@en ;      sh:message "vitalSignDays must be a single integer between 0 and 36500"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:heartRateDays ;      sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Heart Rate Days"@en ;      sh:message "heartRateDays must be a single integer between 0 and 36500"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:bloodPressureDays ;  sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Blood Pressure Days"@en ;  sh:message "bloodPressureDays must be a single integer between 0 and 36500"@en ;  sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:activityDays ;       sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Activity Days"@en ;       sh:message "activityDays must be a single integer between 0 and 36500"@en ;       sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:sleepDays ;          sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Sleep Days"@en ;          sh:message "sleepDays must be a single integer between 0 and 36500"@en ;          sh:severity sh:Violation ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:severity sh:Violation
+    ] .
+
+cascade:InteractionScenarioShape a sh:NodeShape ;
+    sh:targetClass cascade:InteractionScenario ;
+    rdfs:label "Interaction Scenario Shape"@en ;
+    rdfs:comment "Validation constraints for a flagged cross-provenance interaction. A scenario that names no resources is not actionable, so involvedResources is required."@en ;
+
+    sh:property [
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Title"@en ;
+        sh:message "Interaction scenario must carry exactly one non-empty dct:title"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: the resources to correlate. Without them the scenario states a
+    # risk exists but gives a consumer nothing to check it against.
+    sh:property [
+        sh:path cascade:involvedResources ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Involved Resources"@en ;
+        sh:message "Interaction scenario must name exactly one list of involved resources"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:severity ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("low" "moderate" "high" "critical") ;
+        sh:name "Severity"@en ;
+        sh:message "Interaction scenario severity must be low, moderate, high or critical"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:requiresCrossProvenance ;
+        sh:datatype xsd:boolean ;
+        sh:maxCount 1 ;
+        sh:name "Requires Cross-Provenance"@en ;
+        sh:message "requiresCrossProvenance must be a single boolean"@en ;
+        sh:severity sh:Violation
+    ] .

--- a/src/shapes/core.ttl
+++ b/src/shapes/core.ttl
@@ -7,6 +7,8 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix void: <http://rdfs.org/ns/void#> .
 
 # ============================================================================
 # Ontology Metadata
@@ -17,8 +19,8 @@
     dct:description "Core vocabulary for schema versioning, data provenance, identity management, and patient demographics across all Cascade Protocol applications"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-10-31"^^xsd:date ;
-    dct:modified "2026-06-16"^^xsd:date ;
-    owl:versionInfo "3.3" ;
+    dct:modified "2026-08-03"^^xsd:date ;
+    owl:versionInfo "3.4" ;
     rdfs:comment "This vocabulary defines cross-cutting concepts used by all Cascade Protocol health data applications: schema versioning, data provenance, patient demographics (PatientProfile), and supporting identity classes (Address, PharmacyInfo, AdvanceDirectives). Domain-specific vocabularies (e.g., pots:, ecg:, glucose:) import this core vocabulary."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/core/v1.0/> .
 
@@ -675,6 +677,30 @@ cascade:forSystem a owl:DatatypeProperty ;
 
 # ============================================================================
 # Changelog
+#
+# Version 3.4 (2026-08-03)
+# - Defined the pod export manifest vocabulary. 32 cascade: terms appearing in
+#   a conforming pod had no definition in this file at all; all 32 are now
+#   defined, so a manifest is describable rather than only parseable.
+# - cascade:ExportManifest is modelled as rdfs:subClassOf dcat:Dataset (DCAT 3,
+#   https://www.w3.org/TR/vocab-dcat-3/). A pod export is a dataset with a
+#   title, a description, a creation date and a publisher, which is what DCAT
+#   already standardises; inventing a parallel set of terms for it would have
+#   been novelty for its own sake.
+# - cascade:RecordSummary is modelled as rdfs:subClassOf void:Dataset (VoID,
+#   https://www.w3.org/TR/void/). Its ~15 per-domain count properties are
+#   declared rdfs:subPropertyOf void:entities and each is paired with the
+#   void:class it counts, so a VoID-aware consumer can read Cascade record
+#   counts with no Cascade-specific code. The Cascade-specific spellings are
+#   retained because they are what is emitted.
+# - cascade:InteractionScenario is kept as genuinely novel. It describes a
+#   cross-provenance clinical interaction that an agent must correlate across
+#   several resources; no ratified vocabulary covers it, so it is defined here
+#   rather than bent onto something that does not fit.
+# - Also defined the reading-level terms cascade:date, cascade:sampleCount and
+#   cascade:loincCode, which are emitted on every history-container entry and
+#   are constrained by the health v2.5 daily-snapshot shapes.
+#
 # ============================================================================
 # v3.2 (2026-05-06): Forward reference closure for advisory applier.
 #     Added cascade:appliedTriplesCount (DatatypeProperty, range xsd:nonNegativeInteger,
@@ -1138,3 +1164,286 @@ cascade:proxyRevokedAt a owl:DatatypeProperty ;
     rdfs:domain cascade:ProxyAgent ;
     rdfs:range xsd:dateTime ;
     owl:versionInfo "Added in core v3.3" .
+
+# ============================================================================
+# Pod Export Manifest (v3.4)
+# ============================================================================
+#
+# Every term in this section is emitted by a conforming pod export and none of
+# them was defined before v3.4. Defining them is additive: no serializer
+# changes and no manifest is rewritten.
+#
+# Modelling decisions, and the reasoning, because "we invented a term" is the
+# expensive default:
+#
+#   cascade:ExportManifest  -> rdfs:subClassOf dcat:Dataset
+#       A pod export is a published dataset with a title, description,
+#       creation date and publisher. DCAT 3 standardises exactly that and is a
+#       W3C Recommendation. https://www.w3.org/TR/vocab-dcat-3/
+#
+#   cascade:RecordSummary   -> rdfs:subClassOf void:Dataset
+#       A record summary is a statistical description of a subset of a
+#       dataset: how many instances of each class it contains. That is what
+#       VoID is for. Each count property below is declared
+#       rdfs:subPropertyOf void:entities and paired with the void:class it
+#       counts, so a VoID-aware consumer gets the counts for free.
+#       https://www.w3.org/TR/void/
+#
+#   cascade:InteractionScenario -> novel, deliberately
+#       A cross-provenance clinical interaction that an agent must detect by
+#       correlating resources of different provenance. No ratified vocabulary
+#       models this. It stays Cascade-specific rather than being forced onto
+#       something that does not fit.
+
+cascade:ExportManifest a owl:Class ;
+    rdfs:label "Export Manifest"@en ;
+    rdfs:comment "Provenance and completeness metadata for a complete pod export: when it was generated, which schema versions it uses, how many records of each kind it contains, and which provenance layers are represented. Consumers should read this before processing individual resources."@en ;
+    rdfs:subClassOf dcat:Dataset ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:seeAlso <https://www.w3.org/TR/vocab-dcat-3/> ;
+    owl:versionInfo "Added in core v3.4; emitted since schema 1.3" .
+
+cascade:RecordSummary a owl:Class ;
+    rdfs:label "Record Summary"@en ;
+    rdfs:comment "Per-domain record counts for one partition of a pod export. Modelled on void:Dataset because it is a statistical description of a dataset subset; each count property is a subproperty of void:entities scoped to a particular void:class."@en ;
+    rdfs:subClassOf void:Dataset ;
+    rdfs:seeAlso <https://www.w3.org/TR/void/> ;
+    owl:versionInfo "Added in core v3.4; emitted since schema 1.3" .
+
+cascade:InteractionScenario a owl:Class ;
+    rdfs:label "Interaction Scenario"@en ;
+    rdfs:comment "A clinically significant interaction that can only be detected by correlating resources of differing provenance, for example an EHR-prescribed drug against a self-reported supplement against a lab value. Cascade-specific: no ratified vocabulary models cross-provenance correlation as a first-class thing."@en ;
+    rdfs:subClassOf prov:Entity ;
+    owl:versionInfo "Added in core v3.4; emitted since schema 1.3" .
+
+# --- Manifest structure -----------------------------------------------------
+
+cascade:patientProfileVersion a owl:DatatypeProperty ;
+    rdfs:label "Patient Profile Version"@en ;
+    rdfs:comment "Version of the patient profile structure used in this export, independent of cascade:schemaVersion."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:provenanceLayers a owl:ObjectProperty ;
+    rdfs:label "Provenance Layers"@en ;
+    rdfs:comment "Ordered list of the cascade:DataProvenance values represented anywhere in this export. Lets a consumer tell, before reading any resource, whether the export contains device data, EHR data, self-reported data, or a mixture."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:clinicalSummary a owl:ObjectProperty ;
+    rdfs:label "Clinical Summary"@en ;
+    rdfs:comment "Record counts for the clinical partition of this export."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range cascade:RecordSummary ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:wellnessSummary a owl:ObjectProperty ;
+    rdfs:label "Wellness Summary"@en ;
+    rdfs:comment "Record counts for the wellness partition of this export."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range cascade:RecordSummary ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:deviceSources a owl:ObjectProperty ;
+    rdfs:label "Device Sources"@en ;
+    rdfs:comment "Ordered list of the devices that contributed data to this export, each a prov:Agent."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:interactionScenarios a owl:ObjectProperty ;
+    rdfs:label "Interaction Scenarios"@en ;
+    rdfs:comment "Ordered list of cascade:InteractionScenario entries flagged in this export."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+# --- Record summary ---------------------------------------------------------
+
+cascade:domain a owl:DatatypeProperty ;
+    rdfs:label "Domain"@en ;
+    rdfs:comment "Which partition of the export this summary describes, for example 'clinical' or 'wellness'."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:notes a owl:DatatypeProperty ;
+    rdfs:label "Notes"@en ;
+    rdfs:comment "Free-text commentary on a summary or manifest section."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+# Counts. Each is a subproperty of void:entities paired with the void:class it
+# counts, so a VoID-aware consumer reads these without Cascade-specific code.
+
+cascade:conditionCount a owl:DatatypeProperty ;
+    rdfs:label "Condition Count"@en ;
+    rdfs:comment "Number of condition records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#ConditionRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:medicationCount a owl:DatatypeProperty ;
+    rdfs:label "Medication Count"@en ;
+    rdfs:comment "Number of medication records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/clinical/v1#Medication> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:allergyCount a owl:DatatypeProperty ;
+    rdfs:label "Allergy Count"@en ;
+    rdfs:comment "Number of allergy records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#AllergyRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:labResultCount a owl:DatatypeProperty ;
+    rdfs:label "Lab Result Count"@en ;
+    rdfs:comment "Number of laboratory result records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#LabResultRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:immunizationCount a owl:DatatypeProperty ;
+    rdfs:label "Immunization Count"@en ;
+    rdfs:comment "Number of immunization records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:coverageCount a owl:DatatypeProperty ;
+    rdfs:label "Coverage Count"@en ;
+    rdfs:comment "Number of insurance coverage records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:supplementCount a owl:DatatypeProperty ;
+    rdfs:label "Supplement Count"@en ;
+    rdfs:comment "Number of supplement records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/clinical/v1#Supplement> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+# Day counts. These count DAYS COVERED, not entities, so they are deliberately
+# NOT subproperties of void:entities: a 30-day heart rate history may hold many
+# more readings than 30. Conflating the two would make the VoID reading wrong.
+
+cascade:vitalSignDays a owl:DatatypeProperty ;
+    rdfs:label "Vital Sign Days"@en ;
+    rdfs:comment "Number of distinct days covered by vital sign records in this partition. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:heartRateDays a owl:DatatypeProperty ;
+    rdfs:label "Heart Rate Days"@en ;
+    rdfs:comment "Number of distinct days covered by heart rate history. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:bloodPressureDays a owl:DatatypeProperty ;
+    rdfs:label "Blood Pressure Days"@en ;
+    rdfs:comment "Number of distinct days covered by blood pressure history. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:activityDays a owl:DatatypeProperty ;
+    rdfs:label "Activity Days"@en ;
+    rdfs:comment "Number of distinct days covered by activity history. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:sleepDays a owl:DatatypeProperty ;
+    rdfs:label "Sleep Days"@en ;
+    rdfs:comment "Number of distinct nights covered by sleep history. A night count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+# --- Interaction scenario ---------------------------------------------------
+
+cascade:involvedResources a owl:ObjectProperty ;
+    rdfs:label "Involved Resources"@en ;
+    rdfs:comment "Ordered list of the pod resources an agent must read together to detect this interaction."@en ;
+    rdfs:domain cascade:InteractionScenario ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:severity a owl:DatatypeProperty ;
+    rdfs:label "Severity"@en ;
+    rdfs:comment "Severity of the flagged interaction: low, moderate, high, or critical."@en ;
+    rdfs:domain cascade:InteractionScenario ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:requiresCrossProvenance a owl:DatatypeProperty ;
+    rdfs:label "Requires Cross-Provenance"@en ;
+    rdfs:comment "True when detecting this interaction requires correlating resources of different cascade:dataProvenance. The distinguishing property of this class: a single-source consumer cannot find it."@en ;
+    rdfs:domain cascade:InteractionScenario ;
+    rdfs:range xsd:boolean ;
+    owl:versionInfo "Added in core v3.4" .
+
+# --- Device sources ---------------------------------------------------------
+
+cascade:sourceType a owl:DatatypeProperty ;
+    rdfs:label "Source Type"@en ;
+    rdfs:comment "Mechanism a reading arrived through, for example healthKit, bluetoothDevice, manualEntry. Describes the transport, NOT the trustworthiness of the data; that is cascade:dataProvenance."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:dataTypes a owl:DatatypeProperty ;
+    rdfs:label "Data Types"@en ;
+    rdfs:comment "Comma-separated list of the data types a device contributed, for example 'heartRate, activity, sleep'."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:version a owl:DatatypeProperty ;
+    rdfs:label "Version"@en ;
+    rdfs:comment "Version string of a software agent or generator recorded in provenance."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+# ============================================================================
+# Reading-level Terms (v3.4)
+# ============================================================================
+#
+# Emitted on entries inside the health: history containers. Defined here rather
+# than in health: because they are not wellness-specific: any Cascade time
+# series entry carries a date and, where aggregated, a sample count.
+
+cascade:date a owl:DatatypeProperty ;
+    rdfs:label "Date"@en ;
+    rdfs:comment "Timestamp a reading or snapshot applies to. Note that health:date is a second, equivalent spelling emitted by a different serializer for the same purpose; readers of history containers must handle both."@en ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:sampleCount a owl:DatatypeProperty ;
+    rdfs:label "Sample Count"@en ;
+    rdfs:comment "Number of underlying samples aggregated into a single reading. A daily resting heart rate of 68 derived from 142 samples is a stronger observation than one derived from 2, and consumers should be able to tell the difference."@en ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:loincCode a owl:ObjectProperty ;
+    rdfs:label "LOINC Code"@en ;
+    rdfs:comment "LOINC reference for an observation, as an IRI."@en ;
+    rdfs:seeAlso <http://loinc.org/> ;
+    owl:versionInfo "Added in core v3.4" .

--- a/src/shapes/evidence.ttl
+++ b/src/shapes/evidence.ttl
@@ -1,0 +1,305 @@
+# Cascade Evidence Vocabulary (Layer 2, cross-cutting) — v1-draft
+# Authored in spec/. Per draft policy (cf. genomics:, advisory:), NOT registered
+# in spec/VOCAB_VERSIONS until v1.0 graduation.
+#
+# CHANGELOG
+# v1-draft.0.2 (2026-07-01) — Verdict taxonomy v2: the facet model (Workbench
+#   grounding plan §4.1 / platform plan §4.6). The grounding outcome is now
+#   expressed as orthogonal facets on the Assertion — evidence:direction,
+#   evidence:basis, evidence:strength, evidence:settled, evidence:reason
+#   (object properties over new closed enumerations DirectionValue, BasisValue,
+#   StrengthValue, SettledValue, NeedsEvidenceReasonValue) plus
+#   evidence:confidence (xsd:decimal, [0,1]). The FACETS are the canonical
+#   serialized form. The flat evidence:verdict property and the VerdictValue
+#   individuals are DEPRECATED, not removed: draft-period data and fixtures
+#   already carry evidence:verdict, and the SHACL shapes keep a legacy branch
+#   so that data still validates during the one-release transition. Both are
+#   scheduled for removal at v1.0 graduation (see spec/PENDING_DOWNSTREAM_SYNC.md).
+#   Individual reuse: evidence:Supports and evidence:Contradicts are typed as
+#   both StanceValue (per-link) and DirectionValue (aggregate); evidence:None
+#   is both a DirectionValue and a BasisValue; evidence:NeedsLiterature is both
+#   a deprecated VerdictValue and a NeedsEvidenceReasonValue. Local names match
+#   the code mirror (@cascade-workbench/contracts grounding.ts) exactly.
+# v1-draft.0.1 (2026-06-16) — Initial draft: Assertion / EvidenceLink /
+#   Citation / GroundingActivity, flat VerdictValue + StanceValue enumerations,
+#   grounding invariant.
+
+@prefix evidence: <https://ns.cascadeprotocol.org/evidence/v1#> .
+@prefix cascade:  <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+# ============================================================================
+# Ontology Metadata
+# ============================================================================
+
+<https://ns.cascadeprotocol.org/evidence/v1#> a owl:Ontology ;
+    dct:title "Cascade Protocol Evidence Vocabulary"@en ;
+    dct:description "Layer 2 cross-cutting vocabulary for grounding assertions in cited evidence with explicit verdicts."@en ;
+    dct:creator "Cascade Agentic Labs" ;
+    dct:created "2026-06-16"^^xsd:date ;
+    dct:modified "2026-07-01"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.2" ;
+    rdfs:comment "Generalizes the assertion -> evidence -> verdict pattern needed by Cascade Workbench (checking claims pulled from AI conversations against a patient's records and literature), the Cascade Appeal system (citing clinical evidence against policy criteria, cf. coverage:deniedClinicalContext), and PGx/genomics decision support. Reuses core provenance primitives (cascade:extractionModel, cascade:extractionConfidence, cascade:requiresUserReview, prov:wasDerivedFrom) rather than redefining them. Uses 'Assertion' (not 'Claim') to avoid collision with coverage:ClaimRecord. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/evidence/v1-draft/> .
+
+# ============================================================================
+# Classes
+# ============================================================================
+
+evidence:Assertion a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Assertion"@en ;
+    rdfs:comment "A discrete, checkable statement extracted from a source (e.g. an AI conversation) or entered by the user, evaluated against evidence in the Pod and/or literature. Carries exactly one verdict and zero-or-more evidence links. The extraction of an Assertion from its source SHOULD be recorded with a cascade:AIExtractionActivity; an assertion surfaced by a general-purpose AI assistant SHOULD carry cascade:dataProvenance cascade:AIAsserted."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1" .
+
+evidence:EvidenceLink a owl:Class ;
+    rdfs:label "Evidence Link"@en ;
+    rdfs:comment "A reified link from an Assertion to one piece of evidence (a Pod record or an external Citation), carrying a stance (supports / contradicts / contextual). Modeled as a node so a single Assertion can carry multiple, differently-directed pieces of evidence. Pattern mirrors cascade:ConflictDetail."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1" .
+
+evidence:Citation a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Citation"@en ;
+    rdfs:comment "An external bibliographic source (e.g. a research paper) used as evidence, identified by DOI and/or PMID. When retrieved into the Pod it is a first-class resource (recommended path literature/) so an evidence chip can resolve to it exactly as it resolves to a clinical record."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1" .
+
+evidence:GroundingActivity a owl:Class ;
+    rdfs:subClassOf prov:Activity ;
+    rdfs:label "Grounding Activity"@en ;
+    rdfs:comment "A PROV-O Activity representing the model pass that graded an Assertion against evidence and produced its verdict. Distinct from cascade:AIExtractionActivity (which extracts structured records from documents); grounding grades free-text assertions. Reuses cascade:extractionModel to record the model."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1" .
+
+evidence:VerdictValue a owl:Class ;
+    owl:deprecated true ;
+    rdfs:label "Verdict Value (deprecated)"@en ;
+    rdfs:comment "DEPRECATED in v1-draft.0.2: the flat verdict enumeration is superseded by the facet model (evidence:direction / evidence:basis / evidence:strength / evidence:settled / evidence:reason). Retained one release so draft-period data carrying evidence:verdict still validates; clients derive the flat value from the facets in code and MUST NOT serialize it going forward. Scheduled for removal at v1.0 graduation."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1; deprecated in v1-draft.0.2" .
+
+evidence:StanceValue a owl:Class ;
+    rdfs:label "Stance Value"@en ;
+    rdfs:comment "Closed enumeration of the direction of an EvidenceLink. Instances are the named individuals below."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1" .
+
+# ── Facet enumeration classes (verdict taxonomy v2, grounding plan §4.1) ─────
+
+evidence:DirectionValue a owl:Class ;
+    rdfs:label "Direction Value"@en ;
+    rdfs:comment "Closed enumeration of what the evidence, in aggregate, says about the Assertion: Supports | Contradicts | Mixed | None. The per-link analogue is StanceValue; evidence:Supports and evidence:Contradicts are shared individuals of both."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:BasisValue a owl:Class ;
+    rdfs:label "Basis Value"@en ;
+    rdfs:comment "Closed enumeration of where the evidence is: Record | Literature | RecordAndLiterature | None. New bases (guideline, clinician annotation) slot in here without breaking any flat enum."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:StrengthValue a owl:Class ;
+    rdfs:label "Strength Value"@en ;
+    rdfs:comment "Closed enumeration of the quantity/quality of the evidence: Strong | Moderate | Weak. On basis Record, strength is a pure deterministic function of the match (guardrail G-2), never model-emitted."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:SettledValue a owl:Class ;
+    rdfs:label "Settled Value"@en ;
+    rdfs:comment "Closed enumeration of whether the Assertion is resolved: Settled | NeedsEvidence."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:NeedsEvidenceReasonValue a owl:Class ;
+    rdfs:label "Needs-Evidence Reason Value"@en ;
+    rdfs:comment "Closed enumeration of why an Assertion still needs evidence, when it does: NoRecord | NeedsLiterature | NotCheckableByNature."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+# ============================================================================
+# Named Individuals (enumerations)
+# ============================================================================
+
+# Deprecated flat verdicts (v1-draft.0.2): retained one release for draft-period
+# data; derive from the facets in code, do not serialize. Removal at v1.0.
+evidence:Supported       a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Supported (deprecated)"@en ;
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Supports. The patient's records and/or literature substantiate the assertion."@en .
+evidence:Contradicted    a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Contradicted (deprecated)"@en ;
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Contradicts. The patient's records and/or literature directly conflict with the assertion."@en .
+evidence:Unverifiable    a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Unverifiable (deprecated)"@en ;
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NoRecord. No evidence available in the current Pod to support or refute. NOT a judgment that the assertion is false."@en .
+
+evidence:Supports    a owl:NamedIndividual, evidence:StanceValue, evidence:DirectionValue ; rdfs:label "Supports"@en ;
+    rdfs:comment "As a StanceValue: this one link supports. As a DirectionValue (v1-draft.0.2): the evidence in aggregate supports."@en .
+evidence:Contradicts a owl:NamedIndividual, evidence:StanceValue, evidence:DirectionValue ; rdfs:label "Contradicts"@en ;
+    rdfs:comment "As a StanceValue: this one link contradicts. As a DirectionValue (v1-draft.0.2): the evidence in aggregate contradicts."@en .
+evidence:Contextual  a owl:NamedIndividual, evidence:StanceValue ; rdfs:label "Contextual"@en ;
+    rdfs:comment "Relevant background that neither supports nor refutes."@en .
+
+# ── Facet individuals (v1-draft.0.2) ─────────────────────────────────────────
+
+evidence:Mixed a owl:NamedIndividual, evidence:DirectionValue ; rdfs:label "Mixed"@en ;
+    rdfs:comment "The evidence points in both directions; see the individual links."@en .
+evidence:None a owl:NamedIndividual, evidence:DirectionValue, evidence:BasisValue ; rdfs:label "None"@en ;
+    rdfs:comment "As a DirectionValue: the evidence says nothing. As a BasisValue: there is no evidence base. Shared individual; the property it appears on disambiguates."@en .
+
+evidence:Record a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Record"@en ;
+    rdfs:comment "The evidence is the patient's own Pod records (deterministic path, G-2)."@en .
+evidence:Literature a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Literature"@en ;
+    rdfs:comment "The evidence is published research; it has not been checked against the patient's records."@en .
+evidence:RecordAndLiterature a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Record and Literature"@en ;
+    rdfs:comment "Both the patient's records and published research contribute evidence."@en .
+
+evidence:Strong   a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Strong"@en ;
+    rdfs:comment "On the record path: exact code + value/negation match."@en .
+evidence:Moderate a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Moderate"@en ;
+    rdfs:comment "On the record path: code match with value absent or approximate."@en .
+evidence:Weak     a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Weak"@en ;
+    rdfs:comment "On the record path: lexical / recall-fallback match only."@en .
+
+evidence:Settled       a owl:NamedIndividual, evidence:SettledValue ; rdfs:label "Settled"@en ;
+    rdfs:comment "The claim is resolved by the cited evidence."@en .
+evidence:NeedsEvidence a owl:NamedIndividual, evidence:SettledValue ; rdfs:label "Needs Evidence"@en ;
+    rdfs:comment "The claim is not resolved; evidence:reason says why. A NeedsEvidence assertion carries direction None (a grounded direction here is facet-inconsistent and fails validation)."@en .
+
+evidence:NoRecord a owl:NamedIndividual, evidence:NeedsEvidenceReasonValue ; rdfs:label "No Record"@en ;
+    rdfs:comment "Nothing in the patient's records speaks to this. That does not make it wrong."@en .
+evidence:NotCheckableByNature a owl:NamedIndividual, evidence:NeedsEvidenceReasonValue ; rdfs:label "Not Checkable By Nature"@en ;
+    rdfs:comment "Subjective, personal, or otherwise unverifiable by its nature (instruction, opinion, tautology, meta)."@en .
+# evidence:NeedsLiterature doubles as a NeedsEvidenceReasonValue (below) and the
+# deprecated VerdictValue of the same local name; the code mirror uses the same
+# string for both, so one shared individual is exact.
+evidence:NeedsLiterature a owl:NamedIndividual, evidence:VerdictValue, evidence:NeedsEvidenceReasonValue ; rdfs:label "Needs Literature"@en ;
+    rdfs:comment "As a NeedsEvidenceReasonValue (v1-draft.0.2): the patient's records cannot settle this; it needs published evidence. As a VerdictValue it is DEPRECATED (use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NeedsLiterature)."@en .
+
+# ============================================================================
+# Properties — Assertion
+# ============================================================================
+
+evidence:assertionText a owl:DatatypeProperty ;
+    rdfs:label "assertion text"@en ;
+    rdfs:comment "The normalized, atomic statement being evaluated."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
+
+evidence:verdict a owl:ObjectProperty ;
+    owl:deprecated true ;
+    rdfs:label "verdict (deprecated)"@en ;
+    rdfs:comment "DEPRECATED in v1-draft.0.2: superseded by the facet properties (direction / basis / strength / settled / reason / confidence), which are the canonical serialized form. Retained one release so draft-period data validates; derive the flat value from the facets in code, do not serialize it. Removal at v1.0 graduation."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:VerdictValue .
+
+# ── Facet properties (verdict taxonomy v2, v1-draft.0.2) ─────────────────────
+# The canonical grounding outcome. Grounding invariant (SHACL Core, see
+# evidence.shapes.ttl): a grounded result — settled Settled, direction one of
+# Supports/Contradicts/Mixed, basis not None — of EITHER basis requires at
+# least one evidence:hasEvidenceLink.
+
+evidence:direction a owl:ObjectProperty ;
+    rdfs:label "direction"@en ;
+    rdfs:comment "What the evidence, in aggregate, says about the assertion."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:DirectionValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:basis a owl:ObjectProperty ;
+    rdfs:label "basis"@en ;
+    rdfs:comment "Where the evidence is. Tells the UI which regime produced the result: Record is the deterministic path (G-2), Literature is model+search."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:BasisValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:strength a owl:ObjectProperty ;
+    rdfs:label "strength"@en ;
+    rdfs:comment "Quantity/quality of the evidence. On basis Record this is a pure deterministic function of the match (G-2), never model-emitted."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:StrengthValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:settled a owl:ObjectProperty ;
+    rdfs:label "settled"@en ;
+    rdfs:comment "Whether the assertion is resolved by the cited evidence."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:SettledValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:reason a owl:ObjectProperty ;
+    rdfs:label "reason"@en ;
+    rdfs:comment "Why the assertion still needs evidence, when settled is NeedsEvidence."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:NeedsEvidenceReasonValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:confidence a owl:DatatypeProperty ;
+    rdfs:label "confidence"@en ;
+    rdfs:comment "Confidence in the grounding result, [0.0, 1.0]. On basis Record this is a fixed function of match quality, never a model probability (G-2); on the literature path it may reflect model certainty. Distinct from evidence:groundingConfidence, which is the GroundingActivity's raw model confidence."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:decimal ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:rationale a owl:DatatypeProperty ;
+    rdfs:label "rationale"@en ;
+    rdfs:comment "One-line plain-language explanation of the verdict."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
+
+evidence:disconfirming a owl:DatatypeProperty ;
+    rdfs:label "disconfirming consideration"@en ;
+    rdfs:comment "A 'what would argue against this' consideration. Multiple permitted. Required by product design for any material assertion (anti-confirmation-bias)."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
+
+evidence:hasEvidenceLink a owl:ObjectProperty ;
+    rdfs:label "has evidence link"@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:EvidenceLink .
+
+evidence:groundedBy a owl:ObjectProperty ;
+    rdfs:subPropertyOf prov:wasGeneratedBy ;
+    rdfs:label "grounded by"@en ;
+    rdfs:comment "Links an Assertion to the GroundingActivity that produced its verdict."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:GroundingActivity .
+
+evidence:assertedAt a owl:DatatypeProperty ;
+    rdfs:label "asserted at"@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:dateTime .
+
+# Reuse (NOT redefined here): cascade:extractionModel, cascade:extractionConfidence,
+# and cascade:requiresUserReview carry the extraction provenance of an Assertion.
+
+# ============================================================================
+# Properties — EvidenceLink
+# ============================================================================
+
+evidence:evidenceStance a owl:ObjectProperty ;
+    rdfs:label "evidence stance"@en ;
+    rdfs:domain evidence:EvidenceLink ; rdfs:range evidence:StanceValue .
+
+evidence:citesRecord a owl:ObjectProperty ;
+    rdfs:subPropertyOf prov:wasDerivedFrom ;
+    rdfs:label "cites record"@en ;
+    rdfs:comment "Points to a Pod record (clinical:, health:, pots:, genomics: ...) used as evidence. Range intentionally open (rdfs:Resource) for cross-namespace linking, mirroring coverage:deniedClinicalContext."@en ;
+    rdfs:domain evidence:EvidenceLink ; rdfs:range rdfs:Resource .
+
+evidence:citesSource a owl:ObjectProperty ;
+    rdfs:label "cites source"@en ;
+    rdfs:comment "Points to an external Citation (research paper) used as evidence."@en ;
+    rdfs:domain evidence:EvidenceLink ; rdfs:range evidence:Citation .
+
+evidence:evidenceWeight a owl:DatatypeProperty ;
+    rdfs:label "evidence weight"@en ;
+    rdfs:comment "Optional 0.0-1.0 strength of this evidence link toward the verdict."@en ;
+    rdfs:domain evidence:EvidenceLink ; rdfs:range xsd:decimal .
+
+# ============================================================================
+# Properties — Citation
+# ============================================================================
+
+evidence:doi a owl:DatatypeProperty ; rdfs:label "DOI"@en ;
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+evidence:pmid a owl:DatatypeProperty ; rdfs:label "PMID"@en ;
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+evidence:citationTitle a owl:DatatypeProperty ; rdfs:label "title"@en ;
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+evidence:citationYear a owl:DatatypeProperty ; rdfs:label "year"@en ;
+    rdfs:domain evidence:Citation ; rdfs:range xsd:gYear .
+evidence:citationSourceName a owl:DatatypeProperty ; rdfs:label "source name"@en ;
+    rdfs:comment "Retrieval source, e.g. 'PubMed', 'Europe PMC'."@en ;
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+evidence:retrievedAt a owl:DatatypeProperty ; rdfs:label "retrieved at"@en ;
+    rdfs:domain evidence:Citation ; rdfs:range xsd:dateTime .
+
+# ============================================================================
+# Properties — GroundingActivity
+# ============================================================================
+
+evidence:groundingConfidence a owl:DatatypeProperty ;
+    rdfs:label "grounding confidence"@en ;
+    rdfs:comment "Model confidence in the produced verdict, [0.0, 1.0]."@en ;
+    rdfs:domain evidence:GroundingActivity ; rdfs:range xsd:decimal .
+# Reuses cascade:extractionModel to record which model performed the grounding.

--- a/src/shapes/genomics.ttl
+++ b/src/shapes/genomics.ttl
@@ -1,0 +1,1224 @@
+@prefix genomics: <https://ns.cascadeprotocol.org/genomics/v1#> .
+@prefix cascade:  <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix prov:     <http://www.w3.org/ns/prov#> .
+@prefix fhir:     <http://hl7.org/fhir/> .
+@prefix sct:      <http://snomed.info/sct/> .
+@prefix loinc:    <http://loinc.org/rdf#> .
+@prefix hpo:      <http://purl.obolibrary.org/obo/HP_> .
+@prefix mondo:    <http://purl.obolibrary.org/obo/MONDO_> .
+@prefix so:       <http://purl.obolibrary.org/obo/SO_> .
+@prefix hgnc:     <https://identifiers.org/hgnc:> .
+@prefix omim:     <https://omim.org/entry/> .
+@prefix orpha:    <http://www.orpha.net/ORDO/Orphanet_> .
+@prefix clinvar:  <https://www.ncbi.nlm.nih.gov/clinvar/variation/> .
+
+# ============================================================================
+# Ontology Metadata
+# ============================================================================
+
+<https://ns.cascadeprotocol.org/genomics/v1#> a owl:Ontology ;
+    owl:imports <https://ns.cascadeprotocol.org/core/v1#> ,
+                <https://ns.cascadeprotocol.org/clinical/v1#> ;
+    dct:title "Cascade Protocol Genomics Ontology"@en ;
+    dct:description "Layer 2 vocabulary for sequence variants, variant interpretations, haplotypes/diplotypes, copy number variants, sequencing-run metadata, raw-file pointers, pedigrees, and genetic test reports/orders. Bridges Layer 1 standards (HGVS, ClinVar, VRS, HGNC, Sequence Ontology, HPO, MONDO/OMIM/ORDO, ACMG/AMP via LOINC answer codes, ClinGen review-status taxonomy) to Layer 3 patient-facing genetic counseling summaries in checkup:."@en ;
+    dct:creator "Cascade Agentic Labs" ;
+    dct:created "2026-05-05"^^xsd:date ;
+    dct:modified "2026-06-16"^^xsd:date ;
+    owl:versionInfo "1.0-draft" ;
+    rdfs:comment """DRAFT — pre-stable v1 ontology. Property names, ranges, and structure may change before v1.0 stable release.
+        Three-layer ontology for genomics:
+          Layer 1 (Established): HGVS nomenclature, VRS, ClinVar, HGNC, Sequence Ontology,
+                                 HPO, MONDO/OMIM/ORDO, ACMG/AMP (encoded via LOINC),
+                                 ClinGen review-status taxonomy, GA4GH htsget streaming.
+          Layer 2 (genomics:):   Variant, VariantInterpretation, SubmitterAssertion,
+                                 Haplotype, Diplotype, CopyNumberVariant, SequencingRun,
+                                 RawFile, GeneticTest, GeneticTestOrder, Pedigree,
+                                 PedigreeMember — RDF resources binding Layer 1 codes
+                                 to a patient and family with provenance and quality tier.
+          Layer 3 (checkup:):    GeneticCounselingSummary, VariantNarrative — patient-facing
+                                 aggregations and regeneratable narrative (authored separately
+                                 in the checkup vocabulary)."""@en ;
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/genomics/v1/> .
+
+# Changelog:
+# v1.0-draft.0.2 (2026-05-05): Phase 1 evolution candidates landed after the FHIR
+#     Genomics IG importer session surfaced gaps. All four are additive (no breaking
+#     changes):
+#       - genomics:reportedRecord — generic GeneticTest → record predicate (no
+#         rdfs:range, deliberately broad). Resolves the HLA tie-break (TASK-1.9):
+#         existing genomics:variantsObserved has rdfs:range genomics:Variant and
+#         cannot represent non-Variant report links (Diplotypes, Haplotypes, PGx
+#         implications).
+#       - genomics:refAllele, genomics:altAllele, genomics:genomicStartEnd —
+#         VCF-style coordinate properties for FHIR Genomics IG variants that lack
+#         HGVS but carry LOINC 69547-8 / 69551-0 / 81254-5 directly. Required for
+#         the Phase 3 VCF importer.
+#       - genomics:somaticStatus ObjectProperty + genomics:SomaticStatus enum
+#         (Germline / Somatic / UnknownSomaticStatus). Maps LOINC 48002-0.
+#       - genomics:variantAlleleFrequency (xsd:decimal, SHACL-bounded 0.0–1.0).
+#         Distinct from genomics:mosaicismFraction: VAF is a sequencing-evidence
+#         fraction; mosaicism is the clinical conclusion that the variant is
+#         present in only a subset of cells. Phase 1 importer was shoehorning
+#         VAF into mosaicismFraction; importers should now emit VAF here.
+# v1.0-draft (2026-05-05): Initial production version of genomics/v1-draft authored
+#     in spec/ from the v0.1 sketch (cascadeprotocol.org/drafts/genomics-v1/genomics.ttl).
+#     Folds in 9 gaps from GAP-ANALYSIS.md (Haplotype, Diplotype, CopyNumberVariant,
+#     SubmitterAssertion, GeneticTestOrder, mosaicismFraction, interpretationStatus +
+#     CausalityStatus, reviewStatus + 7-value ReviewStatus), directory-session additions
+#     (SequencingRun, RawFile, sequencing/coverage/laboratory metadata, dataProvenance
+#     enum), and the data-quality tier model per D-QUALITY-TIER (dataQualityTier enum +
+#     requiresConfirmation property). Per D-PATH, this draft is NOT yet registered in
+#     spec/VOCAB_VERSIONS — it lands there at v1.0 graduation.
+
+# ============================================================================
+# Core Classes — Variant Identity
+# ============================================================================
+
+genomics:Variant a owl:Class ;
+    rdfs:label "Sequence Variant"@en ;
+    rdfs:comment "A specific sequence variant observed in a patient sample. Carries the four parallel descriptions of variant identity (HGVS for human readability, ClinVar/VRS for stable computable identity, Sequence Ontology for consequence type, gene for biological context). Distinct from VariantInterpretation, which assigns clinical significance."@en ;
+    rdfs:subClassOf fhir:Observation ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty genomics:geneSymbol ;
+        owl:cardinality 1
+    ] .
+
+genomics:VariantInterpretation a owl:Class ;
+    rdfs:label "Variant Interpretation"@en ;
+    rdfs:comment "A clinical-significance assertion linking a Variant to a single condition (per D-Q5 — multi-condition cases produce multiple Interpretation instances), with ACMG/AMP classification, supporting criteria, and an interpreting laboratory or expert panel. Reclassifications produce new Interpretation instances linked to the prior via prov:wasRevisionOf — interpretations are versioned, not edited. SHACL enforces genomics:condition and genomics:variantInterpreted both at cardinality 1..1 (see genomics.shapes.ttl, TASK-0.2)."@en ;
+    rdfs:subClassOf fhir:Observation ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:GeneticTest a owl:Class ;
+    rdfs:label "Genetic Test Report"@en ;
+    rdfs:comment "Result envelope from a clinical genetic test (panel, exome, single-gene). Aggregates Variant observations, gene panel scope, methodology, and ordering provider. Maps to FHIR DiagnosticReport. For test orders that have not yet resulted, see genomics:GeneticTestOrder."@en ;
+    rdfs:subClassOf fhir:DiagnosticReport ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:GeneticTestOrder a owl:Class ;
+    rdfs:label "Genetic Test Order"@en ;
+    rdfs:comment "An order/request for a genetic test, distinct from the resulting GeneticTest. Maps to FHIR ServiceRequest. Counseling workflows track 'ordered but not yet resulted' state via this class. Once the order is fulfilled, link the resulting GeneticTest via genomics:resultedIn."@en ;
+    rdfs:subClassOf fhir:ServiceRequest ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:Gene a owl:Class ;
+    rdfs:label "Gene"@en ;
+    rdfs:comment "A gene reference, identified by HGNC approved symbol and ID. Used as the target of variant observations and gene-disease associations."@en .
+
+# ============================================================================
+# Haplotype, Diplotype, Copy Number Variants
+# ============================================================================
+# Haplotype/Diplotype superClass decision (resolved 2026-05-05):
+# FHIR Genomics IG ships `haplotype` and `genotype` profiles, both extending
+# `Observation` (verified against Bundle-bundle-pgxexample.json — both
+# resourceType "Observation"). We adopt the same anchor for consistency with
+# Variant. See RATIONALE.md.
+
+genomics:Haplotype a owl:Class ;
+    rdfs:label "Haplotype"@en ;
+    rdfs:comment "A multi-variant unit travelling together on one chromosome — the unit of clinical interpretation in pharmacogenomics (PharmVar star alleles like CYP2C19*2, CYP2D6*4) and HLA typing (HLA-DQB1*02:01). Cannot be expressed as a single Variant. Anchored on fhir:Observation per FHIR Genomics IG haplotype profile."@en ;
+    rdfs:subClassOf fhir:Observation ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:Diplotype a owl:Class ;
+    rdfs:label "Diplotype"@en ;
+    rdfs:comment "A pair of haplotypes (e.g., '*1/*2'), required for any pharmacogenomics or HLA typing use case. Anchored on fhir:Observation per FHIR Genomics IG genotype profile."@en ;
+    rdfs:subClassOf fhir:Observation ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:CopyNumberVariant a owl:Class ;
+    rdfs:label "Copy Number Variant"@en ;
+    rdfs:comment "A structural variant defined by deletion or duplication of a genomic interval, expressed as integer copy number plus interval coordinates rather than HGVS. Required for structural-variant cases (e.g., 13q14 deletion in retinoblastoma). subClassOf genomics:Variant — inherits stable-ID and zygosity properties where applicable."@en ;
+    rdfs:subClassOf genomics:Variant .
+
+# ============================================================================
+# Sequencing Run & Raw File Metadata (per D-DIRECTORY)
+# ============================================================================
+# Cascade pods do NOT ingest raw genomic file bytes (BAM/CRAM/FASTQ at
+# 50–100GB+). RawFile carries pointer-and-hash metadata only — bytes live
+# wherever the user keeps them (lab cloud, local disk, NAS, htsget-served).
+# See Critical conventions #9 in the Genomics & Advisory implementation plan.
+
+genomics:SequencingRun a owl:Class ;
+    rdfs:label "Sequencing Run"@en ;
+    rdfs:comment "Metadata for a single sequencing run that produced one or more variants. Captures coverage depth, technology, variant-caller version, laboratory certification, and key dates (sample collection, sequencing, file generation). Used to populate the data-quality tier on derived Variants and to trace provenance back to lab process."@en ;
+    rdfs:subClassOf prov:Activity .
+
+genomics:RawFile a owl:Class ;
+    rdfs:label "Raw Genomic File"@en ;
+    rdfs:comment "Pointer-and-hash record for a raw genomic file (BAM, CRAM, FASTQ, gVCF, VCF, BCF). Cascade does NOT ingest the bytes — only the manifest. The bytes live wherever the user keeps them (lab cloud, local disk, NAS, htsget-served). genomics:fileLocation may be opaque (s3://, https://, file://, or a vendor-specific URI) and is not validated by Cascade."@en ;
+    rdfs:subClassOf prov:Entity .
+
+# ============================================================================
+# Variant Identity Properties — HGVS Nomenclature
+# ============================================================================
+# Per HGVS: a description is incomplete without its reference sequence. Always
+# store the full reference:type.position+change string, never a bare position.
+
+genomics:hgvsCDot a owl:DatatypeProperty ;
+    rdfs:label "HGVS Coding-DNA Description"@en ;
+    rdfs:comment "Variant described against a coding-sequence (transcript) reference, e.g. 'NM_000059.4:c.5946delT'. Includes transcript accession with version. This is the form most often cited in clinical reports."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:48004-6 .  # DNA change (c.HGVS)
+
+genomics:hgvsPDot a owl:DatatypeProperty ;
+    rdfs:label "HGVS Protein Description"@en ;
+    rdfs:comment "Variant described at the protein level, e.g. 'NP_000050.3:p.Ser1982Argfs*22'. Use parentheses (p.(Ser1982Argfs*22)) when the protein consequence is predicted from the DNA change rather than directly observed."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:48005-3 .  # Amino acid change (p.HGVS)
+
+genomics:hgvsGDot a owl:DatatypeProperty ;
+    rdfs:label "HGVS Genomic Description"@en ;
+    rdfs:comment "Variant described against a genomic reference, e.g. 'NC_000013.11:g.32340301del'. Required for cross-transcript joins and for variants outside coding regions."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:81290-9 .  # Genomic ref allele
+
+# Added in v1-draft.0.2: VCF-style coordinate properties. FHIR Genomics IG
+# variants frequently carry the LOINC 69547-8 / 69551-0 / 81254-5 components
+# without HGVS strings; the Phase 3 VCF importer relies on these directly.
+genomics:refAllele a owl:DatatypeProperty ;
+    rdfs:label "Reference Allele"@en ;
+    rdfs:comment "The reference base sequence at the variant position, as defined by the reference genome assembly. ATCG[N], typically 1–N bases. Per VCF REF / FHIR Genomics IG LOINC 69547-8."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:69547-8 .  # Genomic ref allele [ID]
+
+genomics:altAllele a owl:DatatypeProperty ;
+    rdfs:label "Alternate Allele"@en ;
+    rdfs:comment "The variant allele sequence at the variant position. ATCG[N] for substitutions/insertions; '-' or empty for deletions; structured forms like '<DEL>'/'<DUP>' for symbolic alleles. Per VCF ALT / FHIR Genomics IG LOINC 69551-0."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:69551-0 .  # Genomic alt allele [ID]
+
+genomics:genomicStartEnd a owl:DatatypeProperty ;
+    rdfs:label "Genomic Start-End Coordinates"@en ;
+    rdfs:comment "The 1-based inclusive start-end coordinates of the variant on the reference assembly, formatted as 'chrN:start-end' (e.g., 'chr17:43124027-43124028'). Pair with genomics:referenceGenome for full anchoring. Per FHIR Genomics IG LOINC 81254-5."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:81254-5 .  # Genomic allele start-end
+
+genomics:hgvsProteinObserved a owl:DatatypeProperty ;
+    rdfs:label "Protein Consequence Directly Observed"@en ;
+    rdfs:comment "True when the p.HGVS description was directly observed at the protein level (e.g. mass spec, functional assay). False or absent means the protein consequence was predicted from the DNA change. Conventionally encoded in HGVS by parentheses around the p. description."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:boolean .
+
+genomics:transcriptRef a owl:DatatypeProperty ;
+    rdfs:label "Reference Transcript"@en ;
+    rdfs:comment "RefSeq transcript accession with version, e.g. 'NM_000059.4'. Stored separately from the HGVS string so that downstream tools can reason about transcript version drift, the most common source of variant ambiguity in clinical handoffs."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+genomics:genomeAssembly a owl:DatatypeProperty ;
+    rdfs:label "Reference Genome Assembly"@en ;
+    rdfs:comment "Reference genome build, e.g. 'GRCh38' or 'GRCh37'. Required when interpreting g.HGVS coordinates."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Variant Identity Properties — Stable Identifiers
+# ============================================================================
+# HGVS strings are descriptive but normalization-fragile. Stable IDs are what
+# join across databases. Carry as many as the source provides.
+
+genomics:clinvarVariationId a owl:DatatypeProperty ;
+    rdfs:label "ClinVar Variation ID"@en ;
+    rdfs:comment "ClinVar VCV accession identifying the variant (not the variant-condition pair). Example: 'VCV000051062' for BRCA2 c.5946delT."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:81252-9 .  # Discrete genetic variant
+
+genomics:clinvarRcvId a owl:DatatypeProperty ;
+    rdfs:label "ClinVar RCV ID"@en ;
+    rdfs:comment "ClinVar RCV accession identifying a variant-condition assertion. Multiple RCVs typically attach to one VCV. Lives on VariantInterpretation, not Variant."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:string .
+
+genomics:dbsnpRsId a owl:DatatypeProperty ;
+    rdfs:label "dbSNP rsID"@en ;
+    rdfs:comment "NCBI dbSNP reference SNP identifier, e.g. 'rs80359550'. Primary join key for consumer-array (23andMe / AncestryDNA / etc.) imports."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+genomics:caId a owl:DatatypeProperty ;
+    rdfs:label "ClinGen Allele Registry CAid"@en ;
+    rdfs:comment "ClinGen Allele Registry canonical allele identifier. Stable across HGVS reformulations and assembly changes — the recommended primary join key when available."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+genomics:vrsId a owl:DatatypeProperty ;
+    rdfs:label "GA4GH VRS Identifier"@en ;
+    rdfs:comment "Deterministic computable hash identifier per GA4GH Variation Representation Spec. Computed from the normalized sequence-location-state object; identical variants always hash to the same VRS ID regardless of how they were originally described."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+genomics:vrsObject a owl:DatatypeProperty ;
+    rdfs:label "VRS Allele Object (JSON-LD)"@en ;
+    rdfs:comment "Full VRS Allele JSON-LD payload as serialized string. Carries sequence reference, location interval, and state. Permits round-trip to other VRS-aware systems without re-parsing the HGVS."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Gene & Consequence Properties
+# ============================================================================
+
+genomics:geneSymbol a owl:DatatypeProperty ;
+    rdfs:label "Gene Symbol (HGNC Approved)"@en ;
+    rdfs:comment "HGNC approved gene symbol, e.g. 'BRCA2'. Always use the approved symbol, never an alias."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string ;
+    genomics:loincCode loinc:48018-6 .  # Gene studied
+
+genomics:hgncId a owl:DatatypeProperty ;
+    rdfs:label "HGNC ID"@en ;
+    rdfs:comment "HGNC numeric identifier with prefix, e.g. 'HGNC:1101' for BRCA2. Stable across symbol changes."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+genomics:consequenceTerm a owl:ObjectProperty ;
+    rdfs:label "Sequence Ontology Consequence"@en ;
+    rdfs:comment "Sequence Ontology term URI describing the molecular consequence of the variant, e.g. so:0001589 (frameshift_variant), so:0001583 (missense_variant), so:0001587 (stop_gained)."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range owl:Class .
+
+genomics:consequenceLabel a owl:DatatypeProperty ;
+    rdfs:label "Consequence Label"@en ;
+    rdfs:comment "Human-readable consequence label paired with the SO URI for legibility, e.g. 'frameshift_variant'."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:string .
+
+genomics:zygosity a owl:ObjectProperty ;
+    rdfs:label "Zygosity"@en ;
+    rdfs:comment "Zygosity of the observed variant. Named-individual values: genomics:Heterozygous, Homozygous, Hemizygous, CompoundHeterozygous, MosaicLow, MosaicHigh. For mosaic variants, also populate genomics:mosaicismFraction with the actual VAF."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range genomics:ZygosityValue ;
+    genomics:loincCode loinc:53034-5 .  # Allelic state
+
+genomics:mosaicismFraction a owl:DatatypeProperty ;
+    rdfs:label "Mosaicism Fraction (VAF)"@en ;
+    rdfs:comment "Variant allele fraction (0.0–1.0) for mosaic variants. Distinct from zygosity, which is categorical. The continuous VAF is the load-bearing number for clinical decisions in somatic mosaicism scenarios. NOTE (v1-draft.0.2): for the broader 'fraction of reads supporting alt allele' use genomics:variantAlleleFrequency; mosaicismFraction is reserved for the clinical conclusion that the variant is present in only a subset of cells."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:decimal .
+
+# Added in v1-draft.0.2: VAF as a distinct property from mosaicismFraction.
+# VAF is the broader concept (any sequencing read fraction supporting the alt
+# allele); mosaicism is the specific clinical interpretation. Phase 1 importer
+# was shoehorning LOINC 81258-6 into mosaicismFraction; the correct fix is
+# authoring VAF as its own property.
+genomics:variantAlleleFrequency a owl:DatatypeProperty ;
+    rdfs:label "Variant Allele Frequency"@en ;
+    rdfs:comment "Fraction of sequencing reads at the variant position that support the alternate allele. Range 0.0–1.0. Per FHIR Genomics IG LOINC 81258-6. Distinct from genomics:mosaicismFraction — VAF is a sequencing-evidence fraction; mosaicism is the clinical conclusion that the variant is present in only a subset of cells (which often, but not always, manifests as low VAF)."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range xsd:decimal ;
+    genomics:loincCode loinc:81258-6 .  # Sample variant allelic frequency [NFr]
+
+# Added in v1-draft.0.2: variant origin (germline vs. somatic). LOINC 48002-0
+# is one of the most clinically important variant attributes. Critical for
+# cancer interpretation and inheritance reasoning.
+genomics:somaticStatus a owl:ObjectProperty ;
+    rdfs:label "Somatic Status"@en ;
+    rdfs:comment "Whether the variant is germline (inherited / present in all cells) or somatic (acquired / tissue-specific). Critical for cancer interpretation and inheritance reasoning. Per FHIR Genomics IG LOINC 48002-0."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range genomics:SomaticStatus ;
+    genomics:loincCode loinc:48002-0 .  # Genomic source class
+
+genomics:phase a owl:ObjectProperty ;
+    rdfs:label "Allelic Phase"@en ;
+    rdfs:comment "For compound heterozygous calls in the same gene: whether the two variants are in cis (same chromosome) or trans (opposite chromosomes). Values: genomics:Cis, Trans, PhaseUnknown. Critical for autosomal recessive inheritance interpretation."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range genomics:PhaseValue .
+
+genomics:phasedWith a owl:ObjectProperty ;
+    rdfs:label "Phased With Variant"@en ;
+    rdfs:comment "Links to the partner Variant when phase has been determined for a compound-heterozygous pair. Symmetric (each variant phasedWith the other)."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range genomics:Variant .
+
+# ============================================================================
+# Haplotype & Diplotype Properties
+# ============================================================================
+
+genomics:hasComponent a owl:ObjectProperty ;
+    rdfs:label "Haplotype Component Variant"@en ;
+    rdfs:comment "Links a Haplotype to one of its component Variants. A haplotype is composed of multiple variants that travel together on one chromosome."@en ;
+    rdfs:domain genomics:Haplotype ;
+    rdfs:range genomics:Variant .
+
+genomics:starAlleleSymbol a owl:DatatypeProperty ;
+    rdfs:label "Star Allele Symbol"@en ;
+    rdfs:comment "PharmVar/HLA-style nomenclature, e.g. 'CYP2C19*2', 'HLA-DQB1*02:01'. The clinically actionable identifier in pharmacogenomics and HLA typing."@en ;
+    rdfs:domain genomics:Haplotype ;
+    rdfs:range xsd:string .
+
+genomics:diplotypeNotation a owl:DatatypeProperty ;
+    rdfs:label "Diplotype Notation"@en ;
+    rdfs:comment "Compact paired-haplotype notation, e.g. '*1/*2'. Computed from hapA + hapB; carried as a string for human readability and direct match against PGx guideline tables."@en ;
+    rdfs:domain genomics:Diplotype ;
+    rdfs:range xsd:string .
+
+genomics:hapA a owl:ObjectProperty ;
+    rdfs:label "Haplotype A"@en ;
+    rdfs:comment "First haplotype of a diplotype pair. Order (A vs B) is arbitrary but must be stable within a record."@en ;
+    rdfs:domain genomics:Diplotype ;
+    rdfs:range genomics:Haplotype .
+
+genomics:hapB a owl:ObjectProperty ;
+    rdfs:label "Haplotype B"@en ;
+    rdfs:comment "Second haplotype of a diplotype pair."@en ;
+    rdfs:domain genomics:Diplotype ;
+    rdfs:range genomics:Haplotype .
+
+# ============================================================================
+# Copy Number Variant Properties
+# ============================================================================
+
+genomics:copyNumber a owl:DatatypeProperty ;
+    rdfs:label "Copy Number"@en ;
+    rdfs:comment "Integer copy number observed for the genomic interval, e.g. 1 (heterozygous deletion), 0 (homozygous deletion), 3 (single duplication), 4+ (amplification). Distinct from zygosity."@en ;
+    rdfs:domain genomics:CopyNumberVariant ;
+    rdfs:range xsd:integer .
+
+genomics:cnvIntervalStart a owl:DatatypeProperty ;
+    rdfs:label "CNV Interval Start"@en ;
+    rdfs:comment "Start coordinate (1-based, inclusive) of the CNV interval on the reference indicated by cnvIntervalRef."@en ;
+    rdfs:domain genomics:CopyNumberVariant ;
+    rdfs:range xsd:integer .
+
+genomics:cnvIntervalEnd a owl:DatatypeProperty ;
+    rdfs:label "CNV Interval End"@en ;
+    rdfs:comment "End coordinate (1-based, inclusive) of the CNV interval."@en ;
+    rdfs:domain genomics:CopyNumberVariant ;
+    rdfs:range xsd:integer .
+
+genomics:cnvIntervalRef a owl:DatatypeProperty ;
+    rdfs:label "CNV Interval Reference"@en ;
+    rdfs:comment "Genomic reference for the interval coordinates, e.g. 'NC_000013.11' (chromosome 13 in GRCh38) or a chromosome name. Required for downstream analyses to locate the interval."@en ;
+    rdfs:domain genomics:CopyNumberVariant ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Variant Interpretation Properties (ACMG/AMP)
+# ============================================================================
+
+genomics:variantInterpreted a owl:ObjectProperty ;
+    rdfs:label "Variant Interpreted"@en ;
+    rdfs:comment "The Variant being assessed by this VariantInterpretation. SHACL enforces cardinality 1..1 (per D-Q5)."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:Variant .
+
+genomics:acmgClassification a owl:ObjectProperty ;
+    rdfs:label "ACMG/AMP Classification"@en ;
+    rdfs:comment "Five-tier ACMG/AMP classification. Named-individual values map 1:1 to LOINC answer codes: Pathogenic (LA6668-3), LikelyPathogenic (LA26332-9), VUS (LA26333-7), LikelyBenign (LA26334-5), Benign (LA6675-8)."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:AcmgClass ;
+    genomics:loincCode loinc:53037-8 .  # Genetic variation clinical significance
+
+genomics:acmgCriteria a owl:DatatypeProperty ;
+    rdfs:label "ACMG Evidence Criteria"@en ;
+    rdfs:comment "Space-separated ACMG/AMP evidence criteria codes applied in this classification, e.g. 'PVS1 PM2 PP5'. Order is not significant."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:string .
+
+genomics:condition a owl:ObjectProperty ;
+    rdfs:label "Associated Condition"@en ;
+    rdfs:comment "Disease or condition associated with this interpretation. Range is a MONDO/OMIM/ORDO term URI. Per D-Q5, each VariantInterpretation has cardinality 1..1 on this property — multi-condition cases produce multiple interpretation instances."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range owl:Class .
+
+genomics:mondoId a owl:DatatypeProperty ;
+    rdfs:label "MONDO Disease ID"@en ;
+    rdfs:comment "MONDO disease ontology ID, e.g. 'MONDO:0007254' for Hereditary breast carcinoma."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:string .
+
+genomics:omimId a owl:DatatypeProperty ;
+    rdfs:label "OMIM Phenotype/Gene ID"@en ;
+    rdfs:comment "OMIM identifier (six-digit) for a Mendelian phenotype or gene, e.g. '604370' for Breast-ovarian cancer, familial, susceptibility to, 2."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:string .
+
+genomics:orphaCode a owl:DatatypeProperty ;
+    rdfs:label "Orphanet Code"@en ;
+    rdfs:comment "Orphanet rare disease code, e.g. 'ORPHA:145' for Hereditary breast and ovarian cancer syndrome."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:string .
+
+genomics:inheritanceMode a owl:ObjectProperty ;
+    rdfs:label "Mode of Inheritance"@en ;
+    rdfs:comment "GenCC-aligned mode of inheritance for the gene-disease relationship. Named-individual values: AutosomalDominant, AutosomalRecessive, XLinkedDominant, XLinkedRecessive, Mitochondrial, YLinked, MultifactorialPolygenic, UnknownInheritance."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:InheritanceMode .
+
+genomics:allelicRequirement a owl:ObjectProperty ;
+    rdfs:label "Allelic Requirement"@en ;
+    rdfs:comment "GenCC allelic requirement: monoallelic, biallelic, etc. Captures whether one or two copies of a pathogenic variant are required for the disease phenotype."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:AllelicRequirement .
+
+genomics:interpretedBy a owl:DatatypeProperty ;
+    rdfs:label "Interpreting Laboratory or Expert Panel"@en ;
+    rdfs:comment "Name of the lab, ClinGen Variant Curation Expert Panel (VCEP), or curator who issued this interpretation. Free-text for now; will be replaced with a fhir:Organization reference in v1.0."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:string .
+
+genomics:interpretedDate a owl:DatatypeProperty ;
+    rdfs:label "Interpretation Date"@en ;
+    rdfs:comment "Date this interpretation was issued. Reclassifications create new Interpretation instances; the date here is the date of THIS classification, not the original."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:date .
+
+# Reclassifications — use prov:wasRevisionOf to chain interpretation versions.
+# Example: a VUS that becomes Likely Pathogenic links the new Interpretation
+# to the old via prov:wasRevisionOf. Past patient-facing narratives generated
+# from the old interpretation remain valid as historical record.
+
+# ============================================================================
+# Submitter Assertions (ClinVar SCV pattern)
+# ============================================================================
+# A VariantInterpretation's authoritative classification can aggregate dozens
+# of individual submitter assertions (ClinVar SCVs). Track per-submitter
+# detail here so disagreement and review-status arithmetic is preserved.
+
+genomics:SubmitterAssertion a owl:Class ;
+    rdfs:label "Submitter Assertion"@en ;
+    rdfs:comment "A single submitter's assertion about a variant-condition pair, e.g. one ClinVar SCV record. Aggregated assertions roll up into a VariantInterpretation via genomics:aggregatedFrom. Individual submissions may disagree with the aggregate (most agree, but ENIGMA, Mayo, Ambry, etc. can each carry distinct opinions)."@en ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:aggregatedFrom a owl:ObjectProperty ;
+    rdfs:label "Aggregated From"@en ;
+    rdfs:comment "Links a VariantInterpretation to the SubmitterAssertions it aggregates. The aggregate classification is computed from these per-submitter records; preserving the constituents lets downstream tools recompute or audit the rollup."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:SubmitterAssertion .
+
+genomics:assertedClassification a owl:ObjectProperty ;
+    rdfs:label "Asserted ACMG Classification"@en ;
+    rdfs:comment "The ACMG class assigned by this individual submitter. May differ from the aggregate classification on the parent VariantInterpretation."@en ;
+    rdfs:domain genomics:SubmitterAssertion ;
+    rdfs:range genomics:AcmgClass .
+
+genomics:submitter a owl:DatatypeProperty ;
+    rdfs:label "Submitter Name"@en ;
+    rdfs:comment "Name of the submitting laboratory, consortium, or expert panel, e.g. 'ENIGMA', 'Ambry Genetics', 'Mayo Clinic'."@en ;
+    rdfs:domain genomics:SubmitterAssertion ;
+    rdfs:range xsd:string .
+
+genomics:submitterOrgId a owl:DatatypeProperty ;
+    rdfs:label "Submitter Organization ID"@en ;
+    rdfs:comment "ClinVar OrgID (or equivalent submitter registry identifier) for the submitting organization."@en ;
+    rdfs:domain genomics:SubmitterAssertion ;
+    rdfs:range xsd:string .
+
+genomics:submitterCategory a owl:ObjectProperty ;
+    rdfs:label "Submitter Category"@en ;
+    rdfs:comment "Class of submitter: laboratory, consortium, expert-panel, research-group, single-clinician, etc. Drives review-status weighting."@en ;
+    rdfs:domain genomics:SubmitterAssertion ;
+    rdfs:range genomics:SubmitterCategory .
+
+genomics:scvAccession a owl:DatatypeProperty ;
+    rdfs:label "SCV Accession"@en ;
+    rdfs:comment "ClinVar SCV (Submission) accession identifying this individual submission, e.g. 'SCV000123456'."@en ;
+    rdfs:domain genomics:SubmitterAssertion ;
+    rdfs:range xsd:string .
+
+genomics:contributesToAggregate a owl:DatatypeProperty ;
+    rdfs:label "Contributes to Aggregate"@en ;
+    rdfs:comment "True when this submission is included in the aggregate classification. Some submissions are excluded (withdrawn, superseded, flagged) but retained for audit."@en ;
+    rdfs:domain genomics:SubmitterAssertion ;
+    rdfs:range xsd:boolean .
+
+genomics:assertionEvidenceLevel a owl:ObjectProperty ;
+    rdfs:label "Assertion Evidence Level"@en ;
+    rdfs:comment "Strength-of-evidence label per the submitter's review process. Range is a vocabulary-extensible class — no fixed enum to allow lab-specific gradings."@en ;
+    rdfs:domain genomics:SubmitterAssertion .
+
+# ============================================================================
+# Review Status (ClinGen / ClinVar 7-tier taxonomy)
+# ============================================================================
+# Mirrors the de-facto industry standard 0–4 star rating users see in ClinVar
+# UI. Author 7 named individuals (the rating is shared across two pairs).
+
+genomics:reviewStatus a owl:ObjectProperty ;
+    rdfs:label "Review Status"@en ;
+    rdfs:comment "ClinGen / ClinVar review-status classification of this VariantInterpretation, mapping to the 0–4 star confidence rating. Drives advisory engine trust decisions."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:ReviewStatus .
+
+genomics:starRating a owl:DatatypeProperty ;
+    rdfs:label "Star Rating"@en ;
+    rdfs:comment "Integer 0–4 star rating associated with a ReviewStatus, matching ClinVar UI."@en ;
+    rdfs:domain genomics:ReviewStatus ;
+    rdfs:range xsd:integer .
+
+# ============================================================================
+# Causality Status (Phenopacket interpretationStatus)
+# ============================================================================
+
+genomics:interpretationStatus a owl:ObjectProperty ;
+    rdfs:label "Interpretation Status (Causality)"@en ;
+    rdfs:comment "Whether this variant explains THIS patient's phenotype. Distinct from ACMG classification: ACMG classifies the variant; interpretationStatus classifies the variant's role in the patient's clinical picture. Aligned with GA4GH Phenopackets v2 InterpretationStatus enum."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range genomics:CausalityStatus .
+
+# ============================================================================
+# Genetic Test Properties
+# ============================================================================
+
+genomics:testType a owl:ObjectProperty ;
+    rdfs:label "Genetic Test Type"@en ;
+    rdfs:comment "Test methodology category. Named-individual values: SingleGeneTest, GenePanelTest, ExomeSequencing, GenomeSequencing, ChromosomalMicroarray, KaryotypeAnalysis, MLPA, RepeatExpansionTest, MethylationStudy, RNASequencing."@en ;
+    rdfs:domain genomics:GeneticTest ;
+    rdfs:range genomics:TestType .
+
+genomics:genePanel a owl:DatatypeProperty ;
+    rdfs:label "Gene Panel Members"@en ;
+    rdfs:comment "Space-separated HGNC symbols for the genes included in this test's analytical scope. Used to distinguish 'no variant found in BRCA1/2' from 'no variant found across a 47-gene cancer panel'."@en ;
+    rdfs:domain genomics:GeneticTest ;
+    rdfs:range xsd:string .
+
+genomics:variantsObserved a owl:ObjectProperty ;
+    rdfs:label "Variants Observed"@en ;
+    rdfs:comment "Variants reported by this test. Empty list with non-empty genePanel = clinically meaningful negative result."@en ;
+    rdfs:domain genomics:GeneticTest ;
+    rdfs:range genomics:Variant .
+
+# Added in v1-draft.0.2: generic GeneticTest → record predicate. Resolves the
+# HLA tie-break (cascade-coordination/tie-breaks/2026-05-05-task-1.9-hla-variantsObserved.md):
+# genomics:variantsObserved has rdfs:range genomics:Variant and cannot
+# represent non-Variant report links (Diplotypes, Haplotypes, PGx
+# implications). Importers should still emit the most specific predicate
+# available (variantsObserved for Variants).
+genomics:reportedRecord a owl:ObjectProperty ;
+    rdfs:label "Reported Record"@en ;
+    rdfs:comment "A genomics record (Variant, Haplotype, Diplotype, VariantInterpretation, or other genomics:* class) referenced by this GeneticTest. Use this predicate when the test result is a Diplotype, Haplotype, or PGx implication that has no Variant-typed range. For point-Variant references, prefer the type-specific genomics:variantsObserved (rdfs:range genomics:Variant)."@en ;
+    rdfs:domain genomics:GeneticTest .
+    # No rdfs:range — deliberately broad. SHACL won't constrain the object class
+    # so any genomics: record can be referenced.
+
+genomics:orderingProvider a owl:DatatypeProperty ;
+    rdfs:label "Ordering Provider"@en ;
+    rdfs:comment "Name of clinician who ordered the test. Will become a fhir:Practitioner reference in v1.0."@en ;
+    rdfs:domain genomics:GeneticTest ;
+    rdfs:range xsd:string .
+
+genomics:performingLab a owl:DatatypeProperty ;
+    rdfs:label "Performing Laboratory"@en ;
+    rdfs:comment "Name of the laboratory that performed the analysis. Free-text for now; fhir:Organization reference in v1.0."@en ;
+    rdfs:domain genomics:GeneticTest ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Genetic Test Order Properties
+# ============================================================================
+
+genomics:orderedAt a owl:DatatypeProperty ;
+    rdfs:label "Ordered At"@en ;
+    rdfs:comment "Timestamp when the test was ordered."@en ;
+    rdfs:domain genomics:GeneticTestOrder ;
+    rdfs:range xsd:dateTime .
+
+genomics:orderStatus a owl:ObjectProperty ;
+    rdfs:label "Order Status"@en ;
+    rdfs:comment "Status of the test order: Pending, InProgress, Resulted, Cancelled."@en ;
+    rdfs:domain genomics:GeneticTestOrder ;
+    rdfs:range genomics:OrderStatus .
+
+genomics:resultedIn a owl:ObjectProperty ;
+    rdfs:label "Resulted In"@en ;
+    rdfs:comment "Links a fulfilled GeneticTestOrder to the resulting GeneticTest."@en ;
+    rdfs:domain genomics:GeneticTestOrder ;
+    rdfs:range genomics:GeneticTest .
+
+# ============================================================================
+# Sequencing Run Properties (per D-DIRECTORY)
+# ============================================================================
+
+genomics:coverageDepth a owl:DatatypeProperty ;
+    rdfs:label "Coverage Depth"@en ;
+    rdfs:comment "Mean coverage depth across the targeted region, e.g. 30.0 for typical clinical WGS. ClinicalGrade tier requires >=30x for WGS or validated panel-specific equivalents."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range xsd:decimal .
+
+genomics:sequencingTechnology a owl:ObjectProperty ;
+    rdfs:label "Sequencing Technology"@en ;
+    rdfs:comment "Sequencing platform/technology category. Named-individual values: ShortReadIllumina, LongReadONT, LongReadPacBio, Mixed, GenotypingArray."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range genomics:SequencingTechnology .
+
+genomics:variantCallerVersion a owl:DatatypeProperty ;
+    rdfs:label "Variant Caller Version"@en ;
+    rdfs:comment "Variant caller name and version, e.g. 'GATK 4.5.0', 'DeepVariant 1.6'. Important for reproducibility and for distinguishing caller-driven differences from biological ones."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range xsd:string .
+
+genomics:laboratoryCertification a owl:ObjectProperty ;
+    rdfs:label "Laboratory Certification"@en ;
+    rdfs:comment "Regulatory certification of the performing laboratory. Named-individual values: CLIA, CAP, ISO15189, Uncertified."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range genomics:LaboratoryCertification .
+
+genomics:sampleCollectionDate a owl:DatatypeProperty ;
+    rdfs:label "Sample Collection Date"@en ;
+    rdfs:comment "Date the biological sample was collected from the patient."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range xsd:date .
+
+genomics:sequencingDate a owl:DatatypeProperty ;
+    rdfs:label "Sequencing Date"@en ;
+    rdfs:comment "Date sequencing was performed on the sample."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range xsd:date .
+
+genomics:fileGenerationDate a owl:DatatypeProperty ;
+    rdfs:label "File Generation Date"@en ;
+    rdfs:comment "Date the raw genomic file (BAM/CRAM/VCF/etc.) was generated. May post-date sequencingDate by re-alignments or re-calls."@en ;
+    rdfs:domain genomics:SequencingRun ;
+    rdfs:range xsd:date .
+
+# ============================================================================
+# Raw File Properties (pointer-and-hash representation)
+# ============================================================================
+
+genomics:fileFormat a owl:ObjectProperty ;
+    rdfs:label "File Format"@en ;
+    rdfs:comment "Raw genomic file format. Named-individual values: BAM, CRAM, FASTQ, gVCF, VCF, BCF, Other. Hot tier (in-pod, encrypted): VCF, gVCF, BCF. Cold tier (out-of-pod, referenced): BAM, CRAM, FASTQ."@en ;
+    rdfs:domain genomics:RawFile ;
+    rdfs:range genomics:FileFormat .
+
+genomics:fileSizeBytes a owl:DatatypeProperty ;
+    rdfs:label "File Size (Bytes)"@en ;
+    rdfs:comment "Size of the raw file in bytes. xsd:long because BAM/CRAM/FASTQ files routinely exceed 2^31 bytes (50–100 GB+)."@en ;
+    rdfs:domain genomics:RawFile ;
+    rdfs:range xsd:long .
+
+genomics:fileHashSHA256 a owl:DatatypeProperty ;
+    rdfs:label "File SHA-256 Hash"@en ;
+    rdfs:comment "Lowercase hex-encoded SHA-256 digest of the file contents. Integrity check enabling the pod to verify the bytes-on-disk match the manifest."@en ;
+    rdfs:domain genomics:RawFile ;
+    rdfs:range xsd:string .
+
+genomics:fileLocation a owl:DatatypeProperty ;
+    rdfs:label "File Location URI"@en ;
+    rdfs:comment "Opaque pointer to where the bytes live (s3://, https://, file://, vendor-specific). Cascade does NOT validate or fetch this URI; the bytes live wherever the user keeps them. See Critical conventions #9."@en ;
+    rdfs:domain genomics:RawFile ;
+    rdfs:range xsd:anyURI .
+
+genomics:referenceGenome a owl:DatatypeProperty ;
+    rdfs:label "Reference Genome"@en ;
+    rdfs:comment "Reference assembly the file is aligned against, e.g. 'GRCh38', 'GRCh37', 'T2T-CHM13'. Required for any downstream coordinate-based analysis."@en ;
+    rdfs:domain genomics:RawFile ;
+    rdfs:range xsd:string .
+
+genomics:htsgetEndpoint a owl:DatatypeProperty ;
+    rdfs:label "htsget Endpoint"@en ;
+    rdfs:comment "Optional GA4GH htsget endpoint URI for streaming BAM/CRAM regions on demand without ingesting the full file. Letters labs and cloud-genomics services typically expose htsget; consumer providers usually do not."@en ;
+    rdfs:domain genomics:RawFile ;
+    rdfs:range xsd:anyURI .
+
+# ============================================================================
+# Data Provenance (genomics-specific enum)
+# ============================================================================
+# Note: distinct from cascade:dataProvenance (which classifies consumer vs
+# clinical data sources). genomics:dataProvenance captures the genomics-
+# specific origin lane that drives importer routing and quality-tier inference.
+
+genomics:dataProvenance a owl:ObjectProperty ;
+    rdfs:label "Genomic Data Provenance"@en ;
+    rdfs:comment "Origin lane of the genomic data, driving importer routing and quality-tier inference. Named-individual values: ConsumerArray, ClinicalSequencing, ResearchSequencing, Imported, AIExtracted. Distinct from the broader cascade:dataProvenance (consumer-vs-clinical classification) — this is genomics-specific because consumer-array imports (Phase 2C) need a distinct lane that auto-tags ConsumerGrade quality."@en ;
+    rdfs:range genomics:DataProvenance .
+
+# ============================================================================
+# Data Quality Tier (per D-QUALITY-TIER)
+# ============================================================================
+# Quality is a first-class vocabulary citizen. Every Variant carries a
+# dataQualityTier; SHACL (TASK-0.2) enforces that any Pathogenic /
+# LikelyPathogenic VariantInterpretation must either reference a
+# ClinicalGrade Variant OR carry requiresConfirmation true. This is a
+# safety constraint, not a quality nudge.
+
+genomics:dataQualityTier a owl:ObjectProperty ;
+    rdfs:label "Data Quality Tier"@en ;
+    rdfs:comment "Quality tier of the genomic data underlying this Variant, driving downstream advisory and narrative subsystems. Named-individual values: ClinicalGrade, ResearchGrade, ConsumerGrade, UnknownQuality. Aligns with cascadeprotocol.org sequencing-provider directory's three quality criteria (>=30x coverage + raw files + CLIA-certified)."@en ;
+    rdfs:domain genomics:Variant ;
+    rdfs:range genomics:DataQualityTier .
+
+genomics:requiresConfirmation a owl:DatatypeProperty ;
+    rdfs:label "Requires Confirmation"@en ;
+    rdfs:comment "True when this VariantInterpretation requires confirmatory clinical-grade re-testing before it can drive care decisions. SHACL (TASK-0.2): any Pathogenic / LikelyPathogenic interpretation MUST either reference a ClinicalGrade Variant OR carry requiresConfirmation true. The advisory engine MUST NOT auto-apply care recommendations to confirmation-required interpretations regardless of issuer trust."@en ;
+    rdfs:domain genomics:VariantInterpretation ;
+    rdfs:range xsd:boolean .
+
+# ============================================================================
+# Phenotype Properties (HPO)
+# ============================================================================
+
+genomics:hpoTerm a owl:DatatypeProperty ;
+    rdfs:label "HPO Phenotype Term"@en ;
+    rdfs:comment "Human Phenotype Ontology term identifier, e.g. 'HP:0003002' (Breast carcinoma). Multiple HPO terms per patient or relative are expected."@en ;
+    rdfs:range xsd:string .
+
+genomics:phenotypeOnsetAge a owl:DatatypeProperty ;
+    rdfs:label "Phenotype Onset Age"@en ;
+    rdfs:comment "Age in years when the phenotype was first observed. Use HPO onset terms (HP:0011462 Young adult onset, etc.) when only categorical onset is known."@en ;
+    rdfs:range xsd:integer .
+
+# ============================================================================
+# Pedigree Classes
+# ============================================================================
+
+genomics:Pedigree a owl:Class ;
+    rdfs:label "Pedigree"@en ;
+    rdfs:comment "A family pedigree: structured representation of relatives with conditions, ages of onset, and (where available) genotypes. Designed to round-trip with HL7 v3 Family History/Pedigree IG and FHIR FamilyMemberHistory while normalizing to Cascade's three-layer model."@en ;
+    rdfs:subClassOf prov:Entity .
+
+genomics:PedigreeMember a owl:Class ;
+    rdfs:label "Pedigree Member"@en ;
+    rdfs:comment "A single relative within a pedigree. Distinct from checkup:FamilyHistoryEntry, which is the patient-facing Layer 3 summary; PedigreeMember is the Layer 2 structured record carrying full HPO phenotype set, MONDO disease codes, age of onset/death, sex, and (optionally) carrier or affected status for specific variants."@en ;
+    rdfs:subClassOf fhir:FamilyMemberHistory ;
+    rdfs:subClassOf prov:Entity .
+
+# ============================================================================
+# Pedigree Properties
+# ============================================================================
+
+genomics:proband a owl:ObjectProperty ;
+    rdfs:label "Proband"@en ;
+    rdfs:comment "The index patient — the family member who brought the family to clinical attention. Required on every Pedigree."@en ;
+    rdfs:domain genomics:Pedigree ;
+    rdfs:range genomics:PedigreeMember .
+
+genomics:hasMember a owl:ObjectProperty ;
+    rdfs:label "Pedigree Member"@en ;
+    rdfs:comment "A relative included in the pedigree. Includes the proband."@en ;
+    rdfs:domain genomics:Pedigree ;
+    rdfs:range genomics:PedigreeMember .
+
+genomics:relativeRole a owl:ObjectProperty ;
+    rdfs:label "Relationship to Proband"@en ;
+    rdfs:comment "HL7 v3 RoleCode-aligned relationship, e.g. MTH (mother), FTH (father), SIS (sister), MGRMTH (maternal grandmother). Cardinal relations are first-class; complex relations expressed via nested PedigreeMember chains."@en ;
+    rdfs:domain genomics:PedigreeMember ;
+    rdfs:range genomics:RelationshipRole .
+
+genomics:relativeSex a owl:DatatypeProperty ;
+    rdfs:label "Biological Sex"@en ;
+    rdfs:comment "Biological sex of the relative as relevant to inheritance: 'male', 'female', 'unknown'. Distinct from gender identity, which is not modeled here."@en ;
+    rdfs:domain genomics:PedigreeMember ;
+    rdfs:range xsd:string .
+
+genomics:isDeceased a owl:DatatypeProperty ;
+    rdfs:label "Deceased"@en ;
+    rdfs:domain genomics:PedigreeMember ;
+    rdfs:range xsd:boolean .
+
+genomics:ageAtDeath a owl:DatatypeProperty ;
+    rdfs:label "Age at Death"@en ;
+    rdfs:domain genomics:PedigreeMember ;
+    rdfs:range xsd:integer .
+
+genomics:carrierStatus a owl:ObjectProperty ;
+    rdfs:label "Carrier Status for Variant"@en ;
+    rdfs:comment "Tested status of this relative for a specific variant (typically the family's known pathogenic variant). Named-individual values: PositiveAffected, PositiveUnaffected, Negative, NotTested, Obligate."@en ;
+    rdfs:domain genomics:PedigreeMember ;
+    rdfs:range genomics:CarrierStatus .
+
+genomics:testedForVariant a owl:ObjectProperty ;
+    rdfs:label "Tested for Variant"@en ;
+    rdfs:comment "The specific Variant for which this relative's carrierStatus is reported. Allows a relative to have distinct statuses for different variants in the same family."@en ;
+    rdfs:domain genomics:PedigreeMember ;
+    rdfs:range genomics:Variant .
+
+# ============================================================================
+# Named Individuals — ACMG Classification
+# ============================================================================
+
+genomics:Pathogenic a genomics:AcmgClass ;
+    rdfs:label "Pathogenic"@en ;
+    genomics:loincAnswerCode "LA6668-3" .
+
+genomics:LikelyPathogenic a genomics:AcmgClass ;
+    rdfs:label "Likely Pathogenic"@en ;
+    genomics:loincAnswerCode "LA26332-9" .
+
+genomics:VUS a genomics:AcmgClass ;
+    rdfs:label "Uncertain Significance"@en ;
+    genomics:loincAnswerCode "LA26333-7" .
+
+genomics:LikelyBenign a genomics:AcmgClass ;
+    rdfs:label "Likely Benign"@en ;
+    genomics:loincAnswerCode "LA26334-5" .
+
+genomics:Benign a genomics:AcmgClass ;
+    rdfs:label "Benign"@en ;
+    genomics:loincAnswerCode "LA6675-8" .
+
+# ============================================================================
+# Named Individuals — Zygosity, Phase, Inheritance
+# ============================================================================
+
+genomics:Heterozygous          a genomics:ZygosityValue ; rdfs:label "Heterozygous"@en .
+genomics:Homozygous            a genomics:ZygosityValue ; rdfs:label "Homozygous"@en .
+genomics:Hemizygous            a genomics:ZygosityValue ; rdfs:label "Hemizygous"@en .
+genomics:CompoundHeterozygous  a genomics:ZygosityValue ; rdfs:label "Compound Heterozygous"@en .
+genomics:MosaicLow             a genomics:ZygosityValue ; rdfs:label "Mosaic (low VAF)"@en .
+genomics:MosaicHigh            a genomics:ZygosityValue ; rdfs:label "Mosaic (high VAF)"@en .
+
+genomics:Cis           a genomics:PhaseValue ; rdfs:label "Cis (same chromosome)"@en .
+genomics:Trans         a genomics:PhaseValue ; rdfs:label "Trans (opposite chromosomes)"@en .
+genomics:PhaseUnknown  a genomics:PhaseValue ; rdfs:label "Phase Unknown"@en .
+
+genomics:AutosomalDominant       a genomics:InheritanceMode ; rdfs:label "Autosomal Dominant"@en .
+genomics:AutosomalRecessive      a genomics:InheritanceMode ; rdfs:label "Autosomal Recessive"@en .
+genomics:XLinkedDominant         a genomics:InheritanceMode ; rdfs:label "X-Linked Dominant"@en .
+genomics:XLinkedRecessive        a genomics:InheritanceMode ; rdfs:label "X-Linked Recessive"@en .
+genomics:Mitochondrial           a genomics:InheritanceMode ; rdfs:label "Mitochondrial"@en .
+genomics:YLinked                 a genomics:InheritanceMode ; rdfs:label "Y-Linked"@en .
+genomics:MultifactorialPolygenic a genomics:InheritanceMode ; rdfs:label "Multifactorial / Polygenic"@en .
+genomics:UnknownInheritance      a genomics:InheritanceMode ; rdfs:label "Unknown Inheritance"@en .
+
+genomics:Monoallelic a genomics:AllelicRequirement ; rdfs:label "Monoallelic"@en .
+genomics:Biallelic   a genomics:AllelicRequirement ; rdfs:label "Biallelic"@en .
+
+# ============================================================================
+# Named Individuals — Test Type, Carrier Status, Order Status
+# ============================================================================
+
+genomics:SingleGeneTest         a genomics:TestType ; rdfs:label "Single Gene Test"@en .
+genomics:GenePanelTest          a genomics:TestType ; rdfs:label "Gene Panel"@en .
+genomics:ExomeSequencing        a genomics:TestType ; rdfs:label "Whole Exome Sequencing"@en .
+genomics:GenomeSequencing       a genomics:TestType ; rdfs:label "Whole Genome Sequencing"@en .
+genomics:ChromosomalMicroarray  a genomics:TestType ; rdfs:label "Chromosomal Microarray"@en .
+genomics:KaryotypeAnalysis      a genomics:TestType ; rdfs:label "Karyotype"@en .
+genomics:MLPA                   a genomics:TestType ; rdfs:label "MLPA"@en .
+genomics:RepeatExpansionTest    a genomics:TestType ; rdfs:label "Repeat Expansion Test"@en .
+genomics:MethylationStudy       a genomics:TestType ; rdfs:label "Methylation Study"@en .
+genomics:RNASequencing          a genomics:TestType ; rdfs:label "RNA Sequencing"@en .
+
+genomics:PositiveAffected   a genomics:CarrierStatus ; rdfs:label "Positive — Affected"@en .
+genomics:PositiveUnaffected a genomics:CarrierStatus ; rdfs:label "Positive — Unaffected"@en .
+genomics:Negative           a genomics:CarrierStatus ; rdfs:label "Negative"@en .
+genomics:NotTested          a genomics:CarrierStatus ; rdfs:label "Not Tested"@en .
+genomics:Obligate           a genomics:CarrierStatus ; rdfs:label "Obligate Carrier"@en .
+
+genomics:OrderPending    a genomics:OrderStatus ; rdfs:label "Pending"@en .
+genomics:OrderInProgress a genomics:OrderStatus ; rdfs:label "In Progress"@en .
+genomics:OrderResulted   a genomics:OrderStatus ; rdfs:label "Resulted"@en .
+genomics:OrderCancelled  a genomics:OrderStatus ; rdfs:label "Cancelled"@en .
+
+# ============================================================================
+# Named Individuals — Pedigree Relationship Roles (HL7 v3 RoleCode-aligned)
+# ============================================================================
+# Cardinal first-degree, second-degree, and proband-marker relations are
+# first-class. Complex relations are expressed via nested PedigreeMember
+# chains. Codes follow HL7 v3 PersonalRelationshipRoleType (RoleCode).
+
+genomics:Proband a genomics:RelationshipRole ;
+    rdfs:label "Proband"@en ;
+    rdfs:comment "The index patient who brought the family to clinical attention. Marker, not a kinship relation."@en .
+
+genomics:MTH a genomics:RelationshipRole ; rdfs:label "Mother"@en .
+genomics:FTH a genomics:RelationshipRole ; rdfs:label "Father"@en .
+genomics:SIS a genomics:RelationshipRole ; rdfs:label "Sister"@en .
+genomics:BRO a genomics:RelationshipRole ; rdfs:label "Brother"@en .
+genomics:DAU a genomics:RelationshipRole ; rdfs:label "Daughter"@en .
+genomics:SON a genomics:RelationshipRole ; rdfs:label "Son"@en .
+genomics:MAUNT a genomics:RelationshipRole ; rdfs:label "Maternal Aunt"@en .
+genomics:MUNCLE a genomics:RelationshipRole ; rdfs:label "Maternal Uncle"@en .
+genomics:PAUNT a genomics:RelationshipRole ; rdfs:label "Paternal Aunt"@en .
+genomics:PUNCLE a genomics:RelationshipRole ; rdfs:label "Paternal Uncle"@en .
+genomics:MGRMTH a genomics:RelationshipRole ; rdfs:label "Maternal Grandmother"@en .
+genomics:MGRFTH a genomics:RelationshipRole ; rdfs:label "Maternal Grandfather"@en .
+genomics:PGRMTH a genomics:RelationshipRole ; rdfs:label "Paternal Grandmother"@en .
+genomics:PGRFTH a genomics:RelationshipRole ; rdfs:label "Paternal Grandfather"@en .
+genomics:MCOUSN a genomics:RelationshipRole ; rdfs:label "Maternal Cousin"@en .
+genomics:PCOUSN a genomics:RelationshipRole ; rdfs:label "Paternal Cousin"@en .
+genomics:NIECE a genomics:RelationshipRole ; rdfs:label "Niece"@en .
+genomics:NEPHEW a genomics:RelationshipRole ; rdfs:label "Nephew"@en .
+
+# ============================================================================
+# Named Individuals — Submitter Categories
+# ============================================================================
+
+genomics:SubmitterLaboratory  a genomics:SubmitterCategory ; rdfs:label "Clinical Laboratory"@en .
+genomics:SubmitterConsortium  a genomics:SubmitterCategory ; rdfs:label "Consortium"@en ;
+    rdfs:comment "Multi-institution curation consortium (e.g., ENIGMA for BRCA1/2)."@en .
+genomics:SubmitterExpertPanel a genomics:SubmitterCategory ; rdfs:label "Expert Panel"@en ;
+    rdfs:comment "ClinGen Variant Curation Expert Panel (VCEP)."@en .
+genomics:SubmitterResearch    a genomics:SubmitterCategory ; rdfs:label "Research Group"@en .
+genomics:SubmitterClinician   a genomics:SubmitterCategory ; rdfs:label "Single Clinician"@en .
+
+# ============================================================================
+# Named Individuals — Review Status (ClinGen/ClinVar 7-tier taxonomy)
+# ============================================================================
+
+genomics:NoAssertionProvided a genomics:ReviewStatus ;
+    rdfs:label "No Assertion Provided"@en ;
+    genomics:starRating 0 .
+
+genomics:CriteriaNotProvided a genomics:ReviewStatus ;
+    rdfs:label "Criteria Not Provided"@en ;
+    genomics:starRating 0 .
+
+genomics:SingleSubmitter a genomics:ReviewStatus ;
+    rdfs:label "Single Submitter (criteria provided)"@en ;
+    genomics:starRating 1 .
+
+genomics:ConflictingSubmissions a genomics:ReviewStatus ;
+    rdfs:label "Conflicting Submissions"@en ;
+    genomics:starRating 1 .
+
+genomics:MultipleSubmittersNoConflict a genomics:ReviewStatus ;
+    rdfs:label "Multiple Submitters, No Conflict"@en ;
+    genomics:starRating 2 .
+
+genomics:ExpertPanelReviewed a genomics:ReviewStatus ;
+    rdfs:label "Expert Panel Reviewed"@en ;
+    genomics:starRating 3 .
+
+genomics:PracticeGuideline a genomics:ReviewStatus ;
+    rdfs:label "Practice Guideline"@en ;
+    genomics:starRating 4 .
+
+# ============================================================================
+# Named Individuals — Causality Status (Phenopacket-aligned)
+# ============================================================================
+
+genomics:Causative   a genomics:CausalityStatus ; rdfs:label "Causative"@en ;
+    rdfs:comment "This variant is the direct cause of the patient's phenotype."@en .
+genomics:Contributory a genomics:CausalityStatus ; rdfs:label "Contributory"@en ;
+    rdfs:comment "This variant contributes to but is not solely responsible for the phenotype."@en .
+genomics:UncertainCausality a genomics:CausalityStatus ; rdfs:label "Uncertain Causality"@en ;
+    rdfs:comment "Causal role is unclear; further investigation needed."@en .
+genomics:Rejected    a genomics:CausalityStatus ; rdfs:label "Rejected"@en ;
+    rdfs:comment "This variant has been ruled out as the cause."@en .
+
+# ============================================================================
+# Named Individuals — Somatic Status (germline vs. somatic origin)
+# ============================================================================
+# Added in v1-draft.0.2. Maps LOINC 48002-0 (Genomic source class).
+
+genomics:Germline a owl:NamedIndividual, genomics:SomaticStatus ;
+    rdfs:label "Germline"@en ;
+    rdfs:comment "Variant present in the germline; inherited or de novo at conception; present in all cells of the individual."@en .
+
+genomics:Somatic a owl:NamedIndividual, genomics:SomaticStatus ;
+    rdfs:label "Somatic"@en ;
+    rdfs:comment "Variant acquired post-conception in a specific tissue / cell lineage; not heritable. Common in tumor samples."@en .
+
+genomics:UnknownSomaticStatus a owl:NamedIndividual, genomics:SomaticStatus ;
+    rdfs:label "Unknown Somatic Status"@en ;
+    rdfs:comment "Origin not determined by the reporting workflow. Use when the source data is silent on germline-vs-somatic classification rather than guessing."@en .
+
+# ============================================================================
+# Named Individuals — Sequencing Technology
+# ============================================================================
+
+genomics:ShortReadIllumina a genomics:SequencingTechnology ;
+    rdfs:label "Short-read Illumina"@en ;
+    rdfs:comment "Illumina short-read sequencing (NovaSeq, NextSeq, etc.). Dominant clinical platform."@en .
+
+genomics:LongReadONT a genomics:SequencingTechnology ;
+    rdfs:label "Long-read Oxford Nanopore"@en ;
+    rdfs:comment "Oxford Nanopore Technologies long-read sequencing (PromethION, MinION, etc.)."@en .
+
+genomics:LongReadPacBio a genomics:SequencingTechnology ;
+    rdfs:label "Long-read PacBio HiFi"@en ;
+    rdfs:comment "Pacific Biosciences HiFi/CCS long-read sequencing (Revio, Sequel)."@en .
+
+genomics:Mixed a genomics:SequencingTechnology ;
+    rdfs:label "Mixed Technology"@en ;
+    rdfs:comment "Combined short-read + long-read or hybrid sequencing strategies."@en .
+
+genomics:GenotypingArray a genomics:SequencingTechnology ;
+    rdfs:label "Genotyping Array"@en ;
+    rdfs:comment "SNP genotyping array (Illumina Global Screening Array, Affymetrix Axiom, etc.). Used by 23andMe / AncestryDNA / MyHeritage / FTDNA — auto-tagged ConsumerGrade in the importer."@en .
+
+# ============================================================================
+# Named Individuals — Laboratory Certification
+# ============================================================================
+
+genomics:CLIA a genomics:LaboratoryCertification ;
+    rdfs:label "CLIA"@en ;
+    rdfs:comment "Clinical Laboratory Improvement Amendments — US federal regulatory certification of clinical laboratories."@en .
+
+genomics:CAP a genomics:LaboratoryCertification ;
+    rdfs:label "CAP"@en ;
+    rdfs:comment "College of American Pathologists accreditation."@en .
+
+genomics:ISO15189 a genomics:LaboratoryCertification ;
+    rdfs:label "ISO 15189"@en ;
+    rdfs:comment "ISO 15189 medical laboratory accreditation (international)."@en .
+
+genomics:Uncertified a genomics:LaboratoryCertification ;
+    rdfs:label "Uncertified"@en ;
+    rdfs:comment "Laboratory holds no clinical certification (research lab, consumer DTC service)."@en .
+
+# ============================================================================
+# Named Individuals — File Format
+# ============================================================================
+
+genomics:BAM a genomics:FileFormat ;
+    rdfs:label "BAM"@en ;
+    rdfs:comment "Binary Alignment/Map format. Cold tier (out-of-pod, referenced)."@en .
+
+genomics:CRAM a genomics:FileFormat ;
+    rdfs:label "CRAM"@en ;
+    rdfs:comment "Compressed Reference-aligned Alignment/Map format. Cold tier."@en .
+
+genomics:FASTQ a genomics:FileFormat ;
+    rdfs:label "FASTQ"@en ;
+    rdfs:comment "Raw sequencing reads with quality scores. Cold tier."@en .
+
+genomics:gVCF a genomics:FileFormat ;
+    rdfs:label "gVCF"@en ;
+    rdfs:comment "Genomic VCF — per-position records including reference-confidence blocks. Hot tier."@en .
+
+genomics:VCF a genomics:FileFormat ;
+    rdfs:label "VCF"@en ;
+    rdfs:comment "Variant Call Format. Hot tier."@en .
+
+genomics:BCF a genomics:FileFormat ;
+    rdfs:label "BCF"@en ;
+    rdfs:comment "Binary Call Format (binary VCF). Hot tier."@en .
+
+genomics:OtherFileFormat a genomics:FileFormat ;
+    rdfs:label "Other"@en ;
+    rdfs:comment "File format not enumerated above (e.g., methylation tracks, structural-variant-specific formats)."@en .
+
+# ============================================================================
+# Named Individuals — Genomic Data Provenance
+# ============================================================================
+
+genomics:ConsumerArray a genomics:DataProvenance ;
+    rdfs:label "Consumer Array"@en ;
+    rdfs:comment "Direct-to-consumer genotyping-array data (23andMe, AncestryDNA, MyHeritage, FTDNA). Phase 2C importer auto-tags every variant from this lane as genomics:ConsumerGrade with genomics:requiresConfirmation true on any pathogenic interpretation."@en .
+
+genomics:ClinicalSequencing a genomics:DataProvenance ;
+    rdfs:label "Clinical Sequencing"@en ;
+    rdfs:comment "Clinical-grade sequencing performed by a CLIA/CAP/ISO15189-certified laboratory."@en .
+
+genomics:ResearchSequencing a genomics:DataProvenance ;
+    rdfs:label "Research Sequencing"@en ;
+    rdfs:comment "Research-quality sequencing without clinical certification (university cores, biobanks, research consortia)."@en .
+
+genomics:Imported a genomics:DataProvenance ;
+    rdfs:label "Imported"@en ;
+    rdfs:comment "Variant data imported from a third-party report, bundle, or pre-existing record where the original sequencing context is incomplete."@en .
+
+genomics:AIExtractedGenomics a genomics:DataProvenance ;
+    rdfs:label "AI Extracted"@en ;
+    rdfs:comment "Variant extracted by an LLM from unstructured narrative text (e.g., scanned PDF report). Treat as Imported provenance with elevated confirmation requirement."@en .
+
+# ============================================================================
+# Named Individuals — Data Quality Tier (per D-QUALITY-TIER)
+# ============================================================================
+
+genomics:DataQualityTier a owl:Class ;
+    rdfs:label "Data Quality Tier"@en ;
+    rdfs:comment "Tier classification of the quality of genomic data, used by the advisory engine to gate auto-applied recommendations and by narrative subsystems to drive disclosure language."@en .
+
+genomics:ClinicalGrade a genomics:DataQualityTier ;
+    rdfs:label "Clinical Grade"@en ;
+    rdfs:comment "Sequencing performed by a CLIA-, CAP-, or ISO15189-certified laboratory using a clinical-grade method (>=30x mean coverage WGS, validated clinical panel, or equivalent), with raw files (BAM/CRAM/VCF) retained or accessible. The only tier from which Pathogenic / LikelyPathogenic interpretations may drive auto-applied care recommendations without confirmatory re-testing."@en .
+
+genomics:ResearchGrade a genomics:DataQualityTier ;
+    rdfs:label "Research Grade"@en ;
+    rdfs:comment "Research-quality sequencing without clinical certification — typical of university cores, biobanks, and research consortia. Adequate for hypothesis generation but requires confirmatory clinical-grade re-testing before driving care decisions."@en .
+
+genomics:ConsumerGrade a genomics:DataQualityTier ;
+    rdfs:label "Consumer Grade"@en ;
+    rdfs:comment "Direct-to-consumer genotyping arrays (23andMe, AncestryDNA, MyHeritage, FTDNA) and consumer DTC sequencing without clinical certification. Genotyping arrays in particular interrogate only ~600k–900k SNP positions and have non-trivial false-positive rates for pathogenic variant calls. ALL Phase 2C consumer-array imports auto-tag this tier; Pathogenic / LikelyPathogenic interpretations on ConsumerGrade variants MUST carry requiresConfirmation true (SHACL-enforced)."@en .
+
+genomics:UnknownQuality a genomics:DataQualityTier ;
+    rdfs:label "Unknown Quality"@en ;
+    rdfs:comment "Quality tier could not be determined from available metadata (no certification, coverage, or method information). Treated as ConsumerGrade by the downstream safety constraint — assume the worst until promoted."@en .
+
+# ============================================================================
+# Annotation Properties (parallel to health:snomedCode / health:loincCode)
+# ============================================================================
+
+genomics:loincCode a owl:AnnotationProperty ;
+    rdfs:label "LOINC Code Annotation"@en ;
+    rdfs:comment "LOINC code or answer-list URI annotated on a property or named individual to record its Layer 1 standard mapping."@en .
+
+genomics:loincAnswerCode a owl:AnnotationProperty ;
+    rdfs:label "LOINC Answer Code Annotation"@en ;
+    rdfs:comment "LOINC answer code (LA-prefixed string) for an enumerated value, e.g. LA6668-3 = Pathogenic."@en .
+
+# ============================================================================
+# Class Declarations for Named-Individual Ranges
+# ============================================================================
+
+genomics:AcmgClass             a owl:Class ; rdfs:label "ACMG Classification"@en .
+genomics:ZygosityValue         a owl:Class ; rdfs:label "Zygosity Value"@en .
+genomics:PhaseValue            a owl:Class ; rdfs:label "Allelic Phase Value"@en .
+genomics:InheritanceMode       a owl:Class ; rdfs:label "Mode of Inheritance"@en .
+genomics:AllelicRequirement    a owl:Class ; rdfs:label "Allelic Requirement"@en .
+genomics:TestType              a owl:Class ; rdfs:label "Genetic Test Type"@en .
+genomics:CarrierStatus         a owl:Class ; rdfs:label "Carrier Status"@en .
+genomics:RelationshipRole      a owl:Class ; rdfs:label "Pedigree Relationship Role"@en .
+genomics:OrderStatus           a owl:Class ; rdfs:label "Order Status"@en .
+genomics:SubmitterCategory     a owl:Class ; rdfs:label "Submitter Category"@en .
+genomics:ReviewStatus          a owl:Class ; rdfs:label "Review Status"@en .
+genomics:CausalityStatus       a owl:Class ; rdfs:label "Causality Status"@en .
+genomics:SomaticStatus         a owl:Class ;
+    rdfs:label "Somatic Status"@en ;
+    rdfs:comment "Closed enumeration of variant origin classifications (germline / somatic / unknown). Added in v1-draft.0.2."@en .
+genomics:SequencingTechnology  a owl:Class ; rdfs:label "Sequencing Technology"@en .
+genomics:LaboratoryCertification a owl:Class ; rdfs:label "Laboratory Certification"@en .
+genomics:FileFormat            a owl:Class ; rdfs:label "File Format"@en .
+genomics:DataProvenance        a owl:Class ; rdfs:label "Genomic Data Provenance"@en .
+
+# ============================================================================
+# Phenotypic Observation (v1-draft.0.4) — index-patient HPO profile
+# ============================================================================
+
+genomics:PhenotypicObservation a owl:Class ;
+    rdfs:label "Phenotypic Observation"@en ;
+    rdfs:comment "A single HPO-coded phenotypic feature observed in the index patient, captured outside the pedigree/variant context (e.g. during conversational phenotype intake). Supports negated findings (phenotype explicitly absent), essential for narrowing a differential. Provenance is typically cascade:SelfReported. Reuses genomics:hpoTerm for the HPO linkage."@en ;
+    owl:versionInfo "Added in genomics v1-draft.0.4" .
+
+genomics:PhenotypePresenceValue a owl:Class ;
+    rdfs:label "Phenotype Presence Value"@en ;
+    rdfs:comment "Closed enumeration: whether the phenotype is present, absent, or resolved."@en ;
+    owl:versionInfo "Added in genomics v1-draft.0.4" .
+
+genomics:Present  a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Present"@en .
+genomics:Absent   a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Absent"@en ;
+    rdfs:comment "Phenotype explicitly assessed and NOT present (negated finding)."@en .
+genomics:Resolved a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Resolved"@en .
+
+genomics:phenotypePresence a owl:ObjectProperty ;
+    rdfs:label "Phenotype Presence"@en ;
+    rdfs:domain genomics:PhenotypicObservation ;
+    rdfs:range genomics:PhenotypePresenceValue ;
+    owl:versionInfo "Added in genomics v1-draft.0.4" .
+
+genomics:phenotypeOnsetDate a owl:DatatypeProperty ;
+    rdfs:label "Phenotype Onset Date"@en ;
+    rdfs:comment "Calendar date the phenotype was first observed. Use genomics:phenotypeOnsetAge for age-based onset."@en ;
+    rdfs:domain genomics:PhenotypicObservation ;
+    rdfs:range xsd:date ;
+    owl:versionInfo "Added in genomics v1-draft.0.4" .
+
+genomics:phenotypeSeverity a owl:DatatypeProperty ;
+    rdfs:label "Phenotype Severity"@en ;
+    rdfs:comment "Optional HPO severity modifier: mild, moderate, severe, profound (HP:0012823 modifier space)."@en ;
+    rdfs:domain genomics:PhenotypicObservation ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in genomics v1-draft.0.4" .
+
+genomics:phenotypeNote a owl:DatatypeProperty ;
+    rdfs:label "Phenotype Note"@en ;
+    rdfs:domain genomics:PhenotypicObservation ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in genomics v1-draft.0.4" .

--- a/src/shapes/health.shapes.ttl
+++ b/src/shapes/health.shapes.ttl
@@ -1,6 +1,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix fhir: <http://hl7.org/fhir/> .
@@ -8,17 +9,23 @@
 # ============================================================================
 # Cascade Protocol — Health & Wellness Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.0 (Phase 4, 2026-02-18)
+# Version: 1.2 (2026-08-03)
 # Validates: health:SelfReport, health:VO2MaxStatistics, health:HRVStatistics,
 #            health:BPStatistics, health:MetricTrend, health:ActivitySnapshot,
-#            health:SleepSnapshot, health:HealthProfile
+#            health:SleepSnapshot, health:HealthProfile,
+#            health:SocialHistoryRecord,
+#            health:LabResultRecord, health:ConditionRecord,
+#            health:AllergyRecord, health:ImmunizationRecord,
+#            health:FamilyHistoryRecord,
+#            health:DailyVitalReading, health:DailyActivitySnapshot,
+#            health:DailySleepSnapshot
 #
 # SEVERITY LEVELS:
 # - sh:Violation = Must fix (data invalid without) - e.g., missing required stats
 # - sh:Warning = Should address (important for completeness) - e.g., missing period
 # - sh:Info = Nice to have (suggested enrichment) - e.g., optional context fields
 #
-# Validates against: health.ttl v2.2 (2026-02-17)
+# Validates against: health.ttl v2.5 (2026-08-03)
 # ============================================================================
 
 # ============================================================================
@@ -568,6 +575,24 @@ health:SleepSnapshotShape a sh:NodeShape ;
 
 health:HealthProfileShape a sh:NodeShape ;
     sh:targetClass health:HealthProfile ;
+    # The six wellness containers are declared rdfs:subClassOf health:HealthProfile
+    # in health.ttl v2.5, and SHACL sh:targetClass is subclass-aware. But that
+    # aspect of targeting is evaluated against the DATA graph (SHACL 2.1.3.1
+    # defines "SHACL instance of" as rdf:type/rdfs:subClassOf* in the data
+    # graph), so it only fires for a validator that loads the vocabulary
+    # alongside the data. A validator that loads shapes only -- which is the
+    # common case, and is what the reference implementation does -- would see
+    # no target and check nothing, reproducing the vacuous PASS this release
+    # exists to remove.
+    #
+    # These six are therefore named explicitly as well. The subclass axioms
+    # remain the semantic statement; these make it effective today.
+    sh:targetClass health:ActivityData ;
+    sh:targetClass health:SleepData ;
+    sh:targetClass health:HeartRateData ;
+    sh:targetClass health:BloodPressureData ;
+    sh:targetClass health:HRVData ;
+    sh:targetClass health:BodyMeasurements ;
     rdfs:label "Health Profile Shape"@en ;
     rdfs:comment "Validation constraints for the top-level wellness profile aggregating vital signs, body measurements, activity, and sleep data from consumer devices. Stored at /wellness/ in the Cascade Pod."@en ;
 
@@ -704,6 +729,23 @@ health:SocialHistoryRecordShape a sh:NodeShape ;
 # Changelog
 # ============================================================================
 #
+# Version 1.2 (2026-08-03)
+# - Added 5 record shapes for the classes defined in health v2.5:
+#   LabResultRecordShape, ConditionRecordShape, AllergyRecordShape,
+#   ImmunizationRecordShape, FamilyHistoryRecordShape. Before this version
+#   these classes had no sh:targetClass anywhere, so validating a lab result,
+#   condition, allergy, immunization or family history record checked nothing
+#   and returned PASS.
+# - Added 3 shapes for classes that have existed since health v2.0 but were
+#   never targeted: DailyVitalReadingShape, DailyActivitySnapshotShape,
+#   DailySleepSnapshotShape.
+# - Constraint sets lifted from the corresponding clinical:* shapes and
+#   checked against FHIR R4. Where FHIR names a required value set the sh:in
+#   list is that value set verbatim.
+# - sh:Violation severity on all required fields.
+# - 29 conformance fixtures (7 lab, 7 condition, 6 allergy, 3 immunization,
+#   3 family history) become executable against real constraints.
+#
 # Version 1.1 (2026-03-27)
 # - Added SocialHistoryRecordShape for health:SocialHistoryRecord (health v2.4)
 #
@@ -722,3 +764,770 @@ health:SocialHistoryRecordShape a sh:NodeShape ;
 # - sh:in constraints match enumerated values from health.ttl ontology
 # - Range constraints (minInclusive/maxInclusive) reflect physiological bounds
 #
+
+# ============================================================================
+# Clinical Record Shapes (v1.2 — health v2.5)
+# ============================================================================
+#
+# Constraint sets are LIFTED from the corresponding clinical:* shapes in
+# clinical.shapes.ttl (AllergyShape :526, LabResultShape :607, ConditionShape
+# :685, ImmunizationShape :764) so that the two spellings of the same record
+# are held to the same standard, then checked against the FHIR R4 resource
+# definitions. Where FHIR names a required value set, the sh:in list below is
+# that value set verbatim:
+#
+#   health:allergyCategory   AllergyIntoleranceCategory     food | medication | environment | biologic
+#   health:allergySeverity   AllergyIntoleranceSeverity     mild | moderate | severe
+#   health:status (condition) ConditionClinicalStatusCodes  active | recurrence | relapse | inactive | remission | resolved
+#   health:status (immunization) ImmunizationStatusCodes    completed | entered-in-error | not-done
+#
+# health:status is deliberately constrained per-shape rather than on the
+# property: the permitted values differ by record class and a single global
+# sh:in would be wrong for both.
+#
+# Severity is sh:Violation on every required field. A Warning-severity
+# constraint on a required field reproduces the problem these shapes exist to
+# fix (a PASS that means nothing) with extra steps.
+#
+# CONSEQUENCE, STATED PLAINLY: before this release, validating a lab result,
+# condition, allergy, immunization or family-history record returned PASS
+# because no shape targeted it and nothing was checked. Those records are now
+# actually checked. A validation failure appearing after upgrade means the
+# validator improved, not that the data got worse.
+
+# ============================================================================
+# Shape 9: Lab Result Record
+# ============================================================================
+
+health:LabResultRecordShape a sh:NodeShape ;
+    sh:targetClass health:LabResultRecord ;
+    rdfs:label "Lab Result Record Shape"@en ;
+    rdfs:comment "Validation constraints for laboratory result records. Lifted from clinical:LabResultShape and checked against FHIR R4 Observation."@en ;
+
+    # REQUIRED: testName
+    sh:property [
+        sh:path health:testName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Test Name"@en ;
+        sh:message "Lab result must have exactly one non-empty testName"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED cardinality: resultValue is at most one.
+    # A single subject asserting two resultValues is the failure mode this
+    # constraint exists for: two same-day readings of the same analyte merged
+    # onto one record produce a subject with both values, which a consumer
+    # then reads as the single string "95, 310". Unconstrained, that passes.
+    sh:property [
+        sh:path health:resultValue ;
+        sh:maxCount 1 ;
+        sh:name "Result Value"@en ;
+        sh:message "Lab result must not carry more than one resultValue; two readings of the same analyte are two records"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:resultUnit ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Result Unit"@en ;
+        sh:message "Lab result must not carry more than one resultUnit"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:referenceRange ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Reference Range"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:interpretation ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("normal" "high" "low" "abnormal" "critical"
+               "Normal" "High" "Low" "Abnormal" "Critical") ;
+        sh:name "Interpretation"@en ;
+        sh:message "Interpretation must be one of normal, high, low, abnormal, critical"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:performedDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Performed Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:reportedDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Reported Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:testCode ;
+        sh:maxCount 1 ;
+        sh:name "Test Code (LOINC)"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:labCategory ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Lab Category"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:specimenType ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Specimen Type"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:orderingProvider ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Ordering Provider"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:performingLab ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Performing Laboratory"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: provenance
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Lab result must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: schemaVersion
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Lab result must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 10: Condition Record
+# ============================================================================
+
+health:ConditionRecordShape a sh:NodeShape ;
+    sh:targetClass health:ConditionRecord ;
+    rdfs:label "Condition Record Shape"@en ;
+    rdfs:comment "Validation constraints for condition and problem-list records. Lifted from clinical:ConditionShape and checked against FHIR R4 Condition."@en ;
+
+    # REQUIRED: conditionName
+    sh:property [
+        sh:path health:conditionName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Condition Name"@en ;
+        sh:message "Condition must have exactly one non-empty conditionName"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # status: FHIR R4 ConditionClinicalStatusCodes
+    sh:property [
+        sh:path health:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("active" "recurrence" "relapse" "inactive" "remission" "resolved") ;
+        sh:name "Clinical Status"@en ;
+        sh:message "Condition status must be one of the FHIR R4 ConditionClinicalStatusCodes: active, recurrence, relapse, inactive, remission, resolved"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:onsetDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Onset Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:icd10Code ;
+        sh:maxCount 1 ;
+        sh:name "ICD-10-CM Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:snomedCode ;
+        sh:maxCount 1 ;
+        sh:name "SNOMED CT Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:conditionClass ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Condition Class"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:monitoredVitalSigns ;
+        sh:maxCount 1 ;
+        sh:name "Monitored Vital Signs"@en ;
+        sh:message "Monitored vital signs must be a single rdf:List, not repeated"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Condition must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Condition must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 11: Allergy Record
+# ============================================================================
+
+health:AllergyRecordShape a sh:NodeShape ;
+    sh:targetClass health:AllergyRecord ;
+    rdfs:label "Allergy Record Shape"@en ;
+    rdfs:comment "Validation constraints for allergy and intolerance records. Lifted from clinical:AllergyShape and checked against FHIR R4 AllergyIntolerance."@en ;
+
+    # REQUIRED: allergen. An allergy record without an allergen carries no
+    # safety information at all, which is worse than having no record.
+    sh:property [
+        sh:path health:allergen ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Allergen"@en ;
+        sh:message "Allergy must specify exactly one non-empty allergen"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:reaction ;
+        sh:datatype xsd:string ;
+        sh:name "Reaction"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR R4 AllergyIntoleranceSeverity
+    sh:property [
+        sh:path health:allergySeverity ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("mild" "moderate" "severe") ;
+        sh:name "Allergy Severity"@en ;
+        sh:message "Allergy severity must be one of the FHIR R4 AllergyIntoleranceSeverity codes: mild, moderate, severe"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR R4 AllergyIntoleranceCategory
+    sh:property [
+        sh:path health:allergyCategory ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("food" "medication" "environment" "biologic") ;
+        sh:name "Allergy Category"@en ;
+        sh:message "Allergy category must be one of the FHIR R4 AllergyIntoleranceCategory codes: food, medication, environment, biologic"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:onsetDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Onset Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Allergy must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Allergy must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 12: Immunization Record
+# ============================================================================
+
+health:ImmunizationRecordShape a sh:NodeShape ;
+    sh:targetClass health:ImmunizationRecord ;
+    rdfs:label "Immunization Record Shape"@en ;
+    rdfs:comment "Validation constraints for immunization records. Lifted from clinical:ImmunizationShape and checked against FHIR R4 Immunization."@en ;
+
+    # REQUIRED: vaccineName
+    sh:property [
+        sh:path health:vaccineName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Vaccine Name"@en ;
+        sh:message "Immunization must have exactly one non-empty vaccineName"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # NOT required here although FHIR R4 Immunization.occurrence is 1..1.
+    # clinical:ImmunizationShape constrains no date at all, so requiring one
+    # would be a new constraint rather than a lifted one, and would newly fail
+    # existing records. Promoting this to sh:minCount 1 is a candidate for a
+    # release that is explicitly flagged as tightening.
+    sh:property [
+        sh:path health:administrationDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Administration Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR R4 ImmunizationStatusCodes
+    sh:property [
+        sh:path health:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("completed" "entered-in-error" "not-done") ;
+        sh:name "Status"@en ;
+        sh:message "Immunization status must be one of the FHIR R4 ImmunizationStatusCodes: completed, entered-in-error, not-done"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:vaccineCode ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Vaccine Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:manufacturer ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Manufacturer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:lotNumber ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Lot Number"@en ;
+        sh:message "Immunization must not carry more than one lotNumber; a lot number identifies a single administered dose"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:doseQuantity ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Dose Quantity"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:route ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Route"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:site ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Administration Site"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:administeringProvider ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Administering Provider"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:administeringLocation ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Administering Location"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Immunization must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Immunization must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 13: Family History Record
+# ============================================================================
+#
+# There is no clinical:FamilyHistory class and therefore no shape to lift from.
+# Constraints here are derived directly from FHIR R4 FamilyMemberHistory, whose
+# relationship element is 1..1 and whose condition.code is required within each
+# condition entry. The provenance and schemaVersion blocks follow the same
+# pattern as every other record shape.
+
+health:FamilyHistoryRecordShape a sh:NodeShape ;
+    sh:targetClass health:FamilyHistoryRecord ;
+    rdfs:label "Family History Record Shape"@en ;
+    rdfs:comment "Validation constraints for family history records. Derived from FHIR R4 FamilyMemberHistory."@en ;
+
+    # REQUIRED: conditionName (FHIR condition.code is required per entry)
+    sh:property [
+        sh:path health:conditionName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Condition Name"@en ;
+        sh:message "Family history record must name exactly one condition"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: relationship (FHIR FamilyMemberHistory.relationship is 1..1).
+    # A condition with no stated relative is not family history.
+    sh:property [
+        sh:path clinical:relationship ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Relationship"@en ;
+        sh:message "Family history record must state exactly one relationship to the patient"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:onsetAge ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 130 ;
+        sh:name "Onset Age"@en ;
+        sh:message "Onset age must be a single integer between 0 and 130"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Family history record must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Family history record must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Daily Snapshot Shapes (v1.2 — health v2.5)
+# ============================================================================
+#
+# These three classes were defined in health v2.0 and have been emitted ever
+# since, but no shape targeted them, so every reading in every history
+# container validated vacuously.
+#
+# health:DailyVitalReading is emitted in TWO forms that do not share their
+# value and date predicates:
+#
+#   Pattern A (HealthProfileSerializer): health:value, health:unit, health:date
+#   Pattern B (reference pod):           fhir:valueQuantity, cascade:date
+#
+# Both are live. The shape therefore requires a date and a value through
+# sh:or rather than naming one spelling and failing the other. Reconciling the
+# two serializations is a separate change; constraining one of them here would
+# have silently invalidated the other.
+
+health:DailyVitalReadingShape a sh:NodeShape ;
+    sh:targetClass health:DailyVitalReading ;
+    rdfs:label "Daily Vital Reading Shape"@en ;
+    rdfs:comment "Validation constraints for a single day's aggregated vital sign reading inside a history container."@en ;
+
+    # REQUIRED: a timestamp, in either spelling. A reading with no date cannot
+    # be placed in the time series it lives in.
+    sh:or (
+        [ sh:property [ sh:path cascade:date ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path health:date  ; sh:minCount 1 ] ]
+    ) ;
+    sh:message "Daily vital reading must carry a timestamp as either cascade:date or health:date"@en ;
+    sh:severity sh:Violation ;
+
+    sh:property [
+        sh:path cascade:date ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:date ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:sampleCount ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Sample Count"@en ;
+        sh:message "Sample count must be a single non-negative integer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:value ;
+        sh:maxCount 1 ;
+        sh:name "Value"@en ;
+        sh:message "Daily vital reading must not carry more than one value"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:unit ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Unit"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:loincCode ;
+        sh:maxCount 1 ;
+        sh:name "LOINC Code"@en ;
+        sh:severity sh:Violation
+    ] .
+
+health:DailyActivitySnapshotShape a sh:NodeShape ;
+    sh:targetClass health:DailyActivitySnapshot ;
+    rdfs:label "Daily Activity Snapshot Shape"@en ;
+    rdfs:comment "Validation constraints for a single day's activity metrics."@en ;
+
+    sh:property [
+        sh:path cascade:date ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:message "Daily activity snapshot must carry exactly one cascade:date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:steps ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Steps"@en ;
+        sh:message "Steps must be a single non-negative integer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:activeEnergyKcal ;
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Active Energy (kcal)"@en ;
+        sh:message "Active energy must be a single non-negative decimal"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:exerciseMinutes ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 1440 ;
+        sh:name "Exercise Minutes"@en ;
+        sh:message "Exercise minutes must be a single integer between 0 and 1440"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:standHours ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 24 ;
+        sh:name "Stand Hours"@en ;
+        sh:message "Stand hours must be a single integer between 0 and 24"@en ;
+        sh:severity sh:Violation
+    ] .
+
+health:DailySleepSnapshotShape a sh:NodeShape ;
+    sh:targetClass health:DailySleepSnapshot ;
+    rdfs:label "Daily Sleep Snapshot Shape"@en ;
+    rdfs:comment "Validation constraints for a single night's sleep metrics."@en ;
+
+    sh:property [
+        sh:path cascade:date ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:message "Daily sleep snapshot must carry exactly one cascade:date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:durationHours ;
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 24 ;
+        sh:name "Sleep Duration (hours)"@en ;
+        sh:message "Sleep duration must be a single decimal between 0 and 24 hours"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # No sh:datatype: health:sleepQuality is declared owl:DatatypeProperty with
+    # rdfs:range xsd:string in health.ttl, but every known emitter writes an
+    # IRI. Asserting either form here would contradict something real, so the
+    # shape constrains cardinality and the permitted individuals only.
+    sh:property [
+        sh:path health:sleepQuality ;
+        sh:maxCount 1 ;
+        sh:in (health:Excellent health:Good health:Fair health:Poor) ;
+        sh:name "Sleep Quality"@en ;
+        sh:message "Sleep quality must be one of health:Excellent, health:Good, health:Fair, health:Poor"@en ;
+        sh:severity sh:Violation
+    ] .

--- a/src/shapes/health.ttl
+++ b/src/shapes/health.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for consumer-generated wellness observations from wearable devices and HealthKit. Maps Cascade wellness properties to established SNOMED CT and LOINC codes following the three-layer ontology architecture."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-01-29"^^xsd:date ;
-    dct:modified "2026-02-28"^^xsd:date ;
-    owl:versionInfo "2.3" ;
+    dct:modified "2026-08-03"^^xsd:date ;
+    owl:versionInfo "2.5" ;
     rdfs:comment """Three-layer ontology for wellness data:
         Layer 1 (Established standards): SNOMED CT concept IDs + LOINC observation codes
         Layer 2 (Cascade health vocabulary): health: namespace properties linking to Layer 1
@@ -30,6 +30,26 @@
     rdfs:seeAlso <https://cascadeprotocol.org/docs/health/v1/> .
 
 # Changelog:
+# v2.5 (2026-08-03): Clinical record classes. Five classes that serializers have
+#     emitted since v1.3 but that this ontology never defined are now defined:
+#     health:LabResultRecord, health:ConditionRecord, health:AllergyRecord,
+#     health:ImmunizationRecord, health:FamilyHistoryRecord. Adds the 40
+#     properties they use (previously undefined vocabulary), 4 sleep-quality
+#     named individuals, and 6 wellness container classes
+#     (health:ActivityData, SleepData, HeartRateData, BloodPressureData,
+#     HRVData, BodyMeasurements) as rdfs:subClassOf health:HealthProfile.
+#     The subclass declarations make the existing rdfs:domain health:HealthProfile
+#     on the eight history container properties true rather than contradicted,
+#     and bring those containers under health:HealthProfileShape through
+#     SHACL subclass-aware sh:targetClass. Adds a namespace-boundary note
+#     explaining that health: vs clinical: is historical, not a provenance
+#     signal. No serializer changes; every term here was already being emitted.
+#
+# v2.4 (2026-03-27): EHR Import Reconciliation (P1-C) — Added health:SocialHistoryRecord
+#     class for social history observations (smoking, alcohol, exercise, occupation).
+#     Added 4 properties: health:smokingStatus, health:alcoholUse,
+#     health:exerciseFrequency, health:occupationalExposure.
+#
 # v2.3 (2026-02-28): BUG-006 — Added 6 Pattern A flat-property vocabulary terms
 #     for VitalSignReading blank nodes: health:value (generic numeric value),
 #     health:date (observation timestamp), health:sdnn (HRV SDNN measurement),
@@ -926,3 +946,544 @@ health:Unknown a health:WalkingSteadinessLevel ;
 # | Exercise Minutes      | health:exerciseMinutesWeekly | 68130003    | 73985-4  |
 # | Stand Hours           | health:standHoursDaily       | ---         | ---      |
 # | Sleep Duration        | health:averageDurationHours  | 248263006   | 93832-4  |
+
+# ============================================================================
+# Social History (v2.4)
+# ============================================================================
+
+###  Social History Record
+health:SocialHistoryRecord a owl:Class ;
+    rdfs:label "Social History Record"@en ;
+    rdfs:comment "A social history observation about a patient, including smoking status, alcohol use, exercise, occupation, and other lifestyle factors."@en ;
+    owl:versionInfo "Added in health v2.4" .
+
+health:smokingStatus a owl:DatatypeProperty ;
+    rdfs:label "Smoking Status"@en ;
+    rdfs:comment "Patient's smoking status (e.g., current-smoker, former-smoker, never-smoker)."@en ;
+    rdfs:domain health:SocialHistoryRecord ;
+    rdfs:range xsd:string .
+
+health:alcoholUse a owl:DatatypeProperty ;
+    rdfs:label "Alcohol Use"@en ;
+    rdfs:comment "Patient's alcohol consumption description."@en ;
+    rdfs:domain health:SocialHistoryRecord ;
+    rdfs:range xsd:string .
+
+health:exerciseFrequency a owl:DatatypeProperty ;
+    rdfs:label "Exercise Frequency"@en ;
+    rdfs:comment "Patient's reported exercise frequency."@en ;
+    rdfs:domain health:SocialHistoryRecord ;
+    rdfs:range xsd:string .
+
+health:occupationalExposure a owl:DatatypeProperty ;
+    rdfs:label "Occupational Exposure"@en ;
+    rdfs:comment "Occupational exposures relevant to patient health."@en ;
+    rdfs:domain health:SocialHistoryRecord ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Namespace Boundary Note (v2.5)
+# ============================================================================
+#
+# The split between the health: and clinical: namespaces is HISTORICAL, not
+# semantic. It is not a provenance signal and must not be read as one.
+#
+# health: was introduced for consumer- and device-generated wellness data and
+# clinical: for EHR-sourced records, but serializers have never honoured that
+# division. Records typed health:LabResultRecord, health:ConditionRecord,
+# health:AllergyRecord and health:ImmunizationRecord carry EHR-sourced data,
+# and clinical:VitalSign records carry consumer-device data.
+#
+# PROVENANCE IS CARRIED BY cascade:dataProvenance, AND ONLY BY IT.
+# Consumers deciding whether a record came from an EHR, a device, or the
+# patient MUST key on cascade:dataProvenance (ClinicalGenerated, EHRVerified,
+# DeviceGenerated, PatientReported, SelfReported, AIExtracted). Keying on the
+# namespace of the rdf:type will give the wrong answer on real pods.
+#
+# Both namespaces are ratified and neither is being migrated. The clinical:
+# classes that duplicate the five classes defined below are deprecated in
+# clinical v1.13 (owl:deprecated true, rdfs:seeAlso pointing here) but are NOT
+# removed: an existing export path still emits them and existing pods contain
+# them. Readers must accept both spellings; writers should prefer these.
+#
+# ---------------------------------------------------------------------------
+# SocialHistoryRecord: two classes, deliberately kept
+# ---------------------------------------------------------------------------
+#
+# health:SocialHistoryRecord (v2.4, above) and clinical:SocialHistoryRecord
+# (clinical v1.9) both exist and both are retained. The asserted
+# consumer-versus-EHR division does not describe what is emitted:
+#
+#   - clinical:SocialHistoryRecord is emitted, by the free-text LLM extraction
+#     path only.
+#   - health:SocialHistoryRecord is emitted by nothing. The structured C-CDA
+#     Social History path that appears to write it reports the entries it read
+#     but writes no records at all, so the class is defined and shaped but
+#     never instantiated.
+#
+# Neither class is therefore a reliable indicator of how a social-history
+# observation was obtained. Consumers should accept both types and read
+# cascade:dataProvenance for the actual source. Reconciling the two is
+# deferred rather than guessed at.
+
+# ============================================================================
+# Clinical Record Classes (v2.5)
+# ============================================================================
+#
+# These five classes have been emitted by Cascade serializers since schema
+# version 1.3 but were never defined in this ontology. Defining them is purely
+# additive: no serializer changes, no rdf:type changes, no pod migration. It
+# makes existing data describable and, with health.shapes.ttl v1.2, checkable.
+#
+# Layer 1 alignment: each class states the FHIR R4 resource it corresponds to.
+# Layer 2: the properties below. Layer 3: checkup:/pots: aggregations.
+
+health:LabResultRecord a owl:Class ;
+    rdfs:label "Lab Result Record"@en ;
+    rdfs:comment "A laboratory test result: the test performed, its value and unit, the reference range it is read against, and the specimen it came from. Emitted for both EHR-imported and patient-entered results; read cascade:dataProvenance to tell them apart."@en ;
+    rdfs:subClassOf fhir:Observation ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/observation.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:ConditionRecord a owl:Class ;
+    rdfs:label "Condition Record"@en ;
+    rdfs:comment "A diagnosed condition or problem-list entry, with its clinical status, onset, and coding. Emitted for both EHR-imported and self-reported conditions; read cascade:dataProvenance to tell them apart."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/condition.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:AllergyRecord a owl:Class ;
+    rdfs:label "Allergy Record"@en ;
+    rdfs:comment "An allergy or intolerance: the allergen, the reaction it provokes, and the severity of that reaction. Emitted for both EHR-imported and self-reported allergies; read cascade:dataProvenance to tell them apart."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/allergyintolerance.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:ImmunizationRecord a owl:Class ;
+    rdfs:label "Immunization Record"@en ;
+    rdfs:comment "An administered vaccine dose, with product identification, lot, route, site and administering party."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/immunization.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:FamilyHistoryRecord a owl:Class ;
+    rdfs:label "Family History Record"@en ;
+    rdfs:comment "A condition recorded for a relative of the patient, with the relationship and the relative's age at onset. The relationship is expressed with clinical:relationship, which is shared with coverage records."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/familymemberhistory.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+# ----------------------------------------------------------------------------
+# Properties shared across the record classes
+# ----------------------------------------------------------------------------
+# Domains are unions rather than a single class. A single-class rdfs:domain on
+# a property that several classes use is an assertion the data falsifies, which
+# is the defect this release is correcting elsewhere; do not reintroduce it.
+
+health:notes a owl:DatatypeProperty ;
+    rdfs:label "Notes"@en ;
+    rdfs:comment "Free-text clinical or patient commentary attached to a record."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf (
+        health:LabResultRecord health:ConditionRecord health:AllergyRecord
+        health:ImmunizationRecord health:FamilyHistoryRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:sourceRecordId a owl:DatatypeProperty ;
+    rdfs:label "Source Record Identifier"@en ;
+    rdfs:comment "Identifier of this record in the system it was imported from. Opaque to Cascade; used for reconciliation against the source system, not as a Cascade identity."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf (
+        health:LabResultRecord health:ConditionRecord health:AllergyRecord
+        health:ImmunizationRecord health:FamilyHistoryRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:status a owl:DatatypeProperty ;
+    rdfs:label "Status"@en ;
+    rdfs:comment "Lifecycle status of the record. The permitted values differ by class and are constrained per-shape, not here: condition records use the FHIR R4 ConditionClinicalStatusCodes value set, immunization records use ImmunizationStatusCodes."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf ( health:ConditionRecord health:ImmunizationRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:onsetDate a owl:DatatypeProperty ;
+    rdfs:label "Onset Date"@en ;
+    rdfs:comment "When the condition or allergy began, or was first recorded as beginning."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf ( health:ConditionRecord health:AllergyRecord ) ] ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:conditionName a owl:DatatypeProperty ;
+    rdfs:label "Condition Name"@en ;
+    rdfs:comment "Human-readable name of the condition. Used both for the patient's own conditions and for conditions recorded against a relative."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf ( health:ConditionRecord health:FamilyHistoryRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Lab result properties
+# ----------------------------------------------------------------------------
+
+health:testName a owl:DatatypeProperty ;
+    rdfs:label "Test Name"@en ;
+    rdfs:comment "Human-readable name of the laboratory test performed."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:resultValue a owl:DatatypeProperty ;
+    rdfs:label "Result Value"@en ;
+    rdfs:comment "The measured value. Carried as a string because lab results are not uniformly numeric: ratios, titres, qualitative results ('Negative'), and bounded values ('<0.01') all occur. Exactly one value per record."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:resultUnit a owl:DatatypeProperty ;
+    rdfs:label "Result Unit"@en ;
+    rdfs:comment "Unit of measure for health:resultValue, as reported by the performing laboratory."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <http://unitsofmeasure.org/> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:interpretation a owl:DatatypeProperty ;
+    rdfs:label "Interpretation"@en ;
+    rdfs:comment "Categorical reading of the result against its reference range."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:performedDate a owl:DatatypeProperty ;
+    rdfs:label "Performed Date"@en ;
+    rdfs:comment "When the specimen was collected or the test performed. Distinct from health:reportedDate."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:reportedDate a owl:DatatypeProperty ;
+    rdfs:label "Reported Date"@en ;
+    rdfs:comment "When the laboratory released the result. Later than health:performedDate."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:testCode a owl:ObjectProperty ;
+    rdfs:label "Test Code"@en ;
+    rdfs:comment "LOINC reference for the test performed, as an IRI."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:seeAlso <http://loinc.org/> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:labCategory a owl:DatatypeProperty ;
+    rdfs:label "Lab Category"@en ;
+    rdfs:comment "Laboratory department or panel grouping (for example Chemistry, Hematology). Free text: laboratories do not agree on a common set."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:referenceRange a owl:DatatypeProperty ;
+    rdfs:label "Reference Range"@en ;
+    rdfs:comment "The normal range this result is read against, as printed by the performing laboratory (for example '70 - 100'). Not parsed."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:specimenType a owl:DatatypeProperty ;
+    rdfs:label "Specimen Type"@en ;
+    rdfs:comment "The specimen the test was run on (for example Serum, Whole Blood, Urine)."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:orderingProvider a owl:DatatypeProperty ;
+    rdfs:label "Ordering Provider"@en ;
+    rdfs:comment "Name of the clinician who ordered the test."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:performingLab a owl:DatatypeProperty ;
+    rdfs:label "Performing Laboratory"@en ;
+    rdfs:comment "Name of the laboratory that ran the test."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Condition properties
+# ----------------------------------------------------------------------------
+
+health:icd10Code a owl:ObjectProperty ;
+    rdfs:label "ICD-10-CM Code"@en ;
+    rdfs:comment "ICD-10-CM reference for the condition, as an IRI."@en ;
+    rdfs:domain health:ConditionRecord ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/codesystem-icd10.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:conditionClass a owl:DatatypeProperty ;
+    rdfs:label "Condition Class"@en ;
+    rdfs:comment "Body-system grouping used for patient-facing organisation (for example cardiovascular, endocrine, respiratory). A presentation aid, not a clinical classification; do not use it for decision support."@en ;
+    rdfs:domain health:ConditionRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:monitoredVitalSigns a owl:ObjectProperty ;
+    rdfs:label "Monitored Vital Signs"@en ;
+    rdfs:comment "Ordered list of vital-sign names a patient or app tracks because of this condition (for example bloodPressure, heartRate). An rdf:List of string literals."@en ;
+    rdfs:domain health:ConditionRecord ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Allergy properties
+# ----------------------------------------------------------------------------
+
+health:allergen a owl:DatatypeProperty ;
+    rdfs:label "Allergen"@en ;
+    rdfs:comment "The substance the patient reacts to. Required: an allergy record without an allergen carries no safety information."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:allergyCategory a owl:DatatypeProperty ;
+    rdfs:label "Allergy Category"@en ;
+    rdfs:comment "Category of the allergen, using the FHIR R4 AllergyIntoleranceCategory value set: food, medication, environment, biologic."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-allergy-intolerance-category.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:reaction a owl:DatatypeProperty ;
+    rdfs:label "Reaction"@en ;
+    rdfs:comment "Description of the manifestation the allergen produces (for example 'Hives (urticaria)')."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:allergySeverity a owl:DatatypeProperty ;
+    rdfs:label "Allergy Severity"@en ;
+    rdfs:comment "Severity of the reaction as a whole, using the FHIR R4 AllergyIntoleranceSeverity value set: mild, moderate, severe."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-reaction-event-severity.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Immunization properties
+# ----------------------------------------------------------------------------
+
+health:vaccineName a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Name"@en ;
+    rdfs:comment "Human-readable name of the vaccine product administered."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:administrationDate a owl:DatatypeProperty ;
+    rdfs:label "Administration Date"@en ;
+    rdfs:comment "When the dose was administered. Corresponds to FHIR R4 Immunization.occurrence, which is 1..1."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:vaccineCode a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Code"@en ;
+    rdfs:comment "Coded identifier for the vaccine product, typically a CVX code."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-vaccine-code.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:manufacturer a owl:DatatypeProperty ;
+    rdfs:label "Manufacturer"@en ;
+    rdfs:comment "Manufacturer of the administered vaccine product."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:lotNumber a owl:DatatypeProperty ;
+    rdfs:label "Lot Number"@en ;
+    rdfs:comment "Manufacturer lot number of the administered dose. Required for recall tracing."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:doseQuantity a owl:DatatypeProperty ;
+    rdfs:label "Dose Quantity"@en ;
+    rdfs:comment "Amount administered, value and unit together as printed (for example '0.5 mL')."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:route a owl:DatatypeProperty ;
+    rdfs:label "Route"@en ;
+    rdfs:comment "Route of administration (for example intramuscular, oral, intranasal)."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-immunization-route.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:site a owl:DatatypeProperty ;
+    rdfs:label "Administration Site"@en ;
+    rdfs:comment "Body site the dose was administered at (for example 'Left deltoid')."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:administeringProvider a owl:DatatypeProperty ;
+    rdfs:label "Administering Provider"@en ;
+    rdfs:comment "Name of the person who administered the dose."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:administeringLocation a owl:DatatypeProperty ;
+    rdfs:label "Administering Location"@en ;
+    rdfs:comment "Facility where the dose was administered."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Family history properties
+# ----------------------------------------------------------------------------
+
+health:onsetAge a owl:DatatypeProperty ;
+    rdfs:label "Onset Age"@en ;
+    rdfs:comment "Age in years at which the relative's condition began. Corresponds to FHIR R4 FamilyMemberHistory.condition.onsetAge."@en ;
+    rdfs:domain health:FamilyHistoryRecord ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ============================================================================
+# Wellness Container Classes (v2.5)
+# ============================================================================
+#
+# Six containers that HealthProfileSerializer has always emitted at /wellness/.
+# Each is a partition of a health profile carrying one family of history
+# containers. Declaring them subclasses of health:HealthProfile does two things:
+#
+#   1. It makes the rdfs:domain health:HealthProfile already asserted on the
+#      eight history container properties above TRUE. Before this release those
+#      domain statements were contradicted by every pod ever written, because
+#      health:dailyActivityHistory is emitted on a health:ActivityData subject,
+#      never on a health:HealthProfile subject.
+#   2. It brings these subjects under health:HealthProfileShape, whose
+#      sh:targetClass is subclass-aware per SHACL 2.1.3.1.
+#
+# No serializer changes. No rdf:type changes. These subjects were already
+# being written with exactly these types.
+
+health:ActivityData a owl:Class ;
+    rdfs:label "Activity Data"@en ;
+    rdfs:comment "Wellness container for daily activity history: steps, active energy, exercise minutes and stand hours."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:SleepData a owl:Class ;
+    rdfs:label "Sleep Data"@en ;
+    rdfs:comment "Wellness container for nightly sleep history: duration and quality."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:HeartRateData a owl:Class ;
+    rdfs:label "Heart Rate Data"@en ;
+    rdfs:comment "Wellness container for resting and walking heart rate history."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:BloodPressureData a owl:Class ;
+    rdfs:label "Blood Pressure Data"@en ;
+    rdfs:comment "Wellness container for blood pressure history from home monitors."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:HRVData a owl:Class ;
+    rdfs:label "HRV Data"@en ;
+    rdfs:comment "Wellness container for heart rate variability (SDNN) history."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:BodyMeasurements a owl:Class ;
+    rdfs:label "Body Measurements"@en ;
+    rdfs:comment "Wellness container for body mass and related anthropometric history."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+# ============================================================================
+# Daily Snapshot Properties (v2.5)
+# ============================================================================
+#
+# Emitted on health:DailyActivitySnapshot and health:DailySleepSnapshot entries
+# inside the history containers. These are the single-day forms. The similarly
+# named health:activeEnergyBurnedKcal, health:exerciseMinutesWeekly and
+# health:standHoursDaily above are the 7-day aggregate forms carried on
+# health:ActivitySnapshot; the two sets are distinct and both are emitted.
+
+health:steps a owl:DatatypeProperty ;
+    rdfs:label "Steps"@en ;
+    rdfs:comment "Step count for a single day."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:activeEnergyKcal a owl:DatatypeProperty ;
+    rdfs:label "Active Energy (kcal)"@en ;
+    rdfs:comment "Active energy burned in kilocalories for a single day."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:decimal ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:exerciseMinutes a owl:DatatypeProperty ;
+    rdfs:label "Exercise Minutes"@en ;
+    rdfs:comment "Minutes of exercise recorded for a single day."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:standHours a owl:DatatypeProperty ;
+    rdfs:label "Stand Hours"@en ;
+    rdfs:comment "Hours in which standing was recorded for a single day. Bounded 0-24."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:durationHours a owl:DatatypeProperty ;
+    rdfs:label "Sleep Duration (hours)"@en ;
+    rdfs:comment "Total sleep duration in hours for a single night."@en ;
+    rdfs:domain health:DailySleepSnapshot ;
+    rdfs:range xsd:decimal ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Sleep quality individuals (v2.5)
+# ----------------------------------------------------------------------------
+#
+# health:sleepQuality is emitted with an IRI object, not a string literal:
+# HealthProfileSerializer writes `health:sleepQuality health:Good` and
+# HealthProfileDeserializer parses exactly that form. The four individuals it
+# ranges over were never defined. They are defined here.
+#
+# health:sleepQuality itself is left declared as it was (see above). Its
+# rdfs:range xsd:string does not describe what is emitted, and no known emitter
+# produces the string form, but correcting the declaration is a separate change
+# with its own compatibility question and is deferred rather than bundled here.
+# health:DailySleepSnapshotShape therefore constrains this property's
+# cardinality and permitted values but asserts no datatype.
+
+health:SleepQuality a owl:Class ;
+    rdfs:label "Sleep Quality"@en ;
+    rdfs:comment "Qualitative classification of a night's sleep, as derived by the recording device."@en ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:Excellent a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Excellent"@en ;
+    rdfs:comment "Sleep quality classified as excellent."@en .
+
+health:Good a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Good"@en ;
+    rdfs:comment "Sleep quality classified as good."@en .
+
+health:Fair a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Fair"@en ;
+    rdfs:comment "Sleep quality classified as fair."@en .
+
+health:Poor a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Poor"@en ;
+    rdfs:comment "Sleep quality classified as poor."@en .

--- a/src/shapes/pots.ttl
+++ b/src/shapes/pots.ttl
@@ -1,0 +1,411 @@
+@prefix pots: <https://ns.cascadeprotocol.org/pots/v1#> .
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fhir: <http://hl7.org/fhir/> .
+@prefix sct: <http://snomed.info/sct/> .
+@prefix loinc: <http://loinc.org/rdf#> .
+@prefix ucum: <http://unitsofmeasure.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+# ============================================================================
+# Ontology Metadata
+# ============================================================================
+
+<https://ns.cascadeprotocol.org/pots/v1#> a owl:Ontology ;
+    owl:imports <https://ns.cascadeprotocol.org/core/v1#> ;
+    dct:title "Cascade Protocol POTS Check Ontology"@en ;
+    dct:description "Vocabulary for POTS (Postural Orthostatic Tachycardia Syndrome) home screening checks using the NASA Lean Test protocol"@en ;
+    dct:creator "Cascade Agentic Labs" ;
+    dct:created "2025-10-31"^^xsd:date ;
+    dct:modified "2026-02-26"^^xsd:date ;
+    owl:versionInfo "1.4" ;
+    rdfs:comment "Layer 2 domain-specific vocabulary for POTS Check app. Defines the POTS screening test protocol, raw measurement classes, and computed results. Describes consumer-generated wellness data from guided orthostatic screening checks performed with Apple Watch and iPhone."@en ;
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/pots/v1.4/> .
+
+# ============================================================================
+# Core Classes
+# ============================================================================
+
+pots:POTSCheckResult a owl:Class ;
+    rdfs:label "POTS Check Result"@en ;
+    rdfs:comment "Complete result bundle from a guided home orthostatic screening check using Apple Watch heart rate monitoring and iPhone posture detection"@en ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty pots:date ;
+        owl:cardinality 1
+    ] ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty pots:protocol ;
+        owl:cardinality 1
+    ] ;
+    rdfs:subClassOf prov:Entity .
+
+pots:HeartRateMeasurement a owl:Class ;
+    rdfs:label "Heart Rate Measurement"@en ;
+    rdfs:comment "Timed heart rate observation captured during standing phase"@en ;
+    rdfs:subClassOf fhir:Observation .
+
+pots:BloodPressureMeasurement a owl:Class ;
+    rdfs:label "Blood Pressure Measurement"@en ;
+    rdfs:comment "Timed blood pressure observation (systolic/diastolic) captured during check"@en ;
+    rdfs:subClassOf fhir:Observation .
+
+pots:SymptomEvent a owl:Class ;
+    rdfs:label "Symptom Event"@en ;
+    rdfs:comment "User-reported symptom captured during the standing phase of the check"@en .
+
+pots:PostureStability a owl:Class ;
+    rdfs:label "Posture Stability Sample"@en ;
+    rdfs:comment "Posture quality measurement from Core Motion sensors during standing phase"@en .
+
+# ============================================================================
+# Test Protocol Classes
+# ============================================================================
+
+pots:TestProtocol a owl:Class ;
+    rdfs:label "Test Protocol"@en ;
+    rdfs:comment "Standardized orthostatic test protocol"@en .
+
+pots:NASALean a pots:TestProtocol ;
+    rdfs:label "NASA Lean Test"@en ;
+    rdfs:comment "10 minutes supine followed by 10 minutes standing against wall, as specified by NASA research protocols"@en ;
+    rdfs:seeAlso <https://ntrs.nasa.gov/citations/20150001725> .
+
+# ============================================================================
+# Data Properties - Test Metadata
+# ============================================================================
+
+pots:date a owl:DatatypeProperty ;
+    rdfs:label "Check Date"@en ;
+    rdfs:comment "ISO 8601 timestamp when the check was performed"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:dateTime .
+
+pots:protocol a owl:DatatypeProperty ;
+    rdfs:label "Test Protocol"@en ;
+    rdfs:comment "Protocol used for the check (currently only 'nasaLean')"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:string .
+
+pots:baselineDurationSeconds a owl:DatatypeProperty ;
+    rdfs:label "Baseline Duration (seconds)"@en ;
+    rdfs:comment "Duration of the supine baseline phase in seconds (typically 600 for 10 minutes)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:integer .
+
+pots:uprightDurationSeconds a owl:DatatypeProperty ;
+    rdfs:label "Upright Duration (seconds)"@en ;
+    rdfs:comment "Duration of the standing phase in seconds (typically 600 for 10 minutes)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:integer .
+
+# ============================================================================
+# Data Properties - Heart Rate
+# ============================================================================
+
+pots:supineHeartRate a owl:ObjectProperty ;
+    rdfs:label "Supine Heart Rate"@en ;
+    rdfs:comment "Baseline heart rate observation from final 2 minutes of supine phase"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range pots:HeartRateMeasurement ;
+    owl:equivalentProperty sct:78564009 .  # Heart rate at rest
+
+pots:standingHeartRates a owl:ObjectProperty ;
+    rdfs:label "Standing Heart Rates"@en ;
+    rdfs:comment "Ordered list of heart rate measurements captured during standing phase"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range rdf:List .
+
+pots:recoveryHeartRate a owl:DatatypeProperty ;
+    rdfs:label "Recovery Heart Rate"@en ;
+    rdfs:comment "Optional heart rate measurement after returning to supine position (v1.1+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:double .
+
+pots:maxHeartRateDelta a owl:DatatypeProperty ;
+    rdfs:label "Maximum Heart Rate Delta"@en ;
+    rdfs:comment "Pre-computed maximum heart rate increase from baseline using 30-second rolling window average during standing phase (v1.2+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:double .
+
+# ============================================================================
+# Data Properties - Blood Pressure
+# ============================================================================
+
+pots:supineBloodPressure a owl:ObjectProperty ;
+    rdfs:label "Supine Blood Pressure"@en ;
+    rdfs:comment "Blood pressure measurement taken during or just before supine phase"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range pots:BloodPressureMeasurement .
+
+pots:standingBloodPressures a owl:ObjectProperty ;
+    rdfs:label "Standing Blood Pressures"@en ;
+    rdfs:comment "List of blood pressure measurements captured at specific minutes during standing phase (typically minutes 1, 3, 5, 7, 10)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range rdf:List .
+
+# ============================================================================
+# Data Properties - Symptoms
+# ============================================================================
+
+pots:symptomEvents a owl:ObjectProperty ;
+    rdfs:label "Symptom Events"@en ;
+    rdfs:comment "List of symptoms reported by user during the check"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range rdf:List .
+
+pots:symptom a owl:DatatypeProperty ;
+    rdfs:label "Symptom Type"@en ;
+    rdfs:comment "Type of symptom experienced (e.g., 'Dizziness', 'Palpitations')"@en ;
+    rdfs:domain pots:SymptomEvent ;
+    rdfs:range xsd:string .
+
+pots:notes a owl:DatatypeProperty ;
+    rdfs:label "Symptom Notes"@en ;
+    rdfs:comment "Optional user-provided notes describing the symptom (max 100 characters)"@en ;
+    rdfs:domain pots:SymptomEvent ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Data Properties - Clinical Flags
+# ============================================================================
+
+pots:potsThresholdMet a owl:DatatypeProperty ;
+    rdfs:label "POTS Threshold Met"@en ;
+    rdfs:comment "True if heart rate increase meets POTS screening criteria (age-adjusted: >=30 bpm for adults 20+, >=40 bpm for pediatric 13-19)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:boolean .
+
+pots:orthostaticHypotensionSuspected a owl:DatatypeProperty ;
+    rdfs:label "Orthostatic Hypotension Suspected"@en ;
+    rdfs:comment "True if blood pressure drop suggests orthostatic hypotension (systolic >=20 mmHg or diastolic >=10 mmHg drop)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:boolean .
+
+pots:orthostaticHypertensionSuspected a owl:DatatypeProperty ;
+    rdfs:label "Orthostatic Hypertension Suspected"@en ;
+    rdfs:comment "True if blood pressure increase suggests orthostatic hypertension (systolic >=20 mmHg increase) (v1.1+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:boolean .
+
+pots:isIncomplete a owl:DatatypeProperty ;
+    rdfs:label "Is Incomplete"@en ;
+    rdfs:comment "True if the check was terminated early or did not complete all phases"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:boolean .
+
+pots:earlyTerminationReason a owl:DatatypeProperty ;
+    rdfs:label "Early Termination Reason"@en ;
+    rdfs:comment "Human-readable reason why the check was terminated early (v1.1+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:string .
+
+# ============================================================================
+# Data Properties - Posture Quality (v1.1+)
+# ============================================================================
+
+pots:postureQualityScore a owl:DatatypeProperty ;
+    rdfs:label "Posture Quality Score"@en ;
+    rdfs:comment "Letter grade (A-D) indicating overall posture stability during standing phase (v1.1+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:string .
+
+pots:movementArtifactPercentage a owl:DatatypeProperty ;
+    rdfs:label "Movement Artifact Percentage"@en ;
+    rdfs:comment "Percentage of standing phase with excessive movement artifacts (0.0 to 100.0) (v1.1+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:double .
+
+pots:postureStability a owl:ObjectProperty ;
+    rdfs:label "Posture Stability"@en ;
+    rdfs:comment "List of posture stability measurements from Core Motion during standing phase (v1.1+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range rdf:List .
+
+pots:isStable a owl:DatatypeProperty ;
+    rdfs:label "Is Stable"@en ;
+    rdfs:comment "Boolean indicating whether posture was stable at this timestamp"@en ;
+    rdfs:domain pots:PostureStability ;
+    rdfs:range xsd:boolean .
+
+pots:stabilityScore a owl:DatatypeProperty ;
+    rdfs:label "Stability Score"@en ;
+    rdfs:comment "Numerical stability score from 0.0 (unstable) to 1.0 (perfectly stable)"@en ;
+    rdfs:domain pots:PostureStability ;
+    rdfs:range xsd:double .
+
+# ============================================================================
+# Data Properties - User Context (v1.2+)
+# ============================================================================
+
+pots:userAgeAtTest a owl:DatatypeProperty ;
+    rdfs:label "User Age at Test"@en ;
+    rdfs:comment "User's age in years at the time of the check, used for age-based threshold calculation (v1.2+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:integer .
+
+# ============================================================================
+# Data Properties - Timing
+# ============================================================================
+
+pots:atSeconds a owl:DatatypeProperty ;
+    rdfs:label "Seconds Since Standing"@en ;
+    rdfs:comment "Time offset in seconds from the start of the standing phase"@en ;
+    rdfs:range xsd:integer .
+
+pots:secondsSinceStand a owl:DatatypeProperty ;
+    rdfs:label "Seconds Since Stand"@en ;
+    rdfs:comment "Time offset in seconds from the moment the user stood up. Used in standingHeartRates and standingBloodPressures list items for temporal positioning."@en ;
+    rdfs:range xsd:double .
+
+pots:timestampSeconds a owl:DatatypeProperty ;
+    rdfs:label "Timestamp Seconds"@en ;
+    rdfs:comment "Absolute timestamp in seconds, used in SymptomEvent items for precise event timing."@en ;
+    rdfs:range xsd:double .
+
+# ============================================================================
+# Apple Health Import Properties (v1.3)
+# ============================================================================
+
+pots:importedBloodPressureHistory a owl:ObjectProperty ;
+    rdfs:label "Imported Blood Pressure History"@en ;
+    rdfs:comment "Collection of blood pressure readings imported from Apple Health for longitudinal context. Each item is a fhir:Observation with systolic/diastolic components."@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range rdf:List .
+
+pots:importedHRVHistory a owl:ObjectProperty ;
+    rdfs:label "Imported HRV History"@en ;
+    rdfs:comment "Collection of HRV readings imported from Apple Health for longitudinal context. Each item is a fhir:Observation with value in milliseconds."@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range rdf:List .
+
+pots:averageImportedBloodPressure a owl:DatatypeProperty ;
+    rdfs:label "Average Imported Blood Pressure"@en ;
+    rdfs:comment "Computed average of imported blood pressure readings from Apple Health, formatted as 'systolic/diastolic' string."@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:string .
+
+pots:averageImportedHRV a owl:DatatypeProperty ;
+    rdfs:label "Average Imported HRV"@en ;
+    rdfs:comment "Computed average of imported HRV readings from Apple Health (ms)."@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:double .
+
+# ============================================================================
+# V2 Test Configuration & Patient Context (v1.4+)
+# ============================================================================
+
+pots:baselineDurationMinutes a owl:DatatypeProperty ;
+    rdfs:label "Baseline Duration (minutes)"@en ;
+    rdfs:comment "User-selected supine baseline duration in whole minutes. One of: 5, 10, or 15. Captures the deliberate configuration choice (distinct from pots:baselineDurationSeconds which records actual elapsed time). Values below 10 minutes carry a clinical advisory per Bateman Horne Center guidance. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:integer .
+
+pots:testNotes a owl:DatatypeProperty ;
+    rdfs:label "Test Notes"@en ;
+    rdfs:comment "Optional free-text notes entered by the patient about this check session (e.g., current symptoms, recent activity, medication timing). Maximum 500 characters. Distinct from pots:notes which is scoped to individual pots:SymptomEvent items. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:string .
+
+pots:bpProvided a owl:DatatypeProperty ;
+    rdfs:label "Blood Pressure Provided"@en ;
+    rdfs:comment "True if blood pressure cuff data was entered during this check session. False if the user proceeded without a blood pressure cuff. Used by result views and PDF generator to gate BP-dependent sections and display appropriate limitation warnings. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:boolean .
+
+# ============================================================================
+# Proportional Pulse Pressure — Per-Minute Values (v1.4+)
+# ============================================================================
+# PPP = (SBP - DBP) / SBP. Values stored as ratios (0.0 to 1.0).
+# Clinical reference: PPP < 0.25 (25%) may indicate failure to constrict
+# on standing (Bateman Horne Center clinical guidance).
+# Predicates are absent when no BP reading exists at that timepoint.
+# Timepoints mirror the standing BP collection schedule: 1, 3, 5, 7, 10 minutes.
+
+pots:pppMinute1 a owl:DatatypeProperty ;
+    rdfs:label "Proportional Pulse Pressure at 1 Minute"@en ;
+    rdfs:comment "Proportional Pulse Pressure ratio (SBP-DBP)/SBP at 1 minute of standing. Stored as a decimal ratio 0.0-1.0. Absent if no blood pressure reading was taken at this timepoint. Reference: values >= 0.25 (25%) are considered normal per Bateman Horne Center clinical guidance. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:decimal .
+
+pots:pppMinute3 a owl:DatatypeProperty ;
+    rdfs:label "Proportional Pulse Pressure at 3 Minutes"@en ;
+    rdfs:comment "Proportional Pulse Pressure ratio (SBP-DBP)/SBP at 3 minutes of standing. Stored as a decimal ratio 0.0-1.0. Absent if no blood pressure reading was taken at this timepoint. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:decimal .
+
+pots:pppMinute5 a owl:DatatypeProperty ;
+    rdfs:label "Proportional Pulse Pressure at 5 Minutes"@en ;
+    rdfs:comment "Proportional Pulse Pressure ratio (SBP-DBP)/SBP at 5 minutes of standing. Stored as a decimal ratio 0.0-1.0. Absent if no blood pressure reading was taken at this timepoint. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:decimal .
+
+pots:pppMinute7 a owl:DatatypeProperty ;
+    rdfs:label "Proportional Pulse Pressure at 7 Minutes"@en ;
+    rdfs:comment "Proportional Pulse Pressure ratio (SBP-DBP)/SBP at 7 minutes of standing. Stored as a decimal ratio 0.0-1.0. Absent if no blood pressure reading was taken at this timepoint. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:decimal .
+
+pots:pppMinute10 a owl:DatatypeProperty ;
+    rdfs:label "Proportional Pulse Pressure at 10 Minutes"@en ;
+    rdfs:comment "Proportional Pulse Pressure ratio (SBP-DBP)/SBP at 10 minutes of standing. Stored as a decimal ratio 0.0-1.0. Absent if no blood pressure reading was taken at this timepoint. (v1.4+)"@en ;
+    rdfs:domain pots:POTSCheckResult ;
+    rdfs:range xsd:decimal .
+
+# ============================================================================
+# Alignment with Healthcare Standards
+# ============================================================================
+
+# SNOMED CT Mappings
+# - Heart rate: sct:364075005 (Heart rate)
+# - Supine position: sct:40199007 (Supine body position)
+# - Standing position: sct:10904000 (Orthostatic body position)
+# - POTS: sct:703273007 (Postural orthostatic tachycardia syndrome)
+# - Orthostatic hypotension: sct:28651003
+
+# LOINC Mappings
+# - Heart rate: loinc:8867-4 (Heart rate)
+# - Systolic BP: loinc:8480-6 (Systolic blood pressure)
+# - Diastolic BP: loinc:8462-4 (Diastolic blood pressure)
+
+# FHIR Observation Pattern
+# All heart rate and blood pressure measurements use fhir:Observation structure
+# with fhir:code, fhir:valueQuantity, and ucum: units
+
+# ============================================================================
+# Notes
+# ============================================================================
+
+# Data Classification: Consumer wellness data (non-diagnostic)
+# Target Age Range: 13+ (COPPA compliant)
+# Devices: Apple Watch (heart rate), iPhone (posture tracking, UI)
+# Protocol: NASA Lean Test (10 min supine + 10 min standing against wall)
+# Diagnostic Disclaimer: Results are for informational purposes only and should
+# be discussed with a healthcare provider. This is NOT a medical diagnostic tool.
+
+# ============================================================================
+# Changelog
+# ============================================================================
+# v1.4 (2026-02-26): Added pots:baselineDurationMinutes (user-selected baseline
+#     duration in whole minutes, distinct from pots:baselineDurationSeconds).
+#     Added pots:testNotes (free-text patient notes on the result, distinct from
+#     per-symptom pots:notes). Added pots:bpProvided (boolean flag for BP cuff
+#     presence). Added per-minute PPP predicates pots:pppMinute1, pots:pppMinute3,
+#     pots:pppMinute5, pots:pppMinute7, pots:pppMinute10 for Proportional Pulse
+#     Pressure values (ratio 0.0-1.0) at each standard BP timepoint.
+# v1.3 (2026-02-10): Added timing properties (secondsSinceStand, timestampSeconds)
+#     for fine-grained temporal resolution in measurement lists. Added Apple Health
+#     import properties (importedBloodPressureHistory, importedHRVHistory,
+#     averageImportedBloodPressure, averageImportedHRV) for longitudinal context.
+#     Renamed postureStabilitySamples to postureStability to match app serializer.
+# v1.2 (2025-12-15): Added userAgeAtTest, maxHeartRateDelta.
+# v1.1 (2025-11-15): Added recoveryHeartRate, orthostaticHypertensionSuspected,
+#     earlyTerminationReason, posture quality (postureQualityScore,
+#     movementArtifactPercentage, PostureStability class).
+# v1.0 (2025-10-31): Initial release. POTSCheckResult, HeartRateMeasurement,
+#     BloodPressureMeasurement, SymptomEvent, TestProtocol, NASALean.

--- a/src/shapes/workbench.ttl
+++ b/src/shapes/workbench.ttl
@@ -1,0 +1,378 @@
+# Cascade Workbench Vocabulary (Layer 3, app-specific) — v1-draft
+# Authored in spec/. Per draft policy, NOT registered in spec/VOCAB_VERSIONS
+# until v1.0 graduation.
+#
+# Changelog
+#   v1-draft.0.5 (2026-07-15)
+#     - ADDED the notes / flags / follow-ups substrate as W3C WEB ANNOTATIONS
+#       ([NOTES-ANNOTATION-VOCAB]; proposal 2026-07-13-notes-as-web-annotations
+#       in the Workbench vocab-proposals). Caregiver notes, "needs research"
+#       flags, and follow-ups are ONE artifact — an oa:Annotation over one or
+#       more graph nodes — distinguished by oa:motivatedBy (oa:commenting /
+#       oa:questioning / workbench:followUp). Layer-1 reuse, nothing
+#       redeclared: oa: carries body, multi-target, motivation, and span
+#       selectors (oa:TextQuoteSelector / oa:TextPositionSelector, the same
+#       byte-verified-span idea the Claims Ledger uses); PROV-O carries
+#       attribution (prov:wasAttributedTo — the caregiver, distinct from the
+#       patient and from any agent) and prov:generatedAtTime. Follow-ups are
+#       dual-typed cal:Vtodo and reuse W3C RDF Calendar ical:due +
+#       ical:status (RFC 5545 VTODO statuses) — schema:dueDate was considered
+#       and REJECTED because it does not exist (verified 404 at
+#       schema.org/dueDate; schema.org has only paymentDueDate).
+#     - MINTED exactly one term: workbench:followUp, an oa:Motivation with
+#       skos:broader oa:questioning, per the OA model's extension rule for
+#       custom motivations.
+#     - REMOVED workbench:InvestigationNote, workbench:hasNote, and
+#       workbench:noteText (draft removal; never emitted by shipping code —
+#       only type declarations existed in the Workbench contracts package).
+#       Superseded by the oa: substrate: an investigation-scoped note is an
+#       oa:Annotation whose oa:hasTarget is the workbench:Investigation. The
+#       contracts-type cleanup rides with shell Phase 9.
+#     - Pod placement: annotations live in a top-level notes/ container (see
+#       pod-structure.md §5.2), separate from annotations/ (which holds the
+#       record-amendment OVERLAYS below — machinery, not user content).
+#   v1-draft.0.4 (2026-06-28)
+#     - ADDED the filing/organization axis (workbench:userSourceLabel), the
+#       user-chosen label for the SOURCE a record is filed under in the
+#       Workbench "filing cabinet". It is a filing PREFERENCE attributed to the
+#       user: carried on a workbench:Annotation overlay (annotationProperty =
+#       "workbench:userSourceLabel", annotationValue = the label) bearing
+#       cascade:SelfReported provenance. It MUST NOT overwrite the objective
+#       imported origin clinical:sourceEHR, which is preserved and shown
+#       alongside; the effective grouping source prefers this label, else falls
+#       back to clinical:sourceEHR / the import-batch tag. Orthogonal axis with
+#       an open domain, mirroring how workbench:verificationStatus was added in
+#       v1-draft.0.3, so it can file any record. No new SHACL shape required:
+#       the Annotation overlay reuses the already-shaped string predicates
+#       workbench:annotationProperty and workbench:annotationValue.
+#   v1-draft.0.3 (2026-06-23)
+#     - Tombstone: REMOVED workbench:contentHash. A SHA-256 of an erased
+#       record's triples is still pseudonymised personal data (EDPB Guidelines
+#       01/2025; WP29 WP216 Table 5): health content is low-entropy and
+#       enumerable, so the hash is brute-forceable and re-creates the very
+#       erasure obligation the hard-erase discharged. A content-free event
+#       marker is the correct residue.
+#     - Tombstone: ADDED workbench:erasureAction (the action verb), so the
+#       Tombstone is a self-describing, content-free audit event
+#       (opaque id + actor + timestamp + action), not a content fingerprint.
+#     - ADDED the verification axis (workbench:verificationStatus +
+#       VerificationStatusValue {Unverified, Confirmed, Refuted}), orthogonal
+#       to the source axis (cascade:dataProvenance). Patient self-entered data
+#       is self-SOURCED and defaults to UNVERIFIED; this mirrors FHIR
+#       AllergyIntolerance/Condition.verificationStatus and is a candidate to
+#       graduate to clinical:/Layer 2 if it proves broadly useful.
+
+@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
+@prefix evidence:  <https://ns.cascadeprotocol.org/evidence/v1#> .
+@prefix cascade:   <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix oa:   <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ical: <http://www.w3.org/2002/12/cal/ical#> .
+
+# ============================================================================
+# Ontology Metadata
+# ============================================================================
+
+<https://ns.cascadeprotocol.org/workbench/v1#> a owl:Ontology ;
+    dct:title "Cascade Protocol Workbench Vocabulary"@en ;
+    dct:description "Layer 3 vocabulary for the Cascade Workbench desktop investigation app."@en ;
+    dct:creator "Cascade Agentic Labs" ;
+    dct:created "2026-06-16"^^xsd:date ;
+    dct:modified "2026-07-15"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.5" ;
+    rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote, plus the append-only record-amendment overlays (Amendment, Annotation, Retraction, Tombstone). The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/workbench/v1-draft/> .
+
+# ============================================================================
+# Classes
+# ============================================================================
+
+workbench:Investigation a owl:Class ;
+    rdfs:label "Investigation"@en ;
+    rdfs:comment "A named, longitudinal inquiry over one patient's Pod: the top-level workspace object. Aggregates imported conversations, hypotheses, pinned evidence, and notes over time. Only the Workbench UI touches this class directly."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.1" .
+
+workbench:ImportedConversation a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Imported Conversation"@en ;
+    rdfs:comment "A conversation the user had with a general-purpose AI assistant (ChatGPT, Claude, Gemini, etc.), imported into an Investigation as a source. Discrete assertions extracted from it are evidence:Assertion instances produced by a cascade:AIExtractionActivity; those assertions carry cascade:dataProvenance cascade:AIAsserted (ungrounded by construction until graded)."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.1" .
+
+workbench:Hypothesis a owl:Class ;
+    rdfs:label "Hypothesis"@en ;
+    rdfs:comment "A candidate explanation under active consideration in an Investigation, with a lifecycle status. Designed to support widening the differential and explicitly retiring or excluding hypotheses, not just confirming one."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.1" .
+
+workbench:Pin a owl:Class ;
+    rdfs:label "Pin"@en ;
+    rdfs:comment "A curated bookmark within an Investigation pointing at any resource (a record, an assertion, a citation) with an optional note. The mechanism by which the user assembles evidence NotebookLM-style."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.1" .
+
+workbench:InvestigationStatusValue a owl:Class ;
+    rdfs:label "Investigation Status Value"@en ;
+    rdfs:comment "Closed enumeration of Investigation lifecycle states."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.1" .
+
+workbench:HypothesisStatusValue a owl:Class ;
+    rdfs:label "Hypothesis Status Value"@en ;
+    rdfs:comment "Closed enumeration of Hypothesis lifecycle states."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.1" .
+
+# ============================================================================
+# Named Individuals (enumerations)
+# ============================================================================
+
+workbench:Active   a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Active"@en .
+workbench:Paused   a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Paused"@en .
+workbench:Resolved a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Resolved"@en .
+workbench:Archived a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Archived"@en .
+
+workbench:Proposed  a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Proposed"@en .
+workbench:Supported a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Supported"@en .
+workbench:Retired   a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Retired"@en ;
+    rdfs:comment "No longer pursued; kept for the record (not deleted)."@en .
+workbench:Excluded  a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Excluded"@en ;
+    rdfs:comment "Actively ruled out by evidence."@en .
+
+workbench:Unverified a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Unverified"@en ;
+    rdfs:comment "Not corroborated by a clinician or authoritative source. The default for patient self-entered data. Maps to FHIR verificationStatus 'unconfirmed'."@en .
+workbench:Confirmed  a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Confirmed"@en ;
+    rdfs:comment "Corroborated. Maps to FHIR verificationStatus 'confirmed'."@en .
+workbench:Refuted    a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Refuted"@en ;
+    rdfs:comment "Disproved on review. Maps to FHIR verificationStatus 'refuted'."@en .
+
+# ============================================================================
+# Properties — Investigation
+# ============================================================================
+
+workbench:investigationTitle a owl:DatatypeProperty ; rdfs:label "investigation title"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range xsd:string .
+
+workbench:aboutPatient a owl:ObjectProperty ;
+    rdfs:subPropertyOf prov:wasAttributedTo ;
+    rdfs:label "about patient"@en ;
+    rdfs:comment "The patient (profile/card.ttl WebID) this Investigation concerns. With caregiver-proxy, the operating agent is recorded separately via cascade:ProxyAgent."@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range rdfs:Resource .
+
+workbench:investigationStatus a owl:ObjectProperty ; rdfs:label "investigation status"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:InvestigationStatusValue .
+
+workbench:createdAt a owl:DatatypeProperty ; rdfs:label "created at"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range xsd:dateTime .
+workbench:updatedAt a owl:DatatypeProperty ; rdfs:label "updated at"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range xsd:dateTime .
+
+workbench:containsConversation a owl:ObjectProperty ; rdfs:label "contains conversation"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:ImportedConversation .
+workbench:hasHypothesis a owl:ObjectProperty ; rdfs:label "has hypothesis"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:Hypothesis .
+workbench:hasPin a owl:ObjectProperty ; rdfs:label "has pin"@en ;
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:Pin .
+# (workbench:hasNote / workbench:InvestigationNote removed in v1-draft.0.5:
+#  an investigation-scoped note is an oa:Annotation targeting the
+#  Investigation — see the Web Annotation substrate section below.)
+
+# ============================================================================
+# Properties — ImportedConversation
+# ============================================================================
+
+workbench:conversationSource a owl:DatatypeProperty ; rdfs:label "conversation source"@en ;
+    rdfs:comment "Originating assistant, e.g. 'chatgpt', 'claude', 'gemini', 'other'."@en ;
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:string .
+workbench:importedAt a owl:DatatypeProperty ; rdfs:label "imported at"@en ;
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:dateTime .
+workbench:messageCount a owl:DatatypeProperty ; rdfs:label "message count"@en ;
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:integer .
+workbench:rawContentLocation a owl:DatatypeProperty ; rdfs:label "raw content location"@en ;
+    rdfs:comment "Pod-relative path to the stored raw conversation (recommended path sources/)."@en ;
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:string .
+workbench:extractedAssertion a owl:ObjectProperty ; rdfs:label "extracted assertion"@en ;
+    rdfs:comment "An evidence:Assertion decomposed from this conversation."@en ;
+    rdfs:domain workbench:ImportedConversation ; rdfs:range evidence:Assertion .
+
+# ============================================================================
+# Properties — Hypothesis
+# ============================================================================
+
+workbench:hypothesisLabel a owl:DatatypeProperty ; rdfs:label "hypothesis label"@en ;
+    rdfs:domain workbench:Hypothesis ; rdfs:range xsd:string .
+workbench:hypothesisStatus a owl:ObjectProperty ; rdfs:label "hypothesis status"@en ;
+    rdfs:domain workbench:Hypothesis ; rdfs:range workbench:HypothesisStatusValue .
+workbench:supportedByAssertion a owl:ObjectProperty ; rdfs:label "supported by assertion"@en ;
+    rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion .
+workbench:refutedByAssertion a owl:ObjectProperty ; rdfs:label "refuted by assertion"@en ;
+    rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion .
+
+# ============================================================================
+# Properties — Pin
+# ============================================================================
+
+workbench:pinnedResource a owl:ObjectProperty ; rdfs:label "pinned resource"@en ;
+    rdfs:comment "Any resource pinned into the Investigation. Open range for cross-namespace linking."@en ;
+    rdfs:domain workbench:Pin ; rdfs:range rdfs:Resource .
+workbench:pinNote a owl:DatatypeProperty ; rdfs:label "pin note"@en ;
+    rdfs:domain workbench:Pin ; rdfs:range xsd:string .
+
+# ============================================================================
+# Notes, research flags, and follow-ups — the W3C Web Annotation substrate
+# ----------------------------------------------------------------------------
+# Added in workbench v1-draft.0.5 ([NOTES-ANNOTATION-VOCAB]). Caregiver notes
+# ("more tired than usual"), "needs research" flags on claims, and follow-ups
+# ("recheck TSH in 3 months") are ONE artifact: an oa:Annotation over one or
+# more graph nodes, distinguished by oa:motivatedBy. This section deliberately
+# REDECLARES NOTHING from oa:/ical:/prov: — it documents the usage profile and
+# mints the single term the standards lack.
+#
+# The profile (enforced by workbench.shapes.ttl):
+#   - a workbench note IS an oa:Annotation with >= 1 oa:hasTarget (targets may
+#     be any Pod resource: records, conditions, evidence:Assertion instances,
+#     a workbench:Investigation, or an oa:SpecificResource carrying an
+#     oa:TextQuoteSelector / oa:TextPositionSelector to pin a passage inside a
+#     document or transcript — the same byte-verified-span idea the Claims
+#     Ledger uses);
+#   - body text is an oa:TextualBody (rdf:value carries the text);
+#   - motivation mapping: caregiver note = oa:commenting; research flag =
+#     oa:questioning (target is typically an assertion/claim node);
+#     follow-up / open loop = workbench:followUp (below);
+#   - attribution is REQUIRED: prov:wasAttributedTo (who wrote it — the
+#     caregiver, distinct from the patient and from any agent) and
+#     prov:generatedAtTime. A note that flows into grounding as
+#     caregiver-reported evidence carries this provenance with it.
+#   - a follow-up is ADDITIONALLY typed cal:Vtodo and reuses W3C RDF Calendar
+#     terms: ical:due (optional expected-completion date) and ical:status
+#     (REQUIRED; the RFC 5545 VTODO enum "NEEDS-ACTION" / "IN-PROCESS" /
+#     "COMPLETED" / "CANCELLED"). No due-date or status property is minted:
+#     a follow-up genuinely is a to-do. (schema:dueDate was considered and
+#     rejected — it does not exist; schema.org defines only paymentDueDate.)
+#
+# Pod placement: notes/ top-level container (pod-structure.md §5.2), separate
+# from annotations/ (the record-amendment overlays above are edit MACHINERY;
+# notes/ is user-authored content).
+# ============================================================================
+
+workbench:followUp a owl:NamedIndividual, oa:Motivation ;
+    rdfs:label "follow up"@en ;
+    skos:prefLabel "follow up"@en ;
+    skos:broader oa:questioning ;
+    rdfs:comment "The motivation of a follow-up / open loop: an annotation that names something the caregiver intends to resolve later (e.g. \"recheck TSH in 3 months\"). Minted per the Web Annotation model's extension rule (a custom motivation SHOULD be a skos:Concept with skos:broader to a standard one); oa:questioning is the nearest standard motivation — an open question awaiting resolution. An annotation motivated by workbench:followUp is dual-typed cal:Vtodo and carries ical:status (required) + ical:due (optional). Candidate to graduate to a shared layer if other Cascade apps adopt the open-loops worklist."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.5" .
+
+# ============================================================================
+# Append-only record amendment overlays
+# ----------------------------------------------------------------------------
+# Original records in a Pod are immutable. Every edit/delete is a NEW overlay
+# resource (Amendment / Annotation / Retraction / Tombstone) written to the
+# Pod's annotations/ directory and discovered at query time. The overlays carry
+# cascade:dataProvenance cascade:SelfReported, an optional prov:wasAttributedTo
+# actor, and a dct:created timestamp. Added in workbench v1-draft.0.2.
+# ============================================================================
+
+workbench:Amendment a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Amendment"@en ;
+    rdfs:comment "An append-only overlay that overrides one property value on an existing record without mutating the original. Names the amended record, the predicate CURIE being overridden, and the new value. Discovered at query time so the effective value can be projected over the immutable original."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+workbench:Annotation a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Annotation"@en ;
+    rdfs:comment "An append-only overlay that ADDS a note or an extra attribute to an existing record without overriding any of its values. Use Amendment to override; use Annotation to augment."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+workbench:Retraction a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Retraction"@en ;
+    rdfs:comment "An append-only soft-delete / supersede overlay (the entered-in-error pattern). The retracted record's bytes are retained; the Retraction marks it as withdrawn and may point at the kept record when merging duplicates."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+workbench:Tombstone a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Tombstone"@en ;
+    rdfs:comment "A content-free hard-erase audit marker. Unlike a Retraction, the erased record's bytes are gone from its bucket file; the Tombstone records only the EVENT of erasure — the erased record's opaque id, the actor (prov:wasAttributedTo), the timestamp (dct:created), and the action (workbench:erasureAction) — so the deletion is provably logged WITHOUT retaining any content of the erased record. It deliberately holds no content hash: a hash of an erased record's triples is still pseudonymised personal data (low-entropy health content is brute-forceable), which would re-create the erasure obligation the hard-erase just discharged."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2; contentHash removed, erasureAction added in v1-draft.0.3" .
+
+workbench:VerificationStatusValue a owl:Class ;
+    rdfs:label "Verification Status Value"@en ;
+    rdfs:comment "Closed enumeration of a record's clinical verification state — the VERIFICATION axis, orthogonal to the SOURCE axis (cascade:dataProvenance). Mirrors FHIR AllergyIntolerance/Condition.verificationStatus. Candidate to graduate to clinical:/Layer 2."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.3" .
+
+# ── Properties shared by all overlay classes ────────────────────────────────
+# (cascade:dataProvenance, prov:wasAttributedTo, and dct:created are reused
+#  from core/PROV-O/Dublin Core; no new predicates are minted for those.)
+
+# ── Properties — Amendment ──────────────────────────────────────────────────
+
+workbench:amendsRecord a owl:ObjectProperty ; rdfs:label "amends record"@en ;
+    rdfs:comment "The existing record whose property value this Amendment overrides."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range rdfs:Resource .
+workbench:amendsProperty a owl:DatatypeProperty ; rdfs:label "amends property"@en ;
+    rdfs:comment "The predicate CURIE being overridden, e.g. \"clinical:dosage\"."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+workbench:amendedValue a owl:DatatypeProperty ; rdfs:label "amended value"@en ;
+    rdfs:comment "The new value that supersedes the original value of amendsProperty."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+workbench:amendmentReason a owl:DatatypeProperty ; rdfs:label "amendment reason"@en ;
+    rdfs:comment "Optional free-text rationale for the amendment."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+
+# ── Properties — Annotation ─────────────────────────────────────────────────
+
+workbench:annotatesRecord a owl:ObjectProperty ; rdfs:label "annotates record"@en ;
+    rdfs:comment "The existing record this Annotation augments."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range rdfs:Resource .
+workbench:annotationText a owl:DatatypeProperty ; rdfs:label "annotation text"@en ;
+    rdfs:comment "Optional free-text note attached to the record."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+workbench:annotationProperty a owl:DatatypeProperty ; rdfs:label "annotation property"@en ;
+    rdfs:comment "Optional predicate CURIE of an extra attribute being added (paired with annotationValue)."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+workbench:annotationValue a owl:DatatypeProperty ; rdfs:label "annotation value"@en ;
+    rdfs:comment "Optional value of the extra attribute named by annotationProperty."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+
+# ── Properties — Retraction ─────────────────────────────────────────────────
+
+workbench:retractsRecord a owl:ObjectProperty ; rdfs:label "retracts record"@en ;
+    rdfs:comment "The existing record this Retraction soft-deletes / supersedes."@en ;
+    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource .
+workbench:retractionReason a owl:DatatypeProperty ; rdfs:label "retraction reason"@en ;
+    rdfs:comment "Optional free-text rationale (e.g. \"entered in error\")."@en ;
+    rdfs:domain workbench:Retraction ; rdfs:range xsd:string .
+workbench:supersededBy a owl:ObjectProperty ; rdfs:label "superseded by"@en ;
+    rdfs:comment "Optional pointer to the kept record when merging duplicates."@en ;
+    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource .
+
+# ── Properties — Tombstone ──────────────────────────────────────────────────
+
+workbench:erasedRecord a owl:ObjectProperty ; rdfs:label "erased record"@en ;
+    rdfs:comment "The id of the record whose bytes were hard-erased from its bucket file."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range rdfs:Resource .
+workbench:erasedType a owl:DatatypeProperty ; rdfs:label "erased type"@en ;
+    rdfs:comment "Optional rdf:type CURIE of the erased record (a category, e.g. \"clinical:Medication\"), retained for audit. Category-level only — it names the kind of record erased, never its content."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+workbench:erasureAction a owl:DatatypeProperty ; rdfs:label "erasure action"@en ;
+    rdfs:comment "The action this Tombstone records, e.g. \"hard-erase\". Makes the Tombstone a self-describing, content-free audit event."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+workbench:erasureReason a owl:DatatypeProperty ; rdfs:label "erasure reason"@en ;
+    rdfs:comment "Optional free-text rationale for the hard erasure (author-supplied; keep content-free to preserve the erasure)."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+
+# ── Properties — Verification axis (orthogonal to cascade:dataProvenance) ─────
+
+workbench:verificationStatus a owl:ObjectProperty ; rdfs:label "verification status"@en ;
+    rdfs:comment "A record's clinical verification state (VERIFICATION axis), independent of who reported it (SOURCE axis, cascade:dataProvenance). Open domain so it can tag any record; patient self-entered records default to workbench:Unverified."@en ;
+    rdfs:range workbench:VerificationStatusValue ;
+    owl:versionInfo "Added in workbench v1-draft.0.3" .
+
+# ── Properties — Filing / organization axis (orthogonal to the imported origin) ─
+
+workbench:userSourceLabel a owl:DatatypeProperty ; rdfs:label "user source label"@en ;
+    rdfs:comment "The user-chosen FILING label for the SOURCE a record is organized under in the Workbench 'filing cabinet' (the ORGANIZATION axis). It is a filing PREFERENCE attributed to the user, carried on a workbench:Annotation (annotationProperty = \"workbench:userSourceLabel\", annotationValue = the chosen label) whose overlay bears cascade:SelfReported provenance. It MUST NOT alter the objective imported origin clinical:sourceEHR, which is preserved and displayed alongside. The effective source the UI groups records by prefers this label when present, else falls back to the imported origin (clinical:sourceEHR, else the import-batch tag). Open domain (like workbench:verificationStatus) so it can file any record."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in workbench v1-draft.0.4" .

--- a/tests/ccda-converter.test.ts
+++ b/tests/ccda-converter.test.ts
@@ -27,6 +27,10 @@ import { fileURLToPath } from 'node:url';
 import { Parser } from 'n3';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
 import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+import {
+  assertOnlyKnownViolations,
+  expectKnownViolationsStillPresent,
+} from './known-shacl-gaps.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -185,7 +189,7 @@ describe('C-CDA converter — full summarization (P4-A)', () => {
     expect(result.output).toContain('"TestSystem"');
   });
 
-  it('output passes SHACL validation with zero violations on every record type', async () => {
+  it('output passes SHACL validation with no violation beyond the known date-datatype gap', async () => {
     const xml = readFixture('full-summarization.xml');
     const result = await convertCcda(xml, { sourceSystem: 'TestSystem' });
 
@@ -196,12 +200,20 @@ describe('C-CDA converter — full summarization (P4-A)', () => {
     // ClinicalDocument (importedAt, sourceEHR, fhirResourceId, fhirResourceType),
     // PatientProfile (typed dateOfBirth, enum biologicalSex), and the shared
     // cascade:dataProvenance + cascade:schemaVersion on every record. Nothing is
-    // filtered out: the full document must validate clean.
+    // filtered out.
+    //
+    // This asserted zero violations until health v2.5 gave the five health:*Record
+    // classes shapes. The converter's output is byte-identical; three predicates
+    // are simply now checked against the `xsd:dateTime` range they always had.
+    // See `known-shacl-gaps.ts` — that list is exact in both directions, so this
+    // still fails on any new violation AND once the gap is closed.
     const violations = validation.results.filter((r) => r.severity === 'violation');
-    expect(
-      violations,
-      `SHACL violations:\n${violations.map((v) => `  ${v.shape}: ${v.message} (${v.property})`).join('\n')}`,
-    ).toHaveLength(0);
+    assertOnlyKnownViolations(violations);
+    expectKnownViolationsStillPresent(violations, [
+      'performedDate',
+      'onsetDate',
+      'administrationDate',
+    ]);
   });
 });
 

--- a/tests/ccda-provenance-required-fields.test.ts
+++ b/tests/ccda-provenance-required-fields.test.ts
@@ -15,6 +15,10 @@
 import { describe, it, expect } from 'vitest';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
 import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+import {
+  assertOnlyKnownViolations,
+  expectKnownViolationsStillPresent,
+} from './known-shacl-gaps.js';
 
 // A minimal but realistic Epic-style C-CDA: custodian org, patient demographics,
 // a medication whose drug name lives in the narrative (originalText reference),
@@ -194,14 +198,16 @@ describe('C-CDA vital signs', () => {
 });
 
 describe('C-CDA full SHACL validation', () => {
-  it('produces zero SHACL violations across all record types', async () => {
+  it('produces no SHACL violation beyond the known date-datatype gap', async () => {
     const { output } = await convert();
     const { store, shapeFiles } = loadShapes();
     const validation = validateTurtle(output, store, shapeFiles, 'ccda-provenance-test');
     const violations = validation.results.filter((r) => r.severity === 'violation');
-    expect(
-      violations,
-      `SHACL violations:\n${violations.map((v) => `  ${v.shape}: ${v.message} (${v.property})`).join('\n')}`,
-    ).toHaveLength(0);
+
+    // Was zero violations until health v2.5 shaped the health:*Record classes.
+    // This fixture exercises only the labs path, so it reaches one of the three
+    // affected predicates. See `known-shacl-gaps.ts`.
+    assertOnlyKnownViolations(violations);
+    expectKnownViolationsStillPresent(violations, ['performedDate']);
   });
 });

--- a/tests/known-shacl-gaps.ts
+++ b/tests/known-shacl-gaps.ts
@@ -1,0 +1,122 @@
+/**
+ * SHACL violations that the C-CDA converter is currently known to produce, and
+ * the rule that keeps the list from becoming a place to hide new ones.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * health v2.5 defines and shapes five record classes that were emitted but
+ * undefined. Records the validator previously reported as conforming — because
+ * no shape selected them, and a conforming report over zero constraints is
+ * indistinguishable from a conforming report over many — are now actually
+ * checked. Everything below is a finding of that kind: the converter's output
+ * did not change, the constraints did.
+ *
+ * THE ONE FINDING, STATED PRECISELY
+ * ---------------------------------
+ * Four C-CDA section handlers read `<effectiveTime value="20250311"/>`, slice it
+ * to `2025-03-11`, and write it with `literal(dateStr)` — a plain literal, so
+ * `xsd:string`:
+ *
+ *   sections/procedures.ts    -> health:performedDate
+ *   sections/vitals.ts        -> health:performedDate
+ *   sections/labs.ts          -> health:performedDate
+ *   sections/problems.ts      -> health:onsetDate
+ *   sections/immunizations.ts -> health:administrationDate
+ *
+ * health v2.5 constrains all three predicates with `sh:datatype xsd:dateTime`.
+ * That constraint is not new and not an overreach: `health.ttl` declares
+ * `rdfs:range xsd:dateTime` on each of the three, and it is the same constraint
+ * `clinical:onsetDate` has carried since before this release. The emitters have
+ * disagreed with the ratified vocabulary the whole time; nothing was checking.
+ *
+ * `labs.ts:292` already writes `clinical:performedDate` through a
+ * `tripleDateTime()` helper that types the literal correctly. The helper exists.
+ * It was never propagated to the other sites — the same shape of defect as the
+ * identity helpers that had to be pulled into a chokepoint.
+ *
+ * WHY THIS IS PINNED RATHER THAN FIXED HERE
+ * -----------------------------------------
+ * Two reasons, and the second is why it is not a one-line change.
+ *
+ * 1. This change syncs vocabulary and shapes; it deliberately alters no emission
+ *    site. Fixing a converter here would mix a data-output change into a
+ *    vocabulary sync, and the two need to be reviewed and released separately.
+ *
+ * 2. The correct fix is not obvious. The source carries DAY precision. Typing
+ *    `2025-03-11` as `xsd:dateTime` requires appending a time — `T00:00:00` —
+ *    which fabricates precision the C-CDA never had, and midnight-local is a
+ *    real value that downstream arithmetic will treat as real. FHIR R4's
+ *    `dateTime` primitive accepts `YYYY`, `YYYY-MM`, `YYYY-MM-DD` and full
+ *    instants precisely to avoid this, and `health:administrationDate`'s own
+ *    comment says it "Corresponds to FHIR R4 Immunization.occurrence". A single
+ *    `sh:datatype` cannot express that; expressing it needs `sh:or` over
+ *    `xsd:date` / `xsd:dateTime` in the shapes. So the emitter fix is blocked on
+ *    a vocabulary decision, and guessing at it in this change would ratify the
+ *    guess.
+ *
+ * HOW THIS STAYS HONEST
+ * ---------------------
+ * `assertOnlyKnownViolations` fails if a violation appears on any property not
+ * listed here, and `expectKnownViolationsStillPresent` fails once they stop
+ * being produced. So the list cannot silently absorb a new defect, and it cannot
+ * outlive the defect it describes.
+ */
+
+import { expect } from 'vitest';
+
+export interface SeverityIssue {
+  severity: string;
+  shape: string;
+  property: string;
+  message: string;
+}
+
+/**
+ * Local names of the properties whose `sh:datatype xsd:dateTime` constraint the
+ * C-CDA converter currently violates by emitting an untyped day-precision string.
+ */
+export const KNOWN_DATE_DATATYPE_PROPERTIES = new Set([
+  'performedDate',
+  'onsetDate',
+  'administrationDate',
+]);
+
+function isKnownDateDatatypeViolation(v: SeverityIssue): boolean {
+  return (
+    KNOWN_DATE_DATATYPE_PROPERTIES.has(v.property) &&
+    v.message.includes('http://www.w3.org/2001/XMLSchema#dateTime')
+  );
+}
+
+/**
+ * Assert that every violation present is one of the known date-datatype ones.
+ *
+ * The message check matters: without it, ANY violation on `performedDate` — a
+ * missing value, a cardinality breach — would be swallowed by the property name
+ * alone.
+ */
+export function assertOnlyKnownViolations(violations: SeverityIssue[]): void {
+  const unexpected = violations.filter((v) => !isKnownDateDatatypeViolation(v));
+  expect(
+    unexpected,
+    `Unexpected SHACL violations (not the known date-datatype gap):\n${unexpected
+      .map((v) => `  ${v.shape}: ${v.message} (${v.property})`)
+      .join('\n')}`,
+  ).toHaveLength(0);
+}
+
+/**
+ * Assert the known gap is still actually being produced.
+ *
+ * Without this, `assertOnlyKnownViolations` would pass on output containing no
+ * violations at all — including output where the converter had been fixed, or
+ * where a shape had been dropped and stopped firing. Either of those should
+ * force this file to be revisited rather than pass quietly.
+ */
+export function expectKnownViolationsStillPresent(
+  violations: SeverityIssue[],
+  expectedProperties: string[],
+): void {
+  const seen = [...new Set(violations.map((v) => v.property))].sort();
+  expect(seen).toEqual([...expectedProperties].sort());
+}

--- a/tests/pod-family-history-routing.test.ts
+++ b/tests/pod-family-history-routing.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Family-history records must land in the family-history file.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * The C-CDA Family History section emits `health:FamilyHistoryRecord`. That IRI
+ * appeared in no `DATA_TYPES` entry, so `routeTypeKey` (`commands/pod/import.ts`)
+ * matched nothing and fell through to its final `return 'fhir-passthrough'` —
+ * the branch meant for genuinely unmapped `http://hl7.org/fhir/*` types. Every
+ * family-history record a C-CDA import produced was therefore written to
+ * `clinical/fhir-passthrough.ttl`.
+ *
+ * Nothing about that looked wrong from the outside. The import succeeded, the
+ * summary counted the records, and the section reported `Family History: 2 -> 2`.
+ * The records existed; they were just filed under "type we could not map", which
+ * is the one bucket a reader is entitled to ignore.
+ *
+ * WHY IT MATTERS MORE NOW
+ * -----------------------
+ * health v2.5 gives `health:FamilyHistoryRecord` a ratified SHACL shape, and the
+ * conformance corpus carries fixtures against it. A class with a shape whose
+ * records sit in the passthrough bucket is worse than one with neither: the
+ * shape's consumers look at `family-history.ttl`, find no file, and conclude
+ * there is no family history.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT — measured against 1750f16:
+ *   - `writes them to clinical/family-history.ttl` FAILS: the file does not exist.
+ *   - `does not file them under FHIR passthrough` FAILS: both records are in
+ *     `clinical/fhir-passthrough.ttl`.
+ *   - `registers the bucket` FAILS: `DATA_TYPES['family-history']` is undefined.
+ *   - `reaches them through pod query --all` FAILS: the records are reported
+ *     under `fhir-passthrough`, not `family-history`.
+ *
+ * Note the assertions name the FILE, not the type string. An assertion that only
+ * checked the pod's concatenated Turtle for `health:FamilyHistoryRecord` passes
+ * either way — the records were always present, just in the wrong file — and one
+ * such assertion already existed and stayed green throughout.
+ *
+ * The fixture is synthetic, authored from the C-CDA R2.1 specification: two
+ * relatives (mother/Type 2 diabetes mellitus, father/myocardial infarction).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SYNTHETIC_EPIC_CCDA } from './ccda-synthetic-documents.js';
+import { DATA_TYPES } from '../src/lib/pod-data-types.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+const roots: string[] = [];
+
+function cli(args: string[]): { output: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 180000 });
+  return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+function importedPod(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fhx-routing-'));
+  roots.push(root);
+  const podDir = path.join(root, 'pod');
+  const inputs = path.join(root, 'inputs');
+  fs.mkdirSync(inputs);
+  fs.writeFileSync(path.join(inputs, 'summary.xml'), SYNTHETIC_EPIC_CCDA);
+
+  const init = cli(['pod', 'init', podDir]);
+  expect(init.status, init.output).toBe(0);
+  const imp = cli(['pod', 'import', podDir, inputs]);
+  expect(imp.status, imp.output).toBe(0);
+  return podDir;
+}
+
+function read(podDir: string, rel: string): string {
+  const p = path.join(podDir, rel);
+  return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing — run `npm run build` before `npm test`.');
+  }
+});
+
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+describe('the family-history routing bucket', () => {
+  it('registers health:FamilyHistoryRecord against clinical/family-history.ttl', () => {
+    const bucket = DATA_TYPES['family-history'];
+    expect(bucket).toBeDefined();
+    expect(bucket.rdfTypes).toContain('https://ns.cascadeprotocol.org/health/v1#FamilyHistoryRecord');
+    expect(bucket.directory).toBe('clinical');
+    expect(bucket.filename).toBe('family-history.ttl');
+  });
+
+  it('claims the type exclusively — no other bucket also routes it', () => {
+    // Two buckets claiming one type makes routing depend on object key order,
+    // which is a different defect wearing the same symptom.
+    const claimants = Object.entries(DATA_TYPES)
+      .filter(([, info]) =>
+        info.rdfTypes.includes('https://ns.cascadeprotocol.org/health/v1#FamilyHistoryRecord'),
+      )
+      .map(([key]) => key);
+    expect(claimants).toEqual(['family-history']);
+  });
+});
+
+describe('cascade pod import, on a C-CDA carrying a Family History section', () => {
+  it('writes the records to clinical/family-history.ttl', () => {
+    const podDir = importedPod();
+    const familyHistory = read(podDir, 'clinical/family-history.ttl');
+
+    expect(familyHistory).not.toBe('');
+    expect(familyHistory).toContain('health:FamilyHistoryRecord');
+    // The values, not only the type: a file holding the right type and the wrong
+    // content would satisfy the line above.
+    expect(familyHistory).toContain('Type 2 diabetes mellitus');
+    expect(familyHistory).toContain('Myocardial infarction');
+    expect(familyHistory).toContain('Mother');
+    expect(familyHistory).toContain('Father');
+  });
+
+  it('does not file them under FHIR passthrough', () => {
+    const podDir = importedPod();
+    const passthrough = read(podDir, 'clinical/fhir-passthrough.ttl');
+
+    // This is the half that fails on the pre-fix build, where both records were
+    // here and `family-history.ttl` did not exist.
+    expect(passthrough).not.toContain('FamilyHistoryRecord');
+    expect(passthrough).not.toContain('Myocardial infarction');
+  });
+
+  it('writes exactly the two records the section carries', () => {
+    const podDir = importedPod();
+    const familyHistory = read(podDir, 'clinical/family-history.ttl');
+    const count = familyHistory.split('health:FamilyHistoryRecord').length - 1;
+    expect(count).toBe(2);
+  });
+
+  it('reaches them through pod query --all', () => {
+    const podDir = importedPod();
+    const r = cli(['--json', 'pod', 'query', podDir, '--all']);
+    expect(r.status, r.output).toBe(0);
+
+    const parsed = JSON.parse(r.output);
+    // `--all` enumerates DATA_TYPES keys, so an unregistered type is unreachable
+    // through it by construction — which is what "records exist but no read verb
+    // can see them as family history" meant in practice.
+    const serialized = JSON.stringify(parsed);
+    expect(serialized).toContain('family-history');
+    expect(serialized).toContain('Type 2 diabetes mellitus');
+  });
+
+  it('counts the bucket in pod info', () => {
+    const podDir = importedPod();
+    const r = cli(['pod', 'info', podDir]);
+    expect(r.status, r.output).toBe(0);
+
+    // `pod info` enumerates registered files, so before the bucket existed this
+    // line was absent entirely and the two records were counted, if at all, as
+    // `fhir-passthrough.ttl`. Matching the count as well as the name keeps a
+    // stray empty file from satisfying it.
+    expect(r.output).toMatch(/family-history\.ttl\s+2 records/);
+    expect(r.output).not.toMatch(/fhir-passthrough\.ttl/);
+  });
+});

--- a/tests/pod-import-importedat-reimport.test.ts
+++ b/tests/pod-import-importedat-reimport.test.ts
@@ -77,10 +77,27 @@ describe('pod import: re-import keeps exactly one importedAt (root 1.5 symptom 3
       expect(values.size, `${subject} should have exactly one importedAt`).toBe(1);
     }
 
-    // And the pod validates clean: the specific SHACL failure this fix targets
-    // ("must have exactly one importedAt timestamp") is gone, 0 files fail.
+    // And the specific SHACL failure this fix targets ("must have exactly one
+    // importedAt timestamp") is gone from the validate output.
     const out = runCli(`validate ${podDir}`);
     expect(out).not.toMatch(/exactly one importedAt/i);
-    expect(out).toMatch(/0 failed/);
+    expect(out).not.toMatch(/Property: importedAt/);
+
+    // This used to assert `0 failed`. It no longer can, and the reason is not a
+    // regression in this fix: health v2.5 shapes `health:LabResultRecord`, so
+    // this fixture's day-precision `performedDate` literals are checked against
+    // `sh:datatype xsd:dateTime` for the first time and fail. Asserting the
+    // failing file's identity keeps this a real check — a new failure anywhere
+    // else in the pod still breaks it — without pinning it to a count that a
+    // separate, tracked defect controls. See `known-shacl-gaps.ts`.
+    // Per-FILE status lines start at column 0; per-ISSUE lines are indented two
+    // spaces and carry no path, so matching on the bare word would count them
+    // too and make the assertion mean nothing.
+    const failingFiles = out
+      .split('\n')
+      .map((l) => l.replace(/\[[0-9;]*m/g, ''))
+      .filter((l) => /^FAIL\s/.test(l));
+    expect(failingFiles.length, out).toBe(1);
+    expect(failingFiles[0], out).toContain('clinical/lab-results.ttl');
   });
 });

--- a/tests/shapes-sync.test.ts
+++ b/tests/shapes-sync.test.ts
@@ -1,0 +1,268 @@
+/**
+ * The bundled vocabulary must define every class the bundled shapes target.
+ *
+ * WHAT WENT WRONG, AND WHY NO EXISTING TEST SAW IT
+ * ------------------------------------------------
+ * `src/shapes/` holds two kinds of file and `loadShapes()` reads both: every
+ * `*.shapes.ttl` supplies SHACL constraints, and every other `*.ttl` supplies the
+ * vocabulary those constraints are written against. The sync script kept two
+ * independent lists — one naming the vocabularies whose *shapes* to copy (six
+ * stable plus four drafts) and one naming the vocabularies whose *ontology* to
+ * copy (three: core, clinical, coverage). Nothing tied them together, so the
+ * second list simply never grew.
+ *
+ * The result is a validator that loads a shape whose target class its own loaded
+ * vocabulary does not define. That is silent by construction: SHACL resolves
+ * `sh:targetClass` against the data graph, so an undefined target is not an
+ * error, it is a shape that quietly selects nothing and reports nothing. A file
+ * full of such subjects returns `conforms: true`, which reads as "checked and
+ * clean" and means "never checked".
+ *
+ * Measured before the fix: 52 of 89 `sh:targetClass` values in Cascade
+ * namespaces resolved to no loaded class, and `src/shapes/health.ttl` was 928
+ * lines against the 1489 it should have been — it had never been synced once.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT
+ * ------------------------------------------
+ * Measured against the pre-sync tree at commit 1750f16:
+ *   - `every shapes file has a matching ontology file` FAILS: 10 shapes files,
+ *     4 ontology files, 6 missing (health, checkup, pots, genomics, advisory,
+ *     evidence, workbench — health being the one with a stable released version).
+ *   - `every Cascade sh:targetClass resolves` FAILS with 52 unresolved targets
+ *     across 7 vocabularies, health:SocialHistoryRecord among them.
+ *   - `VOCAB_VERSIONS matches the synced ontology` FAILS on health: the file
+ *     said 2.4 while the never-synced ontology declared 2.3.
+ *
+ * These assert on parsed RDF terms and on file inventories, never on substrings
+ * of prose, so no comment or changelog line anywhere can make one pass by
+ * coincidence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser, Store, DataFactory } from 'n3';
+
+const { namedNode } = DataFactory;
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_SHAPES = path.join(REPO, 'src', 'shapes');
+const DIST_SHAPES = path.join(REPO, 'dist', 'shapes');
+
+const SH = 'http://www.w3.org/ns/shacl#';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+const OWL = 'http://www.w3.org/2002/07/owl#';
+const CASCADE_NS_PREFIX = 'https://ns.cascadeprotocol.org/';
+
+/**
+ * `sh:targetClass` values outside the Cascade namespaces. These are classes
+ * owned by other vocabularies, so no Cascade ontology will ever define them and
+ * requiring resolution would be wrong.
+ *
+ * Pinned as an exact set rather than waved through by a namespace test: adding a
+ * dependency on a foreign vocabulary is a decision, and it should show up as a
+ * failing assertion that someone has to look at.
+ */
+const EXTERNAL_TARGET_CLASSES = new Set([
+  // W3C Web Annotation Data Model, targeted by workbench:WebAnnotationShape.
+  'http://www.w3.org/ns/oa#Annotation',
+]);
+
+/**
+ * Cascade-namespace target classes that are known NOT to resolve, with the
+ * reason. Each one is a defect in `spec`, not in the sync.
+ *
+ * checkup v3.0 removed the classes `checkup:PatientProfile` and
+ * `checkup:VitalSignsTrend` (its changelog records the removal, and
+ * `checkup:hasPatientProfile` / `hasVitalsTrend` carry DEPRECATED comments
+ * pointing at the replacements) but `checkup.shapes.ttl` still declares
+ * `PatientProfileShape` and `VitalSignsTrendShape` with `sh:targetClass` on the
+ * removed names. Both shapes are still reachable through `sh:node` from their
+ * parent shapes, so only the class target is dead — which is precisely why it
+ * survived: nothing about it is visibly broken from inside the shapes file.
+ *
+ * The entry below is deliberately not a free pass. The staleness assertion just
+ * under it fails if one of these ever DOES resolve, so when `spec` removes the
+ * orphaned shapes this list must shrink in the same change.
+ */
+const KNOWN_UNRESOLVED_TARGET_CLASSES = new Set([
+  'https://ns.cascadeprotocol.org/checkup/v1#PatientProfile',
+  'https://ns.cascadeprotocol.org/checkup/v1#VitalSignsTrend',
+]);
+
+interface LoadedShapesDir {
+  shapesFiles: string[];
+  ontologyFiles: string[];
+  /** Constraints only. */
+  shapesStore: Store;
+  /** Vocabulary only. */
+  vocabStore: Store;
+}
+
+function loadShapesDir(dir: string): LoadedShapesDir {
+  const all = fs.readdirSync(dir).filter((f) => f.endsWith('.ttl')).sort();
+  const shapesFiles = all.filter((f) => f.endsWith('.shapes.ttl'));
+  const ontologyFiles = all.filter((f) => !f.endsWith('.shapes.ttl'));
+
+  const shapesStore = new Store();
+  const vocabStore = new Store();
+  for (const f of all) {
+    const target = f.endsWith('.shapes.ttl') ? shapesStore : vocabStore;
+    const quads = new Parser().parse(fs.readFileSync(path.join(dir, f), 'utf-8'));
+    for (const q of quads) target.addQuad(q);
+  }
+  return { shapesFiles, ontologyFiles, shapesStore, vocabStore };
+}
+
+/** Vocabulary stem, e.g. `health.shapes.ttl` and `health.ttl` both -> `health`. */
+function stem(file: string): string {
+  return file.replace(/\.shapes\.ttl$/, '').replace(/\.ttl$/, '');
+}
+
+function declaredClasses(vocabStore: Store): Set<string> {
+  const out = new Set<string>();
+  for (const classType of [`${OWL}Class`, `${RDFS}Class`]) {
+    for (const q of vocabStore.getQuads(null, namedNode(RDF_TYPE), namedNode(classType), null)) {
+      out.add(q.subject.value);
+    }
+  }
+  return out;
+}
+
+/** `sh:targetClass` value -> the shapes that declare it, for a readable failure. */
+function targetClasses(shapesStore: Store): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const q of shapesStore.getQuads(null, namedNode(`${SH}targetClass`), null, null)) {
+    const existing = out.get(q.object.value);
+    if (existing) existing.push(q.subject.value);
+    else out.set(q.object.value, [q.subject.value]);
+  }
+  return out;
+}
+
+const src = loadShapesDir(SRC_SHAPES);
+
+describe('bundled shapes and the vocabulary they are written against', () => {
+  it('ships an ontology for every shapes file, and a shapes file for every ontology', () => {
+    const shapeStems = new Set(src.shapesFiles.map(stem));
+    const ontologyStems = new Set(src.ontologyFiles.map(stem));
+
+    // Stated as sorted arrays so a failure names the missing vocabularies rather
+    // than printing two set sizes.
+    expect([...shapeStems].sort()).toEqual([...ontologyStems].sort());
+  });
+
+  it('resolves every Cascade-namespace sh:targetClass to a defined class', () => {
+    const defined = declaredClasses(src.vocabStore);
+    const targets = targetClasses(src.shapesStore);
+
+    const unresolved: string[] = [];
+    for (const [cls, shapes] of targets) {
+      if (!cls.startsWith(CASCADE_NS_PREFIX)) continue;
+      if (defined.has(cls)) continue;
+      if (KNOWN_UNRESOLVED_TARGET_CLASSES.has(cls)) continue;
+      unresolved.push(`${cls} (targeted by ${shapes.join(', ')})`);
+    }
+
+    expect(unresolved.sort()).toEqual([]);
+  });
+
+  it('has no stale entry in the known-unresolved list', () => {
+    const defined = declaredClasses(src.vocabStore);
+    const nowResolving = [...KNOWN_UNRESOLVED_TARGET_CLASSES].filter((c) => defined.has(c));
+
+    // If spec defines one of these again, or removes the orphaned shape, the
+    // exemption has to go with it — otherwise the list slowly becomes a place to
+    // hide real breakage.
+    expect(nowResolving.sort()).toEqual([]);
+  });
+
+  it('targets no foreign class beyond the ones explicitly accepted', () => {
+    const external = [...targetClasses(src.shapesStore).keys()]
+      .filter((c) => !c.startsWith(CASCADE_NS_PREFIX))
+      .filter((c) => !EXTERNAL_TARGET_CLASSES.has(c));
+
+    expect(external.sort()).toEqual([]);
+  });
+
+  it('actually targets something — the assertions above are not vacuous', () => {
+    const targets = targetClasses(src.shapesStore);
+    const cascadeTargets = [...targets.keys()].filter((c) => c.startsWith(CASCADE_NS_PREFIX));
+
+    // An empty shapes directory would satisfy every assertion above. These
+    // floors are set below the current counts (107 Cascade targets, 194 defined
+    // classes) so ordinary vocabulary growth does not touch them, but a sync that
+    // silently produced nothing would.
+    expect(cascadeTargets.length).toBeGreaterThan(90);
+    expect(declaredClasses(src.vocabStore).size).toBeGreaterThan(150);
+    expect(src.shapesFiles.length).toBeGreaterThan(8);
+  });
+});
+
+describe('VOCAB_VERSIONS against the ontologies actually bundled', () => {
+  const rows = new Map<string, string>();
+  for (const line of fs.readFileSync(path.join(REPO, 'VOCAB_VERSIONS'), 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [k, v] = trimmed.split('=');
+    rows.set(k, v);
+  }
+
+  it('declares a version for each stable vocabulary', () => {
+    expect([...rows.keys()].sort()).toEqual(
+      ['checkup', 'clinical', 'core', 'coverage', 'health', 'pots'],
+    );
+  });
+
+  it.each([...rows.keys()])(
+    'the bundled %s ontology declares the version VOCAB_VERSIONS claims',
+    (vocab) => {
+      const file = path.join(SRC_SHAPES, `${vocab}.ttl`);
+      expect(fs.existsSync(file), `${vocab}.ttl is not bundled`).toBe(true);
+
+      const store = new Store();
+      for (const q of new Parser().parse(fs.readFileSync(file, 'utf-8'))) store.addQuad(q);
+
+      // The version on the owl:Ontology node itself, not the per-term
+      // `owl:versionInfo "Added in health v2.4"` annotations that share the
+      // predicate.
+      const ontologyNodes = store
+        .getQuads(null, namedNode(RDF_TYPE), namedNode(`${OWL}Ontology`), null)
+        .map((q) => q.subject);
+      expect(ontologyNodes.length, `${vocab}.ttl declares no owl:Ontology`).toBe(1);
+
+      const versions = store
+        .getQuads(ontologyNodes[0], namedNode(`${OWL}versionInfo`), null, null)
+        .map((q) => q.object.value);
+
+      // This is the assertion that makes a stale bundle loud: bumping the row
+      // without re-running the sync fails here, and so does re-running the sync
+      // without bumping the row.
+      expect(versions).toContain(rows.get(vocab));
+    },
+  );
+});
+
+describe('the built bundle the CLI actually loads', () => {
+  it('mirrors src/shapes byte for byte', () => {
+    // `getShapesDir()` resolves to `dist/shapes` at runtime, so every measurement
+    // taken from a `cascade validate` run reflects dist, not src. Editing src and
+    // reading the old dist result as "no change" is a live trap; this is the
+    // assertion that removes it.
+    expect(fs.existsSync(DIST_SHAPES), 'dist/shapes is missing — run `npm run build`').toBe(true);
+
+    const distFiles = fs.readdirSync(DIST_SHAPES).filter((f) => f.endsWith('.ttl')).sort();
+    const srcFiles = [...src.shapesFiles, ...src.ontologyFiles].sort();
+    expect(distFiles).toEqual(srcFiles);
+
+    const differing = srcFiles.filter(
+      (f) =>
+        !fs
+          .readFileSync(path.join(SRC_SHAPES, f))
+          .equals(fs.readFileSync(path.join(DIST_SHAPES, f))),
+    );
+    expect(differing).toEqual([]);
+  });
+});

--- a/tests/validate-coverage-reference-pod.test.ts
+++ b/tests/validate-coverage-reference-pod.test.ts
@@ -1,17 +1,45 @@
 /**
  * Shape coverage measured against the reference patient pod.
  *
- * This file records the coverage of the bundled shapes over the reference pod
- * AS MEASURED WHEN THE REPORTING WAS BUILT, before SHACL shapes existed for
- * several health record classes. At that point `cascade validate` reported
- * 19 of 19 files passing and exit code 0 on a pod where most subjects matched
- * no shape at all, because a conforming report over zero constraints is
- * indistinguishable from a conforming report over many.
+ * WHAT THIS FILE IS FOR
+ * ---------------------
+ * It records the coverage of the bundled shapes over the reference pod as an
+ * exact measurement, so that a change in coverage has to be acknowledged rather
+ * than merely happening. It was written against a pod where most subjects
+ * matched no shape at all, and it said of itself: "the numbers below are a
+ * deliberate high-water mark of a gap, not a target. Authoring shapes for the
+ * unshaped classes SHOULD move them down, and this file is expected to be
+ * updated in the same change that moves them."
  *
- * The numbers below are therefore a deliberate high-water mark of a gap, not a
- * target. Authoring shapes for the unshaped classes SHOULD move them down, and
- * this file is expected to be updated in the same change that moves them. What
- * must not happen is the numbers moving without anyone noticing.
+ * THIS IS THAT CHANGE. The numbers are updated here, in the same commit that
+ * synced the vocabulary and shapes that moved them.
+ *
+ * WHAT MOVED, AND BY HOW MUCH
+ * ---------------------------
+ * The sync brought in health v2.5, which defines and shapes five record classes
+ * that were previously emitted but undefined, and it fixed a sync script that
+ * had never copied `health.ttl` at all.
+ *
+ *                                    before    after
+ *   subjects checked                  156       277   (of 448)
+ *   subjects with no applicable shape  292       171
+ *   Cascade-typed subjects unshaped    122         1
+ *
+ * The 122 -> 1 line is the one that matters. 121 of those 122 were subjects the
+ * validator reported PASS on while running nothing whatsoever against them. The
+ * single remaining one is a `clinical:CoverageRecord` in `clinical/insurance.ttl`
+ * whose retyping to `coverage:InsurancePlan` is a separate, tracked change to the
+ * reference pod itself.
+ *
+ * The 171 that remain unshaped are subjects typed only in FOREIGN vocabularies —
+ * `prov:Activity` (121), `fhir:Observation` (30), `solid:TypeRegistration` (13),
+ * `prov:Agent`, `foaf:Person`, `ldp:BasicContainer` — which the Cascade shapes
+ * were never written to constrain and which no Cascade release will shape. That
+ * is a floor, not remaining work.
+ *
+ * Zero violations. Four `sh:Info` advisories on the wellness containers, which
+ * fire for the first time because health v2.5 gives `HealthProfileShape` explicit
+ * targets. `cascade validate` reports 19 of 19 files passing, exit 0.
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
@@ -27,8 +55,7 @@ const skipIfNoPod = !existsSync(REFERENCE_POD);
 const CASCADE_NS = 'https://ns.cascadeprotocol.org/';
 
 /**
- * Coverage of the bundled shapes over the reference pod at the commit that
- * introduced this reporting.
+ * Coverage of the bundled shapes over the reference pod.
  *
  * Two denominators are recorded because both are meaningful and they differ a
  * lot. `totalSubjects` counts every subject carrying an rdf:type, including
@@ -36,9 +63,23 @@ const CASCADE_NS = 'https://ns.cascadeprotocol.org/';
  * fhir:) that the Cascade shapes were never written to constrain.
  * `cascadeTypedSubjects` counts only subjects carrying at least one type in the
  * Cascade namespace, which is the population the protocol is responsible for
- * constraining.
+ * constraining — and is therefore the number to watch.
  */
-const PRE_SHAPE_COVERAGE = {
+const COVERAGE = {
+  files: 19,
+  totalSubjects: 448,
+  checkedSubjects: 277,
+  unshapedSubjects: 171,
+  cascadeTypedSubjects: 278,
+  unshapedCascadeTypedSubjects: 1,
+} as const;
+
+/**
+ * The same measurement before the vocabulary and shapes were synced, kept so the
+ * delta is legible and so nobody has to dig through history to see what moved.
+ * Nothing asserts against it.
+ */
+const PRE_SYNC_COVERAGE = {
   files: 19,
   totalSubjects: 448,
   checkedSubjects: 156,
@@ -46,40 +87,63 @@ const PRE_SHAPE_COVERAGE = {
   cascadeTypedSubjects: 278,
   unshapedCascadeTypedSubjects: 122,
 } as const;
+void PRE_SYNC_COVERAGE;
 
 /** Per-file totals, so a shift can be attributed rather than just noticed. */
-const PRE_SHAPE_BY_FILE: Record<string, { total: number; checked: number }> = {
-  'clinical/allergies.ttl': { total: 3, checked: 0 },
-  'clinical/conditions.ttl': { total: 5, checked: 0 },
-  'clinical/immunizations.ttl': { total: 4, checked: 0 },
+const COVERAGE_BY_FILE: Record<string, { total: number; checked: number }> = {
+  'clinical/allergies.ttl': { total: 3, checked: 3 },
+  'clinical/conditions.ttl': { total: 5, checked: 5 },
+  'clinical/immunizations.ttl': { total: 4, checked: 4 },
   'clinical/insurance.ttl': { total: 1, checked: 0 },
-  'clinical/lab-results.ttl': { total: 11, checked: 0 },
+  'clinical/lab-results.ttl': { total: 11, checked: 11 },
   'clinical/medications.ttl': { total: 8, checked: 8 },
   'clinical/patient-profile.ttl': { total: 4, checked: 4 },
   'clinical/vital-signs.ttl': { total: 141, checked: 141 },
   'index.ttl': { total: 1, checked: 0 },
-  'manifest.ttl': { total: 8, checked: 0 },
+  'manifest.ttl': { total: 8, checked: 4 },
   'profile/card.ttl': { total: 2, checked: 0 },
   'profile/extended.ttl': { total: 0, checked: 0 },
   'settings/privateTypeIndex.ttl': { total: 5, checked: 0 },
   'settings/publicTypeIndex.ttl': { total: 8, checked: 0 },
-  'wellness/activity.ttl': { total: 61, checked: 0 },
-  'wellness/blood-pressure.ttl': { total: 61, checked: 0 },
-  'wellness/heart-rate.ttl': { total: 61, checked: 0 },
-  'wellness/sleep.ttl': { total: 61, checked: 0 },
+  'wellness/activity.ttl': { total: 61, checked: 31 },
+  'wellness/blood-pressure.ttl': { total: 61, checked: 1 },
+  'wellness/heart-rate.ttl': { total: 61, checked: 31 },
+  'wellness/sleep.ttl': { total: 61, checked: 31 },
   'wellness/supplements.ttl': { total: 3, checked: 3 },
 };
 
 /**
- * The health record classes carrying real clinical content that no shape
- * constrained at this commit. Each count is a number of subjects that
+ * The health record classes that carried real clinical content and that NO shape
+ * constrained before this sync. Each count was a number of subjects
  * `cascade validate` reported PASS on while running nothing against them.
+ *
+ * All four are now shaped and fully checked. The assertion below is inverted
+ * accordingly: it demands they be absent from the unshaped set, which is a
+ * regression guard rather than a record of a gap.
  */
-const UNSHAPED_CLINICAL_CLASSES: Record<string, number> = {
-  'https://ns.cascadeprotocol.org/health/v1#LabResultRecord': 11,
-  'https://ns.cascadeprotocol.org/health/v1#ConditionRecord': 5,
-  'https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord': 4,
-  'https://ns.cascadeprotocol.org/health/v1#AllergyRecord': 3,
+const FORMERLY_UNSHAPED_CLINICAL_CLASSES = [
+  'https://ns.cascadeprotocol.org/health/v1#LabResultRecord',
+  'https://ns.cascadeprotocol.org/health/v1#ConditionRecord',
+  'https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord',
+  'https://ns.cascadeprotocol.org/health/v1#AllergyRecord',
+];
+
+/**
+ * The types that remain unshaped, all foreign. Pinned exactly so that a NEW
+ * unshaped type — especially a Cascade one — cannot slip in unremarked.
+ */
+const REMAINING_UNSHAPED_TYPES: Record<string, number> = {
+  'http://www.w3.org/ns/prov#Activity': 121,
+  'http://hl7.org/fhir/Observation': 30,
+  'http://www.w3.org/ns/solid/terms#TypeRegistration': 13,
+  'http://www.w3.org/ns/prov#Agent': 2,
+  // The one remaining Cascade-typed holdout; retyping it to
+  // coverage:InsurancePlan is a change to the reference pod, not to the shapes.
+  'https://ns.cascadeprotocol.org/clinical/v1#CoverageRecord': 1,
+  'http://www.w3.org/ns/ldp#BasicContainer': 1,
+  'http://www.w3.org/ns/prov#SoftwareAgent': 1,
+  'http://xmlns.com/foaf/0.1/Person': 1,
+  'http://xmlns.com/foaf/0.1/PersonalProfileDocument': 1,
 };
 
 describe.skipIf(skipIfNoPod)('shape coverage over the reference patient pod', () => {
@@ -90,17 +154,17 @@ describe.skipIf(skipIfNoPod)('shape coverage over the reference patient pod', ()
     results = findTurtleFiles(REFERENCE_POD).map((f) => validateFile(f, store, shapeFiles));
   });
 
-  it('measures the pod at the recorded pre-shape coverage', () => {
+  it('measures the pod at the recorded coverage', () => {
     const totalSubjects = results.reduce((n, r) => n + r.coverage.totalSubjects, 0);
     const checkedSubjects = results.reduce((n, r) => n + r.coverage.checkedSubjects, 0);
 
-    expect(results).toHaveLength(PRE_SHAPE_COVERAGE.files);
-    expect(totalSubjects).toBe(PRE_SHAPE_COVERAGE.totalSubjects);
-    expect(checkedSubjects).toBe(PRE_SHAPE_COVERAGE.checkedSubjects);
-    expect(totalSubjects - checkedSubjects).toBe(PRE_SHAPE_COVERAGE.unshapedSubjects);
+    expect(results).toHaveLength(COVERAGE.files);
+    expect(totalSubjects).toBe(COVERAGE.totalSubjects);
+    expect(checkedSubjects).toBe(COVERAGE.checkedSubjects);
+    expect(totalSubjects - checkedSubjects).toBe(COVERAGE.unshapedSubjects);
   });
 
-  it('measures the Cascade-typed population at the recorded pre-shape coverage', () => {
+  it('measures the Cascade-typed population at the recorded coverage', () => {
     const isCascadeTyped = (s: { types: string[] }) =>
       s.types.some((t) => t.startsWith(CASCADE_NS));
 
@@ -113,8 +177,8 @@ describe.skipIf(skipIfNoPod)('shape coverage over the reference patient pod', ()
       0,
     );
 
-    expect(cascadeTyped).toBe(PRE_SHAPE_COVERAGE.cascadeTypedSubjects);
-    expect(unshapedCascadeTyped).toBe(PRE_SHAPE_COVERAGE.unshapedCascadeTypedSubjects);
+    expect(cascadeTyped).toBe(COVERAGE.cascadeTypedSubjects);
+    expect(unshapedCascadeTyped).toBe(COVERAGE.unshapedCascadeTypedSubjects);
   });
 
   it('attributes the coverage to specific files', () => {
@@ -126,19 +190,35 @@ describe.skipIf(skipIfNoPod)('shape coverage over the reference patient pod', ()
         checked: r.coverage.checkedSubjects,
       };
     }
-    expect(actual).toEqual(PRE_SHAPE_BY_FILE);
+    expect(actual).toEqual(COVERAGE_BY_FILE);
   });
 
-  it('names the clinical record classes no shape constrains', () => {
+  it('leaves no clinical record class unconstrained', () => {
     const counts = new Map<string, number>();
     for (const r of results) {
       for (const t of r.coverage.unshapedTypes) {
         counts.set(t.type, (counts.get(t.type) ?? 0) + t.count);
       }
     }
-    for (const [type, expected] of Object.entries(UNSHAPED_CLINICAL_CLASSES)) {
-      expect(counts.get(type), `unshaped count for ${type}`).toBe(expected);
+    // Each of these had every one of its subjects reported PASS with zero
+    // constraints run. If one reappears here, a shape stopped firing.
+    for (const type of FORMERLY_UNSHAPED_CLINICAL_CLASSES) {
+      expect(counts.get(type), `${type} should now be shaped`).toBeUndefined();
     }
+  });
+
+  it('accounts for every type that remains unshaped', () => {
+    const counts = new Map<string, number>();
+    for (const r of results) {
+      for (const t of r.coverage.unshapedTypes) {
+        counts.set(t.type, (counts.get(t.type) ?? 0) + t.count);
+      }
+    }
+    // Exact, not a subset: a newly unshaped type is a coverage regression and
+    // must not be able to arrive quietly.
+    expect(Object.fromEntries([...counts].sort())).toEqual(
+      Object.fromEntries(Object.entries(REMAINING_UNSHAPED_TYPES).sort()),
+    );
   });
 
   it('reports files that pass while running zero constraints', () => {
@@ -155,15 +235,38 @@ describe.skipIf(skipIfNoPod)('shape coverage over the reference patient pod', ()
   });
 
   it('does not name a shape file for a file whose subjects match no target', () => {
-    // conditions.ttl declares the health: prefix and uses health: predicates,
-    // so prefix-based reporting named health.shapes.ttl and claimed constraints
-    // that never ran.
-    const conditions = results.find((r) => r.file.endsWith('clinical/conditions.ttl'));
-    expect(conditions).toBeDefined();
-    expect(conditions?.valid).toBe(true);
-    expect(conditions?.coverage.totalSubjects).toBe(5);
-    expect(conditions?.coverage.checkedSubjects).toBe(0);
-    expect(conditions?.shapesUsed).toEqual([]);
+    // insurance.ttl declares Cascade prefixes and uses Cascade predicates, so
+    // prefix-based reporting would name a shape file and claim constraints that
+    // never ran. Its single clinical:CoverageRecord matches no shape.
+    //
+    // This assertion used to be made on conditions.ttl, which is now fully
+    // checked — the file moving out from under it is the fix working.
+    const insurance = results.find((r) => r.file.endsWith('clinical/insurance.ttl'));
+    expect(insurance).toBeDefined();
+    expect(insurance?.valid).toBe(true);
+    expect(insurance?.coverage.totalSubjects).toBe(1);
+    expect(insurance?.coverage.checkedSubjects).toBe(0);
+    expect(insurance?.shapesUsed).toEqual([]);
+  });
+
+  it('now fully checks the clinical record files that ran zero constraints', () => {
+    // The other half of the assertion above: these four were the pod's real
+    // clinical content and every one of them was passing vacuously.
+    for (const rel of [
+      'clinical/conditions.ttl',
+      'clinical/allergies.ttl',
+      'clinical/immunizations.ttl',
+      'clinical/lab-results.ttl',
+    ]) {
+      const r = results.find((x) => x.file.endsWith(rel));
+      expect(r, rel).toBeDefined();
+      expect(r!.coverage.checkedSubjects, rel).toBe(r!.coverage.totalSubjects);
+      expect(r!.coverage.checkedSubjects, rel).toBeGreaterThan(0);
+      expect(r!.shapesUsed, rel).toContain('health.shapes.ttl');
+      // Shaped AND clean: the records were correct all along, they were simply
+      // never checked.
+      expect(r!.results.filter((i) => i.severity === 'violation'), rel).toHaveLength(0);
+    }
   });
 
   it('names the shape files that did fire on a file with real coverage', () => {
@@ -191,16 +294,17 @@ describe.skipIf(skipIfNoPod)('cascade validate output over the reference pod', (
     const out = plain(
       runCli(['validate', resolve(REFERENCE_POD, 'clinical/conditions.ttl')], '/'),
     );
-    expect(out).toContain(
-      '0 of 5 subjects checked; 5 subjects of type health:ConditionRecord had no applicable shape',
-    );
+    // Was `0 of 5 subjects checked; 5 subjects of type health:ConditionRecord
+    // had no applicable shape`.
+    expect(out).toContain('5 of 5 subjects checked');
+    expect(out).not.toContain('no applicable shape');
     expect(out).toContain('PASS');
   });
 
   it('does not print a Shapes: line when no shape fired', () => {
     const out = plain(
       runCli(
-        ['--verbose', 'validate', resolve(REFERENCE_POD, 'clinical/conditions.ttl')],
+        ['--verbose', 'validate', resolve(REFERENCE_POD, 'clinical/insurance.ttl')],
         '/',
       ),
     );
@@ -212,7 +316,7 @@ describe.skipIf(skipIfNoPod)('cascade validate output over the reference pod', (
   it('prints a pod-wide coverage summary', () => {
     const out = plain(runCli(['validate', REFERENCE_POD], '/'));
     expect(out).toContain(
-      `Coverage: ${PRE_SHAPE_COVERAGE.checkedSubjects} of ${PRE_SHAPE_COVERAGE.totalSubjects} subjects checked, ${PRE_SHAPE_COVERAGE.unshapedSubjects} with no applicable shape`,
+      `Coverage: ${COVERAGE.checkedSubjects} of ${COVERAGE.totalSubjects} subjects checked, ${COVERAGE.unshapedSubjects} with no applicable shape`,
     );
   });
 
@@ -244,10 +348,31 @@ describe.skipIf(skipIfNoPod)('cascade validate output over the reference pod', (
     const medsCoverage = JSON.parse(meds)[0].coverage;
 
     expect(labsCoverage).not.toEqual(medsCoverage);
-    expect(labsCoverage.checkedSubjects).toBe(0);
+    expect(labsCoverage.checkedSubjects).toBe(11);
     expect(labsCoverage.totalSubjects).toBe(11);
     expect(medsCoverage.checkedSubjects).toBe(8);
     expect(medsCoverage.totalSubjects).toBe(8);
+  });
+
+  it('reports zero coverage distinctly from full coverage', () => {
+    // Both files above are now fully checked, so they no longer contrast a
+    // checked file against an unchecked one. This pair does, which is the
+    // distinctness claim that actually matters: the reporting must not collapse
+    // "everything checked" and "nothing checked" into the same output.
+    const insurance = plain(
+      runCli(['--json', 'validate', resolve(REFERENCE_POD, 'clinical/insurance.ttl')], '/'),
+    );
+    const labs = plain(
+      runCli(['--json', 'validate', resolve(REFERENCE_POD, 'clinical/lab-results.ttl')], '/'),
+    );
+
+    const insuranceCoverage = JSON.parse(insurance)[0].coverage;
+    const labsCoverage = JSON.parse(labs)[0].coverage;
+
+    expect(insuranceCoverage.checkedSubjects).toBe(0);
+    expect(insuranceCoverage.totalSubjects).toBe(1);
+    expect(labsCoverage.checkedSubjects).toBe(11);
+    expect(insuranceCoverage).not.toEqual(labsCoverage);
   });
 
   it('exposes coverage in the JSON output', () => {
@@ -256,15 +381,14 @@ describe.skipIf(skipIfNoPod)('cascade validate output over the reference pod', (
       '/',
     );
     const parsed = JSON.parse(out);
+    // Was `checkedSubjects: 0` with all three subjects listed under
+    // `unshapedTypes` as health:AllergyRecord.
     expect(parsed[0].coverage).toEqual({
       totalSubjects: 3,
-      checkedSubjects: 0,
-      unshapedSubjects: expect.any(Array),
-      unshapedTypes: [
-        { type: 'https://ns.cascadeprotocol.org/health/v1#AllergyRecord', count: 3 },
-      ],
+      checkedSubjects: 3,
+      unshapedSubjects: [],
+      unshapedTypes: [],
     });
-    expect(parsed[0].coverage.unshapedSubjects).toHaveLength(3);
-    expect(parsed[0].shapesUsed).toEqual([]);
+    expect(parsed[0].shapesUsed).toContain('health.shapes.ttl');
   });
 });

--- a/tests/validate-severity-accounting.test.ts
+++ b/tests/validate-severity-accounting.test.ts
@@ -1,0 +1,256 @@
+/**
+ * A file fails validation when it carries a Violation, and not otherwise.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * `ValidationResult.valid` was the SHACL `sh:conforms` value verbatim, and per
+ * [SHACL 3.2](https://www.w3.org/TR/shacl/#validation-report) that is `false`
+ * whenever the report carries ANY result, at any severity. The summary computed
+ * `passed = results.filter(r => r.valid).length`, so a file whose only finding
+ * was an `sh:Info` advisory was printed `WARN` and counted under **failed**.
+ *
+ * Meanwhile the exit code was computed from violations alone. So on a pod with
+ * zero violations and four Info advisories, `cascade validate` printed
+ * `19 total, 15 passed, 4 failed` and exited **0** — the tally and the exit code
+ * asserting opposite things about the same run. Whichever one the caller
+ * trusted, the other was lying to them.
+ *
+ * That is not cosmetic. It lands hardest exactly when a release adds
+ * constraints: the message is that new findings mean the validator improved, not
+ * that the data broke, and `4 failed` on a pod with no defects contradicts it in
+ * the first line anyone reads.
+ *
+ * THE RULE, AND WHY WARNING SITS WHERE IT DOES
+ * --------------------------------------------
+ * A file fails if and only if it carries at least one Violation. Warning and
+ * Info do not fail it. That is not a judgement about how serious a warning is —
+ * it is forced by the exit code, which has always been violations-only. Any
+ * other choice re-creates the original defect in a new place: make Warning fail
+ * the tally and a warning-only run once again reports failures while exiting 0.
+ * The two must agree, and the exit code is the one with existing callers.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT — measured against 1750f16,
+ * 6 of the 10 fail:
+ *   - `counts an Info-only file as passed` FAILS: `2 total, 1 passed, 1 failed`.
+ *   - `prints PASS for an Info-only file` FAILS: prints `WARN`.
+ *   - `counts a Warning-only file as passed` FAILS: `2 total, 1 passed, 1 failed`.
+ *   - `tallies a mixed directory by violations alone` FAILS:
+ *     `4 total, 1 passed, 3 failed` for one violation.
+ *   - `agrees with its own exit code` FAILS on the Info-only directory: the
+ *     summary says 1 failed and the process exits 0.
+ *   - `reports genuinely different inputs differently` FAILS: the Info-only run
+ *     reports a failure, so it no longer differs from the violation run in the
+ *     way that matters.
+ *
+ * And 4 pass against the broken build, deliberately:
+ *   - the fixture self-check, which is about the fixture and not the fix;
+ *   - `prints WARN for a Warning-only file`, unchanged behaviour;
+ *   - `counts a Violation file as failed`, the control that distinguishes
+ *     "accounting fixed" from "accounting removed";
+ *   - determinism, which is orthogonal to severity.
+ *
+ * The fixtures are authored here rather than taken from the bundled shapes, so
+ * this cannot silently stop testing anything when the vocabulary changes: the
+ * bundled shapes' Info constraints are a moving target, and a test that depends
+ * on one existing is a test that quietly evaporates when it is retired.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+
+const SHAPES = `
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix ex:   <https://example.org/severity#> .
+
+ex:InfoShape a sh:NodeShape ;
+    sh:targetClass ex:InfoSubject ;
+    sh:property [
+        sh:path ex:detail ;
+        sh:minCount 1 ;
+        sh:severity sh:Info ;
+        sh:message "Consider recording the optional detail."
+    ] .
+
+ex:WarningShape a sh:NodeShape ;
+    sh:targetClass ex:WarningSubject ;
+    sh:property [
+        sh:path ex:detail ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "The detail is usually present."
+    ] .
+
+ex:ViolationShape a sh:NodeShape ;
+    sh:targetClass ex:ViolationSubject ;
+    sh:property [
+        sh:path ex:detail ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "The detail is required."
+    ] .
+
+ex:CleanShape a sh:NodeShape ;
+    sh:targetClass ex:CleanSubject ;
+    sh:property [
+        sh:path ex:detail ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "The detail is required."
+    ] .
+`;
+
+/** Each subject omits ex:detail, so its shape fires at exactly its severity. */
+const DATA: Record<string, string> = {
+  info: '@prefix ex: <https://example.org/severity#> .\nex:a a ex:InfoSubject .\n',
+  warning: '@prefix ex: <https://example.org/severity#> .\nex:b a ex:WarningSubject .\n',
+  violation: '@prefix ex: <https://example.org/severity#> .\nex:c a ex:ViolationSubject .\n',
+  clean: '@prefix ex: <https://example.org/severity#> .\nex:d a ex:CleanSubject ; ex:detail "present" .\n',
+};
+
+let root: string;
+let shapesDir: string;
+
+/** One directory per severity, plus one holding all four. */
+function dataDir(...names: string[]): string {
+  const dir = path.join(root, `data-${names.join('-')}`);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    for (const n of names) fs.writeFileSync(path.join(dir, `${n}.ttl`), DATA[n]);
+  }
+  return dir;
+}
+
+function validate(target: string): { out: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, 'validate', target, '--shapes', shapesDir], {
+    encoding: 'utf-8',
+    timeout: 120000,
+    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+  });
+  return {
+    out: `${r.stdout ?? ''}${r.stderr ?? ''}`.replace(/\u001b\[[0-9;]*m/g, ''),
+    status: r.status ?? -1,
+  };
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing — run `npm run build` before `npm test`.');
+  }
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'severity-accounting-'));
+  shapesDir = path.join(root, 'shapes');
+  fs.mkdirSync(shapesDir);
+  fs.writeFileSync(path.join(shapesDir, 'severity.shapes.ttl'), SHAPES);
+});
+
+afterAll(() => {
+  if (root) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('the severity fixture itself', () => {
+  it('produces one finding at each severity — otherwise this file proves nothing', () => {
+    const { out } = validate(dataDir('info', 'warning', 'violation', 'clean'));
+    expect(out).toMatch(/1 violation/);
+    expect(out).toMatch(/1 warning/);
+    expect(out).toMatch(/1 info/);
+    expect(out).toContain('Consider recording the optional detail.');
+    expect(out).toContain('The detail is usually present.');
+    expect(out).toContain('The detail is required.');
+  });
+});
+
+describe('cascade validate severity accounting', () => {
+  it('counts an Info-only file as passed, not failed', () => {
+    const { out } = validate(dataDir('info', 'clean'));
+    expect(out).toMatch(/2 total, 2 passed, 0 failed/);
+  });
+
+  it('prints PASS for an Info-only file and still lists the advisory', () => {
+    const { out } = validate(dataDir('info', 'clean'));
+    const line = out.split('\n').find((l) => l.includes('info.ttl') && /^(PASS|WARN|FAIL)/.test(l));
+    expect(line, out).toBeDefined();
+    expect(line).toMatch(/^PASS/);
+    // Reporting it as a pass must not mean hiding it.
+    expect(out).toContain('Consider recording the optional detail.');
+  });
+
+  it('counts a Warning-only file as passed', () => {
+    const { out } = validate(dataDir('warning', 'clean'));
+    expect(out).toMatch(/2 total, 2 passed, 0 failed/);
+  });
+
+  it('prints WARN for a Warning-only file', () => {
+    const { out } = validate(dataDir('warning', 'clean'));
+    const line = out
+      .split('\n')
+      .find((l) => l.includes('warning.ttl') && /^(PASS|WARN|FAIL)/.test(l));
+    expect(line, out).toBeDefined();
+    expect(line).toMatch(/^WARN/);
+  });
+
+  it('counts a Violation file as failed', () => {
+    // The control. If the change had simply stopped counting failures, this
+    // would break; it is what distinguishes "accounting fixed" from "accounting
+    // removed".
+    const { out } = validate(dataDir('violation', 'clean'));
+    expect(out).toMatch(/2 total, 1 passed, 1 failed/);
+    const line = out
+      .split('\n')
+      .find((l) => l.includes('violation.ttl') && /^(PASS|WARN|FAIL)/.test(l));
+    expect(line).toMatch(/^FAIL/);
+  });
+
+  it('tallies a mixed directory by violations alone', () => {
+    const { out } = validate(dataDir('info', 'warning', 'violation', 'clean'));
+    expect(out).toMatch(/4 total, 3 passed, 1 failed/);
+  });
+
+  it('agrees with its own exit code', () => {
+    // The defect in one assertion: the summary and the exit code have to be
+    // answering the same question.
+    for (const [names, expectedFailed, expectedStatus] of [
+      [['info', 'clean'], 0, 0],
+      [['warning', 'clean'], 0, 0],
+      [['violation', 'clean'], 1, 1],
+      [['info', 'warning', 'violation', 'clean'], 1, 1],
+    ] as const) {
+      const { out, status } = validate(dataDir(...names));
+      const m = out.match(/(\d+) total, (\d+) passed, (\d+) failed/);
+      expect(m, `no summary for ${names.join('+')}:\n${out}`).not.toBeNull();
+      expect(Number(m![3]), `failed count for ${names.join('+')}`).toBe(expectedFailed);
+      expect(status, `exit code for ${names.join('+')}`).toBe(expectedStatus);
+      // The invariant the two must share, stated directly.
+      expect(Number(m![3]) > 0, `tally/exit disagreement for ${names.join('+')}`).toBe(
+        status === 1,
+      );
+    }
+  });
+
+  it('is deterministic across processes and working directories', () => {
+    const dir = dataDir('info', 'warning', 'violation', 'clean');
+    const run = (cwd: string) => {
+      const r = spawnSync(process.execPath, [CLI, 'validate', dir, '--shapes', shapesDir], {
+        encoding: 'utf-8',
+        cwd,
+        timeout: 120000,
+        env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+      });
+      return `${r.stdout ?? ''}`.replace(/\u001b\[[0-9;]*m/g, '');
+    };
+    expect(run('/')).toBe(run(REPO));
+  });
+
+  it('reports genuinely different inputs differently', () => {
+    const infoOnly = validate(dataDir('info', 'clean')).out;
+    const violationOnly = validate(dataDir('violation', 'clean')).out;
+    expect(infoOnly).not.toBe(violationOnly);
+    expect(infoOnly).toMatch(/0 failed/);
+    expect(violationOnly).toMatch(/1 failed/);
+  });
+});


### PR DESCRIPTION
Syncs the vendored vocabulary and shapes to core v3.4 / health v2.5 / clinical v1.13, fixes the sync script that made the drift possible, and fixes two reporting defects the sync exposed.

## 1. The sync script only ever copied half of what it should have

`scripts/sync-shapes-from-spec.sh` kept **two independent lists**: one naming the vocabularies whose `.shapes.ttl` to copy (six stable plus four drafts), and one naming the vocabularies whose ontology to copy (`core clinical coverage`). Nothing tied them together, so the second list never grew.

`loadShapes()` reads both kinds of file — every `*.shapes.ttl` for constraints, every other `*.ttl` for the vocabulary those constraints are written against. So the split meant the validator could load a shape whose target class its own loaded vocabulary did not define. That is silent by construction: SHACL resolves `sh:targetClass` against the data graph, so an undefined target is not an error, it is a shape that selects nothing and reports nothing.

**Measured before this change:**

| | |
|---|---|
| Cascade-namespace `sh:targetClass` values resolving to no loaded class | **52 of 89** across 7 vocabularies |
| `src/shapes/health.ttl` | **928 lines** vs. 1489 — never synced once |
| ontologies bundled | 4 of 10 |
| `VOCAB_VERSIONS` said `health=2.4`, bundled ontology declared | **2.3** |

The version mismatch was not in the original report; the new test found it.

**Fixed** by driving ontology and shapes from one list per maturity tier, so a vocabulary cannot be half-synced by omission, and exiting non-zero if any expected file is missing. All ten vocabularies re-synced byte-identical to spec; `checkup`, `pots` and the four drafts get an ontology here for the first time. `VOCAB_VERSIONS` -> core 3.4 / health 2.5 / clinical 1.13.

## 2. The assertion that makes it unrepeatable

`tests/shapes-sync.test.ts`, 13 cases, asserting on parsed RDF terms and file inventories — never on substrings of prose, which can occur by coincidence:

- every Cascade-namespace `sh:targetClass` in the bundled shapes resolves to a class defined in the bundled vocabulary;
- every shapes file has a matching ontology and vice versa;
- each `VOCAB_VERSIONS` row equals the `owl:versionInfo` of the ontology actually bundled — this fails both on a bump without a sync and a sync without a bump;
- `dist/shapes` matches `src/shapes` byte for byte (the CLI loads from `dist`, so a measurement taken without rebuilding is stale);
- floors on the target and class counts, so an empty shapes directory cannot satisfy the assertions above vacuously.

**Negative control.** Against the pre-sync tree, **6 of 13 fail**, the targets assertion reporting 50 unresolved. With *only* `health.ttl` reverted and everything else synced, it fails naming exactly 12 classes:

```
health:SocialHistoryRecord (targeted by health:SocialHistoryRecordShape)
health:LabResultRecord, health:AllergyRecord, health:ConditionRecord,
health:ImmunizationRecord, health:FamilyHistoryRecord,
health:ActivityData, SleepData, HeartRateData, BloodPressureData,
HRVData, BodyMeasurements  (targeted by health:HealthProfileShape)
```

Two Cascade targets remain unresolved and are allowlisted: `checkup:PatientProfile` and `checkup:VitalSignsTrend`, whose classes checkup v3.0 removed while the shapes file kept targeting them. Those are upstream defects and are reported, not papered over. The allowlist carries a companion assertion that **fails once an allowlisted entry resolves**, so it cannot outlive the defect or quietly absorb a new one. One external target is accepted by name (`oa:Annotation`).

## 3. A file whose only findings are advisories is no longer counted as failed

`sh:conforms` is false whenever a report carries any result at any severity, and the summary read it directly. A file with zero violations and one `sh:Info` advisory printed `WARN` and was tallied under **failed**, while the exit code — computed from violations alone — said 0.

```
before:  Files: 19 total, 15 passed, 4 failed     Issues: 4 info    exit 0
after:   Files: 19 total, 19 passed, 0 failed     Issues: 4 info    exit 0
```

Zero violations in both. The tally and the exit code were asserting opposite things about the same run, so whichever a caller trusted, the other misled them.

**Warning deliberately does not fail either.** That is not a judgement about severity, it is forced by the exit code, which has always been violations-only: making Warning fail the tally would re-create this exact defect for warning-only runs. One rule, `failsValidation()`, now drives the per-file status, the tally and the exit code.

`tests/validate-severity-accounting.test.ts` builds its own shapes directory with one constraint at each severity, so it cannot quietly stop testing anything when the bundled Info constraints change. 6 of its 10 cases fail against the pre-fix build; the 4 that pass either way are labelled in place as controls — including "counts a Violation file as failed", which is what distinguishes *accounting fixed* from *accounting removed*.

## 4. Family-history records no longer land in the FHIR passthrough bucket

`health:FamilyHistoryRecord` was registered in no `DATA_TYPES` entry, so `routeTypeKey` matched nothing and fell through to its unmapped-type branch. Every family-history record a C-CDA import produced was written to `clinical/fhir-passthrough.ttl` rather than `clinical/family-history.ttl`. Nothing looked wrong: the import succeeded and the section summary reported `Family History: 2 -> 2`. The records existed, filed under "type we could not map" — the one bucket a reader is entitled to skip — and the class now has a ratified shape whose consumers look for a file that did not exist.

All 7 new cases fail against the base commit. They assert the **file**, not the type string: an existing assertion checking the pod's concatenated Turtle for `health:FamilyHistoryRecord` stayed green throughout, because the records were always present, just in the wrong place.

The reconciler half is deliberately not included — `KNOWN_TYPES` skips unlisted types, and adding one without a matching strategy risks converting "wrong file" into "silently dropped". It needs a matching strategy designed rather than bolted on.

## New violations this surfaces — reported, not silenced

Re-syncing brings in constraints for classes nothing constrained before, and **one real defect fell out**, affecting four test files with a single root cause.

Four C-CDA section handlers read `<effectiveTime value="20250311"/>`, slice it to `2025-03-11`, and write it with `literal(dateStr)` — a plain literal, so `xsd:string`:

| site | predicate |
|---|---|
| `sections/procedures.ts`, `sections/vitals.ts`, `sections/labs.ts:187` | `health:performedDate` |
| `sections/problems.ts:115` | `health:onsetDate` |
| `sections/immunizations.ts:73` | `health:administrationDate` |

health v2.5 constrains all three with `sh:datatype xsd:dateTime` at `sh:Violation`. **The constraint is neither new nor an overreach**: `health.ttl` declares `rdfs:range xsd:dateTime` on each, and it is the same constraint `clinical:onsetDate` has always carried. The emitters have disagreed with the ratified vocabulary for as long as they have existed; nothing was checking. `labs.ts:292` already writes `clinical:performedDate` through a `tripleDateTime()` helper that types the literal correctly — the correct helper exists and was never propagated.

**Not patched here, on purpose.** The source carries DAY precision. Typing `2025-03-11` as `xsd:dateTime` means appending `T00:00:00`, inventing a midnight that downstream date arithmetic will treat as real. FHIR R4's `dateTime` primitive accepts `YYYY-MM-DD` precisely to avoid that, and `health:administrationDate`'s own comment says it corresponds to `Immunization.occurrence`. A single `sh:datatype` cannot express variable precision; it needs `sh:or` over `xsd:date`/`xsd:dateTime`. So the emitter fix is gated on a vocabulary decision, and guessing at it inside a vocabulary sync would ratify the guess. It is also outside this change's remit: no emission site is touched here.

Pinned in `tests/known-shacl-gaps.ts`, which fails on any violation outside this exact set **and** once these stop being produced.

## Reference pod, before and after

|  | before | after |
|---|---|---|
| subjects checked | 156 | **277** (of 448) |
| no applicable shape | 292 | 171 |
| **Cascade-typed, unshaped** | **122** | **1** |
| violations | 0 | 0 |
| summary | 19 total, 19 passed, 0 failed | 19 total, 19 passed, 0 failed |

121 of the 122 close. The one remaining is a `clinical:CoverageRecord` awaiting a separate retyping of the reference pod itself. What stays unshaped is almost entirely foreign-vocabulary subjects (`prov:Activity` 121, `fhir:Observation` 30, `solid:TypeRegistration` 13, `foaf:`, `ldp:`) that Cascade shapes are not written to constrain — a floor, not remaining work.

`tests/validate-coverage-reference-pod.test.ts` said of itself that it was "expected to be updated in the same change that moves them". This is that change; the numbers are updated here, and two assertions are inverted from recording a gap into guarding against its return, including an exact — not subset — pin on the types that remain unshaped.

## Verification

- **Suite: 120 files / 1669 passed / 0 failed / 0 skipped**, from a baseline of **117 / 1636 / 0 / 0** re-measured on the base commit with both sibling checkouts resolved. Skip count zero in both runs.
- Negative controls run for all three fixes against the base commit, with output captured; every new test file fails there.
- **Determinism and distinctness:** same pod, two processes, two working directories, byte-identical output; a different input produces different output. Asserted in-suite and confirmed directly.
- Build clean; lint introduces no new errors (the 11 that remain are pre-existing and in untouched files).
