### PR TITLE
fix(tests): read the reference pod from conformance, and make skips fail CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,8 +143,12 @@ jobs:
           out="${RUNNER_TEMP}/test-output.txt"
 
           # Vitest prints "Tests  N passed | M skipped (T)". Absent the skip
-          # clause there were no skips at all.
-          summary="$(grep -aE '^[[:space:]]*Tests[[:space:]]' "${out}" | tail -1 || true)"
+          # clause there were no skips at all. It also colorizes, so that line
+          # begins with an ANSI escape rather than whitespace -- strip escapes
+          # before matching, or the anchor silently matches nothing and the
+          # result is reported as unreadable.
+          clean="$(sed 's/\x1b\[[0-9;]*m//g' "${out}")"
+          summary="$(printf '%s\n' "${clean}" | grep -aE '^[[:space:]]*Tests[[:space:]]+[0-9]+ passed' | tail -1 || true)"
           if [ -z "${summary}" ]; then
             echo "::error::Could not find the vitest summary line; refusing to publish on an unreadable test result."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,21 @@ permissions:
 env:
   # Tests that are KNOWN to skip on a runner, and why.
   #
-  # The reference patient pod lives in cascadeprotocol.org, a PRIVATE repository
-  # that is not checked out here, and the suites that read it are guarded by
-  # `describe.skipIf(!existsSync(REFERENCE_POD))`. On a runner they therefore
-  # vanish rather than fail. Locally, with the pod present, the same suite runs
-  # 1676 tests with ZERO skips.
+  # The remaining 24 are the CAP advisory suites. They read two *.ldpatch
+  # example files that are not committed to ANY repository -- they exist only in
+  # a local working tree -- so no runner can be given them until they are
+  # committed somewhere. Locally, where those files happen to exist, the suite
+  # runs 1676 tests with ZERO skips.
+  #
+  # The reference-pod half of this number (40) is closed: the pod now lives in
+  # the conformance repository, which this workflow already checks out.
   #
   # This number is a ratchet, not a tolerance. It fails the release in BOTH
   # directions on purpose: if it grows, some test started silently not running
   # and a release must not ship on that; if it shrinks, the gap genuinely closed
   # and the baseline should be lowered in the same commit that closed it. Either
   # way the number stays honest instead of drifting into a rubber stamp.
-  EXPECTED_SKIPPED_TESTS: '64'
+  EXPECTED_SKIPPED_TESTS: '24'
 
 jobs:
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,12 @@ jobs:
           EXPECTED_SKIPPED_TESTS: '24'
         run: |
           set -euo pipefail
-          summary="$(grep -aE '^[[:space:]]*Tests[[:space:]]' "${RUNNER_TEMP}/test-output.txt" | tail -1 || true)"
+          # vitest colorizes, so the summary line starts with an ANSI escape, not
+          # whitespace. Strip escapes before matching: anchoring on ^[[:space:]]*
+          # against raw output silently matches nothing and reports the result as
+          # unreadable.
+          clean="$(sed 's/\x1b\[[0-9;]*m//g' "${RUNNER_TEMP}/test-output.txt")"
+          summary="$(printf '%s\n' "${clean}" | grep -aE '^[[:space:]]*Tests[[:space:]]+[0-9]+ passed' | tail -1 || true)"
           if [ -z "${summary}" ]; then
             echo "::error::Could not find the vitest summary line; refusing to treat an unreadable test result as a pass."
             exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,48 @@ jobs:
         working-directory: cascade-cli
         run: npm run build
 
+      # pipefail is load-bearing: without it the pipeline's status is tee's, so a
+      # failing suite would report success.
       - name: Test
         working-directory: cascade-cli
-        run: npm test
+        shell: bash
+        run: |
+          set -o pipefail
+          npm test 2>&1 | tee "${RUNNER_TEMP}/test-output.txt"
+
+      # Green is not the same as complete. This suite runs 1676 tests with zero
+      # skips locally; on a runner a subset is guarded by describe.skipIf and
+      # vanishes rather than fails, so a passing run can hide an entire suite
+      # that stopped executing.
+      #
+      # The 24 that remain are the CAP advisory suites, whose two *.ldpatch
+      # example files are not committed to any repository and so cannot be
+      # provisioned here. The reference-pod half (40) is closed: the pod now
+      # lives in conformance, which this workflow already checks out.
+      #
+      # This is a ratchet, not a tolerance. It fails in BOTH directions: growth
+      # means something stopped running, and a decrease means the gap closed and
+      # the baseline must be lowered in the same change, so the number cannot
+      # decay into a rubber stamp.
+      - name: Fail if the skip count moved
+        env:
+          EXPECTED_SKIPPED_TESTS: '24'
+        run: |
+          set -euo pipefail
+          summary="$(grep -aE '^[[:space:]]*Tests[[:space:]]' "${RUNNER_TEMP}/test-output.txt" | tail -1 || true)"
+          if [ -z "${summary}" ]; then
+            echo "::error::Could not find the vitest summary line; refusing to treat an unreadable test result as a pass."
+            exit 1
+          fi
+          echo "summary: ${summary}"
+          skipped="$(printf '%s' "${summary}" | sed -n 's/.*[^0-9]\([0-9][0-9]*\) skipped.*/\1/p')"
+          [ -n "${skipped}" ] || skipped=0
+          echo "skipped=${skipped} expected=${EXPECTED_SKIPPED_TESTS}"
+          if [ "${skipped}" -gt "${EXPECTED_SKIPPED_TESTS}" ]; then
+            echo "::error::${skipped} tests skipped, expected ${EXPECTED_SKIPPED_TESTS}. Something stopped running."
+            exit 1
+          fi
+          if [ "${skipped}" -lt "${EXPECTED_SKIPPED_TESTS}" ]; then
+            echo "::error::Only ${skipped} tests skipped, expected ${EXPECTED_SKIPPED_TESTS}. Good news: lower EXPECTED_SKIPPED_TESTS here in the same change that closed the gap."
+            exit 1
+          fi

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,7 +7,7 @@ const require = createRequire(import.meta.url);
 const pkg = require('../package.json') as { version: string };
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
-const REFERENCE_POD = resolve(__dirname, '../../reference-patient-pod');
+const REFERENCE_POD = resolve(__dirname, '../../conformance/reference-patient-pod');
 const skipIfNoPod = !existsSync(REFERENCE_POD);
 
 function runCli(args: string): string {
@@ -94,13 +94,13 @@ describe('cascade CLI', () => {
     });
 
     it.skipIf(skipIfNoPod)('should validate a valid Turtle file', () => {
-      const podPath = resolve(__dirname, '../../reference-patient-pod/clinical/medications.ttl');
+      const podPath = resolve(__dirname, '../../conformance/reference-patient-pod/clinical/medications.ttl');
       const output = runCli(`validate ${podPath}`);
       expect(output).toContain('PASS');
     });
 
     it.skipIf(skipIfNoPod)('should output JSON when --json flag is used', () => {
-      const podPath = resolve(__dirname, '../../reference-patient-pod/clinical/medications.ttl');
+      const podPath = resolve(__dirname, '../../conformance/reference-patient-pod/clinical/medications.ttl');
       const output = runCli(`--json validate ${podPath}`);
       const parsed = JSON.parse(output);
       expect(parsed).toBeInstanceOf(Array);
@@ -109,7 +109,7 @@ describe('cascade CLI', () => {
     });
 
     it.skipIf(skipIfNoPod)('should validate a directory of Turtle files', () => {
-      const podPath = resolve(__dirname, '../../reference-patient-pod/clinical');
+      const podPath = resolve(__dirname, '../../conformance/reference-patient-pod/clinical');
       const output = runCli(`validate ${podPath}`);
       expect(output).toContain('PASS');
       expect(output).toContain('Validation Summary');

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -24,7 +24,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 // Reference patient pod path
-const REFERENCE_POD = path.resolve(__dirname, '..', '..', 'reference-patient-pod');
+const REFERENCE_POD = path.resolve(__dirname, '..', '..', 'conformance', 'reference-patient-pod');
 
 // ─── Server Creation ──────────────────────────────────────────────────────────
 

--- a/tests/pod.test.ts
+++ b/tests/pod.test.ts
@@ -15,7 +15,7 @@ import { resolve } from 'path';
 import { existsSync } from 'fs';
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
-const REFERENCE_POD = resolve(__dirname, '../../reference-patient-pod');
+const REFERENCE_POD = resolve(__dirname, '../../conformance/reference-patient-pod');
 const skipIfNoPod = !existsSync(REFERENCE_POD);
 
 function runCli(args: string): string {

--- a/tests/validate-coverage-reference-pod.test.ts
+++ b/tests/validate-coverage-reference-pod.test.ts
@@ -49,7 +49,7 @@ import { resolve } from 'node:path';
 import { loadShapes, validateFile, findTurtleFiles } from '../src/lib/shacl-validator.js';
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
-const REFERENCE_POD = resolve(__dirname, '../../reference-patient-pod');
+const REFERENCE_POD = resolve(__dirname, '../../conformance/reference-patient-pod');
 const skipIfNoPod = !existsSync(REFERENCE_POD);
 
 const CASCADE_NS = 'https://ns.cascadeprotocol.org/';


### PR DESCRIPTION
**Merge order: this needs `conformance` PR #8 first.** That PR moves the pod into `conformance`; this one repoints at it. Merged in the other order, CI here still shows 64 skips and the new gate fails.

## The problem

Three suites are guarded by `describe.skipIf(!existsSync(REFERENCE_POD))` against a pod that lived in a private repository no runner could reach. So they **vanished instead of failing**, and CI has reported green on that every single run:

| File | Skipped in CI |
|---|---|
| `pod.test.ts` | 18 |
| `validate-coverage-reference-pod.test.ts` | 19 |
| `cli.test.ts` | 3 |
| **total** | **40** |

## The change

Repoints the four `REFERENCE_POD` constants and three inline paths in `cli.test.ts` at `../../conformance/reference-patient-pod`. That resolves identically in the local layout and the CI layout, because `conformance` is a sibling in both — no conditional, no fallback.

**Verified locally against the relocated pod: 121 files, 1676 tests, 0 skipped**, with all three suites executing rather than skipping.

## The gate

`tests.yml` had no notion of how much of the suite actually ran, which is why 40 missing tests went unnoticed indefinitely. Both workflows now carry the skip ratchet, failing in **either** direction:

| Observed | Result |
|---|---|
| 24 | allow |
| more | **block** — something stopped running |
| fewer | **block** — gap closed, lower the baseline in the same change |

`tests.yml` also picks up the `pipefail` fix `release.yml` already had. Without it the pipeline's exit status is `tee`'s, so a failing suite reports success.

## The remaining 24, which I could not close

The CAP advisory suites read two `*.ldpatch` example files that are **committed to no repository at all**. They are untracked in a private repo's working tree — not gitignored, just never added — so they exist on exactly one machine. No runner can be given them, and if that disk failed the tests would skip forever while CI stayed green. Filed in the ecosystem backlog; it needs a decision about where those fixtures should live, not a code change here.