### PR TITLE
fix(cli): route record-data merges through one graph re-serializer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ env:
   # example files that are not committed to ANY repository -- they exist only in
   # a local working tree -- so no runner can be given them until they are
   # committed somewhere. Locally, where those files happen to exist, the suite
-  # runs 1676 tests with ZERO skips.
+  # runs 1854 tests with ZERO skips.
   #
   # The reference-pod half of this number (40) is closed: the pod now lives in
   # the conformance repository, which this workflow already checks out.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           set -o pipefail
           npm test 2>&1 | tee "${RUNNER_TEMP}/test-output.txt"
 
-      # Green is not the same as complete. This suite runs 1676 tests with zero
+      # Green is not the same as complete. This suite runs 1854 tests with zero
       # skips locally; on a runner a subset is guarded by describe.skipIf and
       # vanishes rather than fails, so a passing run can hide an entire suite
       # that stopped executing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+**`pod add-record` no longer destroys prefix declarations it did not author.** Adding a record to a
+bucket an importer had written stripped every `@prefix` line out of the file and re-emitted a
+narrower header of its own, deleting the `rxnorm:`, `sct:`, `loinc:`, `fhir:` and `vcard:`
+declarations while keeping the CURIEs in the body that used them. The file stopped parsing, and
+because one unreadable bucket fails the whole-pod read, `pod query` and `pod info` failed for the
+entire pod. A pod that had imported medications and then had one record added by hand reported
+`Undefined prefix "rxnorm:"` and could not be read at all. The same command also bricked a pod with
+no import involved, by accepting a `core:` CURIE it never declared.
+
+**An unparseable bucket is no longer silently replaced by the next `pod import`.** Import caught the
+parse failure, treated the file as empty, and wrote over it — so a bucket with a damaged header lost
+every record it held, at exit 0, reported as a normal import. The same command on its default flag
+path instead died with an uncaught parser exception and a stack trace. Both paths now refuse that
+single bucket by name, exit non-zero, leave the file byte-unchanged, and continue writing the
+healthy buckets in the same import.
+
+**`pod erase` no longer rewrites relative IRIs in records it was not asked to touch.** Erasing one
+record rewrote the surviving records' `prov:wasAttributedTo </profile/card.ttl#me>` to
+`<undefined/profile/card.ttl#me>`, silently corrupting patient attribution. `pod import`'s merge
+path did the same and additionally demoted the term from an IRI to a string literal.
+
+**`pod add-record` validates `--by` values and property CURIEs before writing.** A value containing
+a character that cannot appear in an IRI produced an unparseable bucket at exit 0; it is now
+rejected with a message naming the offending value.
+
+### Changed
+
+Every record-data merge (`pod add-record`, `pod import`, `pod erase`, and the amend/annotate/retract
+overlays) now writes through a single graph re-serializer rather than by manipulating Turtle text.
+The writer owns the whole document including its header, and emits a full `<IRI>` for any namespace
+it has no prefix for, so a bucket carrying an undeclared CURIE can no longer be produced. The
+prefixes a file already declared are preserved, so a bucket keeps the prefix names it was written
+with. Human-curated files (`settings/publicTypeIndex.ttl`, `index.ttl`, `profile/card.ttl`,
+`profile/extended.ttl`) are deliberately not routed through it and are unchanged.
+
+**Upgrade note.** A bucket already damaged by the first bug above will now be refused by
+`add-record`, `erase` and `import` rather than silently appended to or overwritten. That is
+deliberate — the previous behaviour is what turned a broken header into lost records — but it means
+an already-damaged file must be repaired before those commands will touch it. Repairing it means
+restoring the missing `@prefix` lines; the records themselves are intact.
+
 ## [0.12.0] - 2026-08-04
 
 **If you are upgrading from 0.10.0, this release also contains everything described under 0.11.0

--- a/src/commands/pod/add-record.ts
+++ b/src/commands/pod/add-record.ts
@@ -20,15 +20,14 @@
 
 import type { Command } from 'commander';
 import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
+import { DataFactory } from 'n3';
+import type { Quad } from 'n3';
 import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
 import { DATA_TYPES, resolvePodDir, fileExists, type DataTypeInfo } from './helpers.js';
-import {
-  resolvePodDek,
-  mintUri,
-  escapeTurtleString,
-} from '../../lib/annotations.js';
-import { readResource, writeResource } from '../../lib/pod-encryption.js';
+import { resolvePodDek, mintUri } from '../../lib/annotations.js';
+import { mergeIntoBucket, KNOWN_PREFIXES } from '../../lib/bucket-write.js';
+
+const { namedNode, literal, quad: makeQuad } = DataFactory;
 
 // CURIE prefix -> namespace IRI for expanding --type and property CURIEs.
 const PREFIX_NS: Record<string, string> = {
@@ -43,17 +42,7 @@ const PREFIX_NS: Record<string, string> = {
   fhir: 'http://hl7.org/fhir/',
 };
 
-const TURTLE_PREFIX_HEADER = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
-@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
-@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
-@prefix coverage: <https://ns.cascadeprotocol.org/coverage/v1#> .
-@prefix checkup: <https://ns.cascadeprotocol.org/checkup/v1#> .
-@prefix pots: <https://ns.cascadeprotocol.org/pots/v1#> .
-@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
-@prefix prov: <http://www.w3.org/ns/prov#> .
-@prefix dct: <http://purl.org/dc/terms/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-`;
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
 // The Pod's canonical patient WebID (see `cascade pod init`), used as the
 // default prov:wasAttributedTo actor for a self-entered record when --by is
@@ -155,42 +144,59 @@ export function registerAddRecordSubcommand(pod: Command, program: Command): voi
       const recordUri = mintUri();
       const createdIso = new Date().toISOString();
 
-      // Build the record's predicate/object lines from propsJson.
-      const lines: string[] = [`    a ${options.type}`];
+      // Build the record as QUADS, never as text. Every CURIE is expanded here,
+      // so the serializer decides how (or whether) to abbreviate it — which is
+      // why `--type core:X` / `core:someProperty` can no longer emit a CURIE
+      // whose prefix the header never declared.
+      const subject = namedNode(recordUri);
+      const newQuads: Quad[] = [makeQuad(subject, namedNode(RDF_TYPE), namedNode(typeIri))];
       for (const [curie, value] of Object.entries(props)) {
         // Validate each property CURIE expands to a known namespace.
-        if (!expandCurie(curie)) {
+        const predicateIri = expandCurie(curie);
+        if (!predicateIri) {
           printError(`Unknown property CURIE prefix: ${curie}`, globalOpts);
           process.exitCode = 1;
           return;
         }
-        lines.push(`    ${curie} "${escapeTurtleString(String(value))}"`);
+        newQuads.push(makeQuad(subject, namedNode(predicateIri), literal(String(value))));
       }
       // Source axis: who reported it (self) — and a real attribution triple.
-      lines.push('    cascade:dataProvenance cascade:SelfReported');
-      lines.push(`    prov:wasAttributedTo <${options.by ?? PATIENT_WEBID}>`);
+      newQuads.push(makeQuad(
+        subject,
+        namedNode(KNOWN_PREFIXES.cascade + 'dataProvenance'),
+        namedNode(KNOWN_PREFIXES.cascade + 'SelfReported'),
+      ));
+      newQuads.push(makeQuad(
+        subject,
+        namedNode(KNOWN_PREFIXES.prov + 'wasAttributedTo'),
+        namedNode(options.by ?? PATIENT_WEBID),
+      ));
       // Verification axis (orthogonal to source): self-entered data is unverified
       // until corroborated. Mirrors FHIR verificationStatus.
-      lines.push('    workbench:verificationStatus workbench:Unverified');
-      lines.push(`    dct:created "${escapeTurtleString(createdIso)}"^^xsd:dateTime`);
-
-      const block = `<${recordUri}>\n${lines.join(' ;\n')} .\n`;
+      newQuads.push(makeQuad(
+        subject,
+        namedNode(KNOWN_PREFIXES.workbench + 'verificationStatus'),
+        namedNode(KNOWN_PREFIXES.workbench + 'Unverified'),
+      ));
+      newQuads.push(makeQuad(
+        subject,
+        namedNode(KNOWN_PREFIXES.dct + 'created'),
+        literal(createdIso, namedNode(KNOWN_PREFIXES.xsd + 'dateTime')),
+      ));
 
       const targetFile = path.join(podDir, bucket.info.directory, bucket.info.filename);
 
-      // Read-merge-write into the bucket file (preserve a single prefix header).
-      let mergedBody = block;
-      if (await fileExists(targetFile)) {
-        const existing = readResource(targetFile, dek);
-        const existingBody = stripPrefixHeader(existing);
-        mergedBody = existingBody.trim().length > 0
-          ? `${existingBody.trimEnd()}\n\n${block}`
-          : block;
+      // Read-merge-write through the bucket chokepoint: the existing document's
+      // own prefix declarations are harvested and kept, so a bucket an import
+      // wrote does not lose `rxnorm:` / `sct:` / `loinc:` / `vcard:` the moment
+      // a hand-entered record lands in it.
+      try {
+        await mergeIntoBucket(targetFile, newQuads, dek);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
       }
-      const merged = `${TURTLE_PREFIX_HEADER}\n${mergedBody}`;
-
-      await fs.mkdir(path.dirname(targetFile), { recursive: true });
-      writeResource(targetFile, merged, dek);
 
       const result = { added: true, recordUri, type: options.type };
 
@@ -205,19 +211,4 @@ export function registerAddRecordSubcommand(pod: Command, program: Command): voi
         console.log(`  File: ${bucket.info.directory}/${bucket.info.filename}`);
       }
     });
-}
-
-/** Strip leading @prefix / @base header lines, returning the statement body. */
-function stripPrefixHeader(turtle: string): string {
-  const lines = turtle.split('\n');
-  let i = 0;
-  while (i < lines.length) {
-    const trimmed = lines[i].trim();
-    if (trimmed === '' || trimmed.startsWith('@prefix') || trimmed.startsWith('@base')) {
-      i++;
-      continue;
-    }
-    break;
-  }
-  return lines.slice(i).join('\n');
 }

--- a/src/commands/pod/add-record.ts
+++ b/src/commands/pod/add-record.ts
@@ -25,7 +25,7 @@ import type { Quad } from 'n3';
 import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
 import { DATA_TYPES, resolvePodDir, fileExists, type DataTypeInfo } from './helpers.js';
 import { resolvePodDek, mintUri } from '../../lib/annotations.js';
-import { mergeIntoBucket, KNOWN_PREFIXES } from '../../lib/bucket-write.js';
+import { mergeIntoBucket, KNOWN_PREFIXES, assertWritableIri } from '../../lib/bucket-write.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
@@ -135,6 +135,26 @@ export function registerAddRecordSubcommand(pod: Command, program: Command): voi
       let dek: Buffer | undefined;
       try {
         dek = await resolvePodDek(podDir);
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Validate every user-supplied IRI BEFORE a term is minted from it.
+      //
+      // A NamedNode holding a space serializes to `<https://ex.org/a b#me>`,
+      // which no reader can parse — and an unreadable bucket is one this CLI
+      // correctly refuses to overwrite. So a single accepted typo takes the
+      // bucket out of service for add-record, erase AND import, permanently,
+      // with no repair verb. Rejecting the input is the only place this is
+      // recoverable.
+      try {
+        if (options.by !== undefined) assertWritableIri(options.by, '--by');
+        for (const curie of Object.keys(props)) {
+          const iri = expandCurie(curie);
+          if (iri) assertWritableIri(iri, `the property CURIE "${curie}"`);
+        }
       } catch (e: unknown) {
         printError(e instanceof Error ? e.message : String(e), globalOpts);
         process.exitCode = 1;

--- a/src/commands/pod/erase.ts
+++ b/src/commands/pod/erase.ts
@@ -60,8 +60,7 @@ import {
   type PodReader,
   type PodReadFailure,
 } from '../../lib/pod-read.js';
-import { writeResource } from '../../lib/pod-encryption.js';
-import { quadsToTurtle } from '../../lib/fhir-converter/types.js';
+import { mergeIntoBucket, derelativizeQuads, REL_BASE } from '../../lib/bucket-write.js';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
@@ -163,10 +162,14 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
         if (excludeFiles.has(file)) continue;
         if ([...excludeDirs].some((d) => file.startsWith(d + path.sep))) continue;
 
-        // baseIri '' because the surviving quads are re-serialized back to this
-        // same file: resolving relative IRIs against the file URL here would
-        // rewrite them as a side effect of the erasure.
-        const parsed = reader.parseFile(file, { baseIri: '' });
+        // A SENTINEL base, not the file URL and not '': the surviving quads are
+        // re-serialized back to this same file, so a relative IRI must come out
+        // exactly as it went in. The file URL would rewrite it absolutely; ''
+        // leaves N3's _baseRoot undefined and silently turns
+        // </profile/card.ttl#me> into "undefined/profile/card.ttl#me".
+        // derelativizeQuads strips the sentinel straight back off, so the
+        // subject match below compares the IRI the user typed.
+        const parsed = reader.parseFile(file, { baseIri: REL_BASE });
         if (!parsed.ok) {
           unreadable.push(parsed.failure);
           continue;
@@ -177,7 +180,7 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
         // relative to the file the record was found in.
         if (foundFile) continue;
 
-        const quads = parsed.value.quads;
+        const quads = derelativizeQuads(parsed.value.quads);
         const match = quads.filter((q) => q.subject.value === options.record);
         if (match.length > 0) {
           foundFile = file;
@@ -228,9 +231,16 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
       const typeQuad = subjectQuads.find((q) => q.predicate.value === RDF_TYPE);
       const erasedType = typeQuad ? shortenType(typeQuad.object.value) : undefined;
 
-      // Re-serialize the bucket WITHOUT the erased subject and write it back.
-      const newBucketTurtle = await quadsToTurtle(remainingQuads);
-      writeResource(foundFile, newBucketTurtle, dek);
+      // Re-serialize the bucket WITHOUT the erased subject and write it back,
+      // through the chokepoint so the file keeps the prefixes it declared
+      // rather than being flattened onto whichever set this command knows.
+      try {
+        await mergeIntoBucket(foundFile, [], dek, { combine: () => remainingQuads });
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 1;
+        return;
+      }
 
       // Write the content-free Tombstone overlay (the erasure audit event).
       const tombstoneUri = mintUri();

--- a/src/commands/pod/erase.ts
+++ b/src/commands/pod/erase.ts
@@ -60,7 +60,7 @@ import {
   type PodReader,
   type PodReadFailure,
 } from '../../lib/pod-read.js';
-import { mergeIntoBucket, derelativizeQuads, REL_BASE } from '../../lib/bucket-write.js';
+import { mergeIntoBucket, derelativizeQuads, relBase, relBaseFor } from '../../lib/bucket-write.js';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
@@ -169,7 +169,11 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
         // </profile/card.ttl#me> into "undefined/profile/card.ttl#me".
         // derelativizeQuads strips the sentinel straight back off, so the
         // subject match below compares the IRI the user typed.
-        const parsed = reader.parseFile(file, { baseIri: REL_BASE });
+        //
+        // relBaseFor sees this file's decrypted text and guarantees the base is
+        // not already in it, so an IRI a third party wrote to LOOK like the
+        // sentinel is left alone rather than rewritten into another resource.
+        const parsed = reader.parseFile(file, { baseIri: relBaseFor });
         if (!parsed.ok) {
           unreadable.push(parsed.failure);
           continue;
@@ -180,7 +184,9 @@ export function registerEraseSubcommand(pod: Command, program: Command): void {
         // relative to the file the record was found in.
         if (foundFile) continue;
 
-        const quads = derelativizeQuads(parsed.value.quads);
+        // relBaseFor has just made that base the active one, so it is the base
+        // this file was parsed under.
+        const quads = derelativizeQuads(parsed.value.quads, relBase());
         const match = quads.filter((q) => q.subject.value === options.record);
         if (match.length > 0) {
           foundFile = file;

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -23,7 +23,7 @@ import { Parser } from 'n3';
 import type { Quad } from 'n3';
 import { printResult, printError, printVerbose, printWarning, type OutputOptions } from '../../lib/output.js';
 import { convert } from '../../lib/fhir-converter/index.js';
-import { quadsToTurtle, type SectionCensusEntry } from '../../lib/fhir-converter/types.js';
+import { type SectionCensusEntry } from '../../lib/fhir-converter/types.js';
 import {
   resolveReferenceEdges,
   buildResourceRefsFromQuads,
@@ -59,6 +59,7 @@ import {
 } from '../../lib/pod-encryption.js';
 import { obtainPassphrase } from '../../lib/passphrase.js';
 import { classifyImportInput, isPathInsidePod } from '../../lib/import-input.js';
+import { mergeIntoBucket, derelativizeQuads, REL_BASE } from '../../lib/bucket-write.js';
 
 // ---------------------------------------------------------------------------
 // Import report type
@@ -88,6 +89,14 @@ interface ImportReport {
     type: string;
   }>;
   typeCounts: Record<string, number>;
+  /**
+   * Pod-relative bucket paths this import REFUSED to write because the file
+   * already on disk could not be read as Turtle. Their records were not
+   * imported and those files are byte-unchanged. Non-empty means a non-zero
+   * exit code: an unreadable bucket holds unknown content, and overwriting it
+   * would turn a broken header into lost records.
+   */
+  bucketsRefused: string[];
   /** Record counts grouped by EHR of origin (clinical:sourceEHR), for the plan. */
   sourceBreakdown: Record<string, number>;
   /** "Do we have everything?" checks from container adapters (e.g. source labels). */
@@ -148,10 +157,14 @@ interface ImportReport {
 // Load existing pod data as ReconcilerInput records for cross-batch dedup
 // ---------------------------------------------------------------------------
 
-async function loadExistingPodData(podDir: string, dek?: Buffer): Promise<ReconcilerInput[]> {
+async function loadExistingPodData(
+  podDir: string,
+  dek?: Buffer,
+): Promise<{ inputs: ReconcilerInput[]; unreadable: string[] }> {
   // Pod data directories that contain reconcilable records
   const DATA_DIRS = ['clinical', 'wellness'];
   const inputs: ReconcilerInput[] = [];
+  const unreadable: string[] = [];
 
   for (const dir of DATA_DIRS) {
     const dirPath = path.join(podDir, dir);
@@ -167,16 +180,23 @@ async function loadExistingPodData(podDir: string, dek?: Buffer): Promise<Reconc
       const filePath = path.join(dirPath, file);
       try {
         const content = readResource(filePath, dek);
-        if (content.trim().length > 0) {
-          inputs.push({ content, systemName: 'existing-pod' });
-        }
+        if (content.trim().length === 0) continue;
+        // PARSE-CHECK here, not just read-check. The reconciler parses these
+        // strings with no error handling of its own, so a bucket whose header
+        // was damaged used to take the whole import down with an unhandled
+        // rejection and a raw stack trace. Naming the file and carrying on is
+        // safe because the write chokepoint independently refuses to overwrite
+        // any bucket it cannot parse — the records in it are never lost, and
+        // never silently replaced by a partial rewrite either.
+        await parseTurtleToQuads(content);
+        inputs.push({ content, systemName: 'existing-pod' });
       } catch {
-        // Skip unreadable files
+        unreadable.push(`${dir}/${file}`);
       }
     }
   }
 
-  return inputs;
+  return { inputs, unreadable };
 }
 
 // ---------------------------------------------------------------------------
@@ -185,16 +205,27 @@ async function loadExistingPodData(podDir: string, dek?: Buffer): Promise<Reconc
 
 async function parseTurtleToQuads(turtle: string): Promise<Map<string, Quad[]>> {
   return new Promise((resolve, reject) => {
-    const parser = new Parser({ format: 'Turtle' });
-    const bySubject = new Map<string, Quad[]>();
+    // The SENTINEL base, because this turtle can be a pod file's own content on
+    // its way back to that same file. N3's default leaves _baseRoot undefined,
+    // so </profile/card.ttl#me> resolves to "undefined/profile/card.ttl#me".
+    // derelativizeQuads puts it back, so the subject keys
+    // this map is dedup-ed by are the IRIs the file actually states.
+    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
+    const collected: Quad[] = [];
 
     parser.parse(turtle, (error, quad) => {
       if (error) { reject(error); return; }
-      if (!quad) { resolve(bySubject); return; }
-
-      const subj = quad.subject.value;
-      if (!bySubject.has(subj)) bySubject.set(subj, []);
-      bySubject.get(subj)!.push(quad);
+      if (!quad) {
+        const bySubject = new Map<string, Quad[]>();
+        for (const q of derelativizeQuads(collected)) {
+          const subj = q.subject.value;
+          if (!bySubject.has(subj)) bySubject.set(subj, []);
+          bySubject.get(subj)!.push(q);
+        }
+        resolve(bySubject);
+        return;
+      }
+      collected.push(quad);
     });
   });
 }
@@ -676,7 +707,15 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // Load existing pod data as an implicit source 0 when --reconcile-existing is set
       let existingInputs: ReconcilerInput[] = [];
       if (options.reconcileExisting !== false) {
-        existingInputs = await loadExistingPodData(podDir, dek);
+        const existing = await loadExistingPodData(podDir, dek);
+        existingInputs = existing.inputs;
+        for (const rel of existing.unreadable) {
+          printWarning(
+            `Existing pod file ${rel} could not be read as Turtle and was excluded from ` +
+              `reconciliation. It will NOT be written to either.`,
+            globalOpts,
+          );
+        }
         if (existingInputs.length > 0) {
           printVerbose(`Loaded ${existingInputs.length} existing pod file(s) for cross-batch reconciliation.`, globalOpts);
         }
@@ -870,6 +909,9 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       const filesWritten: ImportReport['filesWritten'] = [];
       const typeCounts: Record<string, number> = {};
       const newFiles: string[] = []; // relative paths (for index.ttl updates)
+      // Buckets this import refused to write because the existing file could
+      // not be read. Named in the summary and fatal to the exit code.
+      const bucketsRefused: string[] = [];
 
       for (const [typeKey, subjectQArrays] of buckets) {
         const info = DATA_TYPES[typeKey];
@@ -881,73 +923,75 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
         const targetFile = path.join(podDir, info.directory, info.filename);
         const relPath = `${info.directory}/${info.filename}`;
 
-        // Serialize new quads
         const allNewQuads = subjectQArrays.flat();
-        const newTurtle = await quadsToTurtle(allNewQuads);
 
-        let finalTurtle: string;
         let recordsAdded = subjectQArrays.length;
         // Of those, the subjects this file did not already hold. Equal to
         // recordsAdded on a fresh file; zero on a fully duplicate re-import.
         let recordsNew = subjectQArrays.length;
-        let isNewFile = true;
+        const isNewFile = !(await fileExists(targetFile));
 
-        if (useCrossBatchReplace) {
-          // Cross-batch reconciliation: the reconciler output already represents
-          // the complete merged state (existing + new, deduped). Write it directly
-          // without re-merging against the existing file to avoid duplicates.
-          isNewFile = !(await fileExists(targetFile));
-          finalTurtle = newTurtle;
-          // recordsAdded reflects the full set of subjects in this bucket after reconciliation
-          recordsAdded = subjectQArrays.length;
-          // Which of them are genuinely new needs the pre-import file: the
-          // replace path never reads it, which is exactly why a re-import used to
-          // report its whole merged output as freshly imported records.
-          if (!isNewFile) {
-            let priorSubjects: Set<string>;
-            try {
-              priorSubjects = new Set(
-                (await parseTurtleToQuads(readResource(targetFile, dek))).keys(),
-              );
-            } catch {
-              priorSubjects = new Set();
+        // Every write below goes through the ONE bucket chokepoint, so the
+        // file's own prefix declarations survive, relative IRIs survive, and an
+        // existing bucket that does not parse is a refusal rather than a
+        // silently emptied Map.
+        try {
+          if (useCrossBatchReplace) {
+            // Cross-batch reconciliation: the reconciler output already
+            // represents the complete merged state (existing + new, deduped),
+            // so the file's contents are REPLACED, not appended to.
+            const priorSubjects = new Set<string>();
+            await mergeIntoBucket(targetFile, allNewQuads, dek, {
+              dryRun,
+              combine: (existing, incoming) => {
+                // Which subjects are genuinely new needs the pre-import file.
+                // The replace path used to never read it, which is why a
+                // re-import reported its whole merged output as fresh records.
+                for (const q of existing) priorSubjects.add(q.subject.value);
+                return incoming;
+              },
+            });
+            recordsAdded = subjectQArrays.length;
+            if (!isNewFile) {
+              recordsNew = subjectQArrays.filter(
+                (quads) => quads.length > 0 && !priorSubjects.has(quads[0].subject.value),
+              ).length;
             }
-            recordsNew = subjectQArrays.filter(
-              (quads) => quads.length > 0 && !priorSubjects.has(quads[0].subject.value),
-            ).length;
+          } else {
+            // Additive merge: keep every subject the file already holds and add
+            // only the ones it lacks (dedup by subject URI).
+            let addedCount = 0;
+            await mergeIntoBucket(targetFile, allNewQuads, dek, {
+              dryRun,
+              combine: (existing) => {
+                const bySubject = new Map<string, Quad[]>();
+                for (const q of existing) {
+                  const bucketQuads = bySubject.get(q.subject.value);
+                  if (bucketQuads) bucketQuads.push(q);
+                  else bySubject.set(q.subject.value, [q]);
+                }
+                for (const [subjectUri, quads] of subjectQuads) {
+                  if (routeTypeKey(quads) === typeKey && !bySubject.has(subjectUri)) {
+                    bySubject.set(subjectUri, quads);
+                    addedCount++;
+                  }
+                }
+                return Array.from(bySubject.values()).flat();
+              },
+            });
+            // The additive path only ever writes subjects the file lacked.
+            recordsAdded = addedCount;
+            recordsNew = addedCount;
           }
-        } else if (await fileExists(targetFile)) {
-          isNewFile = false;
-          // Merge: parse existing, combine unique subjects
-          let existingQuads: Map<string, Quad[]>;
-          try {
-            const existing = readResource(targetFile, dek);
-            existingQuads = await parseTurtleToQuads(existing);
-          } catch {
-            existingQuads = new Map();
-          }
-
-          // Add new subjects (dedup by subject URI)
-          let addedCount = 0;
-          for (const [subjectUri, quads] of subjectQuads) {
-            if (routeTypeKey(quads) === typeKey && !existingQuads.has(subjectUri)) {
-              existingQuads.set(subjectUri, quads);
-              addedCount++;
-            }
-          }
-          recordsAdded = addedCount;
-          // The additive path only ever writes subjects the file lacked.
-          recordsNew = addedCount;
-
-          const mergedQuads = Array.from(existingQuads.values()).flat();
-          finalTurtle = await quadsToTurtle(mergedQuads);
-        } else {
-          finalTurtle = newTurtle;
-        }
-
-        if (!dryRun) {
-          await fs.mkdir(path.dirname(targetFile), { recursive: true });
-          writeResource(targetFile, finalTurtle, dek);
+        } catch (e: unknown) {
+          // An existing bucket this import cannot read is a bucket whose
+          // contents are unknown, and unknown is not empty. Refuse to write
+          // THIS file, name it, and fail the run — overwriting it would take an
+          // already-corrupted pod from "one broken header" to "records gone".
+          const detail = e instanceof Error ? e.message : String(e);
+          printError(`Refusing to write ${relPath}: ${detail}`, globalOpts);
+          bucketsRefused.push(relPath);
+          continue;
         }
 
         typeCounts[typeKey] = (typeCounts[typeKey] ?? 0) + recordsAdded;
@@ -1094,6 +1138,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           : { enabled: false },
         filesWritten,
         typeCounts,
+        bucketsRefused,
         sourceBreakdown,
         completeness,
         totalRecordsImported,
@@ -1225,6 +1270,18 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
             }
           } catch { /* non-fatal */ }
         }
+      }
+
+      // A refused bucket is not a warning. Its records were NOT imported and
+      // the caller must be able to see that without parsing prose.
+      if (bucketsRefused.length > 0) {
+        printError(
+          `${bucketsRefused.length} bucket(s) could not be read and were left untouched: ` +
+            `${bucketsRefused.join(', ')}. The records routed to them were NOT imported. ` +
+            `Repair or remove those files and re-run the import.`,
+          globalOpts,
+        );
+        process.exitCode = 1;
       }
     });
 }

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -59,7 +59,7 @@ import {
 } from '../../lib/pod-encryption.js';
 import { obtainPassphrase } from '../../lib/passphrase.js';
 import { classifyImportInput, isPathInsidePod } from '../../lib/import-input.js';
-import { mergeIntoBucket, derelativizeQuads, REL_BASE } from '../../lib/bucket-write.js';
+import { mergeIntoBucket, derelativizeQuads, relBaseFor } from '../../lib/bucket-write.js';
 
 // ---------------------------------------------------------------------------
 // Import report type
@@ -210,14 +210,20 @@ async function parseTurtleToQuads(turtle: string): Promise<Map<string, Quad[]>> 
     // so </profile/card.ttl#me> resolves to "undefined/profile/card.ttl#me".
     // derelativizeQuads puts it back, so the subject keys
     // this map is dedup-ed by are the IRIs the file actually states.
-    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
+    //
+    // The base is chosen against THIS text and the strip below uses that same
+    // base: third-party Turtle reaches this parser (`pod import` of a .ttl), and
+    // an IRI the document merely wrote to LOOK like the sentinel must not be
+    // rewritten into the different, real resource hiding behind it.
+    const base = relBaseFor(turtle);
+    const parser = new Parser({ format: 'Turtle', baseIRI: base });
     const collected: Quad[] = [];
 
     parser.parse(turtle, (error, quad) => {
       if (error) { reject(error); return; }
       if (!quad) {
         const bySubject = new Map<string, Quad[]>();
-        for (const q of derelativizeQuads(collected)) {
+        for (const q of derelativizeQuads(collected, base)) {
           const subj = q.subject.value;
           if (!bySubject.has(subj)) bySubject.set(subj, []);
           bySubject.get(subj)!.push(q);

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -17,22 +17,45 @@
  */
 
 import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
-import { readResource, writeResource } from './pod-encryption.js';
-import { openPod, fileExists } from './pod-read.js';
+import { DataFactory } from 'n3';
+import type { Quad, Quad_Object } from 'n3';
+import { openPod } from './pod-read.js';
 import { loadShapes, validateTurtle } from './shacl-validator.js';
+import { mergeIntoBucket, KNOWN_PREFIXES } from './bucket-write.js';
+
+const { namedNode, literal, quad: makeQuad } = DataFactory;
 
 /** The pod-relative directory holding append-only overlay resources. */
 export const ANNOTATIONS_DIR = 'annotations';
 
-/** Shared Turtle prefix header for every overlay resource file. */
-export const OVERLAY_PREFIXES = `@prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
-@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
-@prefix prov: <http://www.w3.org/ns/prov#> .
-@prefix dct: <http://purl.org/dc/terms/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-`;
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/**
+ * CURIE prefixes an overlay may name. Expansion happens HERE, at build time,
+ * so no overlay predicate reaches disk as text: a prefix this map does not know
+ * is a loud throw rather than an unparseable `annotations/*.ttl`.
+ */
+const OVERLAY_NS: Record<string, string> = {
+  workbench: KNOWN_PREFIXES.workbench,
+  cascade: KNOWN_PREFIXES.cascade,
+  prov: KNOWN_PREFIXES.prov,
+  dct: KNOWN_PREFIXES.dct,
+  xsd: KNOWN_PREFIXES.xsd,
+};
+
+/** Expand an overlay CURIE to its full IRI. @throws on an unknown prefix. */
+function expandOverlayCurie(curie: string): string {
+  const idx = curie.indexOf(':');
+  const ns = idx > 0 ? OVERLAY_NS[curie.slice(0, idx)] : undefined;
+  if (!ns) {
+    throw new Error(
+      `Unknown overlay CURIE prefix in "${curie}". Overlay terms must use one of: ` +
+        `${Object.keys(OVERLAY_NS).join(', ')}.`,
+    );
+  }
+  return ns + curie.slice(idx + 1);
+}
 
 /**
  * Resolve the DEK for an encrypted pod, or `undefined` for a plaintext pod.
@@ -47,66 +70,59 @@ export async function resolvePodDek(podDir: string): Promise<Buffer | undefined>
   return (await openPod(podDir)).dek;
 }
 
-/** Escape a value for use inside a Turtle "..." string literal. */
-export function escapeTurtleString(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
-}
-
-/** A single `predicate value` line within an overlay subject block. */
+/** A single `predicate value` statement within an overlay subject block. */
 export interface OverlayLine {
   /** Predicate in CURIE form, e.g. 'workbench:amendsRecord'. */
   predicate: string;
-  /** The object term, already serialized (IRI in <...> or "literal"^^type). */
-  object: string;
+  /** The object term. Build it with {@link strLit} / {@link iriRef} / {@link dateTimeLit}. */
+  object: Quad_Object;
 }
 
-/** A literal string object: `"escaped"`. */
-export function strLit(value: string): string {
-  return `"${escapeTurtleString(value)}"`;
+/** A plain string literal object. */
+export function strLit(value: string): Quad_Object {
+  return literal(value);
 }
 
-/** A typed dateTime object: `"..."^^xsd:dateTime`. */
-export function dateTimeLit(iso: string): string {
-  return `"${escapeTurtleString(iso)}"^^xsd:dateTime`;
+/** An `xsd:dateTime` literal object. */
+export function dateTimeLit(iso: string): Quad_Object {
+  return literal(iso, namedNode(KNOWN_PREFIXES.xsd + 'dateTime'));
 }
 
-/** An IRI object: `<iri>`. */
-export function iriRef(iri: string): string {
-  return `<${iri}>`;
+/** An IRI object. */
+export function iriRef(iri: string): Quad_Object {
+  return namedNode(iri);
 }
 
 /**
- * Build the Turtle block for one overlay subject.
+ * Build the quads for one overlay subject.
  *
  * @param subjectUri  the minted urn:uuid: of this overlay
  * @param rdfType     the workbench class CURIE, e.g. 'workbench:Amendment'
- * @param lines       the class-specific predicate/object lines
+ * @param lines       the class-specific predicate/object statements
  * @param actorIri    optional prov:wasAttributedTo actor IRI
  * @param createdIso  dct:created timestamp (ISO 8601)
  */
-export function buildOverlayBlock(
+export function buildOverlayQuads(
   subjectUri: string,
   rdfType: string,
   lines: OverlayLine[],
   actorIri: string | undefined,
   createdIso: string,
-): string {
+): Quad[] {
+  const subject = namedNode(subjectUri);
   const allLines: OverlayLine[] = [
-    ...lines,
-    { predicate: 'cascade:dataProvenance', object: 'cascade:SelfReported' },
+    { predicate: 'cascade:dataProvenance', object: namedNode(KNOWN_PREFIXES.cascade + 'SelfReported') },
   ];
   if (actorIri) {
     allLines.push({ predicate: 'prov:wasAttributedTo', object: iriRef(actorIri) });
   }
   allLines.push({ predicate: 'dct:created', object: dateTimeLit(createdIso) });
 
-  const body = allLines.map((l) => `    ${l.predicate} ${l.object}`).join(' ;\n');
-  return `<${subjectUri}> a ${rdfType} ;\n${body} .\n`;
+  return [
+    makeQuad(subject, namedNode(RDF_TYPE), namedNode(expandOverlayCurie(rdfType))),
+    ...lines.map((l) => makeQuad(subject, namedNode(expandOverlayCurie(l.predicate)), l.object)),
+    ...allLines.map((l) => makeQuad(subject, namedNode(expandOverlayCurie(l.predicate)), l.object)),
+  ];
 }
 
 /** Description of one overlay to be written. */
@@ -126,21 +142,21 @@ export interface OverlaySpec {
 }
 
 /**
- * Append an overlay resource to `<pod>/annotations/<fileName>` via the
- * read-merge-write pattern. The MERGED file content is SHACL-validated before
- * it is written; a malformed overlay throws and nothing is persisted.
+ * Append an overlay resource to `<pod>/annotations/<fileName>` through the
+ * bucket chokepoint. The MERGED document is SHACL-validated before it is
+ * written; a malformed overlay throws and nothing is persisted.
  *
- * @throws {Error} if the merged overlay fails SHACL validation.
+ * @throws {Error}            if the merged overlay fails SHACL validation.
+ * @throws {BucketParseError} if the existing overlay file does not parse.
  */
 export async function appendOverlay(
   podDir: string,
   spec: OverlaySpec,
   dek: Buffer | undefined,
 ): Promise<void> {
-  const annotationsDir = path.join(podDir, ANNOTATIONS_DIR);
-  const filePath = path.join(annotationsDir, spec.fileName);
+  const filePath = path.join(podDir, ANNOTATIONS_DIR, spec.fileName);
 
-  const block = buildOverlayBlock(
+  const newQuads = buildOverlayQuads(
     spec.subjectUri,
     spec.rdfType,
     spec.lines,
@@ -148,42 +164,10 @@ export async function appendOverlay(
     spec.createdIso,
   );
 
-  // Read existing body (without re-applying the prefix header), if present.
-  let existingBody = '';
-  if (await fileExists(filePath)) {
-    const existing = readResource(filePath, dek);
-    // Strip the leading prefix header lines so we keep a single header.
-    existingBody = stripPrefixHeader(existing);
-  }
-
-  const mergedBody = existingBody.trim().length > 0
-    ? `${existingBody.trimEnd()}\n\n${block}`
-    : block;
-  const merged = `${OVERLAY_PREFIXES}\n${mergedBody}`;
-
-  // Validate the merged graph BEFORE writing. A malformed overlay must fail.
-  validateOverlayGraph(merged, filePath);
-
-  await fs.mkdir(annotationsDir, { recursive: true });
-  writeResource(filePath, merged, dek);
-}
-
-/**
- * Remove the leading `@prefix` / `@base` header lines from a Turtle document,
- * returning just the statement body. Lets us re-append a single shared header.
- */
-function stripPrefixHeader(turtle: string): string {
-  const lines = turtle.split('\n');
-  let i = 0;
-  while (i < lines.length) {
-    const trimmed = lines[i].trim();
-    if (trimmed === '' || trimmed.startsWith('@prefix') || trimmed.startsWith('@base')) {
-      i++;
-      continue;
-    }
-    break;
-  }
-  return lines.slice(i).join('\n');
+  await mergeIntoBucket(filePath, newQuads, dek, {
+    // Validate the merged graph BEFORE writing. A malformed overlay must fail.
+    validate: (turtle, file) => validateOverlayGraph(turtle, file),
+  });
 }
 
 let cachedShapes: ReturnType<typeof loadShapes> | undefined;

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -22,7 +22,7 @@ import { DataFactory } from 'n3';
 import type { Quad, Quad_Object } from 'n3';
 import { openPod } from './pod-read.js';
 import { loadShapes, validateTurtle } from './shacl-validator.js';
-import { mergeIntoBucket, KNOWN_PREFIXES } from './bucket-write.js';
+import { mergeIntoBucket, KNOWN_PREFIXES, assertWritableIri } from './bucket-write.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
@@ -109,6 +109,23 @@ export function buildOverlayQuads(
   actorIri: string | undefined,
   createdIso: string,
 ): Quad[] {
+  // Every IRI an overlay command took from the user lands here — `--record`,
+  // `--superseded-by`, `--by` — so this is the one place that has to refuse an
+  // IRI Turtle cannot write. Doing it per-command is how the same hole gets
+  // reopened by the next command that grows a `--record` flag. Without it the
+  // overlay file becomes unparseable, and an unparseable overlay is one every
+  // later write refuses: one typo bricks it for good.
+  //
+  // The failure was not silent before — the SHACL gate caught the unparseable
+  // MERGED document — but it reported "Parse error: Unexpected ..." and never
+  // named the value the user typed, which is the difference between a typo you
+  // fix and a bug you file.
+  assertWritableIri(subjectUri, 'the overlay subject');
+  if (actorIri) assertWritableIri(actorIri, '--by');
+  for (const l of lines) {
+    if (l.object.termType === 'NamedNode') assertWritableIri(l.object.value, l.predicate);
+  }
+
   const subject = namedNode(subjectUri);
   const allLines: OverlayLine[] = [
     { predicate: 'cascade:dataProvenance', object: namedNode(KNOWN_PREFIXES.cascade + 'SelfReported') },

--- a/src/lib/bucket-write.ts
+++ b/src/lib/bucket-write.ts
@@ -30,11 +30,22 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { Parser, Writer, DataFactory } from 'n3';
-import type { Quad, Quad_Object, Quad_Subject } from 'n3';
+import type { Quad, Quad_Graph, Quad_Object, Quad_Predicate, Quad_Subject, Term } from 'n3';
 import { readResource, writeResource } from './pod-encryption.js';
 
-const { namedNode, blankNode, quad: makeQuad } = DataFactory;
+const { namedNode, blankNode, literal, quad: makeQuad } = DataFactory;
+
+/**
+ * A term as it exists at RUNTIME, which is wider than n3's `Term` union.
+ *
+ * n3's TypeScript `Term` has no `'Quad'` member, but its parser really does
+ * produce nested quads (RDF-star) whenever `format` is left unset — which is
+ * exactly how `turtle-parser.ts`, and therefore `pod erase`'s read, parses. A
+ * term walk that trusts the declared union silently skips those.
+ */
+type RuntimeTerm = Term | (Quad & { termType: 'Quad' });
 
 /**
  * Namespaces the CLI itself can emit, so its own output stays compact.
@@ -79,12 +90,107 @@ export const KNOWN_PREFIXES: Record<string, string> = {
  * literal string `"undefined/profile/card.ttl#me"`, and it is silent: the file
  * still parses, it just says something else.
  *
- * A bare-scheme base makes N3's `_base`, `_basePath` and `_baseRoot` the same
- * string, so every relative form (root-relative, doc-relative, empty `<>`,
- * fragment-only `<#x>`) acquires exactly this one prefix, which
- * {@link derelativizeQuads} strips back off on the way out.
+ * SHAPE: the sentinel must be a BARE SCHEME — `<scheme>:` and nothing after the
+ * colon. N3 derives `_baseRoot` with `/^(?:([a-z][a-z0-9+.-]*:))?(?:\/\/[^/]*)?/i`
+ * and root-relative IRIs resolve against `_baseRoot`, not `_base`. A base of
+ * `urn:x-cascade-rel-<nonce>:` therefore yields `_baseRoot === 'urn:'`, and
+ * `</profile/card.ttl#me>` resolves to `urn:/profile/card.ttl#me` — which does
+ * NOT carry the sentinel, so it is never stripped back off and the pod's WebID
+ * silently becomes a different resource. Only a bare scheme makes `_base`,
+ * `_basePath` and `_baseRoot` the same string, which is what makes all four
+ * relative forms (root-relative, doc-relative, empty `<>`, fragment-only
+ * `<#x>`) acquire exactly this one prefix. Verified against n3 1.26.0.
+ *
+ * NONCE: the scheme carries 128 random bits, minted once per process, rather
+ * than being a fixed literal. A fixed literal is FORGEABLE, and forging it is a
+ * silent re-identification attack: the strip cannot tell "this term was
+ * relative in the source" from "this term merely starts with the sentinel", so
+ * third-party Turtle containing `<x-cascade-rel:http://real.example/thing>` —
+ * a perfectly legal absolute IRI, reachable through `pod import` — came back
+ * out as `<http://real.example/thing>`, a statement about a different, real
+ * resource, at exit 0. With a per-process nonce there is no string an attacker
+ * can write down that this process will strip.
  */
-export const REL_BASE = 'x-cascade-rel:';
+const REL_BASE_SCHEME_PREFIX = 'x-cascade-rel-';
+
+/** A fresh sentinel. Bare scheme, 128 bits of entropy, hex so it stays a legal scheme. */
+function mintRelBase(): string {
+  return `${REL_BASE_SCHEME_PREFIX}${randomBytes(16).toString('hex')}:`;
+}
+
+let activeRelBase = mintRelBase();
+
+/**
+ * Every sentinel this process has minted.
+ *
+ * One element in every real run. It exists so {@link assertNoSentinelLeak} can
+ * still catch a term carrying a SUPERSEDED sentinel, which is the one way a
+ * regeneration could otherwise open a leak.
+ */
+const mintedRelBases = new Set<string>([activeRelBase]);
+
+/** The sentinel currently in force for this process. */
+export function relBase(): string {
+  return activeRelBase;
+}
+
+/**
+ * The sentinel to parse `text` under, guaranteed absent from `text`.
+ *
+ * The check is what turns "an attacker practically cannot collide with the
+ * nonce" into "a collision cannot happen at all". Everything downstream — the
+ * strip, and the leak assertion — decides purely on `startsWith(base)`, so if a
+ * source document could contain the base then a document could still name a
+ * term the strip would rewrite. It cannot: any text that happens to hold the
+ * active sentinel gets a fresh one minted for it, so within one parse
+ * `startsWith(base)` means "N3 resolved this against the base", never "the
+ * document said so".
+ *
+ * Reaching the loop body requires source text containing 128 specific random
+ * bits that this process has never written anywhere ({@link
+ * assertNoSentinelLeak} is what keeps that true). It is expected to be dead
+ * code forever; it is here because "unreachable" is a claim about today's
+ * coverage and this is the branch that makes the guarantee unconditional.
+ */
+export function relBaseFor(text: string): string {
+  activeRelBase = pickSentinelBase(text, activeRelBase, () => {
+    const minted = mintRelBase();
+    mintedRelBases.add(minted);
+    return minted;
+  });
+  return activeRelBase;
+}
+
+/** How many draws before {@link pickSentinelBase} concludes minting is broken. */
+const MAX_SENTINEL_DRAWS = 8;
+
+/**
+ * Keep `current` if `text` does not contain it; otherwise draw again, BOUNDED.
+ *
+ * The bound is the point, and `mint` is injected so it can be observed. A
+ * `while (contains) remint` loop terminates only because minting is random —
+ * a property of a DIFFERENT function. If that ever stops holding (a
+ * "simplification", a seeded double, a stubbed RNG) an unbounded loop hangs
+ * the CLI forever on any input containing the sentinel, with no output and no
+ * error. That is not hypothetical: mutating the nonce back to a fixed literal
+ * to check this module's tripwires burned 22 minutes of CPU in a hang instead
+ * of failing in a second.
+ *
+ * Eight colliding draws is not a case worth continuing from. It means the
+ * randomness assumption is broken, and saying so beats spinning.
+ */
+export function pickSentinelBase(text: string, current: string, mint: () => string): string {
+  let candidate = current;
+  for (let draw = 0; draw < MAX_SENTINEL_DRAWS; draw++) {
+    if (!text.includes(candidate)) return candidate;
+    candidate = mint();
+  }
+  throw new Error(
+    `Internal error: could not obtain a relative-IRI sentinel absent from the source text in ` +
+      `${MAX_SENTINEL_DRAWS} draws. The sentinel carries 128 random bits, so this means minting ` +
+      `has stopped being random.`,
+  );
+}
 
 /**
  * An existing bucket file could not be read as Turtle.
@@ -106,22 +212,120 @@ export class BucketParseError extends Error {
   }
 }
 
-/** Undo the {@link REL_BASE} sentinel on every IRI term of every quad. */
-export function derelativizeQuads(quads: Quad[]): Quad[] {
-  const strip = (value: string): string =>
-    value.startsWith(REL_BASE) ? value.slice(REL_BASE.length) : value;
-  return quads.map((q) => {
-    const s = q.subject.termType === 'NamedNode' && q.subject.value.startsWith(REL_BASE)
-      ? (namedNode(strip(q.subject.value)) as Quad_Subject)
-      : q.subject;
-    const p = q.predicate.value.startsWith(REL_BASE)
-      ? namedNode(strip(q.predicate.value))
-      : q.predicate;
-    const o = q.object.termType === 'NamedNode' && q.object.value.startsWith(REL_BASE)
-      ? (namedNode(strip(q.object.value)) as Quad_Object)
-      : q.object;
-    return s === q.subject && p === q.predicate && o === q.object ? q : makeQuad(s, p, o, q.graph);
-  });
+/**
+ * A term that still carries the sentinel was about to be written to a pod.
+ *
+ * Not a user error: a gap in {@link derelativizeQuads}'s term coverage. It is
+ * fatal rather than best-effort because the damage is PERMANENT. Once
+ * `"5"^^<x-cascade-rel-...:myLocalType>` is on disk that datatype IRI is
+ * ABSOLUTE, so no later parse resolves it against anything and no later strip
+ * removes it. There is no second chance to notice.
+ */
+export class SentinelLeakError extends Error {
+  readonly term: string;
+
+  constructor(term: string) {
+    super(
+      `Internal error: the relative-IRI sentinel leaked into a term that was about to be ` +
+        `written: ${term}\n` +
+        `  This is a gap in derelativizeQuads' term coverage, not a problem with your data. ` +
+        `Nothing was written.`,
+    );
+    this.name = 'SentinelLeakError';
+    this.term = term;
+  }
+}
+
+/** Strip one sentinel prefix off a term, recursing into everything that holds an IRI. */
+function derelativizeTerm(term: RuntimeTerm, base: string): RuntimeTerm {
+  switch (term.termType) {
+    case 'NamedNode':
+      return term.value.startsWith(base) ? namedNode(term.value.slice(base.length)) : term;
+    case 'Literal': {
+      // A literal's DATATYPE is a NamedNode, and `"5"^^<myLocalType>` is a
+      // relative IRI like any other. Missing this is what leaked the sentinel
+      // into pod data. A language-tagged literal's datatype is rdf:langString,
+      // which is absolute, so reaching the rebuild means there is no language
+      // to carry across.
+      const dt = term.datatype;
+      if (!dt || !dt.value.startsWith(base)) return term;
+      return literal(term.value, namedNode(dt.value.slice(base.length)));
+    }
+    case 'Quad':
+      return derelativizeQuad(term, base) as RuntimeTerm;
+    default:
+      // BlankNode, Variable, DefaultGraph. No IRI, nothing to strip.
+      return term;
+  }
+}
+
+/** Strip the sentinel off all four positions of one quad, graph included. */
+function derelativizeQuad(q: Quad, base: string): Quad {
+  const s = derelativizeTerm(q.subject as RuntimeTerm, base) as Quad_Subject;
+  const p = derelativizeTerm(q.predicate as RuntimeTerm, base) as Quad_Predicate;
+  const o = derelativizeTerm(q.object as RuntimeTerm, base) as Quad_Object;
+  const g = derelativizeTerm(q.graph as RuntimeTerm, base) as Quad_Graph;
+  return s === q.subject && p === q.predicate && o === q.object && g === q.graph
+    ? q
+    : makeQuad(s, p, o, g);
+}
+
+/**
+ * Undo the sentinel base on every IRI-bearing term of every quad.
+ *
+ * `base` defaults to the sentinel currently in force. A caller that ran its own
+ * parser must pass the base IT parsed under, because that is the only string
+ * whose presence means "N3 resolved this".
+ */
+export function derelativizeQuads(quads: Quad[], base: string = relBase()): Quad[] {
+  return quads.map((q) => derelativizeQuad(q, base));
+}
+
+/** Does any part of this term still mention `base`? */
+function termLeaks(term: RuntimeTerm, base: string): string | undefined {
+  switch (term.termType) {
+    case 'NamedNode':
+      return term.value.includes(base) ? term.value : undefined;
+    case 'Literal':
+      // The literal's own lexical form is checked too: the sentinel reached
+      // pod data once before by a term being DEMOTED from a NamedNode to a
+      // string literal on the reconciler's path.
+      if (term.value.includes(base)) return `"${term.value}"`;
+      return term.datatype?.value.includes(base) ? `^^<${term.datatype.value}>` : undefined;
+    case 'Quad':
+      return quadLeaks(term, base);
+    default:
+      return undefined;
+  }
+}
+
+function quadLeaks(q: Quad, base: string): string | undefined {
+  for (const t of [q.subject, q.predicate, q.object, q.graph]) {
+    const hit = termLeaks(t as RuntimeTerm, base);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/**
+ * Refuse to write anything that still mentions a sentinel this process minted.
+ *
+ * The test is `includes`, not `startsWith`: a sentinel anywhere inside a term
+ * is a leak, and no legitimate term can contain one, because
+ * {@link relBaseFor} has already established that the source text does not and
+ * nothing else mints them. That makes this a coverage tripwire with no way to
+ * misfire on user data — if {@link derelativizeTerm} ever stops covering a term
+ * position, the write fails loudly instead of poisoning a bucket forever.
+ *
+ * @throws {SentinelLeakError}
+ */
+export function assertNoSentinelLeak(quads: Quad[]): void {
+  for (const q of quads) {
+    for (const base of mintedRelBases) {
+      const hit = quadLeaks(q, base);
+      if (hit) throw new SentinelLeakError(hit);
+    }
+  }
 }
 
 /**
@@ -133,9 +337,10 @@ export function derelativizeQuads(quads: Quad[]): Quad[] {
  */
 export function parseBucketTurtle(
   turtle: string,
+  base: string = relBaseFor(turtle),
 ): Promise<{ quads: Quad[]; prefixes: Record<string, string> }> {
   return new Promise((resolve, reject) => {
-    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
+    const parser = new Parser({ format: 'Turtle', baseIRI: base });
     const quads: Quad[] = [];
     parser.parse(turtle, (error, q, prefixes) => {
       if (error) {
@@ -143,7 +348,7 @@ export function parseBucketTurtle(
         return;
       }
       if (!q) {
-        resolve({ quads: derelativizeQuads(quads), prefixes: toIriMap(prefixes) });
+        resolve({ quads: derelativizeQuads(quads, base), prefixes: toIriMap(prefixes) });
         return;
       }
       quads.push(q);
@@ -205,6 +410,98 @@ export function serializeBucket(quads: Quad[], prefixes: Record<string, string>)
   });
 }
 
+// ---------------------------------------------------------------------------
+// IRI legality
+// ---------------------------------------------------------------------------
+
+/**
+ * The characters Turtle forbids inside `<...>`, straight from the grammar:
+ *
+ *   IRIREF ::= '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+ *   — https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+ *
+ * This is the W3C production, not a rule this project invented, and it is
+ * deliberately narrower than "is this a well-formed IRI": a NamedNode is only
+ * rejected when it cannot be SERIALIZED, so `/profile/card.ttl#me` (relative,
+ * and load-bearing for pod attribution) and `https://ex.org/café#me`
+ * (non-ASCII, legal in an IRI) both stay acceptable.
+ */
+const ILLEGAL_IRI_CHAR = /[\u0000-\u0020<>"{}|^`\\]/;
+
+/** The first character of `iri` that Turtle cannot write, if any. */
+export function findIllegalIriChar(iri: string): string | undefined {
+  return ILLEGAL_IRI_CHAR.exec(iri)?.[0];
+}
+
+/** An IRI a caller asked to mint cannot be written as Turtle. */
+export class UnwritableIriError extends Error {
+  readonly iri: string;
+
+  constructor(label: string, iri: string, offending: string) {
+    const codePoint = `U+${(offending.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, '0')}`;
+    super(
+      `Invalid IRI for ${label}: ${iri}\n` +
+        `  It contains ${codePoint}, which Turtle forbids inside <...> ` +
+        "(IRIREF ::= '<' ([^#x00-#x20<>\"{}|^`\\] | UCHAR)* '>').\n" +
+        `  Writing it would produce a bucket file that cannot be parsed, and every later ` +
+        `add-record, erase and import on that file would refuse. Nothing was written.`,
+    );
+    this.name = 'UnwritableIriError';
+    this.iri = iri;
+  }
+}
+
+/**
+ * Refuse an IRI that cannot be serialized, BEFORE a term is minted from it.
+ *
+ * Late is not good enough. A NamedNode holding a space serializes to
+ * `<https://ex.org/a b#me>`, which the next read cannot parse — and this
+ * module's own contract is that an unreadable bucket is never overwritten. So
+ * a single accepted typo takes the bucket out of service permanently, with no
+ * CLI repair path. Validating the INPUT is what keeps that unreachable.
+ *
+ * @param label how the value reached us, e.g. `--by` or a property CURIE.
+ * @throws {UnwritableIriError}
+ */
+export function assertWritableIri(iri: string, label: string): void {
+  const offending = findIllegalIriChar(iri);
+  if (offending !== undefined) throw new UnwritableIriError(label, iri, offending);
+}
+
+/** Walk one term, refusing any NamedNode (nested ones included) that cannot be written. */
+function assertWritableTerm(term: RuntimeTerm, file: string): void {
+  switch (term.termType) {
+    case 'NamedNode':
+      assertWritableIri(term.value, `a term of ${file}`);
+      return;
+    case 'Literal':
+      if (term.datatype) assertWritableIri(term.datatype.value, `a literal datatype of ${file}`);
+      return;
+    case 'Quad':
+      for (const t of [term.subject, term.predicate, term.object, term.graph]) {
+        assertWritableTerm(t as RuntimeTerm, file);
+      }
+      return;
+    default:
+      return;
+  }
+}
+
+/**
+ * The backstop for {@link assertWritableIri}: no document leaves this module
+ * unparseable, whatever the caller handed over.
+ *
+ * Commands validate their own inputs so the user gets an error naming the flag
+ * they typed. This catches the writer that forgets to.
+ */
+function assertWritableQuads(quads: Quad[], file: string): void {
+  for (const q of quads) {
+    for (const t of [q.subject, q.predicate, q.object, q.graph]) {
+      assertWritableTerm(t as RuntimeTerm, file);
+    }
+  }
+}
+
 /** How `newQuads` are combined with what the file already held. */
 export type BucketCombine = (existing: Quad[], incoming: Quad[]) => Quad[];
 
@@ -261,12 +558,19 @@ export async function mergeIntoBucket(
   let existingQuads: Quad[] = [];
   let filePrefixes: Record<string, string> = {};
 
+  // One sentinel for the whole operation: the same string that the existing
+  // document was parsed under is the one stripped off the merged result, so a
+  // caller handing over quads from its OWN parse (the reconciler's path) is
+  // covered by the same guarantee.
+  let relBaseUsed = relBase();
+
   if (existedBefore) {
     // A read failure (bad DEK, unreadable bytes) propagates untouched: it is
     // not a parse error and it must not be reported as one.
     const existing = readResource(targetFile, dek);
+    relBaseUsed = relBaseFor(existing);
     try {
-      const parsed = await parseBucketTurtle(existing);
+      const parsed = await parseBucketTurtle(existing, relBaseUsed);
       existingQuads = parsed.quads;
       filePrefixes = parsed.prefixes;
     } catch (e: unknown) {
@@ -280,7 +584,11 @@ export async function mergeIntoBucket(
   // are compact too.
   const prefixes = { ...KNOWN_PREFIXES, ...filePrefixes };
 
-  const merged = derelativizeQuads(normalizeBlankNodes(combine(existingQuads, newQuads)));
+  const merged = derelativizeQuads(normalizeBlankNodes(combine(existingQuads, newQuads)), relBaseUsed);
+  // Last gate before serialization. A term the strip did not reach must not be
+  // discovered later, because by then it is absolute and permanent.
+  assertNoSentinelLeak(merged);
+  assertWritableQuads(merged, targetFile);
   const turtle = await serializeBucket(merged, prefixes);
 
   options.validate?.(turtle, targetFile);

--- a/src/lib/bucket-write.ts
+++ b/src/lib/bucket-write.ts
@@ -1,0 +1,295 @@
+/**
+ * The single door every RECORD-DATA merge writes through.
+ *
+ * A pod bucket (`clinical/*.ttl`, `wellness/*.ttl`, `annotations/*.ttl`) is
+ * merged by read-modify-write. Doing that with text surgery has now produced
+ * the same shipped defect twice: a writer stripped the leading `@prefix` block,
+ * re-emitted a header of its OWN namespaces, and kept a body full of CURIEs
+ * whose prefixes it had just deleted. The file stopped parsing and the
+ * whole-pod read failed.
+ *
+ * This module makes that class of defect unrepresentable rather than fixed:
+ *
+ *   - No caller emits Turtle text. Callers hand over QUADS.
+ *   - One {@link Writer} owns the entire document, header included. An N3
+ *     writer emits a full `<IRI>` for any namespace it has no prefix for, so an
+ *     undeclared CURIE cannot be written.
+ *   - The prefixes the existing document DECLARED are harvested and win over
+ *     the CLI's own, so a bucket an importer wrote keeps the prefix names it
+ *     was written with and stays as compact as it was.
+ *   - An existing file that does not parse is a hard, named refusal
+ *     ({@link BucketParseError}). Nothing is written. Silently treating an
+ *     unreadable bucket as empty is how a corrupt file became a LOST file.
+ *
+ * NOT for human-curated scaffolding. `settings/publicTypeIndex.ttl`,
+ * `index.ttl`, `profile/card.ttl` and `profile/extended.ttl` are authored with
+ * comments that are load-bearing — `extended.ttl` regex-anchors PHI population
+ * on a literal comment line — and re-serializing them would drop those
+ * comments. The boundary is the one `pod-data-types.ts` already draws.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Parser, Writer, DataFactory } from 'n3';
+import type { Quad, Quad_Object, Quad_Subject } from 'n3';
+import { readResource, writeResource } from './pod-encryption.js';
+
+const { namedNode, blankNode, quad: makeQuad } = DataFactory;
+
+/**
+ * Namespaces the CLI itself can emit, so its own output stays compact.
+ *
+ * The first eleven are `fhir-converter/types.ts`'s `TURTLE_PREFIXES`, in its
+ * order, so a file the importer wrote and this module later rewrites keeps its
+ * header block in place. The last four are the namespaces only the record and
+ * overlay writers use (`add-record`, `amend`, `annotate`, `retract`, `erase`).
+ *
+ * A namespace absent here is not a hazard: the writer falls back to a full
+ * `<IRI>`. Adding one only changes how compactly it is written.
+ */
+export const KNOWN_PREFIXES: Record<string, string> = {
+  cascade: 'https://ns.cascadeprotocol.org/core/v1#',
+  health: 'https://ns.cascadeprotocol.org/health/v1#',
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+  coverage: 'https://ns.cascadeprotocol.org/coverage/v1#',
+  fhir: 'http://hl7.org/fhir/',
+  sct: 'http://snomed.info/sct/',
+  loinc: 'http://loinc.org/rdf#',
+  rxnorm: 'http://www.nlm.nih.gov/research/umls/rxnorm/',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+  prov: 'http://www.w3.org/ns/prov#',
+  vcard: 'http://www.w3.org/2006/vcard/ns#',
+  checkup: 'https://ns.cascadeprotocol.org/checkup/v1#',
+  pots: 'https://ns.cascadeprotocol.org/pots/v1#',
+  workbench: 'https://ns.cascadeprotocol.org/workbench/v1#',
+  dct: 'http://purl.org/dc/terms/',
+};
+
+/**
+ * Sentinel base IRI for round-trip-safe RELATIVE IRIs.
+ *
+ * A pod states attribution as a root-relative IRI: `add-record` writes
+ * `prov:wasAttributedTo </profile/card.ttl#me>`. These quads are re-serialized
+ * back to the SAME file, so a relative IRI has to come out exactly as it went
+ * in.
+ *
+ * `baseIRI: ''` — the mitigation `pod erase` shipped with — does NOT do that.
+ * N3's `_setBase('')` leaves `_baseRoot` undefined and `_resolveRelativeIRI`
+ * then computes `_baseRoot + iri`, so `</profile/card.ttl#me>` resolves to the
+ * literal string `"undefined/profile/card.ttl#me"`, and it is silent: the file
+ * still parses, it just says something else.
+ *
+ * A bare-scheme base makes N3's `_base`, `_basePath` and `_baseRoot` the same
+ * string, so every relative form (root-relative, doc-relative, empty `<>`,
+ * fragment-only `<#x>`) acquires exactly this one prefix, which
+ * {@link derelativizeQuads} strips back off on the way out.
+ */
+export const REL_BASE = 'x-cascade-rel:';
+
+/**
+ * An existing bucket file could not be read as Turtle.
+ *
+ * Thrown BEFORE anything is written. A bucket that does not parse is a bucket
+ * whose contents are unknown, and unknown is not empty.
+ */
+export class BucketParseError extends Error {
+  readonly file: string;
+
+  constructor(file: string, detail: string) {
+    super(
+      `Cannot read ${file} as Turtle: ${detail}\n` +
+        `  This file must parse before anything can be merged into it. ` +
+        `Nothing was written.`,
+    );
+    this.name = 'BucketParseError';
+    this.file = file;
+  }
+}
+
+/** Undo the {@link REL_BASE} sentinel on every IRI term of every quad. */
+export function derelativizeQuads(quads: Quad[]): Quad[] {
+  const strip = (value: string): string =>
+    value.startsWith(REL_BASE) ? value.slice(REL_BASE.length) : value;
+  return quads.map((q) => {
+    const s = q.subject.termType === 'NamedNode' && q.subject.value.startsWith(REL_BASE)
+      ? (namedNode(strip(q.subject.value)) as Quad_Subject)
+      : q.subject;
+    const p = q.predicate.value.startsWith(REL_BASE)
+      ? namedNode(strip(q.predicate.value))
+      : q.predicate;
+    const o = q.object.termType === 'NamedNode' && q.object.value.startsWith(REL_BASE)
+      ? (namedNode(strip(q.object.value)) as Quad_Object)
+      : q.object;
+    return s === q.subject && p === q.predicate && o === q.object ? q : makeQuad(s, p, o, q.graph);
+  });
+}
+
+/**
+ * Parse Turtle into quads AND the prefixes the document declared.
+ *
+ * Harvesting the document's own prefixes is what keeps a re-serialized bucket
+ * as compact and as recognisable as the writer that created it left it, and it
+ * is why a re-serializing merge cannot drop `rxnorm:`, `sct:` or `loinc:`.
+ */
+export function parseBucketTurtle(
+  turtle: string,
+): Promise<{ quads: Quad[]; prefixes: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
+    const quads: Quad[] = [];
+    parser.parse(turtle, (error, q, prefixes) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (!q) {
+        resolve({ quads: derelativizeQuads(quads), prefixes: toIriMap(prefixes) });
+        return;
+      }
+      quads.push(q);
+    });
+  });
+}
+
+/** N3 hands prefixes back as terms; the Writer wants plain namespace strings. */
+function toIriMap(prefixes: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!prefixes || typeof prefixes !== 'object') return out;
+  for (const [k, v] of Object.entries(prefixes as Record<string, unknown>)) {
+    if (typeof v === 'string') out[k] = v;
+    else if (v && typeof v === 'object' && 'value' in v) out[k] = String((v as { value: unknown }).value);
+  }
+  return out;
+}
+
+/**
+ * Rewrite blank-node labels to a bounded, deterministic sequence.
+ *
+ * N3's parser prefixes every label it reads with a fresh per-parse counter, so
+ * a round-tripped `_:b1` comes back as `_:b2_b1`, then `_:b3_b2_b1`. A bucket
+ * holding blank nodes would therefore grow on EVERY write, forever. Labels are
+ * document-scoped and carry no meaning across documents, so renumbering them in
+ * emission order is loss-free.
+ *
+ * No bucket contains a blank node today. This is the insurance that keeps that
+ * true if one ever does.
+ */
+export function normalizeBlankNodes(quads: Quad[]): Quad[] {
+  const seen = new Map<string, ReturnType<typeof blankNode>>();
+  const relabel = (label: string) => {
+    let next = seen.get(label);
+    if (!next) {
+      next = blankNode(`b${seen.size}`);
+      seen.set(label, next);
+    }
+    return next;
+  };
+  return quads.map((q) => {
+    if (q.subject.termType !== 'BlankNode' && q.object.termType !== 'BlankNode') return q;
+    const s = q.subject.termType === 'BlankNode'
+      ? (relabel(q.subject.value) as Quad_Subject)
+      : q.subject;
+    const o = q.object.termType === 'BlankNode'
+      ? (relabel(q.object.value) as Quad_Object)
+      : q.object;
+    return makeQuad(s, q.predicate, o, q.graph);
+  });
+}
+
+/** Serialize a whole bucket document: one Writer owns the header and the body. */
+export function serializeBucket(quads: Quad[], prefixes: Record<string, string>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const writer = new Writer({ prefixes });
+    for (const q of quads) writer.addQuad(q);
+    writer.end((error, result) => (error ? reject(error) : resolve(result)));
+  });
+}
+
+/** How `newQuads` are combined with what the file already held. */
+export type BucketCombine = (existing: Quad[], incoming: Quad[]) => Quad[];
+
+export interface MergeIntoBucketOptions {
+  /**
+   * Combine the parsed existing quads with the incoming ones. Defaults to
+   * append (`[...existing, ...incoming]`).
+   *
+   * A caller that needs subject-level deduplication, or that is REPLACING the
+   * file's contents wholesale (`pod erase`, a cross-batch reconciled import),
+   * supplies its own. It still runs behind the parse, so the refusal to write
+   * over an unreadable file holds for every caller.
+   */
+  combine?: BucketCombine;
+  /**
+   * Inspect the serialized document before it is written. Throwing aborts the
+   * write. `annotations/` uses this for its SHACL gate.
+   */
+  validate?: (turtle: string, filePath: string) => void;
+  /** Compute everything, write nothing. */
+  dryRun?: boolean;
+}
+
+export interface BucketWriteResult {
+  /** Whether the target existed before this write. */
+  existedBefore: boolean;
+  /** Triples parsed out of the existing file (0 when it did not exist). */
+  triplesBefore: number;
+  /** Triples in the document that was written. */
+  triplesAfter: number;
+  /** The serialized document (returned even under `dryRun`). */
+  turtle: string;
+  /** False under `dryRun`. */
+  written: boolean;
+}
+
+/**
+ * THE CHOKEPOINT. Merge `newQuads` into the record file at `targetFile`.
+ *
+ * Reads the existing file as a GRAPH, combines, and writes the whole document
+ * back through one serializer that owns the prefix header.
+ *
+ * @throws {BucketParseError} when the existing file is not valid Turtle.
+ * @throws {PodDecryptError}  when the existing file cannot be decrypted.
+ */
+export async function mergeIntoBucket(
+  targetFile: string,
+  newQuads: Quad[],
+  dek: Buffer | undefined,
+  options: MergeIntoBucketOptions = {},
+): Promise<BucketWriteResult> {
+  const existedBefore = fs.existsSync(targetFile);
+
+  let existingQuads: Quad[] = [];
+  let filePrefixes: Record<string, string> = {};
+
+  if (existedBefore) {
+    // A read failure (bad DEK, unreadable bytes) propagates untouched: it is
+    // not a parse error and it must not be reported as one.
+    const existing = readResource(targetFile, dek);
+    try {
+      const parsed = await parseBucketTurtle(existing);
+      existingQuads = parsed.quads;
+      filePrefixes = parsed.prefixes;
+    } catch (e: unknown) {
+      throw new BucketParseError(targetFile, e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  const combine = options.combine ?? ((existing, incoming) => [...existing, ...incoming]);
+  // The file's own declarations win, so a bucket keeps the prefix names it was
+  // written with; the CLI's namespaces are the floor, so the quads being added
+  // are compact too.
+  const prefixes = { ...KNOWN_PREFIXES, ...filePrefixes };
+
+  const merged = derelativizeQuads(normalizeBlankNodes(combine(existingQuads, newQuads)));
+  const turtle = await serializeBucket(merged, prefixes);
+
+  options.validate?.(turtle, targetFile);
+
+  if (options.dryRun) {
+    return { existedBefore, triplesBefore: existingQuads.length, triplesAfter: merged.length, turtle, written: false };
+  }
+
+  await fs.promises.mkdir(path.dirname(targetFile), { recursive: true });
+  writeResource(targetFile, turtle, dek);
+  return { existedBefore, triplesBefore: existingQuads.length, triplesAfter: merged.length, turtle, written: true };
+}

--- a/src/lib/pod-read.ts
+++ b/src/lib/pod-read.ts
@@ -282,11 +282,20 @@ export class PodReader {
    * read-only caller wants. A caller that RE-SERIALIZES the file it read must
    * pass `''` instead: absolutizing IRIs that were relative on disk would
    * rewrite the document as a side effect of reading it.
+   *
+   * A FUNCTION may be passed instead, and is handed the decrypted text before
+   * it is parsed. That is how the sentinel-base callers pick a base this
+   * document provably does not already contain — a choice that cannot be made
+   * from the outside, because only this method has the plaintext.
    */
-  parseFile(absPath: string, opts?: { baseIri?: string }): PodReadResult<ParseResult> {
+  parseFile(
+    absPath: string,
+    opts?: { baseIri?: string | ((text: string) => string) },
+  ): PodReadResult<ParseResult> {
     const text = this.readText(absPath);
     if (!text.ok) return text;
-    const result = parseTurtle(text.value, opts?.baseIri ?? `file://${absPath}`);
+    const baseIri = typeof opts?.baseIri === 'function' ? opts.baseIri(text.value) : opts?.baseIri;
+    const result = parseTurtle(text.value, baseIri ?? `file://${absPath}`);
     if (!result.success) {
       return { ok: false, failure: this.failure(absPath, 'parse', result.errors.join('; ')) };
     }

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -18,7 +18,7 @@ import {
 import { normalizeMedName, normalizeDose, normalizeFrequency, type DrugNameNormalizer } from './medication-normalize.js';
 import { medicationCodeKeys, sharedMedicationCodeKey } from './code-keys.js';
 import { cascadeTerminologyResolver } from './terminology.js';
-import { REL_BASE } from './bucket-write.js';
+import { relBase, relBaseFor, derelativizeQuads } from './bucket-write.js';
 
 // Re-export so existing consumers of the reconciler's normalizeMedName keep
 // working. The canonical definition now lives in ./medication-normalize.ts
@@ -164,8 +164,9 @@ export async function parseTurtle(turtle: string, defaultSystem: string): Promis
     // Sentinel base: pod content arrives here on its way back to the pod, and a
     // relative IRI must survive the trip. N3's default resolves
     // </profile/card.ttl#me> to "undefined/profile/card.ttl#me"; the sentinel is
-    // stripped back off at the bucket write chokepoint.
-    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
+    // stripped back off at the bucket write chokepoint. It is chosen against
+    // THIS text, so nothing the document itself says can be mistaken for it.
+    const parser = new Parser({ format: 'Turtle', baseIRI: relBaseFor(turtle) });
     const bySubject = new Map<string, Array<{ pred: string; obj: RdfValue }>>();
 
     parser.parse(turtle, (error, quad) => {
@@ -232,7 +233,7 @@ async function collectQuads(turtle: string): Promise<{ passthrough: Quad[]; all:
     // Same sentinel base as parseTurtle above: passthrough subjects are copied
     // verbatim into the reconciled output, so their relative IRIs must not be
     // rewritten on the way through.
-    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
+    const parser = new Parser({ format: 'Turtle', baseIRI: relBaseFor(turtle) });
     const quadsBySubject = new Map<string, Quad[]>();
     const all: Quad[] = [];
 
@@ -1301,6 +1302,15 @@ async function serializeGroups(
     const writer = new Writer({ prefixes: TURTLE_PREFIXES });
     let edgeObjectsRewritten = 0;
 
+    // The sentinel base is a private detail of ONE parse. It must not survive
+    // into this text: the next stage re-parses this output under a base chosen
+    // for THAT text, so a sentinel that arrives already attached is never
+    // resolved, never stripped, and lands on disk absolute and permanent. Every
+    // quad leaves here derelativized, which keeps the invariant global — no
+    // Turtle this CLI produces, intermediate or final, mentions the sentinel.
+    const base = relBase();
+    const emit = (q: Quad): void => { writer.addQuad(derelativizeQuads([q], base)[0]); };
+
     // Redirect a NamedNode edge object that points at a merged-away (discarded)
     // subject to its surviving canonical subject; lineage predicates are left
     // dangling by design (see LINEAGE_PREDICATES). Returns the IRI to serialize
@@ -1318,11 +1328,11 @@ async function serializeGroups(
       if (q.object.termType === 'NamedNode') {
         const rewritten = rewriteEdgeIri(q.predicate.value, q.object.value);
         if (rewritten !== q.object.value) {
-          writer.addQuad(makeQuad(q.subject, q.predicate, namedNode(rewritten)));
+          emit(makeQuad(q.subject, q.predicate, namedNode(rewritten)));
           continue;
         }
       }
-      writer.addQuad(q);
+      emit(q);
     }
 
     for (let i = 0; i < groups.length; i++) {
@@ -1348,7 +1358,7 @@ async function serializeGroups(
               ? literal(val.value, namedNode(val.datatype))
               : literal(val.value);
           if (LINEAGE_PREDICATES.has(pred)) emittedLineage.add(`${pred}|${obj.value}`);
-          writer.addQuad(makeQuad(subj, namedNode(pred), obj));
+          emit(makeQuad(subj, namedNode(pred), obj));
         }
       }
 
@@ -1357,8 +1367,8 @@ async function serializeGroups(
         : g.matchType === 'pass_through' ? 'canonical'
         : (g.matchType === 'status_conflict' || g.matchType === 'value_conflict') ? 'conflict-resolved'
         : 'merged';
-      writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'reconciliationStatus'), literal(status)));
-      writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(res.canonical.sourceSystem)));
+      emit(makeQuad(subj, namedNode(NS.cascade + 'reconciliationStatus'), literal(status)));
+      emit(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(res.canonical.sourceSystem)));
 
       if (g.matchType !== 'pass_through' && res.mergedUris.length > 1) {
         for (const srcUri of res.mergedUris) {
@@ -1367,15 +1377,15 @@ async function serializeGroups(
             // once, not once per re-import.
             if (emittedLineage.has(`${pred}|${srcUri}`)) continue;
             emittedLineage.add(`${pred}|${srcUri}`);
-            writer.addQuad(makeQuad(subj, namedNode(pred), namedNode(srcUri)));
+            emit(makeQuad(subj, namedNode(pred), namedNode(srcUri)));
           }
         }
-        writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'mergedSources'), literal(res.mergedSystems.join(', '))));
-        writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'conflictResolution'), literal(res.strategy)));
-        if (g.conflictField) writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'conflictField'), literal(g.conflictField)));
+        emit(makeQuad(subj, namedNode(NS.cascade + 'mergedSources'), literal(res.mergedSystems.join(', '))));
+        emit(makeQuad(subj, namedNode(NS.cascade + 'conflictResolution'), literal(res.strategy)));
+        if (g.conflictField) emit(makeQuad(subj, namedNode(NS.cascade + 'conflictField'), literal(g.conflictField)));
         if (g.conflictValues) {
           const valDesc = Object.entries(g.conflictValues).map(([s, v]) => `${s}: "${v}"`).join(' vs ');
-          writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'conflictValues'), literal(valDesc)));
+          emit(makeQuad(subj, namedNode(NS.cascade + 'conflictValues'), literal(valDesc)));
         }
       }
     }

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -18,6 +18,7 @@ import {
 import { normalizeMedName, normalizeDose, normalizeFrequency, type DrugNameNormalizer } from './medication-normalize.js';
 import { medicationCodeKeys, sharedMedicationCodeKey } from './code-keys.js';
 import { cascadeTerminologyResolver } from './terminology.js';
+import { REL_BASE } from './bucket-write.js';
 
 // Re-export so existing consumers of the reconciler's normalizeMedName keep
 // working. The canonical definition now lives in ./medication-normalize.ts
@@ -141,6 +142,14 @@ interface RdfValue {
   value: string;
   /** xsd:* datatype URI for typed literals; undefined for URIs and plain strings */
   datatype?: string;
+  /**
+   * True when the object was a NamedNode. Recorded at parse time because the
+   * re-emission below otherwise has to GUESS from the string, and its guess
+   * ("starts with http or urn:") demotes every other scheme to a literal —
+   * which is how a pod's `prov:wasAttributedTo </profile/card.ttl#me>` came
+   * back from an import as the string "undefined/profile/card.ttl#me".
+   */
+  isIri?: boolean;
 }
 
 interface ParsedRecord {
@@ -152,7 +161,11 @@ interface ParsedRecord {
 
 export async function parseTurtle(turtle: string, defaultSystem: string): Promise<ParsedRecord[]> {
   return new Promise((resolve, reject) => {
-    const parser = new Parser({ format: 'Turtle' });
+    // Sentinel base: pod content arrives here on its way back to the pod, and a
+    // relative IRI must survive the trip. N3's default resolves
+    // </profile/card.ttl#me> to "undefined/profile/card.ttl#me"; the sentinel is
+    // stripped back off at the bucket write chokepoint.
+    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
     const bySubject = new Map<string, Array<{ pred: string; obj: RdfValue }>>();
 
     parser.parse(turtle, (error, quad) => {
@@ -186,7 +199,7 @@ export async function parseTurtle(turtle: string, defaultSystem: string): Promis
       const obj = quad.object;
       const rdfVal: RdfValue = obj.termType === 'Literal' && obj.datatype?.value && obj.datatype.value !== NS.xsd + 'string'
         ? { value: obj.value, datatype: obj.datatype.value }
-        : { value: obj.value };
+        : { value: obj.value, isIri: obj.termType === 'NamedNode' };
       bySubject.get(subj)!.push({ pred: quad.predicate.value, obj: rdfVal });
     });
   });
@@ -216,7 +229,10 @@ export async function parseTurtle(turtle: string, defaultSystem: string): Promis
  */
 async function collectQuads(turtle: string): Promise<{ passthrough: Quad[]; all: Quad[] }> {
   return new Promise((resolve, reject) => {
-    const parser = new Parser({ format: 'Turtle' });
+    // Same sentinel base as parseTurtle above: passthrough subjects are copied
+    // verbatim into the reconciled output, so their relative IRIs must not be
+    // rewritten on the way through.
+    const parser = new Parser({ format: 'Turtle', baseIRI: REL_BASE });
     const quadsBySubject = new Map<string, Quad[]>();
     const all: Quad[] = [];
 
@@ -1322,7 +1338,10 @@ async function serializeGroups(
         // Re-derived below for every record; a carried-over copy would double it.
         if (RECONCILER_DERIVED_PREDICATES.has(pred)) continue;
         for (const val of vals) {
-          const isIri = val.value.startsWith('http') || val.value.startsWith('urn:');
+          // What the source term ACTUALLY was, when we recorded it. The
+          // string-shape guess is only the fallback for values this reconciler
+          // derived itself rather than parsed.
+          const isIri = val.isIri ?? (val.value.startsWith('http') || val.value.startsWith('urn:'));
           const obj = isIri
             ? namedNode(rewriteEdgeIri(pred, val.value))
             : val.datatype

--- a/tests/bucket-write-sentinel-safety.test.ts
+++ b/tests/bucket-write-sentinel-safety.test.ts
@@ -1,0 +1,526 @@
+/**
+ * The sentinel base must be invisible to pod data, in BOTH directions.
+ *
+ * `src/lib/bucket-write.ts` parses a bucket under a sentinel base IRI so that a
+ * relative IRI survives a re-serialization round trip. That sentinel is an
+ * internal implementation detail of one parse, and two properties have to hold
+ * for it to stay one:
+ *
+ *   INBOUND  — untrusted document text can never be mistaken for the sentinel.
+ *              An IRI that merely LOOKS like the sentinel is a different, real,
+ *              absolute resource; stripping it re-identifies someone's data.
+ *              Reachable from third-party Turtle via `pod import`.
+ *
+ *   OUTBOUND — the sentinel can never survive into a written document. It is
+ *              sticky if it does: once `"5"^^<x-cascade-rel:myLocalType>` is on
+ *              disk that datatype IRI is ABSOLUTE, so no later parse resolves it
+ *              and no later strip removes it. The corruption is permanent.
+ *
+ * Both were live defects. The fixtures below are the verified reproductions.
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser, DataFactory } from 'n3';
+import type { Quad } from 'n3';
+import {
+  mergeIntoBucket,
+  relBase,
+  relBaseFor,
+  derelativizeQuads,
+  assertNoSentinelLeak,
+  pickSentinelBase,
+  SentinelLeakError,
+} from '../src/lib/bucket-write.js';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { runReconciliation } from '../src/lib/reconciler.js';
+
+const { namedNode, literal, quad: makeQuad } = DataFactory;
+
+const NS = {
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+};
+
+/**
+ * Every sentinel-shaped string an attacker could plausibly try, including the
+ * exact literal the first implementation used. None of these may ever be
+ * treated as "this term was relative in the source".
+ */
+const HOSTILE_IRIS: Array<[string, string]> = [
+  ['a real absolute IRI smuggled behind the sentinel scheme', 'x-cascade-rel:http://real.example/thing'],
+  ['a bare local name', 'x-cascade-rel:foo'],
+  ['an empty local part', 'x-cascade-rel:'],
+  ['a fragment-only local part', 'x-cascade-rel:#f'],
+  ['a nonce-shaped scheme', 'x-cascade-rel-0123456789abcdef0123456789abcdef:evil'],
+];
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-sentinel-'));
+});
+afterEach(() => {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function seed(content: string, name = 'medications.ttl'): string {
+  const p = path.join(tmp, name);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+function strictParse(turtle: string): Quad[] {
+  return new Parser({ format: 'Turtle' }).parse(turtle);
+}
+
+function recordQuads(uri = 'urn:uuid:NEW'): Quad[] {
+  const s = namedNode(uri);
+  return [
+    makeQuad(s, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Medication')),
+    makeQuad(s, namedNode(NS.clinical + 'drugName'), literal('Vitamin D')),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// INBOUND: a document that looks like the sentinel is not the sentinel
+// ---------------------------------------------------------------------------
+
+describe('sentinel collision: untrusted text is never re-identified', () => {
+  for (const [label, iri] of HOSTILE_IRIS) {
+    it(`keeps ${label} in SUBJECT position byte-exact`, async () => {
+      const p = seed(`<${iri}> <urn:p> "v".\n`);
+      await mergeIntoBucket(p, recordQuads(), undefined);
+      const subjects = strictParse(fs.readFileSync(p, 'utf-8')).map((q) => q.subject.value);
+      expect(subjects, `subject ${iri} was rewritten`).toContain(iri);
+    });
+
+    it(`keeps ${label} in OBJECT position byte-exact`, async () => {
+      const p = seed(`<urn:s> <urn:p> <${iri}>.\n`);
+      await mergeIntoBucket(p, recordQuads(), undefined);
+      const objects = strictParse(fs.readFileSync(p, 'utf-8')).map((q) => q.object.value);
+      expect(objects, `object ${iri} was rewritten`).toContain(iri);
+    });
+
+    it(`keeps ${label} in PREDICATE position byte-exact`, async () => {
+      const p = seed(`<urn:s> <${iri}> "v".\n`);
+      await mergeIntoBucket(p, recordQuads(), undefined);
+      const predicates = strictParse(fs.readFileSync(p, 'utf-8')).map((q) => q.predicate.value);
+      expect(predicates, `predicate ${iri} was rewritten`).toContain(iri);
+    });
+  }
+
+  it('does not re-identify a resource into a DIFFERENT absolute resource', async () => {
+    // The sharp edge. Stripping turns a statement about an x-cascade-rel:
+    // resource into a statement about `http://real.example/thing` — a real
+    // resource on a real host that the document never mentioned.
+    const p = seed(`<x-cascade-rel:http://real.example/thing> <urn:p> "v".\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const subjects = strictParse(fs.readFileSync(p, 'utf-8')).map((q) => q.subject.value);
+    expect(subjects).not.toContain('http://real.example/thing');
+  });
+
+  it('is stable: a hostile IRI survives five successive merges unchanged', async () => {
+    const p = seed(`<x-cascade-rel:http://real.example/thing> <urn:p> <x-cascade-rel:foo>.\n`);
+    for (let i = 0; i < 5; i++) {
+      await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
+      const quads = strictParse(fs.readFileSync(p, 'utf-8'));
+      const hit = quads.find((q) => q.predicate.value === 'urn:p');
+      expect(hit?.subject.value, `merge ${i + 1}`).toBe('x-cascade-rel:http://real.example/thing');
+      expect(hit?.object.value, `merge ${i + 1}`).toBe('x-cascade-rel:foo');
+    }
+  });
+
+  it('still resolves genuinely relative IRIs while refusing the lookalikes', async () => {
+    // Both properties at once: the real relative IRI round-trips as a relative
+    // IRI, and the lookalike beside it is untouched.
+    const p = seed(`<urn:s> <urn:p> </profile/card.ttl#me>; <urn:q> <x-cascade-rel:foo>.\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).toContain('</profile/card.ttl#me>');
+    expect(out).toContain('<x-cascade-rel:foo>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OUTBOUND: the sentinel never reaches disk, from ANY term position
+// ---------------------------------------------------------------------------
+
+/** Any IRI in the sentinel FAMILY, whatever nonce it carries. */
+const SENTINEL_RE = /x-cascade-rel/;
+
+describe('sentinel leak: no term position lets the sentinel reach disk', () => {
+  const RELATIVE_IN_EVERY_POSITION: Array<[string, string]> = [
+    ['subject', `</records/1> <urn:p> "v".`],
+    ['predicate', `<urn:s> </vocab#p> "v".`],
+    ['object', `<urn:s> <urn:p> </profile/card.ttl#me>.`],
+    // The leak that shipped: a literal's DATATYPE is a NamedNode too.
+    ['literal datatype', `<urn:s> <urn:p> "5"^^<myLocalType>.`],
+    ['literal datatype, doc-relative', `<urn:s> <urn:p> "5"^^<vocab/myType>.`],
+    ['literal datatype, fragment-only', `<urn:s> <urn:p> "5"^^<#myType>.`],
+    ['literal datatype, empty', `<urn:s> <urn:p> "5"^^<>.`],
+    ['inside a collection', `<urn:s> <urn:p> ( </a> </b> ).`],
+    ['inside a blank node', `<urn:s> <urn:p> [ <urn:q> </a>; <urn:r> "5"^^<myType> ].`],
+  ];
+
+  for (const [label, ttl] of RELATIVE_IN_EVERY_POSITION) {
+    it(`does not leak the sentinel from a relative IRI in ${label}`, async () => {
+      const p = seed(ttl + '\n');
+      await mergeIntoBucket(p, recordQuads(), undefined);
+      expect(fs.readFileSync(p, 'utf-8')).not.toMatch(SENTINEL_RE);
+    });
+
+    it(`keeps ${label} stable, and unpolluted, across three writes`, async () => {
+      // Stickiness is what makes this permanent: once the sentinel is on disk
+      // the IRI is ABSOLUTE, so no later parse resolves it and no later strip
+      // removes it. One contaminated write is forever.
+      const p = seed(ttl + '\n');
+      for (let i = 0; i < 3; i++) {
+        await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
+        expect(fs.readFileSync(p, 'utf-8'), `write ${i + 1}`).not.toMatch(SENTINEL_RE);
+      }
+    });
+  }
+
+  it('preserves the relative datatype IRI exactly, not just "not the sentinel"', async () => {
+    const p = seed(`<urn:s> <urn:p> "5"^^<myLocalType>.\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).toContain('^^<myLocalType>');
+    const dt = strictParse(out).find((q) => q.predicate.value === 'urn:p');
+    expect(dt?.object.termType).toBe('Literal');
+    expect((dt?.object as { datatype: { value: string } }).datatype.value).toBe('myLocalType');
+  });
+
+  it('keeps a language tag intact while covering the datatype', async () => {
+    // rdf:langString is absolute, so it must survive untouched — and the
+    // language must not be dropped by whatever rebuilds the literal.
+    const p = seed(`<urn:s> <urn:p> "hola"@es; <urn:q> "5"^^<myLocalType>.\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).toContain('"hola"@es');
+    expect(out).not.toMatch(SENTINEL_RE);
+  });
+
+  it('sweeps every emitted term of a document that is relative throughout', async () => {
+    const p = seed(
+      `</records/1> </vocab#p> </profile/card.ttl#me>.\n` +
+      `</records/1> </vocab#q> "5"^^<myType>.\n` +
+      `</records/1> </vocab#r> [ </vocab#s> <#frag> ].\n`,
+    );
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).not.toMatch(SENTINEL_RE);
+    for (const q of strictParse(out)) {
+      for (const v of [q.subject.value, q.predicate.value, q.object.value, q.graph.value]) {
+        expect(v).not.toMatch(SENTINEL_RE);
+      }
+      if (q.object.termType === 'Literal') {
+        expect(q.object.datatype.value).not.toMatch(SENTINEL_RE);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The sentinel itself: shape, unguessability, and the coverage tripwire
+// ---------------------------------------------------------------------------
+
+describe('the sentinel is a per-process nonce, not a literal', () => {
+  it('is unguessable: 128 random bits in the scheme', () => {
+    // A fixed literal is forgeable, and forging it re-identifies a resource.
+    // Only entropy makes "this term starts with the base" mean "N3 resolved it".
+    expect(relBase()).toMatch(/^x-cascade-rel-[0-9a-f]{32}:$/);
+  });
+
+  it('is a BARE SCHEME, which is what makes root-relative IRIs resolvable', () => {
+    // N3 resolves a root-relative `</x>` against `_baseRoot`, which it derives
+    // as `/^(?:([a-z][a-z0-9+.-]*:))?(?:\/\/[^/]*)?/i`. Anything with structure
+    // after the scheme (`urn:x-cascade-rel-<nonce>:`) makes `_baseRoot` just
+    // `urn:`, so `</profile/card.ttl#me>` resolves to `urn:/profile/card.ttl#me`
+    // — no sentinel, never stripped, silently a different resource.
+    const base = relBase();
+    expect(base.indexOf(':')).toBe(base.length - 1);
+    expect(base).not.toContain('/');
+    expect(base.slice(0, -1)).toMatch(/^[a-z][a-z0-9+.-]*$/);
+  });
+
+  it('actually round-trips all four relative forms through a real parse', async () => {
+    // The property the bare-scheme shape exists to buy, asserted end to end
+    // rather than by reading the regex.
+    const p = seed(
+      `<urn:s> <urn:a> </profile/card.ttl#me>; <urn:b> <profile/card.ttl>; <urn:c> <>; <urn:d> <#me>.\n`,
+    );
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    for (const form of ['</profile/card.ttl#me>', '<profile/card.ttl>', '<>', '<#me>']) {
+      expect(out, `relative form ${form} was rewritten`).toContain(form);
+    }
+    expect(out).not.toMatch(SENTINEL_RE);
+  });
+
+  it('regenerates rather than reusing a base the source text already contains', () => {
+    // Belt and braces on top of the entropy: the guarantee is not "an attacker
+    // is unlikely to collide", it is "a collision cannot happen", because a
+    // text holding the active base never gets parsed under it.
+    const before = relBase();
+    const chosen = relBaseFor(`<${before}evil> <urn:p> "v".`);
+    expect(chosen).not.toBe(before);
+    expect(chosen).toMatch(/^x-cascade-rel-[0-9a-f]{32}:$/);
+    // ...and a text that does NOT contain it keeps the process base stable, so
+    // quads already in flight under it are still stripped.
+    expect(relBaseFor('<urn:s> <urn:p> "v".')).toBe(chosen);
+  });
+
+  it('keeps the current base when the text does not contain it', () => {
+    expect(pickSentinelBase('nothing to see here', 'A:', () => 'B:')).toBe('A:');
+  });
+
+  it('draws again when the text does contain it', () => {
+    expect(pickSentinelBase('this has A: in it', 'A:', () => 'B:')).toBe('B:');
+  });
+
+  it('gives up rather than spinning when minting stops being random', () => {
+    // The retry has to be BOUNDED. It terminates only because minting is
+    // random — a property of another function entirely. Point it at a mint
+    // that always returns the same colliding value and an unbounded loop hangs
+    // the CLI forever, silently, on any input containing the sentinel. Not
+    // hypothetical: mutating the nonce back to a fixed literal to test this
+    // module's own tripwires burned 22 minutes of CPU in exactly this hang.
+    expect(() => pickSentinelBase('text with FIXED: inside', 'FIXED:', () => 'FIXED:'))
+      .toThrow(/draws|random/);
+  });
+
+  it('never lets a superseded base slip through unnoticed', () => {
+    // After a regeneration, a quad still carrying the OLD base is not stripped
+    // by the new one. It must not be written either.
+    const stale = relBase();
+    relBaseFor(`<${stale}x> <urn:p> "v".`);
+    expect(relBase()).not.toBe(stale);
+    expect(() => assertNoSentinelLeak([
+      makeQuad(namedNode(stale + '/records/1'), namedNode('urn:p'), literal('v')),
+    ])).toThrow(SentinelLeakError);
+  });
+});
+
+describe('the leak assertion is a real tripwire, not decoration', () => {
+  /** A term that MENTIONS the sentinel without starting with it, so no strip applies. */
+  const smuggled = () => 'http://ex.org/' + relBase();
+
+  it('throws rather than writing a term that still mentions the sentinel', async () => {
+    const p = path.join(tmp, 'x.ttl');
+    await expect(
+      mergeIntoBucket(p, [makeQuad(namedNode('urn:s'), namedNode('urn:p'), namedNode(smuggled()))], undefined),
+    ).rejects.toBeInstanceOf(SentinelLeakError);
+    expect(fs.existsSync(p)).toBe(false);
+  });
+
+  it('leaves an existing bucket byte-identical when it fires', async () => {
+    const p = seed(`<urn:uuid:OLD> <urn:p> "v".\n`);
+    const before = fs.readFileSync(p);
+    await expect(
+      mergeIntoBucket(p, [makeQuad(namedNode('urn:s'), namedNode('urn:p'), namedNode(smuggled()))], undefined),
+    ).rejects.toBeInstanceOf(SentinelLeakError);
+    expect(fs.readFileSync(p).equals(before)).toBe(true);
+  });
+
+  it('catches a leak in every term position, datatype and graph included', () => {
+    const s = namedNode('urn:s');
+    const p = namedNode('urn:p');
+    const cases: Array<[string, Quad]> = [
+      ['subject', makeQuad(namedNode(smuggled()), p, literal('v'))],
+      ['predicate', makeQuad(s, namedNode(smuggled()), literal('v'))],
+      ['object', makeQuad(s, p, namedNode(smuggled()))],
+      ['literal datatype', makeQuad(s, p, literal('5', namedNode(smuggled())))],
+      ['literal lexical form', makeQuad(s, p, literal(smuggled()))],
+      ['graph', makeQuad(s, p, literal('v'), namedNode(smuggled()))],
+    ];
+    for (const [label, q] of cases) {
+      expect(() => assertNoSentinelLeak([q]), `${label} leak was not caught`).toThrow(SentinelLeakError);
+    }
+  });
+
+  it('passes clean quads, including ones that merely look sentinel-ish', () => {
+    expect(() => assertNoSentinelLeak([
+      ...recordQuads(),
+      makeQuad(namedNode('x-cascade-rel:foo'), namedNode('urn:p'), literal('v')),
+      makeQuad(namedNode('urn:s'), namedNode('urn:p'), literal('5', namedNode('myLocalType'))),
+    ])).not.toThrow();
+  });
+});
+
+describe('no Turtle this CLI produces mentions the sentinel, intermediate included', () => {
+  it('the reconciler derelativizes its own output before handing it on', async () => {
+    // The reconciler parses pod text under the sentinel and re-serializes. Its
+    // output is INTERMEDIATE — `pod import` re-parses it — so a sentinel left
+    // attached here is never resolved by that second parse, never stripped, and
+    // reaches disk absolute and permanent. Keeping the invariant global (no
+    // Turtle at all, at any stage) is what makes `relBaseFor`'s "the source
+    // never contains the base" precondition true everywhere.
+    const { turtle } = await runReconciliation([
+      {
+        systemName: 'test',
+        content:
+          `@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#>.\n` +
+          `@prefix prov: <http://www.w3.org/ns/prov#>.\n` +
+          `<urn:uuid:A> a clinical:Medication; clinical:drugName "Metformin";\n` +
+          `  prov:wasAttributedTo </profile/card.ttl#me>.\n` +
+          `<urn:uuid:B> <urn:p> </records/passthrough>.\n`,
+      },
+    ]);
+    expect(turtle).not.toMatch(SENTINEL_RE);
+    // ...and the relative IRIs came back out relative, in both a reconciled
+    // record and a passthrough subject.
+    expect(turtle).toContain('</profile/card.ttl#me>');
+    expect(turtle).toContain('</records/passthrough>');
+  }, 60_000);
+});
+
+describe('derelativizeQuads covers every term position', () => {
+  it('strips the sentinel from subject, predicate, object, datatype and graph', () => {
+    const base = relBase();
+    const q = makeQuad(
+      namedNode(base + '/records/1'),
+      namedNode(base + '/vocab#p'),
+      literal('5', namedNode(base + 'myType')),
+      namedNode(base + '/graphs/g'),
+    );
+    const [out] = derelativizeQuads([q], base);
+    expect(out.subject.value).toBe('/records/1');
+    expect(out.predicate.value).toBe('/vocab#p');
+    expect((out.object as { datatype: { value: string } }).datatype.value).toBe('myType');
+    expect(out.graph.value).toBe('/graphs/g');
+  });
+
+  it('keeps a language tag when it rebuilds a literal', () => {
+    const base = relBase();
+    const [out] = derelativizeQuads(
+      [makeQuad(namedNode('urn:s'), namedNode(base + 'p'), literal('hola', 'es'))],
+      base,
+    );
+    expect(out.object.value).toBe('hola');
+    expect((out.object as { language: string }).language).toBe('es');
+  });
+
+  it('recurses into a nested RDF-star quad term', () => {
+    // Reachable: `turtle-parser.ts` leaves `format` unset, which turns n3's
+    // RDF-star support ON, and `pod erase` reads through it.
+    const base = relBase();
+    const inner = makeQuad(namedNode(base + '/records/1'), namedNode('urn:q'), literal('v'));
+    const outer = makeQuad(namedNode('urn:s'), namedNode('urn:p'), inner as unknown as ReturnType<typeof namedNode>);
+    const [out] = derelativizeQuads([outer], base);
+    const nested = out.object as unknown as Quad;
+    expect(nested.subject.value).toBe('/records/1');
+    expect(() => assertNoSentinelLeak([out])).not.toThrow();
+  });
+
+  it('is a no-op on a term that only LOOKS like the sentinel', () => {
+    const q = makeQuad(namedNode('x-cascade-rel:foo'), namedNode('urn:p'), literal('v'));
+    expect(derelativizeQuads([q], relBase())[0]).toBe(q);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end, through the vector that was actually reachable
+// ---------------------------------------------------------------------------
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await buildProgram().parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws; exitCode carries the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+/**
+ * The reproduction, verbatim: third-party Turtle carrying a sentinel-shaped
+ * subject, a sentinel-shaped object and a relative datatype, imported into a
+ * clean pod. Exit 0 and "Records imported: 1" is what made it silent.
+ */
+const THIRD_PARTY_TURTLE = `@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#>.
+<x-cascade-rel:http://real.example/thing> a clinical:Medication;
+    clinical:drugName "Aspirin";
+    clinical:code <x-cascade-rel:http://registry.example/code/1>;
+    clinical:dosage "5"^^<myLocalType>.
+`;
+
+describe('end to end: pod import of third-party Turtle', () => {
+  it('neither re-identifies the subject nor leaks the sentinel into the datatype', async () => {
+    const podDir = path.join(tmp, 'pod');
+    const input = path.join(tmp, 'third-party.ttl');
+    fs.writeFileSync(input, THIRD_PARTY_TURTLE, 'utf-8');
+
+    expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+    expect((await runCli(['pod', 'import', podDir, input])).exitCode).toBe(0);
+
+    const bucket = fs.readFileSync(path.join(podDir, 'clinical', 'medications.ttl'), 'utf-8');
+    // INBOUND: the subject and the coded object are still the resources the
+    // source named, not the absolute resources hiding behind the scheme.
+    expect(bucket).toContain('<x-cascade-rel:http://real.example/thing>');
+    expect(bucket).toContain('<x-cascade-rel:http://registry.example/code/1>');
+    expect(bucket).not.toContain('<http://real.example/thing>');
+    expect(bucket).not.toContain('<http://registry.example/code/1>');
+    // OUTBOUND: the relative datatype came back relative.
+    expect(bucket).toContain('^^<myLocalType>');
+    expect(bucket).not.toContain('^^<x-cascade-rel');
+  }, 60_000);
+
+  it('survives a later add-record without contaminating or rewriting anything', async () => {
+    // Stickiness is only visible on the SECOND write: an absolute
+    // x-cascade-rel: datatype is never resolved again, so it can never be
+    // cleaned up by a later pass.
+    const podDir = path.join(tmp, 'pod');
+    const input = path.join(tmp, 'third-party.ttl');
+    fs.writeFileSync(input, THIRD_PARTY_TURTLE, 'utf-8');
+
+    await runCli(['pod', 'init', podDir]);
+    await runCli(['pod', 'import', podDir, input]);
+    const add = await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+    expect(add.exitCode).toBe(0);
+
+    const bucket = fs.readFileSync(path.join(podDir, 'clinical', 'medications.ttl'), 'utf-8');
+    expect(bucket).toContain('<x-cascade-rel:http://real.example/thing>');
+    expect(bucket).toContain('^^<myLocalType>');
+    expect(bucket).not.toContain('^^<x-cascade-rel');
+    // The pod's own relative WebID still round-trips.
+    expect(bucket).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+  }, 60_000);
+});

--- a/tests/bucket-write.test.ts
+++ b/tests/bucket-write.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Unit acceptance for the bucket write chokepoint (`src/lib/bucket-write.ts`).
+ *
+ * The defect this replaces: a record-data writer stripped every leading
+ * `@prefix` line, re-emitted a header of its OWN namespaces, and kept a body
+ * full of CURIEs whose prefixes it had just deleted. `medications.ttl` written
+ * by an import (which declares `rxnorm:`) stopped parsing the moment a
+ * hand-entered record landed in it, and one unreadable bucket fails the whole
+ * pod read.
+ *
+ * The guarantee under test is structural, not "we remembered the five missing
+ * prefixes": the writer owns the whole document, so a CURIE whose prefix is
+ * undeclared is unrepresentable. These tests pin the properties that guarantee
+ * rests on — prefix harvesting, relative-IRI stability, blank-node label
+ * bounding, and the refusal to write over a file that does not parse.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser, DataFactory } from 'n3';
+import type { Quad } from 'n3';
+import {
+  mergeIntoBucket,
+  BucketParseError,
+  KNOWN_PREFIXES,
+  REL_BASE,
+  derelativizeQuads,
+  normalizeBlankNodes,
+  parseBucketTurtle,
+} from '../src/lib/bucket-write.js';
+import { generateDek, readResource } from '../src/lib/pod-encryption.js';
+
+const { namedNode, literal, blankNode, quad: makeQuad } = DataFactory;
+
+const NS = {
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+  cascade: 'https://ns.cascadeprotocol.org/core/v1#',
+  prov: 'http://www.w3.org/ns/prov#',
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+};
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-bucketwrite-'));
+});
+afterEach(() => {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function file(name = 'medications.ttl'): string {
+  return path.join(tmp, name);
+}
+
+function seed(content: string, name = 'medications.ttl'): string {
+  const p = file(name);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+/** One self-reported Medication, exactly as `pod add-record` builds it. */
+function recordQuads(uri = 'urn:uuid:NEW', drug = 'Vitamin D'): Quad[] {
+  const s = namedNode(uri);
+  return [
+    makeQuad(s, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Medication')),
+    makeQuad(s, namedNode(NS.clinical + 'drugName'), literal(drug)),
+    makeQuad(s, namedNode(NS.cascade + 'dataProvenance'), namedNode(NS.cascade + 'SelfReported')),
+    // Root-relative on purpose: this is the pod's patient WebID.
+    makeQuad(s, namedNode(NS.prov + 'wasAttributedTo'), namedNode('/profile/card.ttl#me')),
+  ];
+}
+
+/** Strict re-parse. Throws exactly the way the whole-pod read would. */
+function strictParse(turtle: string): Quad[] {
+  return new Parser({ format: 'Turtle' }).parse(turtle);
+}
+
+function quadKey(q: Quad): string {
+  const o = q.object.termType === 'Literal'
+    ? `L:${q.object.value}|${q.object.datatype?.value ?? ''}|${q.object.language ?? ''}`
+    : `${q.object.termType}:${q.object.value}`;
+  return `${q.subject.termType}:${q.subject.value}|${q.predicate.value}|${o}`;
+}
+
+/** Quad-set comparison that ignores blank-node LABELS (not RDF-significant). */
+function sameGraph(a: Quad[], b: Quad[]): boolean {
+  const norm = (qs: Quad[]) =>
+    new Set(qs.map((q) => quadKey(q).replace(/BlankNode:[^|]+/g, 'BlankNode:B')));
+  const sa = norm(a);
+  const sb = norm(b);
+  return sa.size === sb.size && [...sa].every((k) => sb.has(k));
+}
+
+// ---------------------------------------------------------------------------
+// The regression: an importer's prefixes must survive a hand-entered record
+// ---------------------------------------------------------------------------
+
+/**
+ * A bucket exactly as `pod import` leaves it: CURIEs from four registries the
+ * record writers have never heard of.
+ */
+const IMPORTED_BUCKET = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#>.
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#>.
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#>.
+@prefix rxnorm: <http://www.nlm.nih.gov/research/umls/rxnorm/>.
+@prefix sct: <http://snomed.info/sct/>.
+@prefix loinc: <http://loinc.org/rdf#>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<urn:uuid:OLD> a clinical:Medication;
+    clinical:rxNormCode rxnorm:860975;
+    clinical:code sct:73211009;
+    clinical:labCode loinc:2345-7;
+    vcard:hasNote "imported";
+    health:startDate "2024-01-15T00:00:00Z"^^xsd:dateTime.
+`;
+
+describe('mergeIntoBucket: the existing document keeps the prefixes it declared', () => {
+  it('leaves an imported bucket parseable after a record is merged in', async () => {
+    const p = seed(IMPORTED_BUCKET);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+
+    const out = fs.readFileSync(p, 'utf-8');
+    // The whole point: a STRICT parse, which is what the whole-pod read does.
+    expect(() => strictParse(out)).not.toThrow();
+    expect(strictParse(out)).toHaveLength(10);
+  });
+
+  it('keeps every registry prefix the file declared and the CURIEs that use them', async () => {
+    const p = seed(IMPORTED_BUCKET);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+
+    for (const prefix of ['rxnorm', 'sct', 'loinc', 'vcard']) {
+      expect(out, `@prefix ${prefix}: was dropped`).toContain(`@prefix ${prefix}:`);
+    }
+    expect(out).toContain('rxnorm:860975');
+    expect(out).toContain('sct:73211009');
+    expect(out).toContain('loinc:2345-7');
+  });
+
+  it('preserves a declared prefix even when nothing in the file uses it', async () => {
+    // A writer that emitted only the prefixes IT could see would silently drop
+    // this, which is invisible until the next record uses the namespace.
+    const p = seed(
+      `@prefix mine: <http://alice.example/vocab#>.\n@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#>.\n<urn:uuid:OLD> a clinical:Medication.\n`,
+    );
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    expect(fs.readFileSync(p, 'utf-8')).toContain('@prefix mine: <http://alice.example/vocab#>');
+  });
+
+  it('keeps a USED namespace KNOWN_PREFIXES has never heard of written as a CURIE', async () => {
+    // This is what harvesting actually buys. The four registries the shipped
+    // defect deleted are now in KNOWN_PREFIXES, so they would survive either
+    // way; a namespace outside it (NDC, ATC, ICD-10, a genomics advisory
+    // vocabulary, a user's own) only stays compact because the document's own
+    // declarations are read back and re-emitted.
+    const p = seed(
+      `@prefix ndc: <http://hl7.org/fhir/sid/ndc/>.\n` +
+      `@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#>.\n` +
+      `<urn:uuid:OLD> a clinical:Medication; clinical:ndcCode ndc:0093-1023.\n`,
+    );
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).toContain('@prefix ndc: <http://hl7.org/fhir/sid/ndc/>');
+    expect(out).toContain('ndc:0093-1023');
+  });
+
+  it('lets the file win when it binds a Cascade prefix name to another namespace', async () => {
+    // The file's `clinical:` is NOT the Cascade clinical namespace. The merged
+    // record must not be silently re-bound to the file's meaning, and the
+    // file's own records must not be re-bound to Cascade's.
+    const hostile = `@prefix clinical: <http://example.org/private-clinical#>.
+<urn:uuid:OLD> a clinical:Medication; clinical:drugName "Aspirin".
+`;
+    const p = seed(hostile);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+
+    const quads = strictParse(fs.readFileSync(p, 'utf-8'));
+    const typeOf = (s: string) =>
+      quads.find((q) => q.subject.value === s && q.predicate.value === NS.rdf + 'type')?.object.value;
+    expect(typeOf('urn:uuid:OLD')).toBe('http://example.org/private-clinical#Medication');
+    expect(typeOf('urn:uuid:NEW')).toBe(NS.clinical + 'Medication');
+  });
+
+  it('writes a full <IRI> rather than an undeclared CURIE for an unknown namespace', async () => {
+    // The structural guarantee. There is no way to emit `weird:Thing` without a
+    // declaration, because the writer decides the abbreviation, not the caller.
+    const p = file();
+    const s = namedNode('urn:uuid:X');
+    await mergeIntoBucket(p, [makeQuad(s, namedNode('http://weird.example/v9#p'), literal('v'))], undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).toContain('<http://weird.example/v9#p>');
+    expect(() => strictParse(out)).not.toThrow();
+  });
+
+  it('is stable: repeated merges neither duplicate nor drop a declaration', async () => {
+    const p = seed(IMPORTED_BUCKET);
+    for (let i = 0; i < 5; i++) {
+      await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
+    }
+    const out = fs.readFileSync(p, 'utf-8');
+    for (const prefix of ['rxnorm', 'sct', 'loinc', 'vcard', 'clinical', 'cascade']) {
+      const count = (out.match(new RegExp(`@prefix ${prefix}:`, 'g')) ?? []).length;
+      expect(count, `@prefix ${prefix}: declared ${count} times`).toBe(1);
+    }
+    expect(strictParse(out)).toHaveLength(6 + 5 * 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refusal: an unreadable bucket is never overwritten
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: an existing file that does not parse is a refusal', () => {
+  /** The exact field state: a body whose CURIE prefixes were deleted. */
+  const CORRUPT = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#>.
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#>.
+
+<urn:uuid:OLD> a clinical:Medication;
+    clinical:rxNormCode rxnorm:860975.
+`;
+
+  it('throws BucketParseError and leaves the file byte-identical', async () => {
+    const p = seed(CORRUPT);
+    const before = fs.readFileSync(p);
+
+    await expect(mergeIntoBucket(p, recordQuads(), undefined)).rejects.toBeInstanceOf(BucketParseError);
+    expect(fs.readFileSync(p).equals(before)).toBe(true);
+  });
+
+  it('names the file and the underlying reason', async () => {
+    const p = seed(CORRUPT);
+    const err = await mergeIntoBucket(p, recordQuads(), undefined).catch((e) => e as BucketParseError);
+    expect(err).toBeInstanceOf(BucketParseError);
+    expect(err.file).toBe(p);
+    expect(err.message).toContain(p);
+    expect(err.message).toMatch(/rxnorm/);
+    expect(err.message).toMatch(/[Nn]othing was written/);
+  });
+
+  it('refuses on outright garbage too', async () => {
+    const p = seed('<<< this is not turtle &&& ');
+    const before = fs.readFileSync(p);
+    await expect(mergeIntoBucket(p, recordQuads(), undefined)).rejects.toBeInstanceOf(BucketParseError);
+    expect(fs.readFileSync(p).equals(before)).toBe(true);
+  });
+
+  it('does not create the file when the merge is refused', async () => {
+    // Belt and braces: the refusal happens before any mkdir/write.
+    const p = seed(CORRUPT, 'nested/deep/meds.ttl');
+    await expect(mergeIntoBucket(p, recordQuads(), undefined)).rejects.toThrow();
+    expect(fs.readdirSync(path.dirname(p))).toEqual(['meds.ttl']);
+  });
+
+  it('writes nothing when the validate hook rejects the merged document', async () => {
+    const p = seed(IMPORTED_BUCKET);
+    const before = fs.readFileSync(p);
+    await expect(
+      mergeIntoBucket(p, recordQuads(), undefined, {
+        validate: () => { throw new Error('SHACL says no'); },
+      }),
+    ).rejects.toThrow(/SHACL says no/);
+    expect(fs.readFileSync(p).equals(before)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Relative IRIs
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: relative IRIs come out exactly as they went in', () => {
+  const FORMS: Array<[string, string]> = [
+    ['root-relative', '</profile/card.ttl#me>'],
+    ['doc-relative', '<profile/card.ttl>'],
+    ['empty', '<>'],
+    ['fragment-only', '<#me>'],
+  ];
+
+  for (const [label, iri] of FORMS) {
+    it(`preserves a ${label} IRI across six successive writes`, async () => {
+      const p = seed(`@prefix prov: <http://www.w3.org/ns/prov#>.\n<urn:uuid:OLD> prov:wasAttributedTo ${iri}.\n`);
+      for (let i = 0; i < 6; i++) {
+        await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
+        const out = fs.readFileSync(p, 'utf-8');
+        // Assert on the IRI TEXT. `baseIRI: ''` still produced a parseable
+        // file; it just said "undefined/profile/card.ttl#me" instead.
+        expect(out, `write ${i + 1}`).toContain(`prov:wasAttributedTo ${iri}`);
+        expect(out, `write ${i + 1}`).not.toContain('undefined/');
+      }
+    });
+  }
+
+  it('never lets the sentinel base reach disk', async () => {
+    const p = seed(`<urn:uuid:OLD> <urn:p> </profile/card.ttl#me>.\n`);
+    for (let i = 0; i < 3; i++) await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
+    expect(fs.readFileSync(p, 'utf-8')).not.toContain(REL_BASE);
+  });
+
+  it('strips the sentinel from quads a CALLER supplies, not only from what it parsed', async () => {
+    // Defence in depth, and the reason the strip runs on the MERGED list rather
+    // than only inside the parse: `pod erase` and `pod import` hand over quads
+    // that travelled through their own parsers. If one of them ever stops
+    // derelativizing, the sentinel must still not reach disk.
+    const p = file();
+    await mergeIntoBucket(p, [
+      makeQuad(
+        namedNode(REL_BASE + '/records/1'),
+        namedNode('urn:p'),
+        namedNode(REL_BASE + '/profile/card.ttl#me'),
+      ),
+    ], undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(out).not.toContain(REL_BASE);
+    expect(out).toContain('</profile/card.ttl#me>');
+    expect(out).toContain('</records/1>');
+  });
+
+  it('leaves absolute IRIs untouched', async () => {
+    const p = seed(`<urn:uuid:OLD> <urn:p> <https://example.org/a?q=1&r=2#f>.\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    expect(fs.readFileSync(p, 'utf-8')).toContain('<https://example.org/a?q=1&r=2#f>');
+  });
+
+  it('resolves a document @base and then states the result absolutely', async () => {
+    // Documented consequence, pinned so it cannot change silently: `@base` is a
+    // parse-time directive the writer does not re-emit, so the IRIs it resolved
+    // are written out in full. Semantics are preserved; the directive is not.
+    const p = seed(`@base <https://pod.example/alice/>.\n<records/1> <urn:p> <urn:o>.\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const quads = strictParse(fs.readFileSync(p, 'utf-8'));
+    expect(quads.some((q) => q.subject.value === 'https://pod.example/alice/records/1')).toBe(true);
+  });
+
+  it('derelativizeQuads is a no-op on quads that carry no sentinel', () => {
+    const qs = recordQuads();
+    expect(derelativizeQuads(qs)).toEqual(qs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blank nodes
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: blank-node labels stay bounded', () => {
+  it('does not grow labels across ten successive writes', async () => {
+    // N3's parser prefixes each label it reads with a fresh counter, so without
+    // normalization `_:b1` becomes `_:b2_b1`, `_:b3_b2_b1`, ... forever.
+    const p = seed(`<urn:uuid:OLD> <urn:p> [ <urn:q> "deep" ].\n`);
+    for (let i = 0; i < 10; i++) await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
+
+    const out = fs.readFileSync(p, 'utf-8');
+    const labels = [...out.matchAll(/_:([A-Za-z0-9_]+)/g)].map((m) => m[1]);
+    for (const l of labels) {
+      expect(l.length, `blank-node label "${l}" is growing`).toBeLessThanOrEqual(4);
+    }
+    // The seed is 2 triples (the record and the blank node's own statement).
+    expect(strictParse(out).length).toBe(2 + 10 * 4);
+  });
+
+  it('preserves blank-node structure, including cycles and shared nodes', async () => {
+    const p = seed(`_:x <urn:p> _:y. _:y <urn:p> _:x. <urn:uuid:OLD> <urn:r> _:x.\n`);
+    const before = strictParse(fs.readFileSync(p, 'utf-8'));
+    await mergeIntoBucket(p, [], undefined);
+    const after = strictParse(fs.readFileSync(p, 'utf-8'));
+    expect(sameGraph(before, after)).toBe(true);
+  });
+
+  it('normalizeBlankNodes renumbers deterministically and loses nothing', () => {
+    const a = blankNode('long_label_from_a_previous_parse');
+    const b = blankNode('another_long_one');
+    const qs = [
+      makeQuad(a, namedNode('urn:p'), b),
+      makeQuad(b, namedNode('urn:p'), a),
+    ];
+    const out = normalizeBlankNodes(qs);
+    expect(out.map((q) => q.subject.value)).toEqual(['b0', 'b1']);
+    expect(out.map((q) => q.object.value)).toEqual(['b1', 'b0']);
+    expect(normalizeBlankNodes(qs)).toEqual(out);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lexical fidelity of everything a bucket could hold
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: round-trip fidelity of Turtle a bucket could hold', () => {
+  const CASES: Record<string, string> = {
+    'xsd:dateTime canonical': `<urn:uuid:a> <urn:p> "2026-08-07T16:27:35.613Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>.`,
+    'xsd:dateTime with offset': `<urn:uuid:a> <urn:p> "2026-08-07T09:27:35.613-07:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>.`,
+    'xsd:date': `<urn:uuid:a> <urn:p> "2026-08-07"^^<http://www.w3.org/2001/XMLSchema#date>.`,
+    'integer shorthand': `<urn:uuid:a> <urn:p> 42.`,
+    'decimal shorthand': `<urn:uuid:a> <urn:p> 3.140.`,
+    'double shorthand': `<urn:uuid:a> <urn:p> 1.0e6.`,
+    'xsd:integer leading zeros': `<urn:uuid:a> <urn:p> "007"^^<http://www.w3.org/2001/XMLSchema#integer>.`,
+    'boolean shorthand': `<urn:uuid:a> <urn:p> true.`,
+    'language tag': `<urn:uuid:a> <urn:p> "hola"@es.`,
+    'language tag with region': `<urn:uuid:a> <urn:p> "colour"@en-GB.`,
+    'plain string': `<urn:uuid:a> <urn:p> "plain".`,
+    'explicit xsd:string': `<urn:uuid:a> <urn:p> "plain"^^<http://www.w3.org/2001/XMLSchema#string>.`,
+    'literal with newline': `<urn:uuid:a> <urn:p> "line1\\nline2".`,
+    'literal with quote and backslash': `<urn:uuid:a> <urn:p> "he said \\"hi\\" \\\\ done".`,
+    'literal with tab and CR': `<urn:uuid:a> <urn:p> "a\\tb\\rc".`,
+    'triple-quoted long string': `<urn:uuid:a> <urn:p> """multi\nline\nnote""".`,
+    'unicode literal': `<urn:uuid:a> <urn:p> "café 😀 日本語".`,
+    'escaped unicode literal': `<urn:uuid:a> <urn:p> "\\u0041\\u00E9".`,
+    'empty literal': `<urn:uuid:a> <urn:p> "".`,
+    'IRI with percent-encoding': `<urn:uuid:a> <urn:p> <http://ex.org/a%20b%2Fc>.`,
+    'IRI with query and fragment': `<urn:uuid:a> <urn:p> <http://ex.org/p?q=1&r=2#frag>.`,
+    'RDF collection': `<urn:uuid:a> <urn:p> ( "1" "2" "3" ).`,
+    'nested blank nodes': `<urn:uuid:a> <urn:p> [ <urn:q> [ <urn:r> "deep" ] ].`,
+    'duplicate triple': `<urn:uuid:a> <urn:p> "v". <urn:uuid:a> <urn:p> "v".`,
+    'CURIE with escaped dash': `@prefix p: <http://ex.org/>.\n<urn:uuid:a> p:has\\-dash "v".`,
+    'a vs rdf:type': `<urn:uuid:a> a <http://ex.org/T>.`,
+    'multiple subjects': `<urn:uuid:a> <urn:p> "1". <urn:uuid:b> <urn:p> "2".`,
+  };
+
+  for (const [name, ttl] of Object.entries(CASES)) {
+    it(`preserves: ${name}`, async () => {
+      const p = seed(ttl + '\n');
+      const before = strictParse(fs.readFileSync(p, 'utf-8'));
+      await mergeIntoBucket(p, [], undefined);
+      const after = strictParse(fs.readFileSync(p, 'utf-8'));
+      expect(after.length).toBeGreaterThan(0);
+      expect(sameGraph(before, after), `${name}: graph changed`).toBe(true);
+    });
+  }
+
+  it('is a fixed point: a second merge of nothing changes nothing', async () => {
+    const p = seed(IMPORTED_BUCKET);
+    await mergeIntoBucket(p, [], undefined);
+    const once = fs.readFileSync(p, 'utf-8');
+    await mergeIntoBucket(p, [], undefined);
+    expect(fs.readFileSync(p, 'utf-8')).toBe(once);
+  });
+
+  it('DOES lose comments — which is why scaffolding files must not route here', async () => {
+    // Pinned as a known, deliberate loss. `profile/extended.ttl` anchors its PHI
+    // population on a literal comment line, so routing it through this chokepoint
+    // would permanently break that. The boundary is not cosmetic.
+    const p = seed(`# a load-bearing comment\n<urn:uuid:a> <urn:p> "v".\n`);
+    await mergeIntoBucket(p, [], undefined);
+    expect(fs.readFileSync(p, 'utf-8')).not.toContain('load-bearing comment');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Degenerate documents
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: degenerate documents', () => {
+  it('creates the file, and its parent directories, when it does not exist', async () => {
+    const p = path.join(tmp, 'clinical', 'medications.ttl');
+    const res = await mergeIntoBucket(p, recordQuads(), undefined);
+    expect(res.existedBefore).toBe(false);
+    expect(res.triplesBefore).toBe(0);
+    expect(res.triplesAfter).toBe(4);
+    expect(() => strictParse(fs.readFileSync(p, 'utf-8'))).not.toThrow();
+  });
+
+  it('handles an empty file', async () => {
+    const p = seed('');
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    expect(strictParse(fs.readFileSync(p, 'utf-8'))).toHaveLength(4);
+  });
+
+  it('handles a whitespace-only file', async () => {
+    const p = seed('   \n\n\t \n');
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    expect(strictParse(fs.readFileSync(p, 'utf-8'))).toHaveLength(4);
+  });
+
+  it('handles a header-only file with no statements', async () => {
+    const p = seed(`@prefix rxnorm: <http://www.nlm.nih.gov/research/umls/rxnorm/>.\n`);
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(strictParse(out)).toHaveLength(4);
+    expect(out).toContain('@prefix rxnorm:');
+  });
+
+  it('handles a header that appears AFTER statements (legal Turtle)', async () => {
+    const p = seed(
+      `<urn:uuid:A> <urn:p> <urn:o>.\n@prefix rxnorm: <http://www.nlm.nih.gov/research/umls/rxnorm/>.\n<urn:uuid:B> <urn:p> rxnorm:1.\n`,
+    );
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(() => strictParse(out)).not.toThrow();
+    expect(out).toContain('@prefix rxnorm:');
+    expect(out).toContain('rxnorm:1');
+  });
+
+  it('handles SPARQL-style PREFIX declarations', async () => {
+    const p = seed(
+      `PREFIX rxnorm: <http://www.nlm.nih.gov/research/umls/rxnorm/>\n<urn:uuid:OLD> <urn:p> rxnorm:1.\n`,
+    );
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(() => strictParse(out)).not.toThrow();
+    expect(out).toContain('rxnorm:1');
+  });
+
+  it('writes an empty document when every quad is combined away', async () => {
+    // `pod erase` of the last record in a bucket.
+    const p = seed(IMPORTED_BUCKET);
+    await mergeIntoBucket(p, [], undefined, { combine: () => [] });
+    const out = fs.readFileSync(p, 'utf-8');
+    expect(strictParse(out)).toHaveLength(0);
+    expect(() => strictParse(out)).not.toThrow();
+  });
+
+  it('parseBucketTurtle reports the prefixes a document declared', async () => {
+    const { quads, prefixes } = await parseBucketTurtle(IMPORTED_BUCKET);
+    expect(quads).toHaveLength(6);
+    expect(prefixes.rxnorm).toBe('http://www.nlm.nih.gov/research/umls/rxnorm/');
+    expect(prefixes.loinc).toBe('http://loinc.org/rdf#');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dryRun and encryption
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: dryRun and encrypted pods', () => {
+  it('computes the document but writes nothing under dryRun', async () => {
+    const p = seed(IMPORTED_BUCKET);
+    const before = fs.readFileSync(p);
+    const res = await mergeIntoBucket(p, recordQuads(), undefined, { dryRun: true });
+    expect(res.written).toBe(false);
+    expect(res.triplesAfter).toBe(10);
+    expect(res.turtle).toContain('@prefix rxnorm:');
+    expect(fs.readFileSync(p).equals(before)).toBe(true);
+  });
+
+  it('still refuses an unreadable file under dryRun', async () => {
+    const p = seed(`@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#>.\n<urn:uuid:O> <urn:p> rxnorm:1.\n`);
+    await expect(mergeIntoBucket(p, recordQuads(), undefined, { dryRun: true }))
+      .rejects.toBeInstanceOf(BucketParseError);
+  });
+
+  it('is transparent over an encrypted resource', async () => {
+    const dek = generateDek();
+    const p = file();
+    await mergeIntoBucket(p, recordQuads('urn:uuid:A'), dek);
+    // Ciphertext on disk: the plaintext must not be readable.
+    expect(fs.readFileSync(p).toString('utf-8')).not.toContain('Vitamin D');
+    // ...and a second merge reads it back, keeping both records.
+    await mergeIntoBucket(p, recordQuads('urn:uuid:B', 'Magnesium'), dek);
+    const plain = readResource(p, dek);
+    expect(plain).toContain('Vitamin D');
+    expect(plain).toContain('Magnesium');
+    expect(strictParse(plain)).toHaveLength(8);
+    expect(plain).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The prefix registry
+// ---------------------------------------------------------------------------
+
+describe('KNOWN_PREFIXES', () => {
+  it('covers every namespace the record and overlay writers emit', () => {
+    for (const p of ['cascade', 'health', 'clinical', 'coverage', 'checkup', 'pots', 'workbench', 'fhir', 'prov', 'dct', 'xsd']) {
+      expect(KNOWN_PREFIXES[p], `${p} missing`).toBeTruthy();
+    }
+  });
+
+  it('covers the registries the importer writes, so an import round-trip stays compact', () => {
+    for (const p of ['sct', 'loinc', 'rxnorm', 'vcard']) {
+      expect(KNOWN_PREFIXES[p], `${p} missing`).toBeTruthy();
+    }
+  });
+
+  it('binds cascade: and core: to the same namespace as the rest of the CLI', () => {
+    expect(KNOWN_PREFIXES.cascade).toBe('https://ns.cascadeprotocol.org/core/v1#');
+  });
+});

--- a/tests/bucket-write.test.ts
+++ b/tests/bucket-write.test.ts
@@ -27,12 +27,13 @@ import {
   mergeIntoBucket,
   BucketParseError,
   KNOWN_PREFIXES,
-  REL_BASE,
+  relBase,
   derelativizeQuads,
   normalizeBlankNodes,
   parseBucketTurtle,
 } from '../src/lib/bucket-write.js';
 import { generateDek, readResource } from '../src/lib/pod-encryption.js';
+import { TURTLE_PREFIXES } from '../src/lib/fhir-converter/types.js';
 
 const { namedNode, literal, blankNode, quad: makeQuad } = DataFactory;
 
@@ -181,11 +182,21 @@ describe('mergeIntoBucket: the existing document keeps the prefixes it declared'
     const p = seed(hostile);
     await mergeIntoBucket(p, recordQuads(), undefined);
 
-    const quads = strictParse(fs.readFileSync(p, 'utf-8'));
+    const out = fs.readFileSync(p, 'utf-8');
+    const quads = strictParse(out);
     const typeOf = (s: string) =>
       quads.find((q) => q.subject.value === s && q.predicate.value === NS.rdf + 'type')?.object.value;
     expect(typeOf('urn:uuid:OLD')).toBe('http://example.org/private-clinical#Medication');
     expect(typeOf('urn:uuid:NEW')).toBe(NS.clinical + 'Medication');
+
+    // PRECEDENCE, asserted on the TEXT. `{...KNOWN_PREFIXES, ...filePrefixes}`
+    // can be written the other way round and the assertions above cannot tell:
+    // both spellings denote the same graph, so a strict parse is identical
+    // either way. Only the header says which binding won, and the module's
+    // contract is that the file's own declarations do — that is what keeps a
+    // bucket recognisable as the document its writer left behind.
+    expect(out).toContain('@prefix clinical: <http://example.org/private-clinical#>');
+    expect(out).not.toContain(`@prefix clinical: <${NS.clinical}>`);
   });
 
   it('writes a full <IRI> rather than an undeclared CURIE for an unknown namespace', async () => {
@@ -197,6 +208,26 @@ describe('mergeIntoBucket: the existing document keeps the prefixes it declared'
     const out = fs.readFileSync(p, 'utf-8');
     expect(out).toContain('<http://weird.example/v9#p>');
     expect(() => strictParse(out)).not.toThrow();
+  });
+
+  it('APPENDS: what the file already held stays put, byte for byte, at the front', async () => {
+    // The default combine is `[...existing, ...incoming]`. Prepending, or
+    // sorting, keeps every graph-level assertion in this file green and keeps
+    // `pod-import-reimport-idempotence` green too — that suite compares import
+    // N against import N+1 under the SAME build, so any consistent order is
+    // idempotent by construction. Nothing else notices that every record in
+    // every bucket moved. A whole-file diff on the next write is not a
+    // cosmetic difference for a document users read and version.
+    const p = seed(IMPORTED_BUCKET);
+    await mergeIntoBucket(p, [], undefined);
+    const before = fs.readFileSync(p, 'utf-8');
+
+    await mergeIntoBucket(p, recordQuads(), undefined);
+    const after = fs.readFileSync(p, 'utf-8');
+
+    expect(after.startsWith(before), 'the existing document was rewritten, not appended to').toBe(true);
+    expect(after.length).toBeGreaterThan(before.length);
+    expect(after.slice(before.length)).toContain('Vitamin D');
   });
 
   it('is stable: repeated merges neither duplicate nor drop a declaration', async () => {
@@ -299,7 +330,7 @@ describe('mergeIntoBucket: relative IRIs come out exactly as they went in', () =
   it('never lets the sentinel base reach disk', async () => {
     const p = seed(`<urn:uuid:OLD> <urn:p> </profile/card.ttl#me>.\n`);
     for (let i = 0; i < 3; i++) await mergeIntoBucket(p, recordQuads(`urn:uuid:N${i}`), undefined);
-    expect(fs.readFileSync(p, 'utf-8')).not.toContain(REL_BASE);
+    expect(fs.readFileSync(p, 'utf-8')).not.toContain(relBase());
   });
 
   it('strips the sentinel from quads a CALLER supplies, not only from what it parsed', async () => {
@@ -310,13 +341,13 @@ describe('mergeIntoBucket: relative IRIs come out exactly as they went in', () =
     const p = file();
     await mergeIntoBucket(p, [
       makeQuad(
-        namedNode(REL_BASE + '/records/1'),
+        namedNode(relBase() + '/records/1'),
         namedNode('urn:p'),
-        namedNode(REL_BASE + '/profile/card.ttl#me'),
+        namedNode(relBase() + '/profile/card.ttl#me'),
       ),
     ], undefined);
     const out = fs.readFileSync(p, 'utf-8');
-    expect(out).not.toContain(REL_BASE);
+    expect(out).not.toContain(relBase());
     expect(out).toContain('</profile/card.ttl#me>');
     expect(out).toContain('</records/1>');
   });
@@ -577,5 +608,45 @@ describe('KNOWN_PREFIXES', () => {
 
   it('binds cascade: and core: to the same namespace as the rest of the CLI', () => {
     expect(KNOWN_PREFIXES.cascade).toBe('https://ns.cascadeprotocol.org/core/v1#');
+  });
+
+  it('opens with TURTLE_PREFIXES, in TURTLE_PREFIXES\' order', () => {
+    // The doc comment states this contract, and reversing all fifteen entries
+    // leaves the whole suite green, so nothing enforced it.
+    //
+    // What the order actually buys, stated precisely so it is not over-claimed:
+    // an N3 Writer emits declarations in insertion order, so matching the
+    // importer's order keeps a bucket an OLDER CLI wrote from having its whole
+    // header block reshuffled the first time this module rewrites it. It is
+    // diff-churn control. It is NOT what keeps the re-import idempotence suite
+    // byte-stable — that compares two runs of the same build, which agree on
+    // any order.
+    expect(Object.keys(KNOWN_PREFIXES).slice(0, Object.keys(TURTLE_PREFIXES).length))
+      .toEqual(Object.keys(TURTLE_PREFIXES));
+    for (const [name, ns] of Object.entries(TURTLE_PREFIXES)) {
+      expect(KNOWN_PREFIXES[name], `${name} bound differently from the importer`).toBe(ns);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A read failure is not a parse failure
+// ---------------------------------------------------------------------------
+
+describe('mergeIntoBucket: a read failure is never reported as a parse failure', () => {
+  it('propagates a wrong-DEK failure untouched instead of blaming the file', async () => {
+    // Moving `readResource` inside the try/catch keeps the whole suite green
+    // while turning "your passphrase is wrong" into "this file is not valid
+    // Turtle: ... Nothing was written." That tells a user to repair, or delete,
+    // a bucket that is perfectly intact — the worst possible advice, given the
+    // file is ciphertext they cannot inspect to check.
+    const p = file();
+    await mergeIntoBucket(p, recordQuads('urn:uuid:A'), generateDek());
+
+    const err = await mergeIntoBucket(p, recordQuads('urn:uuid:B'), generateDek())
+      .then(() => undefined, (e: unknown) => e);
+    expect(err, 'a merge under the wrong DEK must not succeed').toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(BucketParseError);
+    expect((err as Error).message).not.toMatch(/as Turtle/);
   });
 });

--- a/tests/pod-add-record-iri-validation.test.ts
+++ b/tests/pod-add-record-iri-validation.test.ts
@@ -1,0 +1,271 @@
+/**
+ * A user-supplied IRI that cannot be written as Turtle must be refused, not
+ * minted.
+ *
+ * `pod add-record --by 'https://ex.org/a b#me'` and a property CURIE whose local
+ * part contains a space (`{"clinical:drug Name":"x"}`) both used to mint a
+ * NamedNode containing a space, serialize it as `<https://ex.org/a b#me>`, and
+ * exit 0. Turtle's IRIREF production forbids those characters, so the bucket
+ * that came back was unparseable.
+ *
+ * That was survivable while writers rebuilt the header by text surgery. It is
+ * not survivable now: every later `add-record`, `erase` and `import` on that
+ * bucket refuses (correctly — an unreadable bucket must never be overwritten),
+ * so one typo bricks the bucket permanently and the CLI has no repair verb. The
+ * refusal has to happen BEFORE the term is minted.
+ *
+ * The rule under test is Turtle's own, not one this project invented:
+ *   IRIREF ::= '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+
+const MEDS = path.join('clinical', 'medications.ttl');
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await buildProgram().parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws; exitCode carries the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+let tmpDirs: string[] = [];
+function mkPodDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-iri-'));
+  tmpDirs.push(d);
+  return path.join(d, 'pod');
+}
+afterEach(() => {
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  tmpDirs = [];
+});
+
+async function initPod(): Promise<string> {
+  const podDir = mkPodDir();
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+  return podDir;
+}
+
+function addRecord(podDir: string, extra: string[], json = '{"clinical:drugName":"Vitamin D"}') {
+  return runCli(['pod', 'add-record', podDir, '--type', 'clinical:Medication', '--json', json, ...extra]);
+}
+
+/** Every character Turtle's IRIREF production forbids, plus the reported case. */
+const ILLEGAL: Array<[string, string]> = [
+  ['a space', 'https://ex.org/a b#me'],
+  ['a tab', 'https://ex.org/a\tb#me'],
+  ['a newline', 'https://ex.org/a\nb#me'],
+  ['a NUL', 'https://ex.org/a\u0000b#me'],
+  ['an angle bracket', 'https://ex.org/a<b#me'],
+  ['a closing angle bracket', 'https://ex.org/a>b#me'],
+  ['a double quote', 'https://ex.org/a"b#me'],
+  ['a brace', 'https://ex.org/a{b}#me'],
+  ['a pipe', 'https://ex.org/a|b#me'],
+  ['a caret', 'https://ex.org/a^b#me'],
+  ['a backtick', 'https://ex.org/a`b#me'],
+  ['a backslash', 'https://ex.org/a\\b#me'],
+];
+
+describe('pod add-record --by: an unwritable IRI is refused before it is minted', () => {
+  for (const [label, iri] of ILLEGAL) {
+    it(`refuses --by containing ${label}`, async () => {
+      const podDir = await initPod();
+      const res = await addRecord(podDir, ['--by', iri]);
+      expect(res.exitCode, `--by ${JSON.stringify(iri)} was accepted`).toBe(1);
+    });
+  }
+
+  it('names the offending value in the error', async () => {
+    const podDir = await initPod();
+    const res = await addRecord(podDir, ['--by', 'https://ex.org/a b#me']);
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain('https://ex.org/a b#me');
+    expect(res.stdout).toMatch(/--by/);
+  });
+
+  it('writes no bucket file at all', async () => {
+    const podDir = await initPod();
+    await addRecord(podDir, ['--by', 'https://ex.org/a b#me']);
+    expect(fs.existsSync(path.join(podDir, MEDS))).toBe(false);
+  });
+
+  it('leaves an EXISTING bucket byte-identical and still parseable', async () => {
+    const podDir = await initPod();
+    expect((await addRecord(podDir, [])).exitCode).toBe(0);
+    const before = fs.readFileSync(path.join(podDir, MEDS));
+
+    const res = await addRecord(podDir, ['--by', 'https://ex.org/a b#me']);
+    expect(res.exitCode).toBe(1);
+    const after = fs.readFileSync(path.join(podDir, MEDS));
+    expect(after.equals(before)).toBe(true);
+    expect(() => new Parser({ format: 'Turtle' }).parse(after.toString('utf-8'))).not.toThrow();
+  });
+
+  it('does not brick the bucket: a valid add-record still works afterwards', async () => {
+    // The whole reason this matters. A bucket the CLI cannot parse is a bucket
+    // every later write refuses, and there is no repair verb.
+    const podDir = await initPod();
+    await addRecord(podDir, ['--by', 'https://ex.org/a b#me']);
+    const ok = await addRecord(podDir, ['--by', 'https://ex.org/alice#me']);
+    expect(ok.exitCode).toBe(0);
+    const bucket = fs.readFileSync(path.join(podDir, MEDS), 'utf-8');
+    expect(() => new Parser({ format: 'Turtle' }).parse(bucket)).not.toThrow();
+    expect(bucket).toContain('<https://ex.org/alice#me>');
+  });
+
+  it('still accepts legal IRIs, absolute and relative', async () => {
+    for (const iri of [
+      'https://ex.org/alice#me',
+      '/profile/card.ttl#me',
+      'urn:uuid:2b3c4d5e-0000-4000-8000-000000000000',
+      'https://ex.org/a%20b#me',
+      'https://ex.org/café#me',
+      'https://ex.org/a?q=1&r=2#me',
+    ]) {
+      const podDir = await initPod();
+      const res = await addRecord(podDir, ['--by', iri]);
+      expect(res.exitCode, `legal --by ${iri} was rejected`).toBe(0);
+      const bucket = fs.readFileSync(path.join(podDir, MEDS), 'utf-8');
+      expect(() => new Parser({ format: 'Turtle' }).parse(bucket)).not.toThrow();
+    }
+  }, 60_000);
+});
+
+describe('pod add-record property CURIEs: an unwritable local part is refused', () => {
+  it('refuses a property CURIE whose local part contains a space', async () => {
+    const podDir = await initPod();
+    const res = await addRecord(podDir, [], '{"clinical:drug Name":"x"}');
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain('clinical:drug Name');
+    expect(fs.existsSync(path.join(podDir, MEDS))).toBe(false);
+  });
+
+  for (const [label, local] of [
+    ['a newline', 'drug\nName'],
+    ['an angle bracket', 'drug<Name'],
+    ['a double quote', 'drug"Name'],
+    ['a brace', 'drug{Name'],
+    ['a backslash', 'drug\\Name'],
+  ] as Array<[string, string]>) {
+    it(`refuses a property CURIE local part containing ${label}`, async () => {
+      const podDir = await initPod();
+      const res = await addRecord(podDir, [], JSON.stringify({ [`clinical:${local}`]: 'x' }));
+      expect(res.exitCode, `clinical:${JSON.stringify(local)} was accepted`).toBe(1);
+      expect(fs.existsSync(path.join(podDir, MEDS))).toBe(false);
+    });
+  }
+
+  it('refuses the whole record when ONE property of several is illegal', async () => {
+    const podDir = await initPod();
+    const res = await addRecord(
+      podDir,
+      [],
+      '{"clinical:drugName":"Vitamin D","clinical:drug Name":"x","clinical:dosage":"10mg"}',
+    );
+    expect(res.exitCode).toBe(1);
+    expect(fs.existsSync(path.join(podDir, MEDS))).toBe(false);
+  });
+
+  it('still accepts a normal property set', async () => {
+    const podDir = await initPod();
+    const res = await addRecord(podDir, [], '{"clinical:drugName":"Lisinopril","clinical:dosage":"10mg"}');
+    expect(res.exitCode).toBe(0);
+    expect(() => new Parser({ format: 'Turtle' })
+      .parse(fs.readFileSync(path.join(podDir, MEDS), 'utf-8'))).not.toThrow();
+  });
+});
+
+describe('overlay writers: the same rule, at the same chokepoint', () => {
+  // amend / annotate / retract / erase all take a --record IRI and a --by actor
+  // and mint them the same way. The guard lives in the overlay quad builder so
+  // it cannot be reintroduced one command at a time.
+  // These assert the message NAMES THE INPUT, not merely that the write fails.
+  // The chokepoint backstop already refuses an unwritable term, so exit 1 alone
+  // is satisfied without any per-input guard at all — and the error it produces
+  // points at a FILE ("a term of .../amendments.ttl"), which tells the user
+  // nothing about which flag they mistyped. Naming the flag or the predicate is
+  // the entire value of validating at the input, so that is what is pinned.
+  it('refuses pod amend --record with an unwritable IRI, naming the predicate', async () => {
+    const podDir = await initPod();
+    const res = await runCli([
+      'pod', 'amend', podDir, '--record', 'urn:uuid:a b', '--property', 'clinical:drugName', '--value', 'x',
+    ]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain('urn:uuid:a b');
+    expect(res.stdout, 'the error must say WHICH input was rejected').toContain('workbench:amendsRecord');
+    expect(fs.existsSync(path.join(podDir, 'annotations', 'amendments.ttl'))).toBe(false);
+  });
+
+  it('refuses pod annotate --by with an unwritable IRI, naming the flag', async () => {
+    const podDir = await initPod();
+    const res = await runCli([
+      'pod', 'annotate', podDir, '--record', 'urn:uuid:abc', '--text', 'hi', '--by', 'https://ex.org/a b#me',
+    ]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain('https://ex.org/a b#me');
+    expect(res.stdout, 'the error must say WHICH input was rejected').toContain('--by');
+  });
+
+  it('refuses pod retract --superseded-by with an unwritable IRI', async () => {
+    const podDir = await initPod();
+    const res = await runCli([
+      'pod', 'retract', podDir, '--record', 'urn:uuid:abc', '--superseded-by', 'urn:uuid:k ept',
+    ]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain('urn:uuid:k ept');
+    expect(res.stdout).toContain('workbench:supersededBy');
+  });
+
+  it('still accepts a well-formed amend', async () => {
+    const podDir = await initPod();
+    const add = await addRecord(podDir, []);
+    expect(add.exitCode).toBe(0);
+    const recordUri = (fs.readFileSync(path.join(podDir, MEDS), 'utf-8').match(/urn:uuid:[0-9a-f-]+/) ?? [])[0];
+    expect(recordUri).toBeTruthy();
+    const res = await runCli([
+      'pod', 'amend', podDir, '--record', recordUri!, '--property', 'clinical:drugName', '--value', 'Vitamin D3',
+    ]);
+    expect(res.exitCode).toBe(0);
+  });
+});

--- a/tests/pod-bucket-prefix-preservation.test.ts
+++ b/tests/pod-bucket-prefix-preservation.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Integration acceptance for the record-data write path: import, then edit.
+ *
+ * The shipped defect: `pod add-record` merged into a bucket by deleting every
+ * leading `@prefix` line and re-emitting a header of its own ten namespaces.
+ * A bucket written by `pod import` declares `rxnorm:`, `sct:`, `loinc:`,
+ * `vcard:` and `fhir:`; those five vanished while the body CURIEs that used
+ * them stayed, so the file stopped parsing and the WHOLE-POD read failed with
+ * `Undefined prefix "rxnorm:"`.
+ *
+ * The suite that let it ship built every fixture pod with `pod init` +
+ * `add-record`, so no bucket under test ever held an importer-only prefix.
+ * Every test here is therefore IMPORT-then-edit, and asserts a STRICT N3 parse
+ * of the resulting file — the same parse the whole-pod read performs. A test
+ * that only checks "the record was added" reproduces the original gap.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { appendOverlay, mintUri, iriRef, strLit } from '../src/lib/annotations.js';
+
+const TEST_TIMEOUT_MS = 60_000;
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const program = buildProgram();
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws; exitCode carries the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-prefix-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+beforeEach(() => { tmpDirs = []; });
+afterEach(() => {
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  tmpDirs = [];
+});
+
+/**
+ * A one-medication FHIR bundle whose only code is RxNorm. Importing it makes
+ * the bucket declare and USE `rxnorm:`, which is precisely the prefix the old
+ * header swap deleted.
+ */
+const RXNORM_BUNDLE = {
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'MedicationStatement',
+        id: 'm1',
+        status: 'active',
+        medicationCodeableConcept: {
+          coding: [{
+            system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+            code: '860975',
+            display: 'Metformin 500 MG',
+          }],
+        },
+        subject: { reference: 'Patient/p1' },
+      },
+    },
+  ],
+};
+
+/** Strict parse: exactly what the whole-pod read does, and what used to fail. */
+function strictParse(file: string): Quad[] {
+  return new Parser({ format: 'Turtle' }).parse(fs.readFileSync(file, 'utf-8'));
+}
+
+/** Init a pod and import the RxNorm bundle into it. Returns the pod dir. */
+async function importedPod(): Promise<{ podDir: string; medsPath: string }> {
+  const base = mkTmpDir();
+  const podDir = path.join(base, 'pod');
+  const bundle = path.join(base, 'bundle.json');
+  fs.writeFileSync(bundle, JSON.stringify(RXNORM_BUNDLE), 'utf-8');
+
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+  expect((await runCli(['pod', 'import', podDir, bundle])).exitCode).toBe(0);
+
+  const medsPath = path.join(podDir, 'clinical', 'medications.ttl');
+  // The fixture must actually create the hazard, or every assertion below is
+  // vacuous.
+  expect(fs.readFileSync(medsPath, 'utf-8')).toContain('rxnorm:860975');
+  return { podDir, medsPath };
+}
+
+describe('import then add-record: the importer\'s prefixes survive', () => {
+  it('leaves the bucket parseable, with rxnorm: intact and both records present', async () => {
+    const { podDir, medsPath } = await importedPod();
+
+    const add = await runCli([
+      '--json', 'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+    expect(add.exitCode).toBe(0);
+
+    const text = fs.readFileSync(medsPath, 'utf-8');
+    // THE regression assertion: a strict parse, not "the record is in there".
+    expect(() => strictParse(medsPath)).not.toThrow();
+    expect(text).toContain('@prefix rxnorm:');
+    expect(text).toContain('rxnorm:860975');
+    expect(text).toContain('Vitamin D');
+    expect(text).toContain('Metformin 500 MG');
+  }, TEST_TIMEOUT_MS);
+
+  it('keeps the whole pod readable, which is the failure the user actually saw', async () => {
+    const { podDir } = await importedPod();
+    await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+
+    const q = await runCli(['--json', 'pod', 'query', podDir, '--medications']);
+    expect(q.exitCode).toBe(0);
+    expect(q.stdout).toContain('Vitamin D');
+    expect(q.stdout).toContain('Metformin 500 MG');
+  }, TEST_TIMEOUT_MS);
+
+  it('survives ten alternating add-records without accumulating or losing a declaration', async () => {
+    const { podDir, medsPath } = await importedPod();
+    for (let i = 0; i < 10; i++) {
+      const r = await runCli([
+        'pod', 'add-record', podDir,
+        '--type', 'clinical:Medication',
+        '--json', `{"clinical:drugName":"Supplement ${i}"}`,
+      ]);
+      expect(r.exitCode, `add-record ${i}`).toBe(0);
+      expect(() => strictParse(medsPath), `parse after add-record ${i}`).not.toThrow();
+    }
+    const text = fs.readFileSync(medsPath, 'utf-8');
+    expect((text.match(/@prefix rxnorm:/g) ?? []).length).toBe(1);
+    expect((text.match(/@prefix clinical:/g) ?? []).length).toBe(1);
+  }, TEST_TIMEOUT_MS);
+
+  it('re-imports cleanly after a hand-entered record was added', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const bundle = path.join(path.dirname(podDir), 'bundle.json');
+
+    await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+    const reimport = await runCli(['pod', 'import', podDir, bundle]);
+    expect(reimport.exitCode).toBe(0);
+
+    expect(() => strictParse(medsPath)).not.toThrow();
+    const text = fs.readFileSync(medsPath, 'utf-8');
+    expect(text).toContain('Vitamin D');
+    expect(text).toContain('rxnorm:860975');
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('add-record on a FRESH pod: the core: prefix vector', () => {
+  it('accepts a core: property CURIE and still writes a parseable bucket', async () => {
+    // `core:` is accepted by the CURIE expander but was never declared in the
+    // emitted header, so a fresh pod with no import at all was bricked by
+    // `Undefined prefix "core:"`. Building quads closes it by construction:
+    // core: and cascade: are the same namespace, and the writer picks the
+    // abbreviation.
+    const podDir = path.join(mkTmpDir(), 'pod');
+    expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+
+    const add = await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D","core:schemaVersion":"1.3"}',
+    ]);
+    expect(add.exitCode).toBe(0);
+
+    const medsPath = path.join(podDir, 'clinical', 'medications.ttl');
+    expect(() => strictParse(medsPath)).not.toThrow();
+    const quads = strictParse(medsPath);
+    expect(
+      quads.some((q) => q.predicate.value === 'https://ns.cascadeprotocol.org/core/v1#schemaVersion'),
+    ).toBe(true);
+
+    const q = await runCli(['--json', 'pod', 'query', podDir, '--medications']);
+    expect(q.exitCode).toBe(0);
+  }, TEST_TIMEOUT_MS);
+
+  it('accepts every prefix its CURIE expander advertises', async () => {
+    // Any prefix the expander accepts but the writer could not declare was a
+    // brick. There is no longer a header to keep in sync, so this is a check
+    // that the two have not drifted apart again.
+    const podDir = path.join(mkTmpDir(), 'pod');
+    await runCli(['pod', 'init', podDir]);
+    const add = await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"X","core:schemaVersion":"1.3","cascade:sourceSystem":"s",'
+        + '"health:startDate":"2026-01-01","coverage:planName":"p","checkup:note":"n",'
+        + '"pots:protocol":"p","workbench:tag":"t","fhir:status":"active"}',
+    ]);
+    expect(add.exitCode).toBe(0);
+    expect(() => strictParse(path.join(podDir, 'clinical', 'medications.ttl'))).not.toThrow();
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('the patient WebID stays relative through every writer', () => {
+  it('is still </profile/card.ttl#me> after add-record, six imports and an erase', async () => {
+    // Re-serializing quads that came from a parse with N3's default base turns
+    // </profile/card.ttl#me> into "undefined/profile/card.ttl#me" — and on the
+    // import path it was demoted all the way to a string LITERAL. The file
+    // still parsed, so nothing was red; it just said something else.
+    const { podDir, medsPath } = await importedPod();
+    const bundle = path.join(path.dirname(podDir), 'bundle.json');
+
+    const add = await runCli([
+      '--json', 'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+    expect(add.exitCode).toBe(0);
+    expect(fs.readFileSync(medsPath, 'utf-8')).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+
+    for (let i = 0; i < 6; i++) {
+      expect((await runCli(['pod', 'import', podDir, bundle])).exitCode, `import ${i}`).toBe(0);
+      const text = fs.readFileSync(medsPath, 'utf-8');
+      expect(text, `after import ${i}`).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+      expect(text, `after import ${i}`).not.toContain('undefined/profile');
+      // Not a literal, either: the demotion was silent and semantic.
+      expect(text, `after import ${i}`).not.toMatch(/wasAttributedTo\s+"/);
+    }
+
+    // ...and an erase of the OTHER record leaves it alone too.
+    const imported = strictParse(medsPath).find(
+      (q) => q.object.value === 'Metformin 500 MG',
+    )!.subject.value;
+    const erase = await runCli(['pod', 'erase', podDir, '--record', imported, '--confirm']);
+    expect(erase.exitCode).toBe(0);
+
+    const finalText = fs.readFileSync(medsPath, 'utf-8');
+    expect(finalText).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+    expect(finalText).not.toContain('undefined/profile');
+    expect(() => strictParse(medsPath)).not.toThrow();
+  }, TEST_TIMEOUT_MS);
+
+  it('survives an import that RE-ROUTES an existing pod record to another bucket', async () => {
+    // The one path where the import's own parse of concatenated pod text is
+    // what lands on disk: a record whose rdf:type routes it to a bucket other
+    // than the file it is sitting in (a hand edit, an SDK writer, a type that
+    // changed). Its quads come from the merged-text parse rather than from the
+    // target file, so a parse with N3's default base writes
+    // "undefined/profile/card.ttl#me" into a brand new file.
+    const base = mkTmpDir();
+    const podDir = path.join(base, 'pod');
+    const bundle = path.join(base, 'bundle.json');
+    fs.writeFileSync(bundle, JSON.stringify(RXNORM_BUNDLE), 'utf-8');
+    await runCli(['pod', 'init', podDir]);
+    await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication', '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+
+    const medsPath = path.join(podDir, 'clinical', 'medications.ttl');
+    fs.writeFileSync(
+      medsPath,
+      fs.readFileSync(medsPath, 'utf-8')
+        .replace('a clinical:Medication;', 'a health:ConditionRecord;')
+        .replace('@prefix cascade:', '@prefix health: <https://ns.cascadeprotocol.org/health/v1#>.\n@prefix cascade:'),
+      'utf-8',
+    );
+
+    expect((await runCli(['pod', 'import', podDir, bundle, '--no-reconcile'])).exitCode).toBe(0);
+
+    const conditions = path.join(podDir, 'clinical', 'conditions.ttl');
+    expect(fs.existsSync(conditions)).toBe(true);
+    const text = fs.readFileSync(conditions, 'utf-8');
+    expect(text).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+    expect(text).not.toContain('undefined/profile');
+  }, TEST_TIMEOUT_MS);
+
+  it('erase keeps the erased-from bucket\'s own prefix declarations', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const add = await runCli([
+      '--json', 'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+    const uri = JSON.parse(add.stdout.slice(add.stdout.indexOf('{'), add.stdout.lastIndexOf('}') + 1)).recordUri;
+
+    expect((await runCli(['pod', 'erase', podDir, '--record', uri, '--confirm'])).exitCode).toBe(0);
+
+    const text = fs.readFileSync(medsPath, 'utf-8');
+    expect(text).toContain('@prefix rxnorm:');
+    expect(text).toContain('rxnorm:860975');
+    expect(text).not.toContain('Vitamin D');
+    expect(() => strictParse(medsPath)).not.toThrow();
+    // The tombstone is a bucket write too, and it carries the same WebID.
+    const tombstones = path.join(podDir, 'annotations', 'tombstones.ttl');
+    expect(fs.readFileSync(tombstones, 'utf-8')).toContain('prov:wasAttributedTo </profile/card.ttl#me>');
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('an unreadable bucket is never overwritten', () => {
+  /** Corrupt medications.ttl the way the shipped defect did: header only. */
+  function corrupt(medsPath: string): Buffer {
+    const text = fs.readFileSync(medsPath, 'utf-8');
+    const body = text.split('\n').filter((l) => !l.trimStart().startsWith('@prefix')).join('\n');
+    fs.writeFileSync(medsPath, body, 'utf-8');
+    // The fixture must actually be broken.
+    expect(() => strictParse(medsPath)).toThrow();
+    return fs.readFileSync(medsPath);
+  }
+
+  it('pod import exits non-zero and leaves the file byte-identical', async () => {
+    // Without this, fixing the header swap alone leaves every pod already
+    // corrupted in the field ONE import away from losing the bucket entirely:
+    // the import used to catch the parse failure, treat the file as empty, and
+    // overwrite it.
+    const { podDir, medsPath } = await importedPod();
+    const bundle = path.join(path.dirname(podDir), 'bundle.json');
+    const before = corrupt(medsPath);
+
+    const r = await runCli(['pod', 'import', podDir, bundle]);
+    expect(r.exitCode).not.toBe(0);
+    expect(fs.readFileSync(medsPath).equals(before), 'the unreadable bucket was overwritten').toBe(true);
+    expect(r.stdout).toMatch(/medications\.ttl/);
+  }, TEST_TIMEOUT_MS);
+
+  it('pod import names the refusal in its JSON report', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const bundle = path.join(path.dirname(podDir), 'bundle.json');
+    corrupt(medsPath);
+
+    const r = await runCli(['--json', 'pod', 'import', podDir, bundle]);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout).toContain('bucketsRefused');
+    expect(r.stdout).toContain('clinical/medications.ttl');
+  }, TEST_TIMEOUT_MS);
+
+  it('pod add-record refuses and leaves the file byte-identical', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const before = corrupt(medsPath);
+
+    const r = await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+    expect(r.exitCode).not.toBe(0);
+    expect(fs.readFileSync(medsPath).equals(before)).toBe(true);
+    expect(r.stdout).toMatch(/Cannot read .*medications\.ttl as Turtle/);
+  }, TEST_TIMEOUT_MS);
+
+  it('a healthy bucket in the same import still gets written', async () => {
+    // Per-file refusal, not a whole-run abort: the point is not to lose data,
+    // not to punish the rest of the import.
+    const { podDir, medsPath } = await importedPod();
+    const base = path.dirname(podDir);
+    const condBundle = path.join(base, 'conditions.json');
+    fs.writeFileSync(condBundle, JSON.stringify({
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        RXNORM_BUNDLE.entry[0],
+        {
+          resource: {
+            resourceType: 'Condition',
+            id: 'c1',
+            code: { coding: [{ system: 'http://snomed.info/sct', code: '73211009', display: 'Diabetes' }] },
+            subject: { reference: 'Patient/p1' },
+          },
+        },
+      ],
+    }), 'utf-8');
+    corrupt(medsPath);
+
+    const r = await runCli(['pod', 'import', podDir, condBundle]);
+    expect(r.exitCode).not.toBe(0);
+    const conditions = path.join(podDir, 'clinical', 'conditions.ttl');
+    expect(fs.existsSync(conditions)).toBe(true);
+    expect(() => strictParse(conditions)).not.toThrow();
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('the scaffolding boundary holds', () => {
+  it('leaves the comment-anchored profile and type-index templates intact', async () => {
+    // `profile/extended.ttl` anchors PHI population on a LITERAL comment line,
+    // and the type indexes are hand-authored with comments. Re-serializing them
+    // would drop those comments, so they must NOT route through the bucket
+    // chokepoint. If this goes red, the boundary has been crossed.
+    //
+    // The import below deliberately carries a LAB RESULT. The pod templates
+    // name `medications.ttl`, `conditions.ttl` and `heart-rate.ttl` in their
+    // commented examples, and both scaffolding writers decide "already
+    // registered" with a substring check against the whole file — so importing
+    // any of those three never exercises them at all, and this test would pass
+    // without touching the code it is guarding.
+    const base = mkTmpDir();
+    const podDir = path.join(base, 'pod');
+    const bundle = path.join(base, 'labs.json');
+    fs.writeFileSync(bundle, JSON.stringify({
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [{
+        resource: {
+          resourceType: 'Observation',
+          id: 'o1',
+          status: 'final',
+          code: { coding: [{ system: 'http://loinc.org', code: '2345-7', display: 'Glucose' }] },
+          valueQuantity: { value: 99, unit: 'mg/dL' },
+          subject: { reference: 'Patient/p1' },
+        },
+      }],
+    }), 'utf-8');
+
+    expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+    expect((await runCli(['pod', 'import', podDir, bundle])).exitCode).toBe(0);
+    // The scaffolding writers must actually have run, or the assertions below
+    // guard nothing.
+    expect(fs.readFileSync(path.join(podDir, 'index.ttl'), 'utf-8')).toContain('clinical/lab-results.ttl');
+    expect(fs.readFileSync(path.join(podDir, 'settings', 'publicTypeIndex.ttl'), 'utf-8'))
+      .toContain('<#lab-results>');
+
+    await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication',
+      '--json', '{"clinical:drugName":"Vitamin D"}',
+    ]);
+
+    const ANCHORS: Array<[string[], string]> = [
+      // The PHI-population regex matches this line literally. `extended.ttl` is
+      // also 100% comments — zero triples — so a re-serialization would not
+      // merely reformat it, it would empty it.
+      [['profile', 'extended.ttl'], '# ── Demographics ──'],
+      [['index.ttl'], '# Root LDP Container'],
+      [['profile', 'card.ttl'], '# WebID Profile Card'],
+      [['settings', 'publicTypeIndex.ttl'], '# Public Type Index'],
+      [['settings', 'privateTypeIndex.ttl'], '# Private Type Index'],
+    ];
+    for (const [rel, anchor] of ANCHORS) {
+      const p = path.join(podDir, ...rel);
+      expect(fs.readFileSync(p, 'utf-8'), `${rel.join('/')} lost "${anchor}"`).toContain(anchor);
+    }
+  }, TEST_TIMEOUT_MS);
+});
+
+describe('overlay writers merge through the same door', () => {
+  it('amend, annotate and retract all leave annotations/ parseable', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const uri = strictParse(medsPath).find((q) => q.object.value === 'Metformin 500 MG')!.subject.value;
+
+    expect((await runCli(['pod', 'amend', podDir, '--record', uri, '--property', 'clinical:dosage', '--value', '20mg'])).exitCode).toBe(0);
+    expect((await runCli(['pod', 'annotate', podDir, '--record', uri, '--text', 'a note'])).exitCode).toBe(0);
+    expect((await runCli(['pod', 'retract', podDir, '--record', uri, '--reason', 'entered in error'])).exitCode).toBe(0);
+
+    for (const f of ['amendments.ttl', 'annotations.ttl', 'retractions.ttl']) {
+      const p = path.join(podDir, 'annotations', f);
+      expect(fs.existsSync(p), f).toBe(true);
+      expect(() => strictParse(p), f).not.toThrow();
+    }
+  }, TEST_TIMEOUT_MS);
+
+  it('still refuses to persist an overlay that fails SHACL', async () => {
+    // The SHACL gate used to sit between the text merge and the write. It now
+    // rides on the chokepoint's validate hook; if that hook is dropped, a
+    // malformed overlay reaches disk silently.
+    const { podDir } = await importedPod();
+    const filePath = path.join(podDir, 'annotations', 'amendments.ttl');
+
+    await expect(appendOverlay(podDir, {
+      fileName: 'amendments.ttl',
+      subjectUri: mintUri(),
+      rdfType: 'workbench:Amendment',
+      // workbench:amendedValue is required by the shape and deliberately absent.
+      lines: [
+        { predicate: 'workbench:amendsRecord', object: iriRef('urn:uuid:r') },
+        { predicate: 'workbench:amendsProperty', object: strLit('clinical:dosage') },
+      ],
+      createdIso: new Date().toISOString(),
+    }, undefined)).rejects.toThrow(/SHACL/);
+
+    expect(fs.existsSync(filePath), 'a malformed overlay was written').toBe(false);
+  }, TEST_TIMEOUT_MS);
+
+  it('appends repeatedly without duplicating a prefix declaration', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const uri = strictParse(medsPath).find((q) => q.object.value === 'Metformin 500 MG')!.subject.value;
+    for (let i = 0; i < 5; i++) {
+      expect((await runCli(['pod', 'annotate', podDir, '--record', uri, '--text', `note ${i}`])).exitCode).toBe(0);
+    }
+    const p = path.join(podDir, 'annotations', 'annotations.ttl');
+    const text = fs.readFileSync(p, 'utf-8');
+    expect((text.match(/@prefix workbench:/g) ?? []).length).toBe(1);
+    expect(strictParse(p).filter((q) => q.predicate.value.endsWith('annotationText'))).toHaveLength(5);
+  }, TEST_TIMEOUT_MS);
+});

--- a/tests/pod-bucket-prefix-preservation.test.ts
+++ b/tests/pod-bucket-prefix-preservation.test.ts
@@ -537,3 +537,116 @@ describe('overlay writers merge through the same door', () => {
     expect(strictParse(p).filter((q) => q.predicate.value.endsWith('annotationText'))).toHaveLength(5);
   }, TEST_TIMEOUT_MS);
 });
+
+// ---------------------------------------------------------------------------
+// The additive merge keeps what the bucket already held
+// ---------------------------------------------------------------------------
+
+/** A second one-medication bundle, a different drug, routing to the same bucket. */
+const ATORVASTATIN_BUNDLE = {
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'MedicationStatement',
+        id: 'm2',
+        status: 'active',
+        medicationCodeableConcept: {
+          coding: [{
+            system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+            code: '617314',
+            display: 'Atorvastatin 10 MG',
+          }],
+        },
+        subject: { reference: 'Patient/p1' },
+      },
+    },
+  ],
+};
+
+describe('import into a bucket that already holds records', () => {
+  // The additive path's `combine` opens by copying every subject the file
+  // already holds into its accumulator. Delete that copy and the import writes
+  // ONLY the incoming subjects: the bucket's existing records are silently
+  // replaced, not merged. That is the same defect class as the silent
+  // overwrite this whole change exists to close, one line away in the same
+  // function, and nothing pinned it — the nearest existing test imports into a
+  // NEW bucket, so it never exercises "keep what the file already holds".
+  //
+  // Three flag combinations reach the additive path, and they do NOT all pin
+  // the line equally — stated explicitly so a future reader does not assume
+  // more coverage than exists:
+  //
+  //   --no-reconcile-existing  PINS IT. The pod's own records are not loaded,
+  //                            so the copy of `existing` is the only thing
+  //                            keeping them. Deleting the loop loses them.
+  //   --no-reconcile only      Does NOT pin it. `--reconcile-existing` is on by
+  //                            default, so the pod's records are loaded into
+  //                            `allInputs` and ride in as INCOMING quads; the
+  //                            copy loop is redundant on that path. Kept as a
+  //                            no-data-loss regression test, not as a tripwire.
+  //   both flags               Pins it, same as the first.
+  for (const flags of [
+    ['--no-reconcile-existing'],
+    ['--no-reconcile', '--no-reconcile-existing'],
+    ['--no-reconcile'],
+  ]) {
+    it(`keeps the records already in the bucket when importing with ${flags.join(' ')}`, async () => {
+      const base = mkTmpDir();
+      const podDir = path.join(base, 'pod');
+      const bundleA = path.join(base, 'a.json');
+      const bundleB = path.join(base, 'b.json');
+      fs.writeFileSync(bundleA, JSON.stringify(RXNORM_BUNDLE), 'utf-8');
+      fs.writeFileSync(bundleB, JSON.stringify(ATORVASTATIN_BUNDLE), 'utf-8');
+
+      expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+      expect((await runCli(['pod', 'import', podDir, bundleA])).exitCode).toBe(0);
+
+      const medsPath = path.join(podDir, 'clinical', 'medications.ttl');
+      const medicationSubjects = (): string[] => {
+        const isMedication = (q: Quad) =>
+          q.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
+          q.object.value === 'https://ns.cascadeprotocol.org/clinical/v1#Medication';
+        return [...new Set(strictParse(medsPath).filter(isMedication).map((q) => q.subject.value))].sort();
+      };
+
+      const before = medicationSubjects();
+      // The fixture must actually create the hazard, or the assertion is vacuous.
+      expect(before).toHaveLength(1);
+
+      expect((await runCli(['pod', 'import', podDir, bundleB, ...flags])).exitCode).toBe(0);
+
+      const after = medicationSubjects();
+      expect(after, 'the pre-existing record was dropped by the import').toEqual(
+        expect.arrayContaining(before),
+      );
+      expect(after).toHaveLength(2);
+
+      const text = fs.readFileSync(medsPath, 'utf-8');
+      expect(text, 'the pre-existing record was dropped').toContain('Metformin 500 MG');
+      expect(text, 'the incoming record was not written').toContain('Atorvastatin 10 MG');
+      expect(() => strictParse(medsPath)).not.toThrow();
+    }, TEST_TIMEOUT_MS);
+  }
+
+  it('keeps a hand-entered record when a later import lands in its bucket', async () => {
+    // The user-visible shape of the same loss: `add-record` then `import`.
+    const base = mkTmpDir();
+    const podDir = path.join(base, 'pod');
+    const bundle = path.join(base, 'b.json');
+    fs.writeFileSync(bundle, JSON.stringify(ATORVASTATIN_BUNDLE), 'utf-8');
+
+    await runCli(['pod', 'init', podDir]);
+    expect((await runCli([
+      'pod', 'add-record', podDir,
+      '--type', 'clinical:Medication', '--json', '{"clinical:drugName":"Vitamin D"}',
+    ])).exitCode).toBe(0);
+
+    expect((await runCli(['pod', 'import', podDir, bundle, '--no-reconcile-existing'])).exitCode).toBe(0);
+
+    const text = fs.readFileSync(path.join(podDir, 'clinical', 'medications.ttl'), 'utf-8');
+    expect(text, 'the hand-entered record was dropped by the import').toContain('Vitamin D');
+    expect(text).toContain('Atorvastatin 10 MG');
+  }, TEST_TIMEOUT_MS);
+});


### PR DESCRIPTION
Three P1 defects in how pod record files are written, fixed together because fixing only the first
leaves every already-damaged pod one import away from losing a bucket.

## The defects

**1. `pod add-record` deleted prefix declarations it did not author.** It stripped every `@prefix`
line from the bucket it was merging into and re-emitted a narrower header of its own, dropping the
`rxnorm:`/`sct:`/`loinc:`/`fhir:`/`vcard:` declarations an importer had written while keeping the
body CURIEs that used them. The file stopped parsing, and since one unreadable bucket fails the
whole-pod read, `pod query` and `pod info` failed for the entire pod. Reachable with no import at
all via a `core:` CURIE the emitted header never declared.

This is a recurrence of the defect fixed in #17, in a second writer. That fix produced an exported
helper which was never propagated, so the fix here removes the primitive instead: `stripPrefixHeader`
existed as two byte-identical unexported, untested copies, and both are deleted.

**2. An unparseable bucket was silently replaced by the next `pod import`.** The parse failure was
caught, the file treated as empty, and overwritten — losing every record it held at exit 0, reported
as a normal import. The default flag path instead died on an uncaught parser exception with a stack
trace. Both paths now refuse that bucket by name, exit non-zero, leave it byte-unchanged, and still
write the healthy buckets in the same import.

**3. `pod erase` rewrote relative IRIs in records it was not asked to touch,** turning surviving
records' `prov:wasAttributedTo </profile/card.ttl#me>` into `<undefined/profile/card.ttl#me>`.
`pod import`'s merge path did the same and additionally demoted the term from an IRI to a string
literal. There was an in-code mitigation for this (`baseIri: ''`) that never worked: N3 leaves
`_baseRoot` undefined for an empty base and resolves root-relative IRIs to the literal text
`undefined/...`.

## The fix

A single `src/lib/bucket-write.ts` chokepoint. Callers hand over quads, never Turtle text; one N3
Writer owns the whole document including its header. Because that writer emits a full `<IRI>` for
any namespace it has no prefix for, **a bucket carrying an undeclared CURIE can no longer be
produced** — the class is unrepresentable rather than fixed. Prefixes a file already declared are
harvested and preserved, so buckets keep the prefix names they were written with.

Human-curated scaffolding (`publicTypeIndex.ttl`, `index.ttl`, `card.ttl`, `extended.ttl`) is
deliberately NOT routed through it and has its own boundary test: `extended.ttl` regex-anchors PHI
population on a literal comment line, which re-serializing would destroy.

Relative IRIs round-trip through a per-process random nonce base, stripped on the way out, with a
global assertion that no Turtle this CLI emits mentions it at any stage. The nonce must be a bare
scheme; a `urn:`-prefixed one silently breaks the round trip because N3 derives `_baseRoot` as just
`urn:`.

## Tests

`npx vitest run` locally: **125 files / 1854 tests / 0 skipped** (from 121 / 1676 / 0). The CI skip
ratchet is unchanged at 24.

Two new suites plus additions to two existing ones. Every tripwire was observed RED before being
claimed. Notable ones, each verified to fail when the line it protects is removed:

- import-then-add-record parses, and all five importer prefixes survive
- the patient WebID is still `</profile/card.ttl#me>` after an add-record, six imports and an erase
- an unreadable bucket is refused by all four writers and left byte-identical
- pre-existing records survive an additive merge (`--no-reconcile-existing`)
- the scaffolding boundary fails if a curated file is routed through the chokepoint

Two defects introduced by the first commit were found by an adversarial pass and fixed in the
second: the sentinel was strippable from any IRI merely starting with it, so third-party Turtle
imported via `pod import` could silently re-identify a resource; and the sentinel leaked permanently
into `Literal.datatype`, which the strip never covered. The leak assertion added for those then
caught a third instance in the reconciler's intermediate serialization.

## Compatibility

New CLI behaviour, so this is a minor bump rather than a patch. A bucket already damaged by defect 1
is now refused rather than appended to or overwritten. That is the point — the old behaviour is what
turned a broken header into lost records — but it means such a file must have its missing `@prefix`
lines restored before these commands will touch it. The records themselves are intact.

Follow-ups found during this work and filed rather than built: a repair path for an already-damaged
bucket, atomic tmp+rename writes, the reconciler dropping blank nodes and language tags on
`--reconcile-existing`, and the in-memory ceiling for very large buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
