### PR TITLE
feat(cli): add `pod doctor` for diagnosing and repairing damaged pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+**`cascade pod doctor <pod-dir> [--write]` — a recovery path for a pod the write commands refuse.**
+Scans every `.ttl` file in a pod and repairs the ones whose only defect is that the header is
+missing `@prefix` declarations the body uses — the damage the `pod add-record` bug below produced.
+Everything else is reported with a next step rather than repaired.
+
+It is a dry run by default; `--write` is required to change anything. A repair only ever PREPENDS
+the missing declarations, so every existing byte survives verbatim and the command is safe on the
+comment-anchored scaffolding files (`settings/publicTypeIndex.ttl`, `index.ttl`, `profile/card.ttl`,
+`profile/extended.ttl`) as well as on record buckets. The repaired text must pass a strict parse
+before it is written, the original is backed up beside the file as `*.doctor-backup` and restored if
+the post-write read-back does not verify, and a prefix the tool does not know is a refusal naming
+the prefix — it will never invent a namespace. Encrypted pods are handled transparently and stay
+ciphertext.
+
+Reported but deliberately not repaired, because each needs a human decision: empty and truncated
+files (an interrupted write leaves both), IRIs holding a character Turtle forbids, and resources
+that do not decrypt — the last of which says so plainly instead of blaming a passphrase that
+demonstrably worked on the rest of the pod.
+
+Exit codes follow the existing convention: `0` when nothing is wrong or everything found was
+repaired, `1` when damage remains, `2` when the pod itself could not be opened. `--json` prints a
+report distinguishing repaired / repairable / refused / unreadable with a per-file reason.
+
 ### Fixed
 
 **`pod add-record` no longer destroys prefix declarations it did not author.** Adding a record to a
@@ -49,8 +74,9 @@ with. Human-curated files (`settings/publicTypeIndex.ttl`, `index.ttl`, `profile
 **Upgrade note.** A bucket already damaged by the first bug above will now be refused by
 `add-record`, `erase` and `import` rather than silently appended to or overwritten. That is
 deliberate — the previous behaviour is what turned a broken header into lost records — but it means
-an already-damaged file must be repaired before those commands will touch it. Repairing it means
-restoring the missing `@prefix` lines; the records themselves are intact.
+an already-damaged file must be repaired before those commands will touch it. The records themselves
+are intact; run `cascade pod doctor <pod-dir>` to see what is wrong and `--write` to restore the
+missing `@prefix` lines.
 
 ## [0.12.0] - 2026-08-04
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -50,6 +50,24 @@ Two failures, weighed differently, because "fail on anything" is its own outage:
 Warnings go to stderr and never change the exit code. An error message for a
 read failure always names the files it could not read.
 
+### `pod doctor` reads the same three codes as a diagnosis
+
+`cascade pod doctor` scans a pod for damage, so "there is something wrong" is its
+normal successful answer rather than a failure. It maps onto the same three
+codes without bending them:
+
+| Code | For `pod doctor` |
+|---|---|
+| `0` | Nothing is wrong, or (under `--write`) everything found was repaired. |
+| `1` | Damage remains: a dry run that found something, or a file doctor read and will not repair. Also "there is no pod at that path". |
+| `2` | Something could not be **read**: the pod would not open, a resource did not decrypt, or a `.ttl` holds bytes that are not text. |
+
+`2` outranks `1` when both apply. A file doctor could not open was never
+examined, and a verb whose entire job is to report the state of your pod must
+not describe files it never read. Its `--json` report carries a per-file
+`status` of `repaired`, `repairable`, `refused` or `unreadable`, and the
+unreadable ones are also named on stderr in the usual envelope.
+
 ## The `--json` error envelope
 
 With `--json`, an error is a single JSON object on **stderr**. `error` is always

--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -180,6 +180,25 @@ function getCapabilities(version: string): CapabilitiesOutput {
         status: 'implemented',
       },
       {
+        name: 'pod doctor',
+        description:
+          'Diagnose a damaged Cascade Pod and, with --write, repair files whose only defect is a missing @prefix declaration. This is the recovery path when add-record, erase or import refuse a bucket that will not parse. Dry run by default; only ever PREPENDS declarations, never rewrites existing bytes; never invents a namespace.',
+        usage: 'cascade pod doctor <pod-dir> [--write]',
+        parameters: [
+          { name: 'pod-dir', type: 'string', required: true, description: 'Path to the Cascade Pod' },
+          { name: '--write', type: 'boolean', required: false, description: 'Apply the repairs (default is a dry run that modifies nothing)' },
+          { name: '--json', type: 'boolean', required: false, description: 'Output the report as JSON (global flag; place it before "pod")' },
+        ],
+        examples: ['cascade pod doctor ./my-pod', 'cascade pod doctor ./my-pod --write', 'cascade --json pod doctor ./my-pod'],
+        outputSchema: {
+          description: 'JSON report structure for --json',
+          shape: '{ pod, encrypted, mode: "dry-run"|"write", scanned, healthy, repaired, repairable, refused, unreadable, findings: Finding[] }',
+          findingShape: '{ file, status: "repairable"|"repaired"|"refused"|"unreadable", damage, reason, nextStep?, missingPrefixes?, triples?, preservedBytes?, backup? }',
+          exitCodes: '0 = nothing wrong or everything repaired; 1 = damage remains (or no pod at that path); 2 = the pod could not be opened',
+        },
+        status: 'implemented',
+      },
+      {
         name: 'reconcile',
         description: 'Reconcile Cascade RDF records from multiple sources into a normalized record set, resolving conflicts using trust-weighted scoring',
         usage: 'cascade reconcile <files...> [options]',

--- a/src/commands/pod/doctor.ts
+++ b/src/commands/pod/doctor.ts
@@ -1,0 +1,176 @@
+/**
+ * cascade pod doctor <pod-dir> [--write]
+ *
+ * Diagnose, and where it is safe to do so repair, a damaged Cascade Pod.
+ *
+ * This is the recovery path for the refusal every record-data writer now
+ * performs. `add-record`, `erase` and `import` decline to touch a bucket that
+ * will not parse — correct, because appending into one is what turned a broken
+ * header into lost records — but without this verb a user whose pod is already
+ * damaged has no way forward inside the CLI at all.
+ *
+ * The engine, its safety properties and the registry live in
+ * `lib/pod-doctor.ts`. This file is argument parsing, printing and the exit
+ * code, and deliberately holds no repair logic.
+ *
+ * DRY RUN IS THE DEFAULT. `--write` is required to modify anything.
+ *
+ * Exit codes, on the read layer's contract:
+ *   0 — nothing wrong, or everything found was repaired
+ *   1 — damage remains: a dry run that found something, or a refusal. Also the
+ *       usage error of there being no pod at that path.
+ *   2 — something could not be READ: the pod would not open, or a resource
+ *       inside it did not decrypt / is not text.
+ *
+ * The gap between 1 and 2 is the one that matters: "this pod is damaged" and
+ * "I could not look at this pod" are different answers, and a CI job that treats
+ * a locked pod as a clean one is the failure this whole area keeps producing.
+ */
+
+import type { Command } from 'commander';
+import * as path from 'node:path';
+import {
+  printResult,
+  printError,
+  printErrorDetail,
+  type OutputOptions,
+} from '../../lib/output.js';
+import { resolvePodDir, fileExists } from './helpers.js';
+import { openPod, PodUnreadableError, type PodReader } from '../../lib/pod-read.js';
+import {
+  runPodDoctor,
+  doctorExitCode,
+  BACKUP_SUFFIX,
+  type DoctorReport,
+  type DoctorFinding,
+} from '../../lib/pod-doctor.js';
+
+/** One-line marker per finding, so a long report is still skimmable. */
+const MARKER: Record<DoctorFinding['status'], string> = {
+  repaired: 'FIXED',
+  repairable: 'FIX  ',
+  refused: 'STOP ',
+  unreadable: '?????',
+};
+
+export function registerDoctorSubcommand(pod: Command, program: Command): void {
+  pod
+    .command('doctor')
+    .description('Diagnose a damaged pod, and repair missing @prefix declarations with --write')
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    .option('--write', 'Apply the repairs. Without this nothing is modified.', false)
+    .action(async (podDirArg: string, options: { write: boolean }) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const podDir = resolvePodDir(podDirArg);
+
+      if (!(await fileExists(path.join(podDir, 'index.ttl')))) {
+        printError(`Pod not found at ${podDir} (no index.ttl).`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Exit 2, not 1: a pod that will not open has told us nothing about
+      // whether it is damaged, and that must not read as a clean bill of health.
+      let reader: PodReader;
+      try {
+        reader = await openPod(podDir);
+      } catch (e: unknown) {
+        if (e instanceof PodUnreadableError) {
+          printErrorDetail(e.message, { encrypted: true, readable: false, reason: e.reason }, globalOpts);
+        } else {
+          printError(e instanceof Error ? e.message : String(e), globalOpts);
+        }
+        process.exitCode = 2;
+        return;
+      }
+
+      let report: DoctorReport;
+      try {
+        report = await runPodDoctor(reader, { write: options.write });
+      } catch (e: unknown) {
+        printError(e instanceof Error ? e.message : String(e), globalOpts);
+        process.exitCode = 2;
+        return;
+      }
+
+      if (globalOpts.json) {
+        printResult(report, globalOpts);
+      } else {
+        printReport(report, podDirArg);
+      }
+
+      // A file doctor could not read at all goes to STDERR as well as into the
+      // report, in both modes. Everything else here is a finding about a file
+      // that was read; this one is the admission that part of the pod was not
+      // examined, and it must not be reachable only by inspecting a JSON body.
+      const unreadable = report.findings.filter((f) => f.status === 'unreadable');
+      if (unreadable.length > 0) {
+        printErrorDetail(
+          `Could not read ${unreadable.length} of ${report.scanned} file(s) in ${report.pod}: ` +
+            unreadable.map((f) => `${f.file} (${f.reason})`).join('; ') +
+            `. This is NOT the same as those files being healthy — they were not examined.`,
+          { readable: false, files: unreadable.map((f) => f.file) },
+          globalOpts,
+        );
+      }
+
+      process.exitCode = doctorExitCode(report);
+    });
+}
+
+/** The human-readable report. Says what was found, what was done, and what is left. */
+function printReport(report: DoctorReport, podDirArg: string): void {
+  console.log(`Pod: ${report.pod}`);
+  console.log(`Encryption: ${report.encrypted ? 'ENCRYPTED' : 'plaintext'}`);
+  console.log(
+    `Mode: ${report.mode === 'write' ? 'WRITE' : 'DRY RUN (nothing modified; pass --write to apply)'}`,
+  );
+  console.log(`Scanned ${report.scanned} .ttl file(s); ${report.healthy} healthy.\n`);
+
+  for (const f of report.findings) {
+    console.log(`  ${MARKER[f.status]} ${f.file}`);
+    console.log(`        ${f.reason}`);
+    if (f.missingPrefixes?.length) {
+      console.log(`        declarations: ${f.missingPrefixes.map((p) => `${p}:`).join(' ')}`);
+    }
+    if (f.triples !== undefined && f.preservedBytes !== undefined) {
+      console.log(
+        `        parses after repair: yes (${f.triples} triples, ` +
+          `${f.preservedBytes} bytes preserved verbatim)`,
+      );
+    }
+    if (f.backup) console.log(`        backup: ${f.backup}`);
+    if (f.nextStep) console.log(`        ${f.nextStep}`);
+    console.log();
+  }
+
+  if (report.findings.length === 0) {
+    console.log('Nothing to repair. Every .ttl file in this pod parses.');
+    return;
+  }
+
+  const parts = [
+    `${report.repaired} repaired`,
+    `${report.repairable} repairable`,
+    `${report.refused} refused`,
+    `${report.unreadable} unreadable`,
+  ];
+  console.log(parts.join(', ') + '.');
+
+  if (report.repaired > 0) {
+    console.log(
+      `The original of every repaired file is beside it as \`*${BACKUP_SUFFIX}\`. ` +
+        `Delete those once you are satisfied.`,
+    );
+  }
+  if (report.repairable > 0) {
+    console.log(`Re-run with --write to apply: cascade pod doctor ${podDirArg} --write`);
+  }
+  if (report.refused + report.unreadable > 0) {
+    console.log(
+      'The files marked STOP or ????? need a human decision. Doctor repairs missing ' +
+        '`@prefix` declarations and nothing else, on purpose: every other repair would ' +
+        'mean guessing at the contents of a health record.',
+    );
+  }
+}

--- a/src/commands/pod/index.ts
+++ b/src/commands/pod/index.ts
@@ -8,6 +8,7 @@
  *   query <pod-dir>     Query data within a pod
  *   export <pod-dir>    Export pod data
  *   info <pod-dir>      Show pod metadata and statistics
+ *   doctor <pod-dir>    Diagnose a damaged pod, and repair it with --write
  *
  * This module delegates to focused subcommand modules:
  *   - init.ts    Pod initialization with templates
@@ -32,6 +33,7 @@ import { registerAnnotateSubcommand } from './annotate.js';
 import { registerAddRecordSubcommand } from './add-record.js';
 import { registerRetractSubcommand } from './retract.js';
 import { registerEraseSubcommand } from './erase.js';
+import { registerDoctorSubcommand } from './doctor.js';
 
 export function registerPodCommand(program: Command): void {
   const pod = program.command('pod').description('Manage Cascade Pod structures');
@@ -51,4 +53,5 @@ export function registerPodCommand(program: Command): void {
   registerAddRecordSubcommand(pod, program);
   registerRetractSubcommand(pod, program);
   registerEraseSubcommand(pod, program);
+  registerDoctorSubcommand(pod, program);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ Examples:
   cascade pod init ./my-pod
   cascade pod import ./my-pod records.xml
   cascade pod extract ./my-pod
+  cascade pod doctor ./my-pod
+  cascade pod doctor ./my-pod --write
   cascade agent
   cascade agent serve
   cascade capabilities

--- a/src/lib/pod-doctor.ts
+++ b/src/lib/pod-doctor.ts
@@ -1,0 +1,743 @@
+/**
+ * The diagnosis-and-repair engine behind `cascade pod doctor`.
+ *
+ * WHY this exists
+ * ---------------
+ * Every record-data writer now REFUSES a bucket that will not parse rather than
+ * appending into it or silently overwriting it. That is the right behaviour —
+ * the old one is what turned a broken header into lost records — but it leaves a
+ * user whose pod is ALREADY damaged with no way forward inside the CLI at all:
+ * `add-record`, `erase` and `import` all decline, and the whole-pod read fails.
+ * This module is the way forward. It ships in the same release as the refusal so
+ * the two reach users together.
+ *
+ * WHAT IT REPAIRS, and nothing else
+ * ---------------------------------
+ * Exactly one damage shape: a file whose ONLY defect is that its header lacks
+ * `@prefix` declarations its body uses. That is the shape the shipped defect
+ * produced, and it is the only one whose correct repair is knowable without
+ * asking a human. Every other shape is reported with a next step
+ * ({@link DoctorDamage}).
+ *
+ * THE SAFETY PROPERTIES, in order of how much they matter
+ * ------------------------------------------------------
+ *  1. DRY RUN BY DEFAULT. Writing requires an explicit `--write`.
+ *  2. ONLY EVER PREPENDS. {@link assertPrependOnly} refuses unless the original
+ *     content is a strict suffix of the repaired content. This is what makes the
+ *     verb safe on human-curated scaffolding as well as on record buckets — see
+ *     "SCAFFOLDING" below.
+ *  3. The repaired text must pass a STRICT parse BEFORE anything is written.
+ *  4. The original bytes are BACKED UP before the write, and restored from that
+ *     backup if the post-write read-back does not verify.
+ *  5. NEVER invents a namespace. A prefix outside {@link DOCTOR_PREFIXES} is a
+ *     refusal naming the prefix, not a guess.
+ *  6. IDEMPOTENT. A file that parses is never touched, so a second run reports
+ *     nothing to do.
+ *  7. Encrypted-pod transparent: reads and writes go through the pod's DEK.
+ *
+ * SCAFFOLDING: why this module must NOT use `mergeIntoBucket`
+ * ----------------------------------------------------------
+ * Doctor scans `settings/publicTypeIndex.ttl`, `index.ttl`, `profile/card.ttl`
+ * and `profile/extended.ttl` too, because damaged scaffolding exists in the
+ * field. Those files are authored with LOAD-BEARING comments — `extended.ttl`
+ * regex-anchors PHI population on a literal comment line, and is 100% comments,
+ * so a re-serialization would not merely reformat it, it would empty it. That is
+ * exactly why the bucket chokepoint excludes them. Prepending a declaration
+ * preserves every existing byte, which is what makes scanning them safe, and it
+ * is the whole reason property 2 is an assertion in code rather than a habit.
+ *
+ * DISCOVERY: from the parser, never from a regex
+ * ----------------------------------------------
+ * Which prefixes are missing is read out of the PARSER'S OWN ERROR — heal one,
+ * re-parse, repeat, bounded. A regex over the text finds false positives inside
+ * comments, inside string literals, and inside absolute IRIs that contain a
+ * colon, and each of those would make doctor author a declaration the document
+ * never needed.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { KNOWN_PREFIXES, findIllegalIriChar } from './bucket-write.js';
+import { encryptResource, readResource } from './pod-encryption.js';
+import { atomicWriteBytes, looksLikePlaintext } from './pod-resources.js';
+import { tidyReason, type PodReader, type PodReadFailure } from './pod-read.js';
+
+// ─── The registry ─────────────────────────────────────────────────────────────
+
+/**
+ * Namespaces doctor may author that the record writers never emit.
+ *
+ * Every entry needs a reason, because each one widens the set of files this tool
+ * will rewrite. DERIVED, not retyped: see {@link DOCTOR_PREFIXES}.
+ */
+export const REPAIR_ONLY_PREFIXES: Record<string, string> = {
+  /**
+   * The pre-fix `pod add-record` accepted `core:` as an input CURIE while never
+   * declaring it, so real damaged pods in the field contain `core:` CURIEs.
+   * Same namespace as `cascade:` — this is an alias, not a second vocabulary.
+   */
+  core: 'https://ns.cascadeprotocol.org/core/v1#',
+
+  // The rest are the pod SCAFFOLDING templates' namespaces (`profile/card.ttl`,
+  // `profile/extended.ttl`, `index.ttl`, both type indexes,
+  // `settings/preferences.ttl`) plus `pod extract`'s output. The record writers
+  // never emit them, so `KNOWN_PREFIXES` has no reason to carry them — but the
+  // files that use them are files doctor scans.
+  rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  solid: 'http://www.w3.org/ns/solid/terms#',
+  ldp: 'http://www.w3.org/ns/ldp#',
+  /** `index.ttl` declares dc terms under this name; `dct:` is the same namespace. */
+  dcterms: 'http://purl.org/dc/terms/',
+  /** `profile/card.ttl` and `settings/preferences.ttl` declare it. */
+  pim: 'http://www.w3.org/ns/pim/space#',
+  /** Not in any template, but `rdf:type` is spellable in any hand-edited file. */
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+};
+
+/**
+ * The complete set of declarations doctor is willing to author.
+ *
+ * DERIVED from {@link KNOWN_PREFIXES} rather than retyped. This defect class
+ * recurred in the first place because a correct prefix table was COPIED instead
+ * of shared, so a second hand-maintained copy of those fifteen entries is the
+ * one thing this verb must not introduce. A prefix added to `KNOWN_PREFIXES`
+ * tomorrow is repairable by doctor the same day, with no second edit.
+ *
+ * The spread order lets a repair-only entry SHADOW a known one, which is the
+ * only remaining way the two could disagree — the drift test in
+ * `tests/pod-doctor.test.ts` is what makes that impossible in practice.
+ */
+export const DOCTOR_PREFIXES: Readonly<Record<string, string>> = Object.freeze({
+  ...KNOWN_PREFIXES,
+  ...REPAIR_ONLY_PREFIXES,
+});
+
+// ─── Parsing ──────────────────────────────────────────────────────────────────
+
+/** A strict Turtle parse: the same one the whole-pod read performs, and fails. */
+export type StrictParse =
+  | { ok: true; quads: Quad[] }
+  | { ok: false; error: string };
+
+/**
+ * Parse `ttl` exactly as strictly as the read path does.
+ *
+ * No `baseIRI`: doctor never re-serializes, so how a relative IRI RESOLVES is
+ * none of its business — only whether the document parses at all. Passing a base
+ * here would change nothing about that answer and would invite the impression
+ * that this function's output is safe to write back. It is not; nothing but the
+ * prepended header is ever written.
+ */
+export function strictParseTurtle(ttl: string): StrictParse {
+  try {
+    return { ok: true, quads: new Parser({ format: 'Turtle' }).parse(ttl) };
+  } catch (e: unknown) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * Prefix names the document already binds, in either Turtle spelling.
+ *
+ * Used ONLY as the no-progress guard in {@link planPrefixRepair}, never to
+ * decide what to add. A file that binds `foo:` on line 50 and uses it on line 10
+ * really does fail with `Undefined prefix "foo:"`, and prepending a SECOND
+ * binding for it would silently re-point every CURIE between those two lines at
+ * a different namespace. This is what turns that into a refusal.
+ */
+export function declaredPrefixes(ttl: string): Set<string> {
+  return new Set(
+    [...ttl.matchAll(/(?:@prefix|PREFIX)\s+([A-Za-z][\w.-]*):/gi)].map((m) => m[1]),
+  );
+}
+
+/** How many heal-and-re-parse rounds before doctor concludes it is not converging. */
+const MAX_HEALING_PASSES = 64;
+
+/** N3's message for the one defect this tool repairs. */
+const UNDEFINED_PREFIX = /Undefined prefix "([^":]+):"/;
+
+// ─── Damage shapes ────────────────────────────────────────────────────────────
+
+/**
+ * What is wrong with a file. Exactly one shape is repairable; the rest are
+ * reported with a next step, because their correct repair is a human decision
+ * and a tool that guessed would be writing the user's health record for them.
+ */
+export type DoctorDamage =
+  /** REPAIRABLE. The header lacks `@prefix` declarations the body uses. */
+  | 'missing-prefix'
+  /** A used prefix is not in {@link DOCTOR_PREFIXES}. Doctor will not invent one. */
+  | 'unknown-prefix'
+  /** The prefix is already bound, later in the file, so prepending would re-point it. */
+  | 'prefix-bound-late'
+  /** The file holds no bytes (or only whitespace). An interrupted write looks like this. */
+  | 'empty'
+  /** The file stops mid-statement. An interrupted write looks like this too. */
+  | 'truncated'
+  /** An IRI contains a character Turtle forbids inside `<...>`. */
+  | 'illegal-iri'
+  /** Not valid Turtle, and not any shape named above. */
+  | 'unparseable'
+  /** The bytes did not decrypt under this pod's key. */
+  | 'undecryptable'
+  /** The bytes are not text at all, in a pod with no encryption manifest. */
+  | 'not-text'
+  /** The file could not be read at all. */
+  | 'unreadable'
+  /** The repair was written and did not read back correctly; the original was restored. */
+  | 'write-verify-failed';
+
+/** What doctor did, or would do, about one file. */
+export type DoctorStatus = 'repairable' | 'repaired' | 'refused' | 'unreadable';
+
+/** One file doctor has something to say about. Healthy files produce none. */
+export interface DoctorFinding {
+  /** Pod-relative path, forward slashes, so output is stable across OSes. */
+  file: string;
+  status: DoctorStatus;
+  damage: DoctorDamage;
+  /** What is wrong, in one sentence. */
+  reason: string;
+  /** What the user should do about it. Absent when doctor already did it. */
+  nextStep?: string;
+  /** The declarations doctor added, or would add, in the order it found them. */
+  missingPrefixes?: string[];
+  /** Triples the repaired document parses to. Only on a repair. */
+  triples?: number;
+  /** Bytes of the original content preserved verbatim. Only on a repair. */
+  preservedBytes?: number;
+  /** Pod-relative path of the backup taken before the write. Only on `repaired`. */
+  backup?: string;
+}
+
+/** The whole run. `--json` prints this verbatim. */
+export interface DoctorReport {
+  pod: string;
+  encrypted: boolean;
+  mode: 'dry-run' | 'write';
+  /** `.ttl` files examined. */
+  scanned: number;
+  /** Files that parsed and were not touched. */
+  healthy: number;
+  repaired: number;
+  repairable: number;
+  refused: number;
+  unreadable: number;
+  findings: DoctorFinding[];
+}
+
+// ─── Planning a repair ────────────────────────────────────────────────────────
+
+/** A repair doctor is prepared to make, or the reason it is not. */
+export type PrefixRepairPlan =
+  | { ok: true; header: string; added: string[]; triples: number }
+  | { ok: false; damage: DoctorDamage; reason: string; nextStep: string };
+
+/**
+ * The one comment doctor writes. Explains an otherwise mysterious header to
+ * whoever opens the file next, and is itself a prepend like any other.
+ */
+export const REPAIR_BANNER =
+  '# Declarations restored by `cascade pod doctor`: used by this file, missing from its header.\n';
+
+/**
+ * Work out the header that makes `original` parse, WITHOUT modifying anything.
+ *
+ * Heals one prefix, re-parses, repeats. The parser is the only thing that gets
+ * to say which prefixes the document uses; see the module header for why a regex
+ * cannot do this job.
+ *
+ * @param registry the namespaces doctor may author. Injected so a test can
+ *        exercise the refusal path without depending on which prefixes happen to
+ *        be in the real registry today.
+ */
+export function planPrefixRepair(
+  original: string,
+  registry: Readonly<Record<string, string>> = DOCTOR_PREFIXES,
+): PrefixRepairPlan {
+  const bound = declaredPrefixes(original);
+  const added: string[] = [];
+  let declarations = '';
+
+  for (let pass = 0; pass < MAX_HEALING_PASSES; pass++) {
+    const parsed = strictParseTurtle(declarations + original);
+    if (parsed.ok) {
+      if (declarations === '') return { ok: true, header: '', added, triples: parsed.quads.length };
+      // Verify the text that will ACTUALLY be written, banner and all — not the
+      // declarations-only text the loop happened to converge on. Property 3 is
+      // "the repaired text parses", and the repaired text is this one.
+      const header = REPAIR_BANNER + declarations + '\n';
+      const verified = strictParseTurtle(header + original);
+      if (!verified.ok) {
+        return {
+          ok: false,
+          damage: 'unparseable',
+          reason: `The repaired text did not parse: ${tidyReason(verified.error)}`,
+          nextStep: 'Nothing was written. This is a doctor bug, not a problem with your pod.',
+        };
+      }
+      return { ok: true, header, added, triples: verified.quads.length };
+    }
+
+    const missing = UNDEFINED_PREFIX.exec(parsed.error);
+    // The text the PARSER saw, not the original: once declarations have been
+    // prepended the error's line number counts from the top of the combined
+    // text, and handing `classifyParseFailure` a different string would make it
+    // compare that line number against the wrong document.
+    if (!missing) return classifyParseFailure(declarations + original, parsed.error);
+    const prefix = missing[1];
+
+    if (bound.has(prefix) || added.includes(prefix)) {
+      return {
+        ok: false,
+        damage: 'prefix-bound-late',
+        reason:
+          `"${prefix}:" is used before the line that binds it (${tidyReason(parsed.error)}).`,
+        nextStep:
+          `Move the \`@prefix ${prefix}:\` declaration above its first use. Doctor will not ` +
+          `prepend a second binding: that would re-point every "${prefix}:" CURIE above the ` +
+          `existing declaration at a possibly different namespace.`,
+      };
+    }
+
+    const namespace = registry[prefix];
+    if (namespace === undefined) {
+      return {
+        ok: false,
+        damage: 'unknown-prefix',
+        reason: `"${prefix}:" is used but never declared, and it is not a prefix doctor knows.`,
+        nextStep:
+          `Add \`@prefix ${prefix}: <the namespace it means> .\` to the top of the file by hand. ` +
+          `Doctor refuses to guess a namespace: writing the wrong one would leave the file ` +
+          `parseable while saying something else.`,
+      };
+    }
+
+    declarations += `@prefix ${prefix}: <${namespace}> .\n`;
+    added.push(prefix);
+  }
+
+  return {
+    ok: false,
+    damage: 'unparseable',
+    reason: `Still not parseable after ${MAX_HEALING_PASSES} prefix repairs; giving up.`,
+    nextStep: 'This file needs a human. Nothing was written.',
+  };
+}
+
+/**
+ * Name a parse failure that is NOT a missing prefix, so the user gets a next
+ * step instead of a raw parser message.
+ *
+ * These heuristics only ever REFINE the report on a file that has already failed
+ * a strict parse. Nothing is repaired on their say-so, so a false positive costs
+ * a slightly wrong sentence and never a byte.
+ */
+export function classifyParseFailure(
+  text: string,
+  error: string,
+): { ok: false; damage: DoctorDamage; reason: string; nextStep: string } {
+  const illegal = firstIllegalIri(text);
+  if (illegal) {
+    const codePoint = `U+${(illegal.offending.codePointAt(0) ?? 0)
+      .toString(16)
+      .toUpperCase()
+      .padStart(4, '0')}`;
+    return {
+      ok: false,
+      damage: 'illegal-iri',
+      reason:
+        `An IRI contains ${codePoint}, which Turtle forbids inside <...>: <${tidyReason(illegal.iri)}>.`,
+      nextStep:
+        `Correct that IRI by hand, or delete the statement that carries it. It was almost ` +
+        `certainly written by an older \`pod add-record\` that did not validate its input; ` +
+        `doctor cannot know what the value was meant to be.`,
+    };
+  }
+
+  if (/but got eof|Unexpected end/i.test(error) || breaksAtLastLine(text, error)) {
+    return {
+      ok: false,
+      damage: 'truncated',
+      reason: `The file breaks at its final line: ${tidyReason(error)}`,
+      nextStep:
+        `A file that stops mid-statement is what an interrupted write leaves behind — ` +
+        `\`writeResource\` is not atomic. Restore it from a backup or from a \`pod export\`; ` +
+        `doctor will not guess the missing text.`,
+    };
+  }
+
+  return {
+    ok: false,
+    damage: 'unparseable',
+    reason: tidyReason(error),
+    nextStep:
+      'Open the file at the point named above and correct it by hand. Doctor repairs missing ' +
+      '`@prefix` declarations only.',
+  };
+}
+
+/** N3 ends every message with the line it gave up on. */
+const ERROR_LINE = /on line (\d+)\.?\s*$/;
+
+/**
+ * Does the document break on its LAST line?
+ *
+ * The definitive truncation signal is the parser saying `eof`, but it only says
+ * that when the cut lands between tokens. A cut through the MIDDLE of a token —
+ * an IRI, a quoted literal — leaves a fragment the parser rejects by name
+ * instead, with no mention of eof, and that is the same damage from the same
+ * cause. What both have in common is that the failure is at the end of the file
+ * rather than somewhere inside it.
+ *
+ * Multi-line only: on a one-line document "the last line" is every line, and
+ * calling every one-line syntax error a truncation would be a guess.
+ */
+function breaksAtLastLine(text: string, error: string): boolean {
+  const at = ERROR_LINE.exec(error.trim());
+  if (!at) return false;
+  const lastContentLine = text.replace(/\s+$/, '').split('\n').length;
+  return lastContentLine > 1 && Number(at[1]) >= lastContentLine;
+}
+
+/**
+ * The first `<...>` in `text` holding a character Turtle forbids, if any.
+ *
+ * Reuses {@link findIllegalIriChar}, which encodes the W3C IRIREF production, so
+ * there is no second opinion about which characters are legal. The scan stays on
+ * one line so an unterminated `<` cannot swallow the rest of the document.
+ */
+function firstIllegalIri(text: string): { iri: string; offending: string } | undefined {
+  for (const m of text.matchAll(/<([^<>\n]*)>/g)) {
+    const offending = findIllegalIriChar(m[1]);
+    if (offending !== undefined) return { iri: m[1], offending };
+  }
+  return undefined;
+}
+
+// ─── Applying a repair ────────────────────────────────────────────────────────
+
+/** Suffix of the backup doctor takes before it writes. Never a `.ttl`, so it is never rescanned. */
+export const BACKUP_SUFFIX = '.doctor-backup';
+
+/**
+ * THE INVARIANT: a repair only ever prepends.
+ *
+ * Asserted rather than assumed, because it is the single property that makes
+ * this verb safe to point at comment-anchored scaffolding. If a future change
+ * ever makes doctor re-serialize, reformat or normalise anything, this throws
+ * instead of quietly destroying a load-bearing comment.
+ */
+export function assertPrependOnly(original: string, repaired: string, header: string): void {
+  if (repaired.length !== header.length + original.length || !repaired.endsWith(original)) {
+    throw new Error(
+      'Internal error: a pod doctor repair was not a pure prepend. Nothing was written. ' +
+        'This tool may only ever add lines above the existing content.',
+    );
+  }
+}
+
+/**
+ * Write a resource the way `writeResource` does, but atomically.
+ *
+ * Same transparency (`dek` present means the bytes on disk are ciphertext), via
+ * a temp file plus a rename. `writeResource` is a bare `writeFileSync`, so a
+ * crash mid-write leaves a truncated resource — and "truncated file" is one of
+ * the damage shapes this very command exists to report. A repair tool that can
+ * create the damage it diagnoses is not one to ship.
+ */
+function writeResourceAtomic(absPath: string, content: string, dek: Buffer | undefined): void {
+  atomicWriteBytes(absPath, dek ? encryptResource(content, dek) : Buffer.from(content, 'utf-8'));
+}
+
+/** What {@link applyRepair} did. */
+type RepairOutcome =
+  | { ok: true; backup: string }
+  | { ok: false; reason: string; nextStep: string };
+
+/**
+ * Write the repair, then prove it. Restores the original if the proof fails.
+ *
+ * Order is the point: verify the repaired TEXT parses (already done by
+ * {@link planPrefixRepair}), assert the prepend invariant, back up, write, read
+ * BACK through the same door a later command will, and only then call it done.
+ */
+function applyRepair(
+  absPath: string,
+  original: string,
+  header: string,
+  dek: Buffer | undefined,
+): RepairOutcome {
+  const repaired = header + original;
+  assertPrependOnly(original, repaired, header);
+
+  // Property 3, restated at the door that actually writes. The planner already
+  // proved this, but the proof must sit between the last chance to change the
+  // text and the write, not somewhere upstream where a later refactor could
+  // slip past it.
+  const proof = strictParseTurtle(repaired);
+  if (!proof.ok) {
+    return {
+      ok: false,
+      reason: `The repaired text does not parse (${tidyReason(proof.error)}).`,
+      nextStep: 'Nothing was written and no backup was taken. The file is untouched.',
+    };
+  }
+
+  // Always a FRESH backup of the bytes about to be replaced. Keeping an older
+  // one would break the restore below: it would put back a file that is not what
+  // this write replaced.
+  const backup = absPath + BACKUP_SUFFIX;
+  fs.copyFileSync(absPath, backup);
+
+  writeResourceAtomic(absPath, repaired, dek);
+
+  let readBack: string;
+  try {
+    readBack = readResource(absPath, dek);
+  } catch (e: unknown) {
+    fs.copyFileSync(backup, absPath);
+    return {
+      ok: false,
+      reason: `The repaired file could not be read back (${tidyReason(errText(e))}).`,
+      nextStep: `The original was restored from ${path.basename(backup)}. Nothing was lost.`,
+    };
+  }
+
+  if (!strictParseTurtle(readBack).ok || !readBack.endsWith(original)) {
+    fs.copyFileSync(backup, absPath);
+    return {
+      ok: false,
+      reason: 'The repaired file did not verify after being written.',
+      nextStep: `The original was restored from ${path.basename(backup)}. Nothing was lost.`,
+    };
+  }
+
+  return { ok: true, backup };
+}
+
+// ─── The scan ─────────────────────────────────────────────────────────────────
+
+/**
+ * Diagnose one file's TEXT. No I/O, no decisions about writing.
+ *
+ * Split out from the sweep so the whole decision table is reachable from a unit
+ * test with a string.
+ */
+export type TextDiagnosis =
+  | { kind: 'healthy' }
+  | { kind: 'repairable'; header: string; added: string[]; triples: number }
+  | { kind: 'refused'; damage: DoctorDamage; reason: string; nextStep: string };
+
+export function diagnoseText(text: string): TextDiagnosis {
+  // An empty file PARSES — as zero triples — so this cannot be left to the
+  // parser. `writeResource` is not atomic, and an interrupted write is exactly
+  // how a bucket ends up holding nothing. "Zero records" and "the records are
+  // gone" must not share an answer.
+  if (text.trim() === '') {
+    return {
+      kind: 'refused',
+      damage: 'empty',
+      reason: 'The file is empty. It parses as zero triples, which is not the same as being healthy.',
+      nextStep:
+        'An interrupted write leaves a file like this. If this bucket should hold records, ' +
+        'restore it from a backup or a `pod export`. Doctor will not invent contents.',
+    };
+  }
+
+  if (strictParseTurtle(text).ok) return { kind: 'healthy' };
+
+  const plan = planPrefixRepair(text);
+  if (!plan.ok) {
+    return { kind: 'refused', damage: plan.damage, reason: plan.reason, nextStep: plan.nextStep };
+  }
+  return { kind: 'repairable', header: plan.header, added: plan.added, triples: plan.triples };
+}
+
+/**
+ * Scan every `.ttl` in the pod and, under `write`, repair the ones whose only
+ * defect is a missing declaration.
+ *
+ * Reads go through the {@link PodReader}, so an encrypted pod is handled with no
+ * special case here and a per-file decrypt failure is told apart from the pod's
+ * key being wrong (which never reaches this function — `openPod` has already
+ * failed by then).
+ */
+export async function runPodDoctor(
+  reader: PodReader,
+  options: { write: boolean },
+): Promise<DoctorReport> {
+  const files = await reader.listTtlFiles();
+  const findings: DoctorFinding[] = [];
+  let healthy = 0;
+
+  for (const absPath of files) {
+    const file = reader.relativePath(absPath);
+
+    // On a pod with NO manifest there is no key and no decrypt step, so
+    // `readResource` hands back whatever the bytes decode to — and Node's UTF-8
+    // read never fails, it substitutes U+FFFD. Ciphertext therefore arrives as a
+    // string of replacement characters and reports as "this file is corrupt
+    // Turtle", which is a misdiagnosis of the one situation where the user still
+    // has something to save. Ask the bytes first.
+    if (reader.dek === undefined && looksLikeSealedBytes(absPath)) {
+      findings.push(notTextFinding(file));
+      continue;
+    }
+
+    const text = reader.readText(absPath);
+    if (!text.ok) {
+      findings.push(unreadableFinding(file, text.failure));
+      continue;
+    }
+
+    const diagnosis = diagnoseText(text.value);
+    if (diagnosis.kind === 'healthy') {
+      healthy += 1;
+      continue;
+    }
+    if (diagnosis.kind === 'refused') {
+      findings.push({
+        file,
+        status: 'refused',
+        damage: diagnosis.damage,
+        reason: diagnosis.reason,
+        nextStep: diagnosis.nextStep,
+      });
+      continue;
+    }
+
+    const shared = {
+      file,
+      damage: 'missing-prefix' as const,
+      missingPrefixes: diagnosis.added,
+      triples: diagnosis.triples,
+      preservedBytes: text.value.length,
+    };
+
+    if (!options.write) {
+      findings.push({
+        ...shared,
+        status: 'repairable',
+        reason: `Missing declarations: ${diagnosis.added.map((p) => `${p}:`).join(' ')}.`,
+        nextStep: 'Re-run with --write to prepend them. Nothing has been changed.',
+      });
+      continue;
+    }
+
+    const outcome = applyRepair(absPath, text.value, diagnosis.header, reader.dek);
+    if (!outcome.ok) {
+      findings.push({
+        ...shared,
+        status: 'refused',
+        damage: 'write-verify-failed',
+        reason: outcome.reason,
+        nextStep: outcome.nextStep,
+      });
+      continue;
+    }
+    findings.push({
+      ...shared,
+      status: 'repaired',
+      reason: `Prepended: ${diagnosis.added.map((p) => `${p}:`).join(' ')}.`,
+      backup: reader.relativePath(absPath + BACKUP_SUFFIX),
+    });
+  }
+
+  const count = (status: DoctorStatus) => findings.filter((f) => f.status === status).length;
+  return {
+    pod: reader.podDir,
+    encrypted: reader.encrypted,
+    mode: options.write ? 'write' : 'dry-run',
+    scanned: files.length,
+    healthy,
+    repaired: count('repaired'),
+    repairable: count('repairable'),
+    refused: count('refused'),
+    unreadable: count('unreadable'),
+    findings,
+  };
+}
+
+/**
+ * Are these bytes something other than text?
+ *
+ * {@link looksLikePlaintext} is the same authority `pod encrypt`/`pod decrypt`
+ * use, so there is no second opinion here about what "text" means. Only asked of
+ * pods with no manifest: when a DEK exists, GCM authentication has already
+ * answered the question properly.
+ */
+function looksLikeSealedBytes(absPath: string): boolean {
+  try {
+    return !looksLikePlaintext(fs.readFileSync(absPath));
+  } catch {
+    // Unreadable for some other reason; let the normal read report it.
+    return false;
+  }
+}
+
+/** A pod resource that is not text, in a pod that claims not to be encrypted. */
+function notTextFinding(file: string): DoctorFinding {
+  return {
+    file,
+    status: 'unreadable',
+    damage: 'not-text',
+    reason:
+      'These bytes are not valid UTF-8, so they are not Turtle. They look like an encrypted ' +
+      'pod resource in a pod that has no settings/encryption.json.',
+    nextStep:
+      'Restore settings/encryption.json from a backup: it holds the only wrapped copy of this ' +
+      "pod's key, and without it these resources cannot be decrypted by anyone. Doctor did not " +
+      'change the file.',
+  };
+}
+
+/**
+ * Turn a read-layer failure into a finding.
+ *
+ * The decrypt reason arrives already discriminated by the read layer: a file
+ * that was never sealed says so, rather than blaming a passphrase that is
+ * perfectly correct. Repeating that misattribution here is the error this
+ * function exists to not make.
+ */
+function unreadableFinding(file: string, failure: PodReadFailure): DoctorFinding {
+  const decrypt = failure.kind === 'decrypt';
+  return {
+    file,
+    status: 'unreadable',
+    damage: decrypt ? 'undecryptable' : 'unreadable',
+    reason: failure.reason,
+    nextStep: decrypt
+      ? 'This one resource did not authenticate under the pod key. The rest of the pod was ' +
+        'read with that same key, so the passphrase is not the problem: these bytes are. ' +
+        'Restore the file from a backup, or re-seal it if it was written unencrypted.'
+      : 'The file could not be read at all. Check its permissions and that it still exists.',
+  };
+}
+
+/**
+ * The exit code for a finished run, on the read layer's contract:
+ *
+ *   0 — nothing is wrong, or everything found was repaired.
+ *   1 — damage remains: doctor could READ the file and will not repair it.
+ *   2 — something could not be read at all (a resource that did not decrypt, a
+ *       file that is not text, an I/O failure).
+ *
+ * 2 outranks 1 deliberately. "I could not look at part of this pod" is a weaker
+ * claim than "I looked and here is what is wrong", and reporting the weaker one
+ * as the stronger is the exact defect this area of the CLI keeps re-shipping.
+ * The pod failing to OPEN at all is also 2, decided by the command.
+ */
+export function doctorExitCode(report: DoctorReport): 0 | 1 | 2 {
+  if (report.unreadable > 0) return 2;
+  return report.repairable + report.refused > 0 ? 1 : 0;
+}
+
+/** Error text, whatever was thrown. */
+function errText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/tests/pod-doctor-encrypted.test.ts
+++ b/tests/pod-doctor-encrypted.test.ts
@@ -1,0 +1,329 @@
+/**
+ * `cascade pod doctor` on an ENCRYPTED pod.
+ *
+ * Split from `pod-doctor.test.ts` because the Argon2id KDF is deliberately
+ * expensive (t=3, m=64 MiB) and runs on every open.
+ *
+ * Three things are under test here and nowhere else:
+ *
+ *   1. ENCRYPTION TRANSPARENCY. The repair must go through the pod's DEK in both
+ *      directions, and the file must still be ciphertext afterwards. A repair
+ *      tool that "fixed" a bucket by leaving the patient's medication list in
+ *      plaintext on disk would be a far worse bug than the one it repaired.
+ *   2. A pod that will NOT OPEN is exit 2, not a clean bill of health. "This pod
+ *      is fine" and "I could not look at this pod" must never share an answer —
+ *      the mistake this whole area of the CLI keeps re-making.
+ *   3. ONE resource that does not decrypt is reported as that, not as a wrong
+ *      passphrase. The passphrase demonstrably worked: every other file in the
+ *      pod opened with it. Blaming it sends the user to re-check the one thing
+ *      that is not wrong.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { resolveDek, readResource, writeResource } from '../src/lib/pod-encryption.js';
+import { BACKUP_SUFFIX, type DoctorReport } from '../src/lib/pod-doctor.js';
+
+const PASSPHRASE = 'doctor-encrypted-pod-passphrase';
+const TEST_TIMEOUT_MS = 120_000;
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+/** Streams kept APART: the report is stdout, the unreadable-file shout is stderr. */
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = buildProgram();
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws; exitCode carries the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+async function doctorJson(
+  args: string[],
+): Promise<{ report: DoctorReport; stderr: string; exitCode: number }> {
+  const r = await runCli(['--json', 'pod', 'doctor', ...args]);
+  const start = r.stdout.indexOf('{');
+  expect(start, `no JSON in doctor output: ${r.stdout}`).toBeGreaterThanOrEqual(0);
+  return {
+    report: JSON.parse(r.stdout.slice(start, r.stdout.lastIndexOf('}') + 1)) as DoctorReport,
+    stderr: r.stderr,
+    exitCode: r.exitCode,
+  };
+}
+
+const RXNORM_BUNDLE = JSON.stringify({
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'MedicationStatement',
+        id: 'm1',
+        status: 'active',
+        medicationCodeableConcept: {
+          coding: [
+            {
+              system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+              code: '860975',
+              display: 'Metformin 500 MG',
+            },
+          ],
+        },
+        subject: { reference: 'Patient/p1' },
+      },
+    },
+  ],
+});
+
+let root: string;
+/** Built ONCE: the KDF is the slow part, and every test wants the same pod. */
+let sealedPod: string;
+
+beforeAll(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-doctor-enc-'));
+  process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+  sealedPod = path.join(root, 'sealed-pod');
+  expect((await runCli(['pod', 'init', sealedPod, '--encrypt'])).exitCode).toBe(0);
+  const bundle = path.join(root, 'bundle.json');
+  fs.writeFileSync(bundle, RXNORM_BUNDLE, 'utf-8');
+  expect((await runCli(['pod', 'import', sealedPod, bundle])).exitCode).toBe(0);
+  delete process.env.CASCADE_POD_PASSPHRASE;
+}, TEST_TIMEOUT_MS);
+
+afterAll(() => {
+  try {
+    fs.rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+beforeEach(() => {
+  process.env.CASCADE_POD_PASSPHRASE = PASSPHRASE;
+});
+afterEach(() => {
+  delete process.env.CASCADE_POD_PASSPHRASE;
+});
+
+/** A throwaway copy of the sealed pod, so a test can damage it freely. */
+function copyOfSealedPod(name: string): string {
+  const dest = path.join(root, name);
+  fs.cpSync(sealedPod, dest, { recursive: true });
+  return dest;
+}
+
+/** Bytes on disk that are NOT the plaintext Turtle: the ciphertext check. */
+function isCiphertext(file: string): boolean {
+  const blob = fs.readFileSync(file);
+  return !blob.toString('utf-8').includes('@prefix');
+}
+
+/**
+ * Damage the bucket INSIDE the envelope, the way the shipped defect did: strip
+ * the `@prefix` block from the plaintext and re-seal it. The file stays
+ * ciphertext; what is wrong is only visible with the key.
+ */
+function stripPrefixHeaderSealed(podDir: string, relFile: string): string {
+  const dek = resolveDek(podDir, PASSPHRASE);
+  const abs = path.join(podDir, relFile);
+  const plaintext = readResource(abs, dek);
+  expect(plaintext, 'the fixture does not carry the prefix header').toContain('@prefix rxnorm:');
+  const damaged = plaintext
+    .split('\n')
+    .filter((l) => !l.trimStart().startsWith('@prefix'))
+    .join('\n');
+  writeResource(abs, damaged, dek);
+  expect(isCiphertext(abs), 'the fixture stopped being ciphertext').toBe(true);
+  return damaged;
+}
+
+function plaintextOf(podDir: string, relFile: string): string {
+  return readResource(path.join(podDir, relFile), resolveDek(podDir, PASSPHRASE));
+}
+
+function parsesStrictly(ttl: string): boolean {
+  try {
+    new Parser({ format: 'Turtle' }).parse(ttl);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function snapshot(dir: string): Map<string, Buffer> {
+  const out = new Map<string, Buffer>();
+  const walk = (d: string): void => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.isFile()) out.set(path.relative(dir, full), fs.readFileSync(full));
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+function expectUnchanged(before: Map<string, Buffer>, dir: string): void {
+  const after = snapshot(dir);
+  expect([...after.keys()].sort(), 'files appeared or vanished').toEqual([...before.keys()].sort());
+  for (const [rel, bytes] of before) {
+    expect(after.get(rel)!.equals(bytes), `${rel} was modified`).toBe(true);
+  }
+}
+
+const MEDS = 'clinical/medications.ttl';
+
+describe('doctor on an encrypted pod', () => {
+  it(
+    'repairs through the DEK, leaves the file ciphertext, and the pod reads back',
+    async () => {
+      const pod = copyOfSealedPod('repairs-through-dek');
+      const damaged = stripPrefixHeaderSealed(pod, MEDS);
+      expect(parsesStrictly(damaged)).toBe(false);
+
+      // The pod really is unreadable first.
+      expect((await runCli(['--json', 'pod', 'query', pod, '--medications'])).exitCode).not.toBe(0);
+
+      const r = await doctorJson([pod, '--write']);
+      expect(r.exitCode).toBe(0);
+      expect(r.report.encrypted).toBe(true);
+      expect(r.report.repaired).toBe(1);
+      expect(r.report.findings[0].file).toBe(MEDS);
+      expect(r.report.findings[0].missingPrefixes).toContain('rxnorm');
+
+      // Still ciphertext. This is the assertion that a "repair" which quietly
+      // wrote plaintext would fail.
+      expect(isCiphertext(path.join(pod, MEDS)), 'the repair wrote plaintext').toBe(true);
+      // The backup is ciphertext too — it is a byte copy of a sealed file.
+      expect(isCiphertext(path.join(pod, MEDS + BACKUP_SUFFIX)), 'the backup is plaintext').toBe(true);
+
+      // Prepend-only holds through the envelope.
+      const repaired = plaintextOf(pod, MEDS);
+      expect(parsesStrictly(repaired)).toBe(true);
+      expect(repaired.endsWith(damaged)).toBe(true);
+
+      const q = await runCli(['--json', 'pod', 'query', pod, '--medications']);
+      expect(q.exitCode).toBe(0);
+      expect(q.stdout).toContain('Metformin 500 MG');
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'is idempotent on a sealed pod, and re-sealing does not churn the healthy files',
+    async () => {
+      const pod = copyOfSealedPod('idempotent-sealed');
+      stripPrefixHeaderSealed(pod, MEDS);
+      expect((await doctorJson([pod, '--write'])).report.repaired).toBe(1);
+
+      const after = snapshot(pod);
+      const second = await doctorJson([pod, '--write']);
+      expect(second.exitCode).toBe(0);
+      expect(second.report.findings).toEqual([]);
+      expectUnchanged(after, pod);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'a WRONG passphrase exits 2 and modifies nothing',
+    async () => {
+      const pod = copyOfSealedPod('wrong-passphrase');
+      stripPrefixHeaderSealed(pod, MEDS);
+      const before = snapshot(pod);
+
+      process.env.CASCADE_POD_PASSPHRASE = 'not-the-passphrase';
+      const r = await runCli(['pod', 'doctor', pod, '--write']);
+      expect(r.exitCode, 'a locked pod must not read as a clean pod').toBe(2);
+      expect(r.stderr).toMatch(/passphrase did not open it/);
+      expectUnchanged(before, pod);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'NO passphrase at all exits 2 and modifies nothing',
+    async () => {
+      const pod = copyOfSealedPod('no-passphrase');
+      stripPrefixHeaderSealed(pod, MEDS);
+      const before = snapshot(pod);
+
+      delete process.env.CASCADE_POD_PASSPHRASE;
+      const r = await runCli(['pod', 'doctor', pod, '--write']);
+      expect(r.exitCode).toBe(2);
+      expectUnchanged(before, pod);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'reports ONE undecryptable resource without blaming the passphrase',
+    async () => {
+      // Root 3.160(b): the shipped message misattributes "this one resource
+      // failed authentication" to "your passphrase is wrong". The passphrase
+      // demonstrably works — every other file in this pod opened with it.
+      const pod = copyOfSealedPod('unsealed-resource');
+      const stray = path.join(pod, 'clinical', 'conditions.ttl');
+      fs.writeFileSync(stray, '@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .\n', 'utf-8');
+      const before = snapshot(pod);
+
+      const r = await doctorJson([pod, '--write']);
+      // 2, not 1: this file was never examined, and "I could not look" must not
+      // be reported as "I looked and here is what is wrong".
+      expect(r.exitCode).toBe(2);
+      expect(r.report.unreadable).toBe(1);
+      const finding = r.report.findings.find((f) => f.file === 'clinical/conditions.ttl');
+      expect(finding).toBeTruthy();
+      expect(finding!.status).toBe('unreadable');
+      expect(finding!.damage).toBe('undecryptable');
+      expect(finding!.reason).toMatch(/NOT sealed/);
+      expect(finding!.reason).not.toMatch(/incorrect passphrase/);
+      expect(finding!.nextStep).toMatch(/passphrase is not the problem/);
+      // Said out loud on stderr, with the right cause, not only in the report.
+      expect(r.stderr).toContain('clinical/conditions.ttl');
+      expect(r.stderr).toMatch(/NOT sealed/);
+      expect(r.stderr).not.toMatch(/incorrect passphrase/);
+
+      // And an unreadable file is never rewritten on a guess.
+      expectUnchanged(before, pod);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/tests/pod-doctor-write-verify.test.ts
+++ b/tests/pod-doctor-write-verify.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The one safety property of `pod doctor` that a healthy run never exercises:
+ * READ THE REPAIR BACK, and put the original returned if it does not verify.
+ *
+ * Every other property is visible on the happy path. This one only fires when a
+ * write goes wrong — a short write, a filesystem that lied about the rename, a
+ * key that no longer opens what it just sealed — and code that only runs on a
+ * bad day is code nobody has ever seen run. So the bad day is injected here:
+ * `atomicWriteBytes` is stubbed to put DIFFERENT bytes on disk than doctor asked
+ * it to, and the whole recovery is then real. Doctor's own read-back, its own
+ * strict parse, its own restore-from-backup.
+ *
+ * The mock is why this lives in its own file: `vi.mock` is module-scoped, and
+ * every other doctor test needs the real writer.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { BACKUP_SUFFIX, type DoctorReport } from '../src/lib/pod-doctor.js';
+
+/**
+ * Corrupt exactly one write, on demand. Everything else in the module — the
+ * plaintext/ciphertext classifier doctor uses to spot an unkeyed sealed pod
+ * included — stays real.
+ */
+const corruptNextWrite = { armed: false };
+
+vi.mock('../src/lib/pod-resources.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/pod-resources.js')>();
+  return {
+    ...actual,
+    atomicWriteBytes: (absPath: string, bytes: Buffer): void => {
+      actual.atomicWriteBytes(
+        absPath,
+        corruptNextWrite.armed ? Buffer.from('this is not Turtle at all ;;; }{\n', 'utf-8') : bytes,
+      );
+    },
+  };
+});
+
+const TEST_TIMEOUT_MS = 60_000;
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = buildProgram();
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws; exitCode carries the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-doctor-verify-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+beforeEach(() => {
+  tmpDirs = [];
+  corruptNextWrite.armed = false;
+});
+afterEach(() => {
+  corruptNextWrite.armed = false;
+  for (const d of tmpDirs) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  tmpDirs = [];
+});
+
+const RXNORM_BUNDLE = JSON.stringify({
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'MedicationStatement',
+        id: 'm1',
+        status: 'active',
+        medicationCodeableConcept: {
+          coding: [
+            {
+              system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+              code: '860975',
+              display: 'Metformin 500 MG',
+            },
+          ],
+        },
+        subject: { reference: 'Patient/p1' },
+      },
+    },
+  ],
+});
+
+/** An imported pod whose medications bucket has had its `@prefix` block deleted. */
+async function damagedPod(): Promise<{ podDir: string; medsPath: string; damaged: Buffer }> {
+  const base = mkTmpDir();
+  const podDir = path.join(base, 'pod');
+  const bundle = path.join(base, 'bundle.json');
+  fs.writeFileSync(bundle, RXNORM_BUNDLE, 'utf-8');
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+  expect((await runCli(['pod', 'import', podDir, bundle])).exitCode).toBe(0);
+
+  const medsPath = path.join(podDir, 'clinical', 'medications.ttl');
+  const text = fs.readFileSync(medsPath, 'utf-8');
+  expect(text).toContain('rxnorm:860975');
+  fs.writeFileSync(
+    medsPath,
+    text.split('\n').filter((l) => !l.trimStart().startsWith('@prefix')).join('\n'),
+    'utf-8',
+  );
+  return { podDir, medsPath, damaged: fs.readFileSync(medsPath) };
+}
+
+async function doctorJson(args: string[]): Promise<{ report: DoctorReport; exitCode: number }> {
+  const r = await runCli(['--json', 'pod', 'doctor', ...args]);
+  const start = r.stdout.indexOf('{');
+  expect(start, `no JSON in doctor output: ${r.stdout}`).toBeGreaterThanOrEqual(0);
+  return {
+    report: JSON.parse(r.stdout.slice(start, r.stdout.lastIndexOf('}') + 1)) as DoctorReport,
+    exitCode: r.exitCode,
+  };
+}
+
+describe('a repair that does not read back is undone', () => {
+  it(
+    'restores the original from the backup and reports the failure',
+    async () => {
+      const { podDir, medsPath, damaged } = await damagedPod();
+
+      corruptNextWrite.armed = true;
+      const r = await doctorJson([podDir, '--write']);
+
+      // The write happened and was rejected: not repaired, and said so.
+      expect(r.report.repaired).toBe(0);
+      expect(r.report.refused).toBe(1);
+      expect(r.exitCode).toBe(1);
+      const finding = r.report.findings[0];
+      expect(finding.file).toBe('clinical/medications.ttl');
+      expect(finding.damage).toBe('write-verify-failed');
+      expect(finding.nextStep).toMatch(/restored/i);
+
+      // THE POINT: the file on disk is the original, byte for byte. Not the
+      // corrupt bytes, and not a half-repair.
+      expect(
+        fs.readFileSync(medsPath).equals(damaged),
+        'the corrupt write was left on disk',
+      ).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'the control: the same run with the write left alone repairs normally',
+    async () => {
+      // Without this the test above passes just as well against a doctor that
+      // never writes anything at all.
+      const { podDir, medsPath, damaged } = await damagedPod();
+
+      corruptNextWrite.armed = false;
+      const r = await doctorJson([podDir, '--write']);
+
+      expect(r.report.repaired).toBe(1);
+      expect(r.exitCode).toBe(0);
+      const repaired = fs.readFileSync(medsPath, 'utf-8');
+      expect(repaired.endsWith(damaged.toString('utf-8'))).toBe(true);
+      expect(repaired.length).toBeGreaterThan(damaged.length);
+      expect(fs.existsSync(medsPath + BACKUP_SUFFIX)).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/tests/pod-doctor.test.ts
+++ b/tests/pod-doctor.test.ts
@@ -1,0 +1,700 @@
+/**
+ * `cascade pod doctor` — the recovery path for a pod the write verbs refuse.
+ *
+ * Every safety property this verb claims has a test here, and every test was
+ * built by DAMAGING a real pod the way the shipped defect damaged one (strip the
+ * `@prefix` lines an importer wrote, leave the CURIEs that used them) rather
+ * than by hand-writing a convenient fixture.
+ *
+ * The properties under test, in the order they matter:
+ *   1. dry run by default — `--write` is required to change a byte
+ *   2. ONLY EVER PREPENDS — the original content is a strict suffix of the result
+ *   3. the repaired text parses BEFORE anything is written
+ *   4. the original is backed up before the write
+ *   5. a prefix outside the registry is a refusal, never a guessed namespace
+ *   6. idempotent — a second run has nothing to do
+ *   7. (encrypted-pod transparency lives in pod-doctor-encrypted.test.ts, which
+ *      is split out because the Argon2id KDF makes it slow)
+ *
+ * Plus the two that guard the SCOPE of the verb: a healthy pod is byte-identical
+ * after `--write`, and a repaired `settings/publicTypeIndex.ttl` keeps its
+ * load-bearing comments verbatim — the property that makes it safe to point this
+ * at human-curated scaffolding at all.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { KNOWN_PREFIXES } from '../src/lib/bucket-write.js';
+import {
+  DOCTOR_PREFIXES,
+  REPAIR_ONLY_PREFIXES,
+  BACKUP_SUFFIX,
+  planPrefixRepair,
+  diagnoseText,
+  declaredPrefixes,
+  strictParseTurtle,
+  assertPrependOnly,
+  doctorExitCode,
+  type DoctorReport,
+} from '../src/lib/pod-doctor.js';
+
+const TEST_TIMEOUT_MS = 60_000;
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+  return program;
+}
+
+/**
+ * Streams are kept APART. Doctor prints its report on stdout and shouts about
+ * files it could not read on stderr, and a harness that merges them cannot tell
+ * the two claims apart — nor parse the report.
+ */
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = buildProgram();
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* exitOverride throws; exitCode carries the failure */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+/** Run doctor in `--json` mode and return the parsed report. */
+async function doctorJson(
+  args: string[],
+): Promise<{ report: DoctorReport; stderr: string; exitCode: number }> {
+  const r = await runCli(['--json', 'pod', 'doctor', ...args]);
+  const start = r.stdout.indexOf('{');
+  expect(start, `no JSON in doctor output: ${r.stdout}`).toBeGreaterThanOrEqual(0);
+  return {
+    report: JSON.parse(r.stdout.slice(start, r.stdout.lastIndexOf('}') + 1)) as DoctorReport,
+    stderr: r.stderr,
+    exitCode: r.exitCode,
+  };
+}
+
+let tmpDirs: string[] = [];
+function mkTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-doctor-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+beforeEach(() => {
+  tmpDirs = [];
+});
+afterEach(() => {
+  for (const d of tmpDirs) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  tmpDirs = [];
+});
+
+/** One medication whose only code is RxNorm, so the bucket really declares `rxnorm:`. */
+const RXNORM_BUNDLE = {
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'MedicationStatement',
+        id: 'm1',
+        status: 'active',
+        medicationCodeableConcept: {
+          coding: [
+            {
+              system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+              code: '860975',
+              display: 'Metformin 500 MG',
+            },
+          ],
+        },
+        subject: { reference: 'Patient/p1' },
+      },
+    },
+  ],
+};
+
+/** The strict parse the whole-pod read performs, and that a damaged bucket fails. */
+function parses(file: string): boolean {
+  try {
+    new Parser({ format: 'Turtle' }).parse(fs.readFileSync(file, 'utf-8'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Init a pod and import the RxNorm bundle, so its bucket carries importer-only prefixes. */
+async function importedPod(): Promise<{ podDir: string; medsPath: string }> {
+  const base = mkTmpDir();
+  const podDir = path.join(base, 'pod');
+  const bundle = path.join(base, 'bundle.json');
+  fs.writeFileSync(bundle, JSON.stringify(RXNORM_BUNDLE), 'utf-8');
+
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+  expect((await runCli(['pod', 'import', podDir, bundle])).exitCode).toBe(0);
+
+  const medsPath = path.join(podDir, 'clinical', 'medications.ttl');
+  expect(fs.readFileSync(medsPath, 'utf-8')).toContain('rxnorm:860975');
+  return { podDir, medsPath };
+}
+
+/**
+ * Damage a file exactly the way the shipped defect did: delete the `@prefix`
+ * block, keep the body that uses it.
+ */
+function stripPrefixHeader(file: string): Buffer {
+  const text = fs.readFileSync(file, 'utf-8');
+  const body = text
+    .split('\n')
+    .filter((l) => !l.trimStart().startsWith('@prefix'))
+    .join('\n');
+  fs.writeFileSync(file, body, 'utf-8');
+  // The fixture must actually create the hazard, or every assertion is vacuous.
+  expect(parses(file), 'the fixture is not actually damaged').toBe(false);
+  return fs.readFileSync(file);
+}
+
+/** Every file under `dir`, pod-relative, with its bytes. */
+function snapshot(dir: string): Map<string, Buffer> {
+  const out = new Map<string, Buffer>();
+  const walk = (d: string): void => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.isFile()) out.set(path.relative(dir, full), fs.readFileSync(full));
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+function expectUnchanged(before: Map<string, Buffer>, dir: string): void {
+  const after = snapshot(dir);
+  expect([...after.keys()].sort(), 'files appeared or vanished').toEqual([...before.keys()].sort());
+  for (const [rel, bytes] of before) {
+    expect(after.get(rel)!.equals(bytes), `${rel} was modified`).toBe(true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The repair the verb exists for
+// ---------------------------------------------------------------------------
+
+describe('repairing the damage the real bug produced', () => {
+  it('repairs the bucket and the pod reads again through the real CLI', async () => {
+    const { podDir, medsPath } = await importedPod();
+    stripPrefixHeader(medsPath);
+
+    // The pod really is unreadable first, or "it reads afterwards" proves nothing.
+    expect((await runCli(['--json', 'pod', 'query', podDir, '--medications'])).exitCode).not.toBe(0);
+
+    const fixed = await doctorJson([podDir, '--write']);
+    expect(fixed.exitCode).toBe(0);
+    expect(fixed.report.repaired).toBe(1);
+    expect(fixed.report.findings[0].file).toBe('clinical/medications.ttl');
+    expect(fixed.report.findings[0].missingPrefixes).toContain('rxnorm');
+
+    expect(parses(medsPath)).toBe(true);
+    const q = await runCli(['--json', 'pod', 'query', podDir, '--medications']);
+    expect(q.exitCode).toBe(0);
+    expect(q.stdout).toContain('Metformin 500 MG');
+  }, TEST_TIMEOUT_MS);
+
+  it('is idempotent: a second --write has nothing to do', async () => {
+    const { podDir, medsPath } = await importedPod();
+    stripPrefixHeader(medsPath);
+    expect((await doctorJson([podDir, '--write'])).report.repaired).toBe(1);
+
+    const after = snapshot(podDir);
+    const second = await doctorJson([podDir, '--write']);
+    expect(second.exitCode).toBe(0);
+    expect(second.report.repaired).toBe(0);
+    expect(second.report.findings).toEqual([]);
+    expectUnchanged(after, podDir);
+  }, TEST_TIMEOUT_MS);
+
+  it('adds every declaration the body uses and NOT ONE MORE', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const before = fs.readFileSync(medsPath, 'utf-8');
+    const declaredBefore = declaredPrefixes(before);
+    stripPrefixHeader(medsPath);
+
+    await runCli(['pod', 'doctor', podDir, '--write']);
+
+    const after = fs.readFileSync(medsPath, 'utf-8');
+    // A declaration the body does not use is not a repair, it is noise the user
+    // did not ask for in a file holding their health record.
+    for (const p of declaredPrefixes(after)) {
+      expect(declaredBefore.has(p), `doctor authored an unused declaration: ${p}:`).toBe(true);
+      expect(after.includes(`${p}:`), `${p}: was declared but is unused`).toBe(true);
+    }
+  }, TEST_TIMEOUT_MS);
+});
+
+// ---------------------------------------------------------------------------
+// Property 1: dry run by default
+// ---------------------------------------------------------------------------
+
+describe('dry run is the default', () => {
+  it('changes nothing at all, and writes no backup, on a damaged pod', async () => {
+    const { podDir, medsPath } = await importedPod();
+    stripPrefixHeader(medsPath);
+    const before = snapshot(podDir);
+
+    const dry = await doctorJson([podDir]);
+    expect(dry.exitCode).toBe(1);
+    expect(dry.report.mode).toBe('dry-run');
+    expect(dry.report.repairable).toBe(1);
+    expect(dry.report.repaired).toBe(0);
+
+    expectUnchanged(before, podDir);
+    expect(fs.existsSync(medsPath + BACKUP_SUFFIX), 'a dry run wrote a backup').toBe(false);
+  }, TEST_TIMEOUT_MS);
+
+  it('leaves a HEALTHY pod byte-identical even under --write', async () => {
+    // The zero-change guarantee. A repair tool that reformats a file it had no
+    // business touching is a repair tool nobody can be told to run.
+    const { podDir } = await importedPod();
+    const before = snapshot(podDir);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode).toBe(0);
+    expect(r.report.findings).toEqual([]);
+    expect(r.report.healthy).toBe(r.report.scanned);
+    expect(r.report.scanned).toBeGreaterThan(0);
+
+    expectUnchanged(before, podDir);
+  }, TEST_TIMEOUT_MS);
+});
+
+// ---------------------------------------------------------------------------
+// Property 2: only ever prepends
+// ---------------------------------------------------------------------------
+
+describe('a repair is a pure prepend', () => {
+  it('leaves the original content as an exact suffix of the repaired file', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const damaged = stripPrefixHeader(medsPath).toString('utf-8');
+
+    await runCli(['pod', 'doctor', podDir, '--write']);
+
+    const repaired = fs.readFileSync(medsPath, 'utf-8');
+    expect(repaired.endsWith(damaged), 'the original bytes did not survive verbatim').toBe(true);
+    expect(repaired.indexOf(damaged)).toBe(repaired.length - damaged.length);
+    expect(repaired.length).toBeGreaterThan(damaged.length);
+  }, TEST_TIMEOUT_MS);
+
+  it('backs the original up, and the backup is the damaged bytes exactly', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const damaged = stripPrefixHeader(medsPath);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.report.findings[0].backup).toBe('clinical/medications.ttl' + BACKUP_SUFFIX);
+    expect(fs.readFileSync(medsPath + BACKUP_SUFFIX).equals(damaged)).toBe(true);
+  }, TEST_TIMEOUT_MS);
+
+  it('assertPrependOnly rejects anything that is not a pure prepend', () => {
+    // The invariant, tested directly, because it is the guard that would fire if
+    // a future change ever made doctor re-serialize instead of prepend.
+    expect(() => assertPrependOnly('body', 'HDR\nbody', 'HDR\n')).not.toThrow();
+    expect(() => assertPrependOnly('body', 'HDR\nbodyX', 'HDR\n')).toThrow(/pure prepend/);
+    expect(() => assertPrependOnly('body', 'HDR\nBODY', 'HDR\n')).toThrow(/pure prepend/);
+    expect(() => assertPrependOnly('body', 'body', 'HDR\n')).toThrow(/pure prepend/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The scaffolding boundary — why prepend-only is what makes this safe
+// ---------------------------------------------------------------------------
+
+describe('human-curated scaffolding is repaired without losing a comment', () => {
+  it('keeps publicTypeIndex.ttl\'s comment anchors verbatim through a repair', async () => {
+    // These files are deliberately NOT routed through the bucket chokepoint,
+    // because re-serializing them drops their comments — and `extended.ttl`
+    // regex-anchors PHI population on a literal comment line. Doctor scans them
+    // anyway (archived backlog 1.6 was exactly this defect in this exact file),
+    // and it is safe ONLY because it prepends. If this goes red, doctor has
+    // started rewriting instead of prepending.
+    const { podDir } = await importedPod();
+    const indexPath = path.join(podDir, 'settings', 'publicTypeIndex.ttl');
+
+    const original = fs.readFileSync(indexPath, 'utf-8');
+    const anchors = original
+      .split('\n')
+      .filter((l) => l.trimStart().startsWith('#') && l.trim().length > 2);
+    expect(anchors.length, 'the fixture carries no comments to lose').toBeGreaterThan(3);
+
+    stripPrefixHeader(indexPath);
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode).toBe(0);
+    expect(r.report.repaired).toBe(1);
+    expect(r.report.findings[0].file).toBe('settings/publicTypeIndex.ttl');
+
+    const repaired = fs.readFileSync(indexPath, 'utf-8');
+    expect(parses(indexPath)).toBe(true);
+    for (const anchor of anchors) {
+      expect(repaired, `lost the comment line: ${anchor}`).toContain(anchor);
+    }
+    // And the triples the index carries are still there, in their original text.
+    expect(repaired).toContain('<> a solid:TypeIndex');
+  }, TEST_TIMEOUT_MS);
+});
+
+// ---------------------------------------------------------------------------
+// Property 5: never invent a namespace
+// ---------------------------------------------------------------------------
+
+describe('a prefix outside the registry is a refusal', () => {
+  it('refuses, names the prefix, exits non-zero and leaves the file byte-identical', async () => {
+    const { podDir, medsPath } = await importedPod();
+    // Damage it the usual way, then re-point one CURIE at a prefix nobody knows.
+    fs.writeFileSync(
+      medsPath,
+      fs.readFileSync(medsPath, 'utf-8').replace(/rxnorm:/g, 'mysteryvocab:'),
+      'utf-8',
+    );
+    const damaged = stripPrefixHeader(medsPath);
+    const before = snapshot(podDir);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode).toBe(1);
+    expect(r.report.repaired).toBe(0);
+    expect(r.report.refused).toBe(1);
+    const finding = r.report.findings[0];
+    expect(finding.status).toBe('refused');
+    expect(finding.damage).toBe('unknown-prefix');
+    expect(finding.reason).toContain('mysteryvocab:');
+
+    expect(fs.readFileSync(medsPath).equals(damaged)).toBe(true);
+    expect(fs.existsSync(medsPath + BACKUP_SUFFIX), 'a refusal wrote a backup').toBe(false);
+    expectUnchanged(before, podDir);
+  }, TEST_TIMEOUT_MS);
+
+  it('refuses the WHOLE file even though some of its prefixes are known', () => {
+    // Partial repair is the trap: healing `clinical:` and stopping at the
+    // unknown one would leave a file that still does not parse AND has been
+    // rewritten. It is all or nothing.
+    const plan = planPrefixRepair('clinical:s a mysteryvocab:Thing .\n');
+    expect(plan.ok).toBe(false);
+    if (plan.ok) return;
+    expect(plan.damage).toBe('unknown-prefix');
+    expect(plan.reason).toContain('mysteryvocab');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Discovery comes from the parser, not from a regex over the text
+// ---------------------------------------------------------------------------
+
+describe('missing prefixes are discovered from the parser, not by pattern-matching', () => {
+  it('ignores colons in comments, string literals and absolute IRIs', () => {
+    // Every one of these would make a regex-based implementation author a
+    // declaration the document never asked for. Only `health:` is really used.
+    const doc = [
+      '# see rxnorm:860975 and loinc:2345-7 for details',
+      'health:s health:p "sct:73211009 was recorded" .',
+      'health:s health:q <http://example.org/thing#pots:x> .',
+    ].join('\n');
+
+    const plan = planPrefixRepair(doc);
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.added).toEqual(['health']);
+    expect(plan.header).not.toContain('rxnorm');
+    expect(plan.header).not.toContain('loinc');
+    expect(plan.header).not.toContain('sct:');
+    expect(plan.header).not.toContain('pots');
+  });
+
+  it('refuses a prefix bound BELOW its first use rather than prepending a second binding', () => {
+    // The parser really does report this as an undefined prefix. Prepending
+    // would make it parse while silently re-pointing every CURIE above the
+    // existing declaration at whichever namespace doctor chose.
+    const doc = 'health:s health:p "x" .\n@prefix health: <https://example.org/other#> .\n';
+    const plan = planPrefixRepair(doc);
+    expect(plan.ok).toBe(false);
+    if (plan.ok) return;
+    expect(plan.damage).toBe('prefix-bound-late');
+  });
+
+  it('n3 still words an undefined prefix the way the repair reads it', () => {
+    // The whole repair hangs off ONE string in a third-party parser's error
+    // message. An n3 upgrade that reworded it would not break a build or fail a
+    // type check: doctor would simply stop recognising the defect it exists to
+    // fix, refuse every damaged bucket as "unparseable", and nobody would find
+    // out until a user with a broken pod did. That is a silent capability loss,
+    // so the dependency is stated here rather than left implicit.
+    const err = strictParseTurtle('<urn:a> rxnorm:p <urn:b> .');
+    expect(err.ok).toBe(false);
+    if (err.ok) return;
+    expect(
+      err.error,
+      'n3 changed its undefined-prefix message; update UNDEFINED_PREFIX in pod-doctor.ts',
+    ).toMatch(/Undefined prefix "rxnorm:"/);
+  });
+
+  it('honours the registry it is handed, so the refusal path is not registry-dependent', () => {
+    const doc = 'health:s health:p "x" .\n';
+    expect(planPrefixRepair(doc, { health: 'https://ns.cascadeprotocol.org/health/v1#' }).ok).toBe(true);
+    const empty = planPrefixRepair(doc, {});
+    expect(empty.ok).toBe(false);
+    if (empty.ok) return;
+    expect(empty.damage).toBe('unknown-prefix');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Report, do not repair
+// ---------------------------------------------------------------------------
+
+describe('the damage shapes doctor reports instead of repairing', () => {
+  it('reports an EMPTY bucket rather than calling it healthy', async () => {
+    // An empty file PARSES, as zero triples. `writeResource` is not atomic, so
+    // an interrupted write is exactly how a bucket ends up holding nothing —
+    // and "no records" must not be the answer to "your records are gone".
+    const { podDir, medsPath } = await importedPod();
+    fs.writeFileSync(medsPath, '', 'utf-8');
+    const before = snapshot(podDir);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode).toBe(1);
+    expect(r.report.findings[0].damage).toBe('empty');
+    expect(r.report.findings[0].status).toBe('refused');
+    expect(r.report.findings[0].nextStep).toBeTruthy();
+    expectUnchanged(before, podDir);
+  }, TEST_TIMEOUT_MS);
+
+  it('reports a TRUNCATED bucket', async () => {
+    const { podDir, medsPath } = await importedPod();
+    const text = fs.readFileSync(medsPath, 'utf-8');
+    // Cut immediately after a `;`, so the document ends owing a predicate. That
+    // is the deterministic form of "the write was interrupted".
+    fs.writeFileSync(medsPath, text.slice(0, text.indexOf(';') + 1) + '\n', 'utf-8');
+    expect(parses(medsPath)).toBe(false);
+    const before = snapshot(podDir);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode).toBe(1);
+    expect(r.report.findings[0].damage).toBe('truncated');
+    expect(r.report.findings[0].status).toBe('refused');
+    expectUnchanged(before, podDir);
+  }, TEST_TIMEOUT_MS);
+
+  it('reports a cut that lands MID-TOKEN as truncated too, not as a mystery', () => {
+    // The parser only says "eof" when the cut falls between tokens. A cut
+    // through the middle of a literal is the same damage from the same cause,
+    // and reporting it as a generic syntax error sends the user hunting for a
+    // typo they did not make.
+    const whole = [
+      '@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .',
+      'health:s health:p "a complete value" .',
+      'health:s health:q "an interrupted val',
+    ].join('\n');
+    const d = diagnoseText(whole);
+    expect(d.kind).toBe('refused');
+    if (d.kind !== 'refused') return;
+    expect(d.damage).toBe('truncated');
+  });
+
+  it('does not call a break in the MIDDLE of a file a truncation', () => {
+    // The other direction: the heuristic must not relabel every syntax error.
+    const d = diagnoseText(
+      [
+        '@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .',
+        'health:s health:p } { .',
+        'health:s health:q "fine" .',
+      ].join('\n'),
+    );
+    expect(d.kind).toBe('refused');
+    if (d.kind !== 'refused') return;
+    expect(d.damage).toBe('unparseable');
+  });
+
+  it('reports an IRI holding a character Turtle forbids, and names the code point', async () => {
+    // The pre-fix `add-record` accepted a `--by` value containing a space and
+    // wrote a bucket nothing could parse. Input validation closed that, but pods
+    // damaged before it exist.
+    const { podDir, medsPath } = await importedPod();
+    fs.writeFileSync(
+      medsPath,
+      '@prefix prov: <http://www.w3.org/ns/prov#> .\n' +
+        '<urn:uuid:a> prov:wasAttributedTo <https://example.org/Dr Who#me> .\n',
+      'utf-8',
+    );
+    expect(parses(medsPath)).toBe(false);
+    const before = snapshot(podDir);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode).toBe(1);
+    expect(r.report.findings[0].damage).toBe('illegal-iri');
+    expect(r.report.findings[0].reason).toContain('U+0020');
+    expectUnchanged(before, podDir);
+  }, TEST_TIMEOUT_MS);
+
+  it('reports Turtle that is broken in no recognised way, with a next step', () => {
+    const d = diagnoseText(
+      '@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .\n}{ ;;\nhealth:s health:p "ok" .\n',
+    );
+    expect(d.kind).toBe('refused');
+    if (d.kind !== 'refused') return;
+    expect(d.damage).toBe('unparseable');
+    expect(d.nextStep).toBeTruthy();
+    // The raw parser message survives, because it names the line.
+    expect(d.reason).toMatch(/line 2/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit codes and the JSON envelope
+// ---------------------------------------------------------------------------
+
+describe('exit codes and JSON', () => {
+  it('exits 1 with a clear message when there is no pod at that path', async () => {
+    const r = await runCli(['pod', 'doctor', path.join(mkTmpDir(), 'nope')]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/Pod not found/);
+  }, TEST_TIMEOUT_MS);
+
+  it('distinguishes repaired, repairable and refused in one report', async () => {
+    const { podDir, medsPath } = await importedPod();
+    // Two damaged files: one repairable, one refused.
+    stripPrefixHeader(medsPath);
+    const conditions = path.join(podDir, 'clinical', 'conditions.ttl');
+    fs.writeFileSync(conditions, '<urn:uuid:c> a mysteryvocab:Condition .\n', 'utf-8');
+
+    const dry = await doctorJson([podDir]);
+    expect(dry.exitCode).toBe(1);
+    expect(dry.report.repairable).toBe(1);
+    expect(dry.report.refused).toBe(1);
+    expect(dry.report.findings.map((f) => f.status).sort()).toEqual(['refused', 'repairable']);
+    for (const f of dry.report.findings) expect(f.reason.length).toBeGreaterThan(0);
+
+    const written = await doctorJson([podDir, '--write']);
+    // Damage REMAINS (the refusal), so this must not exit 0.
+    expect(written.exitCode).toBe(1);
+    expect(written.report.repaired).toBe(1);
+    expect(written.report.refused).toBe(1);
+    expect(written.report.repairable).toBe(0);
+  }, TEST_TIMEOUT_MS);
+
+  it('separates "this pod is damaged" (1) from "I could not read it" (2)', () => {
+    const base: DoctorReport = {
+      pod: '/p',
+      encrypted: false,
+      mode: 'write',
+      scanned: 1,
+      healthy: 1,
+      repaired: 0,
+      repairable: 0,
+      refused: 0,
+      unreadable: 0,
+      findings: [],
+    };
+    expect(doctorExitCode(base)).toBe(0);
+    expect(doctorExitCode({ ...base, repaired: 3 })).toBe(0);
+    expect(doctorExitCode({ ...base, repairable: 1 })).toBe(1);
+    expect(doctorExitCode({ ...base, refused: 1 })).toBe(1);
+    // Unreadable outranks: a partial look must not be reported as a full one.
+    expect(doctorExitCode({ ...base, unreadable: 1 })).toBe(2);
+    expect(doctorExitCode({ ...base, refused: 4, unreadable: 1 })).toBe(2);
+  });
+
+  it('reports a pod whose encryption manifest is gone, instead of calling it corrupt', async () => {
+    // Ciphertext read without a key comes back as replacement characters, and
+    // Node's UTF-8 read never fails — so this used to look like "every file in
+    // your pod is corrupt Turtle". It is not: the data is intact and the KEY is
+    // missing, which is the one diagnosis that changes what the user should do.
+    const { podDir, medsPath } = await importedPod();
+    // Longer than a GCM envelope's floor (nonce + tag), and not valid UTF-8 —
+    // i.e. indistinguishable from a sealed resource, which is the point.
+    fs.writeFileSync(medsPath, Buffer.alloc(64, 0x8a));
+    const before = snapshot(podDir);
+
+    const r = await doctorJson([podDir, '--write']);
+    expect(r.exitCode, 'an unreadable file must not read as mere damage').toBe(2);
+    expect(r.report.unreadable).toBe(1);
+    const finding = r.report.findings[0];
+    expect(finding.damage).toBe('not-text');
+    expect(finding.reason).toMatch(/encryption\.json/);
+    // And it is said out loud, not buried in a JSON body nobody printed.
+    expect(r.stderr).toContain('clinical/medications.ttl');
+    expect(r.stderr).toMatch(/NOT the same as those files being healthy/);
+    expectUnchanged(before, podDir);
+  }, TEST_TIMEOUT_MS);
+});
+
+// ---------------------------------------------------------------------------
+// The registry cannot drift from the writers' one
+// ---------------------------------------------------------------------------
+
+describe('the doctor prefix registry', () => {
+  it('agrees with KNOWN_PREFIXES on every entry, name and namespace', () => {
+    // Doctor DERIVES its registry from KNOWN_PREFIXES rather than retyping it,
+    // because a second hand-maintained prefix table is precisely the mistake
+    // that caused this whole defect family. Derivation makes "an entry is
+    // missing" impossible; what this test closes is the one gap left, a
+    // repair-only entry SHADOWING a known one with a different namespace.
+    for (const [prefix, namespace] of Object.entries(KNOWN_PREFIXES)) {
+      expect(DOCTOR_PREFIXES[prefix], `doctor lost or re-pointed ${prefix}:`).toBe(namespace);
+    }
+    expect(Object.keys(KNOWN_PREFIXES).length).toBeGreaterThan(10);
+  });
+
+  it('carries the repair-only extension the record writers do not need', () => {
+    // `core:` is the one real damaged pods in the field contain: the pre-fix
+    // add-record accepted it as an input CURIE and never declared it.
+    expect(DOCTOR_PREFIXES.core).toBe(KNOWN_PREFIXES.cascade);
+    // The scaffolding templates' namespaces, which the record writers never emit.
+    for (const p of ['rdfs', 'foaf', 'solid', 'ldp', 'dcterms', 'pim', 'rdf']) {
+      expect(DOCTOR_PREFIXES[p], `missing scaffolding prefix ${p}:`).toBeTruthy();
+    }
+    // `dct:` and `dcterms:` are two names for one namespace; they must not drift.
+    expect(REPAIR_ONLY_PREFIXES.dcterms).toBe(KNOWN_PREFIXES.dct);
+  });
+
+  it('every namespace it will author is an absolute IRI', () => {
+    for (const [prefix, ns] of Object.entries(DOCTOR_PREFIXES)) {
+      expect(ns, `${prefix}: is not absolute`).toMatch(/^https?:\/\/\S+$/);
+      expect(ns, `${prefix}: has whitespace`).not.toMatch(/\s/);
+    }
+  });
+});

--- a/tests/pod-read-conformance.test.ts
+++ b/tests/pod-read-conformance.test.ts
@@ -320,6 +320,24 @@ const VERBS: Record<string, VerbSpec> = {
     strayOutcome: 'warn',
     mutates: true,
   },
+  doctor: {
+    category: 'read',
+    // The DRY RUN, which is the default and reads every .ttl in the pod. Its
+    // repair path has its own suites (pod-doctor.test.ts, and the sealed-pod
+    // half in pod-doctor-encrypted.test.ts); what belongs here is the read.
+    argv: (pod) => ['--json', 'pod', 'doctor', pod],
+    successExit: 0,
+    // `"unreadable": 0` is the honest-read assertion in this verb's own
+    // vocabulary: with the key, nothing in the pod is unexaminable. A keyless
+    // read makes it the file count instead, so it cannot pass hollow.
+    successMustContain: '"unreadable": 0',
+    strayTarget: 'clinical/medications.ttl',
+    // Fatal, at exit 2, even though doctor's job is to report per-file damage.
+    // A file it could not READ was never examined, and a verb whose whole
+    // purpose is to tell you the state of your pod must not answer "here is the
+    // state of your pod" about files it never opened.
+    strayOutcome: 'fatal',
+  },
   export: {
     category: 'read',
     // D-CLI-2: an encrypted pod is refused before any read, in EVERY scenario,


### PR DESCRIPTION
Adds `cascade pod doctor`, the recovery path for a pod whose bucket will not parse.

Closes the gap #49 opened. That PR made every record-data writer REFUSE a bucket it cannot read,
which is correct — the old behaviour is what turned a broken header into lost records — but it left
anyone already damaged with no way forward: `add-record`, `erase` and `import` all decline, the
whole-pod read fails, and `pod export` copies the bad bytes out without warning. These two ship
together on purpose, so the refusal and the recovery reach users in the same release.

## What it does

```
cascade pod doctor <pod-dir> [--write] [--json]
```

Scans every `.ttl` in the pod. Where a file fails a strict Turtle parse and the only defect is one
or more `@prefix` declarations the body uses and the header lacks, it prepends those declarations
and nothing else. Everything else is reported, not touched.

**Dry run is the default.** `--write` is required to change anything.

## Safety properties

Every one of these has a test and an observed-RED mutation:

- **Dry run by default**, and a dry run writes nothing at all, not even a backup.
- **Only ever prepends.** The repaired content must have the original as a strict suffix; asserted
  in code, and independently pinned by a behavioural test (verified: with the internal assertion
  disabled, a repair that drops comment lines still fails the scaffolding test).
- **Strict parse before writing.** If the repaired text does not parse, nothing is written.
- **Backup before write, restore on failed read-back.** Pinned by fault injection.
- **Never invents a namespace.** A prefix outside the registry is a refusal naming it, not a guess.
- **Idempotent.** A file that parses is never touched.
- **A healthy pod is byte-identical after `--write`**, with no backups created.

Prepend-only is what makes it safe on human-curated scaffolding as well as record buckets.
`profile/extended.ttl` regex-anchors PHI population on a literal comment line, and the type indexes
carry curated comments — re-serializing them would destroy that, which is why #49 deliberately kept
them out of the write chokepoint. Doctor is **not** routed through `mergeIntoBucket` for exactly
this reason, and a test asserts a repaired `publicTypeIndex.ttl` keeps its comment anchors verbatim.

## Implementation notes

- The prefix registry is **derived** from `KNOWN_PREFIXES` plus an explicit repair-only extension,
  with a drift test. A second hand-maintained prefix table is the mistake that produced this whole
  defect family; it is not repeated here. The extension covers prefixes the record writers never
  emit but damaged pods contain — `core:` in particular, which pre-fix `add-record` accepted as
  input while never declaring.
- Missing prefixes are discovered from **the parser's own error**, not a regex over the text, so a
  CURIE appearing inside a comment, a string literal, or an absolute IRI is not a false positive.
  The loop is bounded and fails loudly if it stops making progress.
- Doctor composes `encryptResource` + an atomic write rather than `writeResource`, which is a bare
  `writeFileSync`. A repair tool must not be able to create the truncation it diagnoses.
- Damage it deliberately does **not** auto-repair, because each needs a human: truncated or empty
  files, IRIs containing illegal characters, and undecryptable resources. These are reported with
  guidance, and the message distinguishes a wrong passphrase from a single resource that failed
  authentication.

## Tests

`npx vitest run`: **128 files / 1894 tests / 0 skipped** (from 125 / 1854 / 0). CI skip ratchet
unchanged at 24.

35 new tests across three files, plus doctor added to the read-conformance verb matrix — whose
enumeration gate caught the new verb immediately and forced two real improvements: unreadable files
are now surfaced on stderr as well as in the JSON, and non-UTF-8 bytes in a pod with no encryption
manifest are identified as a missing key file rather than reported as corrupt Turtle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
