### PR TITLE
Sync shapes to health 2.6 / clinical 1.14 / coverage 1.4 / checkup 3.3 so conformant FHIR validates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+**Bundled shapes synced to health 2.6 / clinical 1.14 / coverage 1.4 / checkup 3.3, so a conformant
+FHIR record validates.** Real-world Epic FHIR exports, and C-CDA documents through the same
+pipeline, were failing `cascade validate` on records that are correct at source. Every failure was a
+Cascade constraint narrower than the standard the data had been converted from, not a defect in the
+converter and not a defect in the data.
+
+Measured on a synthetic Epic-shaped bundle carrying one susceptibility lab, one dual-coded
+problem-list entry, one visit, one employer-sponsored policy and one Category III procedure: **7
+violations and 1 warning before, 0 and 0 after**, and the Encounter went from "no applicable shape"
+to checked. What the old shapes rejected:
+
+- `interpretation` accepted five words invented in `spec` (normal / high / low / abnormal /
+  critical). FHIR R4 binds `Observation.interpretation` to the HL7 v3 ObservationInterpretation code
+  system, which also carries susceptibility (S/I/R), detection (POS/NEG/DET/ND/IND), reactivity
+  (RR/WR/NR) and change (B/D/U/W) results. The converter writes the data-absent-reason code
+  `unknown` when a source Observation carries no interpretation, and that was not in the enum
+  either, so the single most common value in a real export was also a Violation.
+- `labCategory` was single-valued while `Observation.category` is 0..\*, and `testCode`,
+  `icd10Code` and `snomedCode` were single-valued while `CodeableConcept.coding` is 0..\*. Records
+  were rejected for preserving what the source sent.
+- `cptCode` required five digits, which is CPT Category I only.
+- `coverageType` enforced a closed four-member enum at Violation severity on an element FHIR binds
+  extensibly, and `subscriberRelationship` held five of the seven codes in the value set it points
+  at.
+- `clinical:Encounter` had no shape at all, so `validate` reported PASS on encounters having
+  evaluated zero constraints. clinical v1.14 adds `EncounterShape` and `EncounterTemporalShape`.
+- Date properties carried over from a source document now accept `xsd:date` as well as
+  `xsd:dateTime`, because FHIR's `dateTime` primitive is explicitly partial-precision and C-CDA
+  `effectiveTime` commonly states a calendar day and nothing more.
+
+New `tests/fhir-standards-alignment.test.ts` converts that bundle through the real converter and
+validates it against the real bundled shapes, asserting zero violations and full shape coverage. It
+also pins what the converter EMITS, which is what separates "the shapes were widened" from "the
+converter started dropping the values that used to fail". Verified RED against the previous shapes
+before being kept: 3 of its 6 assertions fail there.
+
+`tests/known-shacl-gaps.ts` is updated rather than deleted. It had argued that the C-CDA
+day-precision emitters could not be fixed until the vocabulary decided how to express partial
+precision; that decision is now made, in the direction it argued for. The gap it records is smaller
+and sharper: the five emitters write a PLAIN literal, which is `xsd:string`, and `xsd:string` is
+neither `xsd:date` nor `xsd:dateTime`. Typing the literal `xsd:date` now validates with no invented
+time and no further shape change. That emitter fix is still deliberately out of scope for a
+vocabulary sync.
+
+Not synced in this pass: the sync script also produces diffs for the draft `evidence.ttl` and
+`genomics.shapes.ttl`, which are pre-existing drift from spec's 2026-08-03 Validation Profile
+release. They are left for their own sync so that a genomics `sh:class` semantics change is not
+folded into a clinical alignment.
+
+
 **`cascade capabilities` is generated from the command registry instead of being maintained by
 hand.** The document is what an AI agent reads to learn what this CLI can do, and the hand-written
 version described 12 of the 34 invocable commands: every write verb and every recovery verb was

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -56,9 +56,34 @@
 #   fails the suite.
 # Updated 2026-08-04: removed internal tracker references from the bundled
 #   shapes comments. Comment-only; no vocabulary version changed.
+# Updated 2026-08-08: health v2.6 + clinical v1.14 + coverage v1.4 + checkup v3.3.
+#   Shapes-only alignment to ratified standards, after real-world Epic FHIR
+#   exports (and C-CDA documents through the same pipeline) failed validation on
+#   records that are correct at source:
+#     - interpretation bound to the HL7 v3 ObservationInterpretation code system
+#       plus the data-absent-reason code "unknown"; the previous five-member
+#       enum was invented in spec and rejected susceptibility, detection,
+#       reactivity and change results;
+#     - labCategory, testCode, icd10Code and snomedCode made multi-valued, per
+#       FHIR R4 Observation.category 0..* and CodeableConcept.coding 0..*;
+#     - source-carried date properties accept xsd:date alongside xsd:dateTime,
+#       per FHIR's partial-precision dateTime primitive;
+#     - cptCode and checkup:icd10Code patterns corrected;
+#     - coverage:coverageType value check demoted to Warning (FHIR binds
+#       Coverage.type extensibly); subscriberRelationship enum completed;
+#     - NEW clinical:EncounterShape + EncounterTemporalShape. clinical:Encounter
+#       had no shape at all, so encounters validated to PASS with zero
+#       constraints evaluated.
+#   spec PR the-cascade-protocol/spec#16; tags vocab/health-v2.6,
+#   vocab/clinical-v1.14, vocab/coverage-v1.4, vocab/checkup-v3.3.
+#   NOT synced in this pass: the draft evidence.ttl and genomics.shapes.ttl
+#   diffs the sync script also produces are pre-existing drift from spec's
+#   2026-08-03 Validation Profile release and are unrelated to this change; they
+#   are left for their own sync so a genomics sh:class semantics change is not
+#   folded into a clinical alignment.
 core=3.4
-health=2.5
-clinical=1.13
-coverage=1.3
-checkup=3.2
+health=2.6
+clinical=1.14
+coverage=1.4
+checkup=3.3
 pots=1.4

--- a/src/shapes/checkup.shapes.ttl
+++ b/src/shapes/checkup.shapes.ttl
@@ -688,13 +688,22 @@ checkup:ConditionSummaryShape a sh:NodeShape ;
         sh:message "Condition status should be a recognized value"
     ] ;
 
-    # ICD-10 code pattern if present
+    # ICD-10-CM code pattern if present.
+    #
+    # The previous pattern required the second AND third characters to be
+    # digits. The ICD-10-CM Official Guidelines for Coding and Reporting,
+    # Section I.A.2, say the opposite: "Characters for categories, subcategories
+    # and codes may be either a letter or a number. All categories are 3
+    # characters. ... Codes may be 3, 4, 5, 6 or 7 characters." Categories with
+    # a letter in the third position are ordinary, not exotic — C4A (Merkel cell
+    # carcinoma), D3A (benign neuroendocrine tumors) and M1A (chronic gout) are
+    # all live ICD-10-CM categories, and every code under them was rejected.
     sh:property [
         sh:path checkup:icd10Code ;
         sh:datatype xsd:string ;
-        sh:pattern "^[A-Z][0-9]{2}(\\.[0-9A-Z]{1,4})?$" ;
+        sh:pattern "^[A-Z][0-9A-Z]{2}(\\.[0-9A-Z]{1,4})?$" ;
         sh:severity sh:Info ;
-        sh:message "ICD-10 code should follow standard format (e.g., I10, E11.9)"
+        sh:message "ICD-10-CM code should be 3 to 7 characters: a letter, two letters-or-digits, then optionally a dot and 1 to 4 more (e.g., I10, E11.9, C4A.51, M1A.0110)"
     ] .
 
 # ============================================================================
@@ -1414,6 +1423,16 @@ checkup:DiscussionTopicShape a sh:NodeShape ;
 # ============================================================================
 # CHANGELOG
 # ============================================================================
+#
+# v2.1 (2026-08-08) - checkup v3.3
+# - checkup:icd10Code pattern corrected. It required digits in the second and
+#   third characters; the ICD-10-CM Official Guidelines for Coding and
+#   Reporting, Section I.A.2, state that "Characters for categories,
+#   subcategories and codes may be either a letter or a number" and that codes
+#   may be 3 to 7 characters. Categories such as C4A, D3A and M1A are ordinary
+#   ICD-10-CM, and every code under them failed the old pattern. Info severity
+#   throughout, so this changed an advisory that fired wrongly, not a rejection.
+#   No other checkup shape changed.
 #
 # v2.0 (2026-02-18): WS8 - Shapes for v1.5-v2.0 ontology classes
 # - Added health: and clinical: prefix declarations for cross-namespace shapes

--- a/src/shapes/checkup.ttl
+++ b/src/shapes/checkup.ttl
@@ -21,8 +21,8 @@
     dct:description "Structured health data for patient intake forms and pre-visit preparation. Enables aggregation of EHR, HealthKit, and manually entered health data."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-01-03"^^xsd:date ;
-    dct:modified "2026-02-26"^^xsd:date ;
-    owl:versionInfo "3.2" ;
+    dct:modified "2026-08-08"^^xsd:date ;
+    owl:versionInfo "3.3" ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/checkup/v1/> .
 
 # ============================================================================
@@ -1791,6 +1791,17 @@ checkup:supplementUPC a owl:DatatypeProperty ;
 # ============================================================================
 # CHANGELOG
 # ============================================================================
+#
+# v3.3 (2026-08-08): SHACL only; no class or property added, removed or
+# renamed. The checkup:icd10Code sh:pattern required a digit in the second and
+# third characters of an ICD-10-CM code. The ICD-10-CM Official Guidelines for
+# Coding and Reporting, Section I.A.2, state that "Characters for categories,
+# subcategories and codes may be either a letter or a number" and that codes may
+# be 3, 4, 5, 6 or 7 characters. Live categories with a letter in the third
+# position (C4A Merkel cell carcinoma, D3A benign neuroendocrine tumors, M1A
+# chronic gout) and every code beneath them failed the pattern. Corrected to
+# "^[A-Z][0-9A-Z]{2}(\\.[0-9A-Z]{1,4})?$". Info severity, so this fixes an
+# advisory that fired on valid codes rather than a rejection.
 #
 # v3.2 (2026-02-26, BUG-002): Added checkup:supplyEndDate DatatypeProperty on
 # MedicationSummary. Computed as startDate + supplyDurationDays, this field

--- a/src/shapes/clinical.shapes.ttl
+++ b/src/shapes/clinical.shapes.ttl
@@ -13,6 +13,52 @@
 # different data sources (EHR, device, patient-reported).
 #
 # Changelog:
+# v1.14 (2026-08-08): Align to ratified standards; add the missing Encounter
+#     shape. Shapes-only, and strictly widening apart from the new shape: every
+#     graph that validated before still validates.
+#
+#     Motivation: real-world Epic FHIR exports, and C-CDA documents through the
+#     same pipeline, fail validation on records that are correct at source.
+#
+#     1. clinical:interpretation is now bound to the HL7 v3
+#        ObservationInterpretation code system,
+#        http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+#        (version 3.0.0) — 49 selectable codes, abstract concepts excluded —
+#        plus the data-absent-reason code "unknown"
+#        (http://terminology.hl7.org/CodeSystem/data-absent-reason) and the ten
+#        retained legacy words. The previous five-member list was invented here
+#        and had no standards basis. Kept identical to health:interpretation.
+#     2. clinical:snomedCode (4 shapes) and clinical:icd10Code are now
+#        multi-valued: FHIR R4 CodeableConcept.coding is 0..*
+#        (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept).
+#     3. clinical:cptCode accepted only five digits, which is Category I only.
+#        The AMA CPT code set also defines Category II (four digits + F),
+#        Category III (four digits + T) and Proprietary Laboratory Analyses
+#        (four digits + U) codes, all five characters. Pattern widened to
+#        "^[0-9]{4}[0-9FTU]$".
+#     4. Date properties carried over from a source document —
+#        clinical:encounterDate, clinical:documentDate, clinical:onsetDate,
+#        clinical:procedureDate — now accept xsd:date as well as xsd:dateTime.
+#        FHIR's dateTime primitive is explicitly partial-precision ("YYYY,
+#        YYYY-MM, YYYY-MM-DD or YYYY-MM-DDThh:mm:ss+zz:zz",
+#        https://build.fhir.org/datatypes.html) and C-CDA effectiveTime is
+#        commonly date-precision, so demanding an instant forced importers to
+#        invent a midnight the source never stated. Timestamps Cascade itself
+#        generates (clinical:importedAt, the derived episode dates) are
+#        unchanged and still require xsd:dateTime.
+#     5. NEW clinical:EncounterShape + clinical:EncounterTemporalShape.
+#        clinical:Encounter has existed since v1.7 with no shape, so encounters
+#        validated to PASS without a single constraint being evaluated. The new
+#        shape is deliberately minimal — cardinality, datatype, provenance, and
+#        an IRI requirement implied by the clinical:hasEncounter edge. See the
+#        long note above the shape for what is deliberately NOT constrained.
+#
+#     Deliberately NOT changed: no sh:pattern is introduced on snomedCode or
+#     icd10Code. SNOMED CT identifiers are 6-18 digit integers and ICD-10-CM
+#     permits a letter in any character position (ICD-10-CM Official Guidelines
+#     for Coding and Reporting, Section I.A.2), so a pattern would reject valid
+#     codes without catching anything a code system lookup would not.
+#
 # v1.10 (2026-07-16): Add open-world PropertyShapes for the three record-to-record
 #     edges introduced in clinical v1.10 (hasEncounter, indicationReference,
 #     linkedCondition). Each targets the subjects that use the predicate, checks
@@ -215,7 +261,8 @@ clinical:ProgressNoteShape a sh:NodeShape ;
     # Progress notes should have encounterDate
     sh:property [
         sh:path clinical:encounterDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Encounter Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Encounter Date"@en ;
@@ -237,7 +284,8 @@ clinical:DischargeSummaryShape a sh:NodeShape ;
     # Discharge summaries should have document date
     sh:property [
         sh:path clinical:documentDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Document Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Document Date"@en ;
@@ -268,7 +316,8 @@ clinical:ConsultationNoteShape a sh:NodeShape ;
     # Consultation notes should record when the consultation happened
     sh:property [
         sh:path clinical:encounterDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Encounter Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Encounter Date"@en ;
         sh:message "Consultation note must not carry more than one encounter date"@en
@@ -289,7 +338,8 @@ clinical:LaboratoryReportShape a sh:NodeShape ;
     # Lab reports should have documentDate (when results were finalized)
     sh:property [
         sh:path clinical:documentDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Document Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:minCount 1 ;
         sh:name "Document Date"@en ;
         sh:message "Lab reports must have a document date"@en
@@ -310,7 +360,8 @@ clinical:ImagingReportShape a sh:NodeShape ;
     # Imaging reports should have document date
     sh:property [
         sh:path clinical:documentDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Document Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:minCount 1 ;
         sh:name "Document Date"@en ;
         sh:message "Imaging reports must have a document date"@en
@@ -331,7 +382,8 @@ clinical:VisitSummaryShape a sh:NodeShape ;
     # Visit summaries should have encounter date
     sh:property [
         sh:path clinical:encounterDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Encounter Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Encounter Date"@en ;
@@ -401,10 +453,13 @@ clinical:MedicationShape a sh:NodeShape ;
         sh:name "RxNorm Code"@en
     ] ;
 
-    # Optional: snomedCode (can be string or URI reference)
+    # Optional: snomedCode (string or URI reference). Repeatable: FHIR R4
+    # CodeableConcept.coding is 0..*
+    # (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept). No sh:pattern:
+    # SNOMED CT identifiers are 6-18 digit integers and format belongs to the
+    # code system.
     sh:property [
         sh:path clinical:snomedCode ;
-        sh:maxCount 1 ;
         sh:name "SNOMED Code"@en
     ] ;
 
@@ -604,10 +659,13 @@ clinical:AllergyShape a sh:NodeShape ;
         sh:name "Allergy Category"@en
     ] ;
 
-    # Optional: snomedCode (can be string or URI reference)
+    # Optional: snomedCode (string or URI reference). Repeatable: FHIR R4
+    # CodeableConcept.coding is 0..*
+    # (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept). No sh:pattern:
+    # SNOMED CT identifiers are 6-18 digit integers and format belongs to the
+    # code system.
     sh:property [
         sh:path clinical:snomedCode ;
-        sh:maxCount 1 ;
         sh:name "SNOMED Code"@en
     ] ;
 
@@ -673,13 +731,41 @@ clinical:LabResultShape a sh:NodeShape ;
         sh:name "Reference Range"@en
     ] ;
 
-    # Optional: interpretation (accepts both cases)
+    # Optional: interpretation
+    #
+    # Bound to the HL7 v3 ObservationInterpretation code system, the code system
+    # FHIR R4 binds Observation.interpretation to. This list is the 49
+    # SELECTABLE codes of
+    # http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+    # (version 3.0.0), verbatim; the eight abstract (notSelectable) hierarchy
+    # concepts are excluded because they are not values. Deprecated codes are
+    # accepted: historical results carry them.
+    #
+    # Plus "unknown" from
+    # http://terminology.hl7.org/CodeSystem/data-absent-reason, written by
+    # importers when the source Observation carried no interpretation, and the
+    # ten words of the previous enum, retained so data written against earlier
+    # clinical versions keeps validating.
+    #
+    # Kept byte-identical to the health:interpretation list in
+    # health.shapes.ttl. These are two spellings of one record (clinical:LabResult
+    # is deprecated in favour of health:LabResultRecord since clinical v1.13) and
+    # letting them drift is how one spelling silently becomes the lenient one.
     sh:property [
         sh:path clinical:interpretation ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
-        sh:in ("normal" "high" "low" "abnormal" "critical" "Normal" "High" "Low" "Abnormal" "Critical") ;
-        sh:name "Interpretation"@en
+        sh:in ("EX" "HM" "OBX" "CAR" "Carrier" "B" "D" "U" "W"
+               "<" ">" "AC" "IE" "QCF" "TOX"
+               "A" "N" "I" "MS" "NCL" "NS" "R" "S" "VS"
+               "AA" "H" "L" "HH" "LL" "HX" "LX" "H>" "HU" "E" "L<" "LU"
+               "ND" "IND" "NEG" "POS" "EXP" "UNE" "DET"
+               "SYN-R" "NR" "RR" "WR" "SDD" "SYN-S"
+               "unknown"
+               "normal" "high" "low" "abnormal" "critical"
+               "Normal" "High" "Low" "Abnormal" "Critical") ;
+        sh:name "Interpretation"@en ;
+        sh:message "Interpretation must be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), the data-absent-reason code 'unknown', or one of the retained legacy words"@en
     ] ;
 
     # Optional: loincCode (can be string or URI reference)
@@ -749,22 +835,29 @@ clinical:ConditionShape a sh:NodeShape ;
     # Optional: onsetDate
     sh:property [
         sh:path clinical:onsetDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Onset Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Onset Date"@en
     ] ;
 
-    # Optional: snomedCode (can be string or URI reference)
+    # Optional: snomedCode (string or URI reference). Repeatable: FHIR R4
+    # CodeableConcept.coding is 0..*
+    # (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept). No sh:pattern:
+    # SNOMED CT identifiers are 6-18 digit integers and format belongs to the
+    # code system.
     sh:property [
         sh:path clinical:snomedCode ;
-        sh:maxCount 1 ;
         sh:name "SNOMED Code"@en
     ] ;
 
-    # Optional: icd10Code (can be string or URI reference)
+    # Optional: icd10Code (string or URI reference). Repeatable for the same
+    # reason as snomedCode above; problem-list entries are routinely dual coded.
+    # No sh:pattern: ICD-10-CM permits a letter in any character position
+    # (C4A, D3A and M1A are ordinary categories), per the ICD-10-CM Official
+    # Guidelines for Coding and Reporting, Section I.A.2.
     sh:property [
         sh:path clinical:icd10Code ;
-        sh:maxCount 1 ;
         sh:name "ICD-10 Code"@en
     ] ;
 
@@ -897,7 +990,8 @@ clinical:ProcedureShape a sh:NodeShape ;
     # Optional: procedureDate
     sh:property [
         sh:path clinical:procedureDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Procedure Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Procedure Date"@en
     ] ;
@@ -928,19 +1022,30 @@ clinical:ProcedureShape a sh:NodeShape ;
     ] ;
 
     # Optional: cptCode
+    #
+    # Every CPT code is five characters, but only Category I codes are five
+    # DIGITS. The AMA CPT code set also defines Category II codes (four digits
+    # followed by the letter F), Category III codes (four digits followed by the
+    # letter T) and Proprietary Laboratory Analyses codes (four digits followed
+    # by the letter U). "^[0-9]{5}$" rejected all three of those, so an ordinary
+    # emerging-technology or performance-measurement procedure failed validation.
+    # See https://www.ama-assn.org/practice-management/cpt/cpt-code-set-overview
     sh:property [
         sh:path clinical:cptCode ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
-        sh:pattern "^[0-9]{5}$" ;
+        sh:pattern "^[0-9]{4}[0-9FTU]$" ;
         sh:name "CPT Code"@en ;
-        sh:message "CPT code must be 5 digits"@en
+        sh:message "CPT code must be five characters: five digits (Category I), or four digits followed by F (Category II), T (Category III) or U (Proprietary Laboratory Analyses)"@en
     ] ;
 
-    # Optional: snomedCode (can be string or URI reference)
+    # Optional: snomedCode (string or URI reference). Repeatable: FHIR R4
+    # CodeableConcept.coding is 0..*
+    # (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept). No sh:pattern:
+    # SNOMED CT identifiers are 6-18 digit integers and format belongs to the
+    # code system.
     sh:property [
         sh:path clinical:snomedCode ;
-        sh:maxCount 1 ;
         sh:name "SNOMED Code"@en
     ] ;
 
@@ -1421,6 +1526,198 @@ clinical:SocialHistoryRecordShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Encounter (v1.14)
+# ============================================================================
+#
+# clinical:Encounter has existed since clinical v1.7 and until now had NO shape,
+# so every encounter a pod contained was imported and stored unvalidated:
+# validating a file of encounters checked nothing and returned PASS. This shape
+# closes that hole. It is deliberately minimal.
+#
+# WHY IT IS MINIMAL, STATED SO IT IS NOT "TIGHTENED" LATER BY MISTAKE
+# -------------------------------------------------------------------
+# Encounters vary more than any other record here: a same-day telephone note, a
+# three-week inpatient admission, a planned appointment that has no period at
+# all, and a historical visit reconstructed from a summary document are all
+# legitimately clinical:Encounter. So this shape constrains SHAPE, not content:
+# cardinality and datatype on the properties importers actually write, the
+# standard Cascade provenance pair, and nothing else at Violation severity.
+#
+# In particular:
+#   - clinical:encounterClass carries NO sh:in. FHIR R4 binds Encounter.class
+#     EXTENSIBLY to the v3-ActCode ActEncounterCode value set, and servers send
+#     either the abbreviation (AMB, EMER, IMP, HH) or a display string. An enum
+#     here would reject conformant data in both directions.
+#   - clinical:encounterStatus DOES carry an sh:in, because FHIR R4 binds
+#     Encounter.status with REQUIRED strength, and the list below is that value
+#     set verbatim (https://hl7.org/fhir/R4/valueset-encounter-status.html).
+#     It is sh:Warning, not sh:Violation: an unrecognised status is worth
+#     surfacing but is not a reason to reject the record and lose the visit.
+#   - Dates accept xsd:date as well as xsd:dateTime. FHIR's dateTime primitive
+#     is explicitly partial-precision ("YYYY, YYYY-MM, YYYY-MM-DD or
+#     YYYY-MM-DDThh:mm:ss+zz:zz", https://build.fhir.org/datatypes.html) and
+#     C-CDA effectiveTime is commonly date-precision, so requiring an instant
+#     would force importers to invent a midnight that the source never stated.
+#
+# WHAT THE clinical:hasEncounter EDGE IMPLIES, AND WHAT IT DOES NOT
+# -----------------------------------------------------------------
+# clinical:hasEncounter is the panel-to-visit edge: a lab result, medication,
+# condition, procedure or report points at the visit it happened in.
+# HasEncounterEdgeShape (below) already requires that object to be an IRI. Two
+# consequences are carried here:
+#   1. sh:nodeKind sh:IRI on the Encounter itself. An edge can only resolve to a
+#      node that HAS an IRI, so a blank-node encounter is unreachable by the very
+#      edge the class exists to serve.
+#   2. An encounter should be placeable in time, since grouping events "by visit"
+#      is only meaningful if the visit has one. That is expressed as a
+#      sh:Warning requiring a start, an end or an encounter date — NOT a
+#      Violation, because FHIR R4 Encounter.period is 0..1 and a planned or
+#      referenced-only encounter legitimately has none.
+# What is deliberately NOT added is an sh:class check back along the edge; see
+# the v1.11 note under HasEncounterEdgeShape for why that produced only false
+# positives under per-file validation.
+
+clinical:EncounterShape a sh:NodeShape ;
+    sh:targetClass clinical:Encounter ;
+    sh:nodeKind sh:IRI ;
+    rdfs:label "Encounter Shape"@en ;
+    rdfs:comment "Minimal validation constraints for clinical encounters (visits). Constrains cardinality, datatype and provenance; deliberately does not constrain what kind of visit an encounter may be."@en ;
+    sh:message "A clinical:Encounter must be identified by an IRI so that clinical:hasEncounter edges can resolve to it"@en ;
+
+    # Optional: encounterClass. No enum — FHIR R4 binds Encounter.class
+    # extensibly to v3-ActCode ActEncounterCode and servers send codes or
+    # display strings.
+    sh:property [
+        sh:path clinical:encounterClass ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Class"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Optional: encounterStatus. FHIR R4 EncounterStatus, verbatim.
+    sh:property [
+        sh:path clinical:encounterStatus ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("planned" "arrived" "triaged" "in-progress" "onleave" "finished"
+               "cancelled" "entered-in-error" "unknown") ;
+        sh:name "Encounter Status"@en ;
+        sh:message "Encounter status should be one of the FHIR R4 EncounterStatus codes: planned, arrived, triaged, in-progress, onleave, finished, cancelled, entered-in-error, unknown"@en ;
+        sh:severity sh:Warning
+    ] ;
+
+    # Optional: encounterType (display name from a SNOMED CT / FHIR code)
+    sh:property [
+        sh:path clinical:encounterType ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Type"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Optional: encounterStart / encounterEnd. Date precision accepted.
+    sh:property [
+        sh:path clinical:encounterStart ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Encounter Start must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Start"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:encounterEnd ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Encounter End must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
+        sh:maxCount 1 ;
+        sh:name "Encounter End"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Optional: snomedCode for the encounter type. Repeatable and unpatterned,
+    # for the reasons given on the other snomedCode shapes above.
+    sh:property [
+        sh:path clinical:snomedCode ;
+        sh:name "SNOMED Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Optional: who and where.
+    sh:property [
+        sh:path clinical:providerName ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Provider Name"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:facilityName ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Facility Name"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Optional: source linkage back to the record this was converted from.
+    sh:property [
+        sh:path clinical:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record ID"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:sourceEHR ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:maxLength 100 ;
+        sh:name "Source EHR"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Required: provenance (accepts multiple valid sources)
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Encounter must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Required: schemaVersion
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# An encounter should be placeable in time, because grouping clinical events
+# "by visit" is only useful if the visit has a position in the timeline. Kept in
+# its own shape so that its severity is unambiguous: this is sh:Warning, while
+# EncounterShape's own constraints (including sh:nodeKind sh:IRI) stay at the
+# default sh:Violation. It is not a Violation because FHIR R4 Encounter.period
+# is 0..1 and a planned or merely referenced encounter legitimately has none.
+clinical:EncounterTemporalShape a sh:NodeShape ;
+    sh:targetClass clinical:Encounter ;
+    rdfs:label "Encounter Temporal Shape"@en ;
+    sh:or (
+        [ sh:path clinical:encounterStart ; sh:minCount 1 ]
+        [ sh:path clinical:encounterEnd ; sh:minCount 1 ]
+        [ sh:path clinical:encounterDate ; sh:minCount 1 ]
+    ) ;
+    sh:message "Encounter should carry a start, an end or an encounter date so that records linked to it can be placed in time"@en ;
+    sh:severity sh:Warning .
+
+# ============================================================================
 # Graph Edge Property Shapes (v1.10)
 # Open-world, non-required constraints for the record-to-record edges added in
 # clinical v1.10. Each targets the subjects that USE the predicate (so nothing
@@ -1484,7 +1781,7 @@ clinical:ParsedIndicationReferenceEdgeShape a sh:PropertyShape ;
 #   deliberately NOT constrained, both because FHIR permits a Condition or an
 #   Observation as the reason and because cascade-cli validates each per-type
 #   pod file independently, so a cross-file sh:class check produces false
-#   positives (the v1.11 rationale).
+#   positives (the v1.11 rationale,).
 #
 # Version 1.11 (2026-07-16)
 # - Removed the sh:class constraint from HasEncounterEdgeShape (clinical:Encounter)

--- a/src/shapes/clinical.ttl
+++ b/src/shapes/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-08-03"^^xsd:date ;
-    owl:versionInfo "1.13" ;
+    dct:modified "2026-08-08"^^xsd:date ;
+    owl:versionInfo "1.14" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -1330,6 +1330,36 @@ clinical:isActive a owl:DatatypeProperty ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.14 (2026-08-08)
+# - SHACL only; no class or property added, removed, renamed or deprecated.
+#   Aligns four constraint families to the ratified standards they describe, and
+#   shapes a class that had no shape. Full detail in clinical.shapes.ttl's own
+#   changelog; summarised here because the version number lives in this file.
+# - clinical:interpretation bound to the HL7 v3 ObservationInterpretation code
+#   system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation,
+#   version 3.0.0), the code system FHIR R4 binds Observation.interpretation to,
+#   plus the data-absent-reason code "unknown"
+#   (http://terminology.hl7.org/CodeSystem/data-absent-reason). The previous
+#   five-member enum was invented here; real exports carry susceptibility,
+#   detection, reactivity and change codes that have no member of it.
+# - clinical:snomedCode and clinical:icd10Code made multi-valued, per FHIR R4
+#   CodeableConcept.coding 0..*
+#   (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept).
+# - clinical:cptCode pattern widened from five digits to the full AMA CPT code
+#   set structure: five digits (Category I) or four digits plus F, T or U
+#   (Category II, Category III, Proprietary Laboratory Analyses).
+# - Source-carried date properties (encounterDate, documentDate, onsetDate,
+#   procedureDate) now accept xsd:date alongside xsd:dateTime, because FHIR's
+#   dateTime primitive is explicitly partial-precision
+#   (https://build.fhir.org/datatypes.html) and C-CDA effectiveTime is commonly
+#   date-precision. Cascade-generated timestamps are unchanged.
+# - Added clinical:EncounterShape and clinical:EncounterTemporalShape.
+#   clinical:Encounter has been defined since v1.7 and targeted by no shape, so
+#   validating an encounter checked nothing and returned PASS. Encounters vary
+#   widely, so the shape constrains cardinality, datatype, provenance and the
+#   IRI requirement that clinical:hasEncounter implies, and leaves the kind of
+#   visit unconstrained.
 #
 # Version 1.13 (2026-08-03)
 # - Deprecated 4 classes: clinical:LabResult, clinical:Condition,

--- a/src/shapes/coverage.shapes.ttl
+++ b/src/shapes/coverage.shapes.ttl
@@ -51,14 +51,34 @@ coverage:InsurancePlanShape a sh:NodeShape ;
     ] ;
 
     # Required: coverageType
+    #
+    # PRESENCE is required. The VALUE is checked separately, at sh:Warning, by
+    # coverage:CoverageTypeVocabularyShape below.
+    #
+    # WHY THE VALUE CHECK IS NOT A VIOLATION
+    # --------------------------------------
+    # This property maps to FHIR R4 Coverage.type, whose binding to
+    # http://hl7.org/fhir/ValueSet/coverage-type is EXTENSIBLE, not required.
+    # FHIR defines extensible as: codes SHALL come from the value set if one of
+    # them applies, and "if the value set does not cover the concept, alternate
+    # codes MAY be used" (https://hl7.org/fhir/R4/terminologies.html#extensible).
+    # A closed enum at Violation severity therefore contradicted the binding
+    # strength of the element the data is converted from: a payer sending a
+    # v3-ActCode coverage-type code such as EHCPOL, or its own local code, had a
+    # conformant Coverage resource rejected outright.
+    #
+    # Note also that the original four values conflated two different FHIR
+    # elements: "primary"/"secondary" describe Coverage.order (which plan pays
+    # first), while "dental"/"vision" describe Coverage.type (what is covered).
+    # Both spellings are retained below for backward compatibility.
     sh:property [
         sh:path coverage:coverageType ;
         sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:in ("primary" "secondary" "dental" "vision") ;
+        sh:minLength 1 ;
         sh:name "Coverage Type"@en ;
-        sh:message "Coverage type must be primary, secondary, dental, or vision"@en ;
+        sh:message "Coverage type is required"@en ;
         sh:severity sh:Violation
     ] ;
 
@@ -98,13 +118,20 @@ coverage:InsurancePlanShape a sh:NodeShape ;
     ] ;
 
     # Warning: subscriberRelationship
+    #
+    # The list is the SubscriberPolicyholder code system in full and verbatim,
+    # http://terminology.hl7.org/CodeSystem/subscriber-relationship, which is
+    # what FHIR R4 Coverage.relationship binds to. The previous list held five
+    # of its seven codes; "common" (Common Law Spouse) and "injured" (Injured
+    # Party) were simply missing, so an export carrying either produced a
+    # warning for being correct.
     sh:property [
         sh:path coverage:subscriberRelationship ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
-        sh:in ("self" "spouse" "child" "parent" "other") ;
+        sh:in ("child" "parent" "spouse" "common" "other" "self" "injured") ;
         sh:name "Subscriber Relationship"@en ;
-        sh:message "Subscriber relationship needed for dependent verification"@en ;
+        sh:message "Subscriber relationship should be a code from the HL7 SubscriberPolicyholder code system (http://terminology.hl7.org/CodeSystem/subscriber-relationship): child, parent, spouse, common, other, self, injured"@en ;
         sh:severity sh:Warning
     ] ;
 
@@ -201,8 +228,67 @@ coverage:InsurancePlanShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Coverage Type vocabulary (advisory)
+# ============================================================================
+#
+# Split out of InsurancePlanShape so that the REQUIREMENT (a coverage type is
+# present) and the RECOMMENDATION (it comes from the value set FHIR names) can
+# carry different severities, which a single sh:property cannot do.
+#
+# The list is the union of:
+#   - the v3-ActCode coverage-type codes reachable from
+#     http://hl7.org/fhir/ValueSet/coverage-type, the value set FHIR R4 binds
+#     Coverage.type to;
+#   - the four values this vocabulary has accepted since v1.0, retained so no
+#     existing record starts warning.
+#
+# Severity is sh:Warning because the FHIR binding is EXTENSIBLE: alternate codes
+# MAY be used where the value set does not cover the concept
+# (https://hl7.org/fhir/R4/terminologies.html#extensible). A payer's local code
+# is therefore worth flagging for review and is not grounds for rejecting the
+# record.
+
+coverage:CoverageTypeVocabularyShape a sh:NodeShape ;
+    sh:targetClass coverage:InsurancePlan ;
+    rdfs:label "Coverage Type Vocabulary Shape"@en ;
+    rdfs:comment "Advisory check that coverage:coverageType comes from the value set FHIR R4 binds Coverage.type to. Warning severity, because that binding is extensible."@en ;
+
+    sh:property [
+        sh:path coverage:coverageType ;
+        sh:in (
+            # Retained Cascade values (v1.0-v1.3).
+            "primary" "secondary" "dental" "vision"
+            # v3-ActCode coverage types.
+            "EHCPOL" "HSAPOL" "AUTOPOL" "COL" "UNINSMOT" "PUBLICPOL"
+            "DENTPRG" "DISEASEPRG" "CANPRG" "ENDRENAL" "HIVAIDS" "MANDPOL"
+            "MENTPRG" "SAFNET" "SUBPRG" "SUBSIDIZ" "SUBSIDMC" "SUBSUPP"
+            "WCBPOL" "DENTAL" "DISEASE" "DRUGPOL" "HIP" "LTC" "MCPOL"
+            "POS" "HMO" "PPO" "MENTPOL" "SUBPOL" "VISPOL"
+        ) ;
+        sh:name "Coverage Type Vocabulary"@en ;
+        sh:message "Coverage type should come from the value set FHIR R4 binds Coverage.type to (http://hl7.org/fhir/ValueSet/coverage-type), or one of the retained Cascade values primary, secondary, dental, vision. That binding is extensible, so a payer-local code is acceptable where no listed code applies."@en ;
+        sh:severity sh:Warning
+    ] .
+
+# ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.1 (2026-08-08) — coverage v1.4
+# - coverage:subscriberRelationship: the sh:in list is now the HL7
+#   SubscriberPolicyholder code system in full,
+#   http://terminology.hl7.org/CodeSystem/subscriber-relationship, which is what
+#   FHIR R4 Coverage.relationship binds to. Two of its seven codes were missing:
+#   "common" (Common Law Spouse) and "injured" (Injured Party). An export
+#   carrying either was warned for being correct.
+# - coverage:coverageType: the closed four-member enum was a sh:Violation on an
+#   element FHIR R4 binds EXTENSIBLY (Coverage.type), so a payer sending a
+#   conformant v3-ActCode code such as EHCPOL had the record rejected. The
+#   Violation now checks presence only; the value is checked against the FHIR
+#   value set plus the four retained Cascade values by the new
+#   coverage:CoverageTypeVocabularyShape, at sh:Warning.
+# - Strictly widening: nothing that validated under v1.0 fails under v1.1, and
+#   two classes of previously-rejected conformant record now pass.
 #
 # Version 1.0 (2026-02-18)
 # - Initial release with InsurancePlanShape

--- a/src/shapes/coverage.ttl
+++ b/src/shapes/coverage.ttl
@@ -18,8 +18,8 @@
     dct:description "Domain vocabulary for patient-owned insurance, benefits, and financial health data. Layer 2 vocabulary resolving the overlap between checkup:InsuranceInfo (patient-reported) and clinical:CoverageRecord (EHR-imported) with a unified, standardized representation."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-02-18"^^xsd:date ;
-    dct:modified "2026-03-17"^^xsd:date ;
-    owl:versionInfo "1.3" ;
+    dct:modified "2026-08-08"^^xsd:date ;
+    owl:versionInfo "1.4" ;
     rdfs:comment "Insurance and benefits data is cross-cutting: not clinical (it's administrative/financial), not app-specific (any health app benefits from knowing coverage), and contributed by both patient self-report and EHR import. This vocabulary provides a single Layer 2 domain model that both checkup: (Layer 3, patient-reported) and clinical: (Layer 2, EHR-imported) can reference via the mixed namespace pattern. Recommended Pod storage path: /coverage/"@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/coverage/v1/> .
 
@@ -80,9 +80,11 @@ coverage:planType a owl:DatatypeProperty ;
 
 coverage:coverageType a owl:DatatypeProperty ;
     rdfs:label "Coverage Type"@en ;
-    rdfs:comment "Classification of coverage: primary, secondary, dental, vision."@en ;
+    rdfs:comment "Classification of coverage. Maps to FHIR R4 Coverage.type, whose binding to http://hl7.org/fhir/ValueSet/coverage-type is EXTENSIBLE: a payer-local code is permitted where no listed code applies. The four values this property carried through v1.3 (primary, secondary, dental, vision) are still accepted; note that primary/secondary actually describe FHIR Coverage.order rather than Coverage.type."@en ;
     rdfs:domain coverage:InsurancePlan ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/coverage-definitions.html#Coverage.type> ;
+    owl:versionInfo "Value constraint relaxed to Warning in coverage v1.4, matching the extensible FHIR binding" .
 
 coverage:effectiveStart a owl:DatatypeProperty ;
     rdfs:label "Effective Start"@en ;
@@ -114,9 +116,11 @@ coverage:subscriberName a owl:DatatypeProperty ;
 
 coverage:subscriberRelationship a owl:DatatypeProperty ;
     rdfs:label "Subscriber Relationship"@en ;
-    rdfs:comment "Relationship of patient to subscriber: self, spouse, child, parent, other. Unifies clinical:relationship and checkup:subscriberRelationship with a typed enum constraint."@en ;
+    rdfs:comment "Relationship of the patient to the subscriber, from the HL7 SubscriberPolicyholder code system that FHIR R4 Coverage.relationship binds to: child, parent, spouse, common, other, self, injured. Unifies clinical:relationship and checkup:subscriberRelationship."@en ;
     rdfs:domain coverage:InsurancePlan ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/subscriber-relationship> ;
+    owl:versionInfo "Completed to the full SubscriberPolicyholder code system in coverage v1.4 (added common, injured)" .
 
 # ============================================================================
 # Data Properties - Pharmacy Benefits (from InsuranceInfo model)
@@ -172,6 +176,20 @@ coverage:rxGroup a owl:DatatypeProperty ;
 #   rdfs:seeAlso mappings to HL7 ClaimResponse.adjudication and CARIN IG adjudication codes.
 #
 # v1.2 (2026-03-16): Added coverage:DenialNotice class, coverage:AppealRecord class, and 11 new properties for denial/appeal workflow.
+#
+# Version 1.4 (2026-08-08)
+# - SHACL only; no class or property added, removed or renamed.
+# - coverage:subscriberRelationship enum completed to the full HL7
+#   SubscriberPolicyholder code system
+#   (http://terminology.hl7.org/CodeSystem/subscriber-relationship), which is
+#   what FHIR R4 Coverage.relationship binds to. "common" (Common Law Spouse)
+#   and "injured" (Injured Party) were missing, so a conformant export warned.
+# - coverage:coverageType no longer fails a record for carrying a code from
+#   outside a four-member Cascade list. FHIR R4 binds Coverage.type EXTENSIBLY
+#   (https://hl7.org/fhir/R4/terminologies.html#extensible), so a payer sending
+#   EHCPOL or a local code is conformant. Presence stays a Violation; the value
+#   is now an advisory Warning against the FHIR value set plus the retained
+#   Cascade values.
 #
 # Version 1.0 (2026-02-18)
 # - Initial release as part of Schema Refactoring Plan Phase 2 (WS4)

--- a/src/shapes/health.shapes.ttl
+++ b/src/shapes/health.shapes.ttl
@@ -9,7 +9,7 @@
 # ============================================================================
 # Cascade Protocol — Health & Wellness Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.2 (2026-08-03)
+# Version: 1.3 (2026-08-08)
 # Validates: health:SelfReport, health:VO2MaxStatistics, health:HRVStatistics,
 #            health:BPStatistics, health:MetricTrend, health:ActivitySnapshot,
 #            health:SleepSnapshot, health:HealthProfile,
@@ -25,7 +25,7 @@
 # - sh:Warning = Should address (important for completeness) - e.g., missing period
 # - sh:Info = Nice to have (suggested enrichment) - e.g., optional context fields
 #
-# Validates against: health.ttl v2.5 (2026-08-03)
+# Validates against: health.ttl v2.6 (2026-08-08)
 # ============================================================================
 
 # ============================================================================
@@ -729,6 +729,23 @@ health:SocialHistoryRecordShape a sh:NodeShape ;
 # Changelog
 # ============================================================================
 #
+# Version 1.3 (2026-08-08) — health v2.6
+# - health:interpretation: the sh:in list is now the 49 selectable codes of the
+#   HL7 v3 ObservationInterpretation code system,
+#   http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation (3.0.0),
+#   plus the data-absent-reason code "unknown" and the ten retained v2.5 words.
+#   The previous list was a five-member set with no standards basis, so a lab
+#   reporting a susceptibility, detection, reactivity or change result — all
+#   conformant FHIR — failed validation.
+# - health:labCategory: sh:maxCount 1 removed. FHIR R4 Observation.category is
+#   0..*.
+# - health:testCode, health:icd10Code, health:snomedCode: sh:maxCount 1 removed.
+#   FHIR R4 CodeableConcept.coding is 0..*, and dual-coded problem-list entries
+#   and multi-coding lab observations are ordinary EHR output.
+# - No sh:pattern added to any code property; see the note at
+#   health:icd10Code for why a lexical pattern would reject valid codes.
+# - Strictly widening: every graph valid under v1.2 is valid under v1.3.
+#
 # Version 1.2 (2026-08-03)
 # - Added 5 record shapes for the classes defined in health v2.5:
 #   LabResultRecordShape, ConditionRecordShape, AllergyRecordShape,
@@ -846,20 +863,57 @@ health:LabResultRecordShape a sh:NodeShape ;
         sh:severity sh:Violation
     ] ;
 
+    # Interpretation is bound to the HL7 v3 ObservationInterpretation code
+    # system, which is the code system FHIR R4 binds Observation.interpretation
+    # to. The previous list was a five-member set Cascade invented; laboratories
+    # report susceptibility (S/I/R), detection (POS/NEG/DET/ND/IND), reactivity
+    # (RR/WR/NR) and change (B/D/U/W) results that have no member of that set,
+    # so a conformant export failed validation for being conformant.
+    #
+    # The list below is the 49 SELECTABLE codes of
+    # http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+    # (version 3.0.0), verbatim and in the code system's own order. The eight
+    # abstract concepts (_GeneticObservationInterpretation,
+    # _ObservationInterpretationChange, _ObservationInterpretationExceptions,
+    # _ObservationInterpretationNormality,
+    # _ObservationInterpretationSusceptibility, ObservationInterpretationDetection,
+    # ObservationInterpretationExpectation, ReactivityObservationInterpretation)
+    # are marked notSelectable there and are deliberately absent here: they are
+    # hierarchy nodes, not values. Codes the code system marks deprecated
+    # (Carrier, AC, QCF, TOX, MS, VS, HM, OBX, H>, L<) ARE accepted, because a
+    # deprecated code is still a defined code and historical results carry them.
+    #
+    # Then two additions that are not from that code system and are named here
+    # rather than left to be inferred:
+    #   - "unknown", from http://terminology.hl7.org/CodeSystem/data-absent-reason
+    #     ("The value is expected to exist but is not known"). Importers write it
+    #     when the source Observation carried no interpretation at all, which is
+    #     the single most common value in a real export.
+    #   - the ten lower- and title-case English words of the previous enum,
+    #     retained so that data already written against health v2.5 keeps
+    #     validating. They are NOT recommended for new writes.
     sh:property [
         sh:path health:interpretation ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
-        sh:in ("normal" "high" "low" "abnormal" "critical"
+        sh:in ("EX" "HM" "OBX" "CAR" "Carrier" "B" "D" "U" "W"
+               "<" ">" "AC" "IE" "QCF" "TOX"
+               "A" "N" "I" "MS" "NCL" "NS" "R" "S" "VS"
+               "AA" "H" "L" "HH" "LL" "HX" "LX" "H>" "HU" "E" "L<" "LU"
+               "ND" "IND" "NEG" "POS" "EXP" "UNE" "DET"
+               "SYN-R" "NR" "RR" "WR" "SDD" "SYN-S"
+               "unknown"
+               "normal" "high" "low" "abnormal" "critical"
                "Normal" "High" "Low" "Abnormal" "Critical") ;
         sh:name "Interpretation"@en ;
-        sh:message "Interpretation must be one of normal, high, low, abnormal, critical"@en ;
+        sh:message "Interpretation must be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), the data-absent-reason code 'unknown', or one of the retained health v2.5 words"@en ;
         sh:severity sh:Violation
     ] ;
 
     sh:property [
         sh:path health:performedDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Performed Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Performed Date"@en ;
         sh:severity sh:Violation
@@ -867,23 +921,33 @@ health:LabResultRecordShape a sh:NodeShape ;
 
     sh:property [
         sh:path health:reportedDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Reported Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Reported Date"@en ;
         sh:severity sh:Violation
     ] ;
 
+    # Multi-valued: FHIR R4 CodeableConcept.coding is 0..*
+    # (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept), and an
+    # Observation.code routinely carries more than one LOINC coding for the same
+    # test. Importers emit one health:testCode per coding, so sh:maxCount 1
+    # rejected the record for preserving what the source sent. No cardinality
+    # ceiling; each value is still a single code.
     sh:property [
         sh:path health:testCode ;
-        sh:maxCount 1 ;
         sh:name "Test Code (LOINC)"@en ;
         sh:severity sh:Violation
     ] ;
 
+    # Multi-valued: FHIR R4 Observation.category is 0..*
+    # (https://hl7.org/fhir/R4/observation-definitions.html#Observation.category).
+    # Real exports categorise one result several ways at once (for example a
+    # department grouping alongside "laboratory"), so a single-valued constraint
+    # here contradicted the resource definition the data comes from.
     sh:property [
         sh:path health:labCategory ;
         sh:datatype xsd:string ;
-        sh:maxCount 1 ;
         sh:name "Lab Category"@en ;
         sh:severity sh:Violation
     ] ;
@@ -978,22 +1042,33 @@ health:ConditionRecordShape a sh:NodeShape ;
 
     sh:property [
         sh:path health:onsetDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Onset Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Onset Date"@en ;
         sh:severity sh:Violation
     ] ;
 
+    # Multi-valued for the same reason as health:testCode above: FHIR R4
+    # CodeableConcept.coding is 0..*
+    # (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept). A Condition.code
+    # commonly carries two ICD-10-CM codings, or an ICD-10-CM coding beside a
+    # SNOMED CT one, and dual coding is the normal shape of EHR problem lists
+    # rather than an anomaly.
+    #
+    # NOTE ON FORMAT: neither of these carries an sh:pattern, and that is
+    # deliberate. ICD-10-CM permits a letter in any character position
+    # (categories such as C4A and M1A are ordinary codes) and SNOMED CT
+    # identifiers are 6-18 digit integers, so a naive pattern here would reject
+    # valid codes. Format is left to the code system.
     sh:property [
         sh:path health:icd10Code ;
-        sh:maxCount 1 ;
         sh:name "ICD-10-CM Code"@en ;
         sh:severity sh:Violation
     ] ;
 
     sh:property [
         sh:path health:snomedCode ;
-        sh:maxCount 1 ;
         sh:name "SNOMED CT Code"@en ;
         sh:severity sh:Violation
     ] ;
@@ -1097,7 +1172,8 @@ health:AllergyRecordShape a sh:NodeShape ;
 
     sh:property [
         sh:path health:onsetDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Onset Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Onset Date"@en ;
         sh:severity sh:Violation
@@ -1161,7 +1237,8 @@ health:ImmunizationRecordShape a sh:NodeShape ;
     # release that is explicitly flagged as tightening.
     sh:property [
         sh:path health:administrationDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
+        sh:message "Administration Date must be an xsd:date or an xsd:dateTime. FHIR's dateTime primitive permits date precision (YYYY, YYYY-MM, YYYY-MM-DD), so a source that stated only a calendar day must not be given an invented time; an untyped or xsd:string literal is not either type."@en ;
         sh:maxCount 1 ;
         sh:name "Administration Date"@en ;
         sh:severity sh:Violation

--- a/src/shapes/health.ttl
+++ b/src/shapes/health.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for consumer-generated wellness observations from wearable devices and HealthKit. Maps Cascade wellness properties to established SNOMED CT and LOINC codes following the three-layer ontology architecture."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-01-29"^^xsd:date ;
-    dct:modified "2026-08-03"^^xsd:date ;
-    owl:versionInfo "2.5" ;
+    dct:modified "2026-08-08"^^xsd:date ;
+    owl:versionInfo "2.6" ;
     rdfs:comment """Three-layer ontology for wellness data:
         Layer 1 (Established standards): SNOMED CT concept IDs + LOINC observation codes
         Layer 2 (Cascade health vocabulary): health: namespace properties linking to Layer 1
@@ -30,6 +30,45 @@
     rdfs:seeAlso <https://cascadeprotocol.org/docs/health/v1/> .
 
 # Changelog:
+# v2.6 (2026-08-08): Align the lab-result constraints to the ratified standards
+#     they claim to follow. Shapes-only; no class or property is added, removed
+#     or renamed, and nothing that validated under v2.5 stops validating.
+#
+#     Motivation: real-world Epic FHIR exports fail validation on records that
+#     are correct FHIR. Four constraints on health:LabResultRecordShape and
+#     health:ConditionRecordShape were narrower than the resource definitions
+#     the data is converted from.
+#
+#     1. health:interpretation was constrained to a five-member set Cascade
+#        invented (normal/high/low/abnormal/critical). It is now the 49
+#        selectable codes of the HL7 v3 ObservationInterpretation code system,
+#        http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+#        (version 3.0.0) — the code system FHIR R4 binds
+#        Observation.interpretation to — plus the data-absent-reason code
+#        "unknown" (http://terminology.hl7.org/CodeSystem/data-absent-reason)
+#        for the very common case of a source Observation that carried no
+#        interpretation at all. The ten v2.5 words are retained so existing
+#        data keeps validating; they are not recommended for new writes.
+#        The eight abstract (notSelectable) concepts of the code system are
+#        excluded: they are hierarchy nodes, not values.
+#     2. health:labCategory is now multi-valued. FHIR R4 Observation.category
+#        is 0..* (https://hl7.org/fhir/R4/observation-definitions.html#Observation.category)
+#        and real exports categorise one result several ways at once.
+#     3. health:testCode is now multi-valued, and
+#     4. health:icd10Code and health:snomedCode are now multi-valued, all three
+#        because FHIR R4 CodeableConcept.coding is 0..*
+#        (https://hl7.org/fhir/R4/datatypes.html#CodeableConcept). Dual coding
+#        of a problem-list entry, and multiple LOINC codings of one test, are
+#        the normal shape of EHR output.
+#
+#     Deliberately NOT changed: no sh:pattern is introduced on any code
+#     property. ICD-10-CM permits a letter in any character position (per the
+#     ICD-10-CM Official Guidelines for Coding and Reporting, Section I.A.2:
+#     "Characters for categories, subcategories and codes may be either a letter
+#     or a number"), and SNOMED CT identifiers are 6-18 digit integers, so a
+#     pattern would reject valid codes for no gain. Format stays with the code
+#     system that defines it.
+#
 # v2.5 (2026-08-03): Clinical record classes. Five classes that serializers have
 #     emitted since v1.3 but that this ontology never defined are now defined:
 #     health:LabResultRecord, health:ConditionRecord, health:AllergyRecord,
@@ -1143,11 +1182,12 @@ health:resultUnit a owl:DatatypeProperty ;
 
 health:interpretation a owl:DatatypeProperty ;
     rdfs:label "Interpretation"@en ;
-    rdfs:comment "Categorical reading of the result against its reference range."@en ;
+    rdfs:comment "Categorical reading of the result, as a code from the HL7 v3 ObservationInterpretation code system: normality (N, A, H, L, HH, LL, ...), susceptibility (S, I, R, SDD, ...), detection (POS, NEG, DET, ND, IND), reactivity (RR, WR, NR), change (B, D, U, W) and the exception codes. The data-absent-reason code 'unknown' is also accepted, for a source observation that carried no interpretation. At most one value per record."@en ;
     rdfs:domain health:LabResultRecord ;
     rdfs:range xsd:string ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation> ;
     rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
-    owl:versionInfo "Added in health v2.5" .
+    owl:versionInfo "Added in health v2.5; bound to HL7 v3 ObservationInterpretation in health v2.6" .
 
 health:performedDate a owl:DatatypeProperty ;
     rdfs:label "Performed Date"@en ;
@@ -1165,17 +1205,19 @@ health:reportedDate a owl:DatatypeProperty ;
 
 health:testCode a owl:ObjectProperty ;
     rdfs:label "Test Code"@en ;
-    rdfs:comment "LOINC reference for the test performed, as an IRI."@en ;
+    rdfs:comment "LOINC reference for the test performed, as an IRI. Repeatable: FHIR R4 CodeableConcept.coding is 0..*, and one test is often carried under more than one LOINC coding."@en ;
     rdfs:domain health:LabResultRecord ;
     rdfs:seeAlso <http://loinc.org/> ;
-    owl:versionInfo "Added in health v2.5" .
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#CodeableConcept> ;
+    owl:versionInfo "Added in health v2.5; made repeatable in health v2.6" .
 
 health:labCategory a owl:DatatypeProperty ;
     rdfs:label "Lab Category"@en ;
-    rdfs:comment "Laboratory department or panel grouping (for example Chemistry, Hematology). Free text: laboratories do not agree on a common set."@en ;
+    rdfs:comment "Laboratory department or panel grouping (for example Chemistry, Hematology). Free text: laboratories do not agree on a common set. Repeatable, mirroring FHIR R4 Observation.category, which is 0..*."@en ;
     rdfs:domain health:LabResultRecord ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in health v2.5" .
+    rdfs:seeAlso <https://hl7.org/fhir/R4/observation-definitions.html#Observation.category> ;
+    owl:versionInfo "Added in health v2.5; made repeatable in health v2.6" .
 
 health:referenceRange a owl:DatatypeProperty ;
     rdfs:label "Reference Range"@en ;
@@ -1211,10 +1253,11 @@ health:performingLab a owl:DatatypeProperty ;
 
 health:icd10Code a owl:ObjectProperty ;
     rdfs:label "ICD-10-CM Code"@en ;
-    rdfs:comment "ICD-10-CM reference for the condition, as an IRI."@en ;
+    rdfs:comment "ICD-10-CM reference for the condition, as an IRI. Repeatable: FHIR R4 CodeableConcept.coding is 0..*, and problem-list entries are routinely dual coded. Note that ICD-10-CM permits a letter in any character position (C4A, D3A and M1A are ordinary categories), so no lexical pattern is imposed here."@en ;
     rdfs:domain health:ConditionRecord ;
     rdfs:seeAlso <https://hl7.org/fhir/R4/codesystem-icd10.html> ;
-    owl:versionInfo "Added in health v2.5" .
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#CodeableConcept> ;
+    owl:versionInfo "Added in health v2.5; made repeatable in health v2.6" .
 
 health:conditionClass a owl:DatatypeProperty ;
     rdfs:label "Condition Class"@en ;

--- a/tests/fhir-standards-alignment.test.ts
+++ b/tests/fhir-standards-alignment.test.ts
@@ -1,0 +1,332 @@
+/**
+ * A conformant FHIR record converts and then VALIDATES.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * Real-world Epic FHIR exports failed `cascade validate` at scale, and every
+ * failure was a Cascade constraint narrower than the standard the data was
+ * converted from. Nothing was wrong with the source resources, and nothing was
+ * wrong with the converter: the shapes described a FHIR that does not exist.
+ *
+ *   - `interpretation` was constrained to five words invented in `spec`
+ *     (normal / high / low / abnormal / critical). FHIR R4 binds
+ *     `Observation.interpretation` to the HL7 v3 ObservationInterpretation code
+ *     system, which also carries susceptibility (S/I/R), detection
+ *     (POS/NEG/DET/ND/IND), reactivity (RR/WR/NR) and change (B/D/U/W)
+ *     results. The converter maps what it recognizes and writes the
+ *     data-absent-reason code `unknown` for everything else, which was not in
+ *     the enum either — so the single most common value in a real export was
+ *     also a Violation.
+ *   - `labCategory` was `sh:maxCount 1` while `Observation.category` is 0..*.
+ *   - `testCode`, `icd10Code` and `snomedCode` were `sh:maxCount 1` while
+ *     `CodeableConcept.coding` is 0..*. Dual-coded problem lists are ordinary.
+ *   - `cptCode` required five digits, which is CPT Category I only.
+ *   - `coverageType` enforced a closed four-member enum at Violation severity
+ *     on an element FHIR binds EXTENSIBLY, and `subscriberRelationship` held
+ *     five of the seven codes in the value set it points at.
+ *   - `clinical:Encounter` had NO SHAPE AT ALL. Encounters did not fail; they
+ *     were never checked. `validate` reported PASS having evaluated zero
+ *     constraints against them, which is the more dangerous failure of the two.
+ *
+ * WHAT THIS TEST IS
+ * -----------------
+ * One synthetic Epic-shaped bundle carrying every one of those cases at once,
+ * converted through the real converter and validated against the real bundled
+ * shapes. The assertion is the whole point: ZERO violations, and every subject
+ * covered by a shape. It is an end-to-end lock, not a unit test of an enum,
+ * because the defect was only ever visible end to end — each half looked
+ * correct on its own.
+ *
+ * WHAT THESE DO IF THE FIX IS ABSENT — measured, not predicted, by restoring
+ * `src/shapes/` to 522c6fc (health v2.5 / clinical v1.13 / coverage v1.3) and
+ * running this file. 3 of the 6 fail:
+ *   - `converts and validates with zero violations` FAILS with 7 violations:
+ *     cptCode, coverageType, interpretation, testCode, labCategory, icd10Code,
+ *     snomedCode.
+ *   - `covers every converted subject with a shape` FAILS: 4 of 5 subjects
+ *     checked, the Encounter unshaped.
+ *   - `raises no warning on a conformant subscriber relationship` FAILS on
+ *     `common`.
+ *
+ * And 3 pass against the broken build, deliberately:
+ *   - `preserves every category and code the source sent` pins CONVERTER
+ *     behaviour, which did not change here. It is what distinguishes "the
+ *     shapes were widened" from "the converter started dropping the values that
+ *     used to fail".
+ *   - `writes an interpretation the shapes accept ...` likewise pins what the
+ *     converter emits, not what the shapes accept.
+ *   - `is looking at findings at all` is the non-vacuity control and must hold
+ *     in both directions.
+ *
+ * A NOTE ON HOW THIS FILE NEARLY SHIPPED GREEN AND EMPTY
+ * ------------------------------------------------------
+ * `ValidationIssue.severity` is lowercase ('violation' | 'warning' | 'info').
+ * The first draft filtered on 'Violation', matched nothing, and asserted [] ==
+ * [] — so it passed against the very build it was written to catch. That is why
+ * `is looking at findings at all` exists, and why the RED run above was
+ * measured rather than assumed.
+ *
+ * EVERY VALUE BELOW IS SYNTHETIC. The names, identifiers, dates and results are
+ * invented for this test.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Parser, Store } from 'n3';
+import { convert } from '../src/lib/fhir-converter/index.js';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+
+const NS = {
+  health: 'https://ns.cascadeprotocol.org/health/v1#',
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+  coverage: 'https://ns.cascadeprotocol.org/coverage/v1#',
+};
+
+/**
+ * An Epic-shaped bundle. Every element here is one the exports actually carry:
+ * an antimicrobial susceptibility result (whose interpretation code has no
+ * member of the old enum, and whose Observation is categorised twice and coded
+ * twice), a dual-coded oncology problem-list entry using ICD-10-CM categories
+ * with a LETTER in the third character, a visit, an employer-sponsored policy
+ * typed with a v3-ActCode code, and a Category III procedure.
+ */
+const SYNTHETIC_EPIC_BUNDLE = {
+  resourceType: 'Bundle',
+  id: 'bundle-standards-alignment-synthetic',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Observation',
+        id: 'obs-synthetic-susceptibility-1',
+        status: 'final',
+        // Observation.category is 0..*, and real exports use all of it.
+        category: [
+          {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+                code: 'laboratory',
+                display: 'Laboratory',
+              },
+            ],
+          },
+          {
+            coding: [
+              {
+                system: 'urn:oid:1.2.3.4.5.6.7.8.9',
+                code: 'MICROBIOLOGY',
+                display: 'Microbiology',
+              },
+            ],
+            text: 'Antimicrobial Susceptibility',
+          },
+        ],
+        // CodeableConcept.coding is 0..*: two LOINC codings for one test.
+        code: {
+          coding: [
+            { system: 'http://loinc.org', code: '18864-9', display: 'Ampicillin [Susceptibility]' },
+            { system: 'http://loinc.org', code: '18928-2', display: 'Ampicillin [Susceptibility] by Method' },
+          ],
+          text: 'Ampicillin susceptibility',
+        },
+        subject: { reference: 'Patient/pat-synthetic-1' },
+        effectiveDateTime: '2031-04-17T08:15:00Z',
+        valueQuantity: { value: 4, unit: 'ug/mL', system: 'http://unitsofmeasure.org', code: 'ug/mL' },
+        // "I" (Intermediate) is a susceptibility interpretation. It is a
+        // perfectly ordinary HL7 code and had no member of the old five.
+        interpretation: [
+          {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation',
+                code: 'I',
+                display: 'Intermediate',
+              },
+            ],
+          },
+        ],
+        encounter: { reference: 'Encounter/enc-synthetic-1' },
+      },
+    },
+    {
+      resource: {
+        resourceType: 'Condition',
+        id: 'cond-synthetic-1',
+        clinicalStatus: {
+          coding: [
+            { system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active' },
+          ],
+        },
+        // Two ICD-10-CM codings and two SNOMED CT codings on one problem.
+        // C4A and M1A are live ICD-10-CM categories whose THIRD character is a
+        // letter, which is what the ICD pattern elsewhere in the vocabulary
+        // used to reject.
+        code: {
+          coding: [
+            { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'C4A.51', display: 'Synthetic Merkel cell carcinoma site' },
+            { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'M1A.0110', display: 'Synthetic chronic gout site' },
+            { system: 'http://snomed.info/sct', code: '254837009', display: 'Synthetic neoplasm concept' },
+            { system: 'http://snomed.info/sct', code: '363418001', display: 'Synthetic secondary concept' },
+          ],
+          text: 'Synthetic skin neoplasm',
+        },
+        subject: { reference: 'Patient/pat-synthetic-1' },
+        onsetDateTime: '2030-11-02T00:00:00Z',
+        encounter: { reference: 'Encounter/enc-synthetic-1' },
+      },
+    },
+    {
+      resource: {
+        resourceType: 'Encounter',
+        id: 'enc-synthetic-1',
+        status: 'finished',
+        class: {
+          system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+          code: 'AMB',
+          display: 'ambulatory',
+        },
+        type: [
+          {
+            coding: [
+              { system: 'http://snomed.info/sct', code: '185349003', display: 'Encounter for check up' },
+            ],
+            text: 'Ambulatory visit',
+          },
+        ],
+        subject: { reference: 'Patient/pat-synthetic-1' },
+        period: { start: '2031-04-17T08:00:00Z', end: '2031-04-17T08:45:00Z' },
+        participant: [{ individual: { display: 'Dr Wrenfield Ashcombe' } }],
+        serviceProvider: { display: 'Northbrook Synthetic Clinic' },
+      },
+    },
+    {
+      resource: {
+        resourceType: 'Coverage',
+        id: 'cov-synthetic-1',
+        status: 'active',
+        // EHCPOL is from the value set FHIR binds Coverage.type to. The old
+        // enum accepted only primary / secondary / dental / vision.
+        type: {
+          coding: [
+            { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'EHCPOL', display: 'extended healthcare' },
+          ],
+          text: 'Extended healthcare',
+        },
+        subscriberId: 'SYN-000-1234',
+        beneficiary: { reference: 'Patient/pat-synthetic-1' },
+        // "common" is one of the two codes the old enum was missing.
+        relationship: {
+          coding: [
+            { system: 'http://terminology.hl7.org/CodeSystem/subscriber-relationship', code: 'common', display: 'Common Law Spouse' },
+          ],
+        },
+        payor: [{ display: 'Meadowlark Synthetic Health Plan' }],
+        period: { start: '2031-01-01', end: '2031-12-31' },
+      },
+    },
+    {
+      resource: {
+        resourceType: 'Procedure',
+        id: 'proc-synthetic-1',
+        status: 'completed',
+        // A CPT Category III code: four digits and a T, five characters.
+        code: {
+          coding: [
+            { system: 'http://www.ama-assn.org/go/cpt', code: '0042T', display: 'Synthetic category III procedure' },
+          ],
+          text: 'Synthetic category III procedure',
+        },
+        subject: { reference: 'Patient/pat-synthetic-1' },
+        performedDateTime: '2031-04-17T09:00:00Z',
+      },
+    },
+  ],
+};
+
+describe('a conformant Epic-shaped FHIR bundle converts and validates', () => {
+  let turtle: string;
+  let store: Store;
+  let result: ReturnType<typeof validateTurtle>;
+
+  beforeAll(async () => {
+    const converted = await convert(JSON.stringify(SYNTHETIC_EPIC_BUNDLE), 'fhir', 'turtle');
+    expect(converted.success, converted.errors.join('; ')).toBe(true);
+    turtle = converted.output;
+
+    store = new Store();
+    for (const q of new Parser().parse(turtle)) store.addQuad(q);
+
+    const shapes = loadShapes();
+    result = validateTurtle(turtle, shapes.store, shapes.shapeFiles, 'synthetic-epic-bundle.ttl');
+  });
+
+  const objects = (predicate: string): string[] =>
+    store
+      .getQuads(null, predicate, null, null)
+      .map((q) => q.object.value)
+      .sort();
+
+  it('converts and validates with zero violations', () => {
+    // `severity` is lowercase in ValidationIssue. Filtering on 'Violation'
+    // matches nothing and asserts [] against [], which is a test that passes
+    // against a broken build; the control below is what proves it does not.
+    const violations = result.results.filter((r) => r.severity === 'violation');
+    // Named, so a failure says WHICH constraint regressed rather than a count.
+    expect(violations.map((v) => `${v.property || '?'}: ${v.message}`)).toEqual([]);
+  });
+
+  it('is looking at findings at all — the filters above are not vacuous', () => {
+    // The control for the trap named in the previous test. If the validator
+    // ever stops populating `severity`, or renames its values, every
+    // "expect([]).toEqual([])" above turns green while checking nothing. This
+    // asserts that the severities present in a report are drawn from the set
+    // the filters actually match.
+    const seen = new Set(result.results.map((r) => r.severity));
+    for (const s of seen) expect(['violation', 'warning', 'info']).toContain(s);
+    // And that the validator really did run: shapes selected focus nodes here.
+    expect(result.shapesUsed.length).toBeGreaterThan(0);
+    expect(result.shapesUsed).toContain('health.shapes.ttl');
+    expect(result.shapesUsed).toContain('clinical.shapes.ttl');
+    expect(result.shapesUsed).toContain('coverage.shapes.ttl');
+  });
+
+  it('covers every converted subject with a shape', () => {
+    // The Encounter is the reason this assertion exists: it used to be the one
+    // subject no shape targeted, and an unchecked subject reports PASS.
+    expect(result.coverage.unshapedSubjects.map((u) => u.types.join(','))).toEqual([]);
+    expect(result.coverage.checkedSubjects).toBe(result.coverage.totalSubjects);
+    expect(result.coverage.totalSubjects).toBe(5);
+  });
+
+  it('raises no warning on a conformant subscriber relationship', () => {
+    const warnings = result.results.filter((r) => r.severity === 'warning');
+    expect(warnings.map((w) => `${w.property || '?'}: ${w.message}`)).toEqual([]);
+  });
+
+  it('preserves every category and code the source sent', () => {
+    // Pins CONVERTER behaviour. Widening a shape and dropping the values that
+    // used to trip it produce the same green suite; this separates them.
+    expect(objects(`${NS.health}labCategory`)).toEqual([
+      'Antimicrobial Susceptibility',
+      'MICROBIOLOGY',
+    ]);
+    expect(objects(`${NS.health}testCode`)).toHaveLength(2);
+    expect(objects(`${NS.health}icd10Code`)).toEqual([
+      'http://hl7.org/fhir/sid/icd-10-cm/C4A.51',
+      'http://hl7.org/fhir/sid/icd-10-cm/M1A.0110',
+    ]);
+    expect(objects(`${NS.health}snomedCode`)).toHaveLength(2);
+    expect(objects(`${NS.coverage}coverageType`)).toEqual(['EHCPOL']);
+    expect(objects(`${NS.coverage}subscriberRelationship`)).toEqual(['common']);
+    expect(objects(`${NS.clinical}cptCode`)).toEqual(['0042T']);
+  });
+
+  it('writes an interpretation the shapes accept for a code outside the old enum', () => {
+    // The converter has no mapping for the susceptibility code "I" and writes
+    // the data-absent-reason code `unknown`. That value is now IN the value
+    // set, which is the specific thing that used to fail. This asserts the
+    // value that is actually written rather than the one we wish were written;
+    // widening the converter's own HL7 mapping is a separate change.
+    expect(objects(`${NS.health}interpretation`)).toEqual(['unknown']);
+  });
+});

--- a/tests/known-shacl-gaps.ts
+++ b/tests/known-shacl-gaps.ts
@@ -11,6 +11,30 @@
  * checked. Everything below is a finding of that kind: the converter's output
  * did not change, the constraints did.
  *
+ * WHAT CHANGED AT health v2.6 / clinical v1.14
+ * --------------------------------------------
+ * The vocabulary question this file said the emitter fix was blocked on has
+ * been answered, in the direction this file argued for. The date properties
+ * below are no longer `sh:datatype xsd:dateTime`; they are
+ * `sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] )`, because
+ * FHIR's `dateTime` primitive is explicitly partial-precision and a C-CDA
+ * `<effectiveTime value="20250311"/>` states a calendar day and nothing more.
+ * Appending `T00:00:00` to satisfy a validator would have fabricated precision
+ * the source never had.
+ *
+ * THE GAP DID NOT GO AWAY, AND IS NOW SMALLER AND SHARPER. The remaining
+ * violation is no longer a disagreement about which datatype is right. It is
+ * that the emitters write `literal(dateStr)` — a PLAIN literal, which is
+ * `xsd:string` — and `xsd:string` is neither `xsd:date` nor `xsd:dateTime`. The
+ * shapes now accept exactly what the source can honestly say; the converter
+ * still has to say it, by typing the literal. `2025-03-11`^^`xsd:date`
+ * validates today, with no invented time and no shape change.
+ *
+ * That emitter fix is deliberately still not made here, for reason 1 below: a
+ * change that syncs vocabulary and shapes must not also alter what the
+ * converter writes. Reason 2 — "the correct fix is not obvious" — no longer
+ * applies and has been struck.
+ *
  * THE ONE FINDING, STATED PRECISELY
  * ---------------------------------
  * Four C-CDA section handlers read `<effectiveTime value="20250311"/>`, slice it
@@ -23,11 +47,11 @@
  *   sections/problems.ts      -> health:onsetDate
  *   sections/immunizations.ts -> health:administrationDate
  *
- * health v2.5 constrains all three predicates with `sh:datatype xsd:dateTime`.
- * That constraint is not new and not an overreach: `health.ttl` declares
- * `rdfs:range xsd:dateTime` on each of the three, and it is the same constraint
- * `clinical:onsetDate` has carried since before this release. The emitters have
- * disagreed with the ratified vocabulary the whole time; nothing was checking.
+ * health v2.5 constrained all three predicates with `sh:datatype xsd:dateTime`;
+ * health v2.6 widened them to `xsd:date` OR `xsd:dateTime`. Either way the
+ * emitters disagree with the ratified vocabulary, because a plain literal is
+ * `xsd:string` and always was. Nothing was checking until v2.5 shaped these
+ * classes at all.
  *
  * `labs.ts:292` already writes `clinical:performedDate` through a
  * `tripleDateTime()` helper that types the literal correctly. The helper exists.
@@ -36,23 +60,18 @@
  *
  * WHY THIS IS PINNED RATHER THAN FIXED HERE
  * -----------------------------------------
- * Two reasons, and the second is why it is not a one-line change.
+ * One reason now, not two.
  *
  * 1. This change syncs vocabulary and shapes; it deliberately alters no emission
  *    site. Fixing a converter here would mix a data-output change into a
  *    vocabulary sync, and the two need to be reviewed and released separately.
  *
- * 2. The correct fix is not obvious. The source carries DAY precision. Typing
- *    `2025-03-11` as `xsd:dateTime` requires appending a time — `T00:00:00` —
- *    which fabricates precision the C-CDA never had, and midnight-local is a
- *    real value that downstream arithmetic will treat as real. FHIR R4's
- *    `dateTime` primitive accepts `YYYY`, `YYYY-MM`, `YYYY-MM-DD` and full
- *    instants precisely to avoid this, and `health:administrationDate`'s own
- *    comment says it "Corresponds to FHIR R4 Immunization.occurrence". A single
- *    `sh:datatype` cannot express that; expressing it needs `sh:or` over
- *    `xsd:date` / `xsd:dateTime` in the shapes. So the emitter fix is blocked on
- *    a vocabulary decision, and guessing at it in this change would ratify the
- *    guess.
+ * 2. STRUCK at health v2.6. It read: "the correct fix is not obvious", because
+ *    a single `sh:datatype` could not express FHIR's partial-precision
+ *    `dateTime` and the emitter fix was therefore blocked on a vocabulary
+ *    decision. That decision is made. The fix is now obvious and small: type
+ *    the literal `xsd:date` at the five sites listed above, using the same
+ *    kind of helper `labs.ts:292` already uses for `clinical:performedDate`.
  *
  * HOW THIS STAYS HONEST
  * ---------------------
@@ -72,8 +91,8 @@ export interface SeverityIssue {
 }
 
 /**
- * Local names of the properties whose `sh:datatype xsd:dateTime` constraint the
- * C-CDA converter currently violates by emitting an untyped day-precision string.
+ * Local names of the properties whose date-datatype constraint the C-CDA
+ * converter currently violates by emitting an untyped day-precision string.
  */
 export const KNOWN_DATE_DATATYPE_PROPERTIES = new Set([
   'performedDate',
@@ -81,10 +100,23 @@ export const KNOWN_DATE_DATATYPE_PROPERTIES = new Set([
   'administrationDate',
 ]);
 
+/**
+ * The substring that identifies the date-datatype finding specifically.
+ *
+ * At health v2.5 this was the `xsd:dateTime` IRI, which appeared in the
+ * `sh:datatype` report. health v2.6 replaced that constraint with an `sh:or`
+ * over `xsd:date` and `xsd:dateTime`, and an `sh:or` report carries the
+ * property shape's own `sh:message` instead. So the matcher keys on that
+ * message. This is deliberately a phrase from the SHAPES, not a phrase invented
+ * here: if `spec` reworded or dropped the message, the match stops and this
+ * file is forced open rather than silently widening.
+ */
+const DATE_DATATYPE_MESSAGE = 'must be an xsd:date or an xsd:dateTime';
+
 function isKnownDateDatatypeViolation(v: SeverityIssue): boolean {
   return (
     KNOWN_DATE_DATATYPE_PROPERTIES.has(v.property) &&
-    v.message.includes('http://www.w3.org/2001/XMLSchema#dateTime')
+    v.message.includes(DATE_DATATYPE_MESSAGE)
   );
 }
 


### PR DESCRIPTION
Syncs the bundled shapes from the-cascade-protocol/spec#16 and adds the end-to-end regression test that would have caught the problem.

Real-world Epic FHIR exports, and C-CDA documents through the same pipeline, were failing `cascade validate` on records that are correct at source. Every failure was a Cascade constraint narrower than the standard the data had been converted from. Nothing was wrong with the converter and nothing was wrong with the data.

## Measured

One synthetic Epic-shaped bundle, converted through `cascade convert` and validated against the bundled shapes:

| | Before | After |
|---|---|---|
| Violations | 7 | 0 |
| Warnings | 1 | 0 |
| Subjects checked | 4 of 5 | 5 of 5 |

The unchecked subject was the Encounter, which is the more dangerous half: `clinical:Encounter` had no shape, so `validate` reported PASS having evaluated zero constraints against every encounter in every pod.

The seven violations were `cptCode` (a Category III code against a five-digit pattern), `coverageType` (`EHCPOL` against a four-word enum), `interpretation` (`unknown` against the invented five), and `sh:maxCount 1` on `testCode`, `labCategory`, `icd10Code` and `snomedCode` where FHIR is 0..*. The warning was `subscriberRelationship` `common`, one of two codes missing from a value set the shape claimed to implement.

## New test

`tests/fhir-standards-alignment.test.ts` converts that bundle through the real converter and validates it against the real bundled shapes. It asserts zero violations, zero warnings and full shape coverage, and it separately pins what the converter EMITS, which is what distinguishes "the shapes were widened" from "the converter started dropping the values that used to fail".

Verified RED before being kept, by restoring `src/shapes/` to `522c6fc` and running it: 3 of its 6 assertions fail there, with the exact findings above. The other 3 pass in both directions by design and say so.

Worth recording: the first draft filtered `severity === 'Violation'` where the field is lowercase. It matched nothing, asserted `[] === []`, and passed against the very build it was written to catch. The non-vacuity control now in the file exists because of that.

## `known-shacl-gaps.ts` updated, not deleted

That file argued the C-CDA day-precision emitters could not be fixed until the vocabulary decided how to express partial precision, because typing `2025-03-11` as `xsd:dateTime` fabricates a midnight the source never stated. That decision is now made, in the direction it argued for: the date properties are `sh:or ( xsd:date, xsd:dateTime )`.

The gap did not disappear; it got smaller and sharper. The five emitters write `literal(dateStr)`, a plain literal, which is `xsd:string` — neither of the accepted types. Typing it `xsd:date` now validates with no invented time and no further shape change. That emitter fix stays out of a vocabulary sync deliberately, and is called out as a follow-up.

## Verification

```
tsc --noEmit           clean
Test Files   130 passed (130)
Tests        1931 passed (1931)
Skipped      0
Todo         0
```

Baseline before this change on the same checkout was 129 files / 1925 tests / 0 skipped, so the delta is exactly the new file. Skip count confirmed zero from the JSON reporter (`numPendingTests: 0`), not read off the terminal summary.

`cascade validate` passes all 57 positive conformance fixtures (57 passed, 0 failed) and rejects both new negative fixtures with the expected constraint named. `clinical:Encounter` no longer appears in its "no applicable shape" report.

## Notes for review

- The sync script also produces diffs for the draft `evidence.ttl` and `genomics.shapes.ttl`. Those are pre-existing drift from spec's 2026-08-03 Validation Profile release and are reverted here, so a genomics `sh:class` semantics change is not folded into a clinical alignment. They need their own sync.
- No change to `deterministicUuid` or any identity path.

Depends on the-cascade-protocol/spec#16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)