### PR TITLE
fix(cli): emit what the ratified shapes accept in the C-CDA and FHIR converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+**C-CDA date properties are emitted as typed literals, at the precision the source stated.** Five
+section handlers each sliced `<effectiveTime value="20250311"/>` down to `2025-03-11` with their own
+copy of the same expression and wrote it with `literal(dateStr)`, which is a PLAIN literal and
+therefore `xsd:string`. health 2.6 / clinical 1.14 constrain those properties to `xsd:date` or
+`xsd:dateTime`, so every C-CDA-converted record carrying one failed validation on a date the
+document had stated perfectly well. The sites now build the literal through one helper,
+`src/lib/ccda-converter/dates.ts`, which reads the datatype off the source precision:
+
+- `20250311143000-0500` becomes `"2025-03-11T14:30:00-05:00"^^xsd:dateTime`
+- `20250311` becomes `"2025-03-11"^^xsd:date`
+
+A day-precision value is not promoted to `T00:00:00`. Appending midnight would satisfy the datatype
+check by asserting a time of day the source never gave, and a fabricated 00:00 is indistinguishable
+downstream from a real one. A value coarser than a calendar day (`202503`) is not emitted at all,
+because neither accepted datatype can express it. Affects `health:performedDate` (results,
+procedures, and the vital-sign-to-lab fallback), `health:onsetDate` (problems) and
+`health:administrationDate` (immunizations). Identity keys are untouched: they still read the
+day-truncated string, so no record IRI moves.
+
+**C-CDA record names are recovered from the section narrative when the structured code omits them.**
+C-CDA lets an entry name its concept in the attested narrative and point at it from the structured
+data (`<code><originalText><reference value="#result1"/></originalText>`) instead of repeating the
+name as a `@displayName` attribute. The results, problems and procedures handlers read
+`@displayName` only, so those records reached the pod with no name at all — and `health:testName`
+and `health:conditionName` are `sh:minCount 1`, so each was invalid for missing a name the document
+stated one dereference away. The resolver that `medications.ts` already carried privately moved to
+`src/lib/ccda-converter/narrative-reference.ts`, unchanged, and the three sites call it. A
+structured `@displayName` still wins where both are present.
+
+When a reference does not resolve — no element declares that ID, or the element it names is empty —
+nothing is emitted and the `minCount` violation stands, because it is then a true statement about
+the document. Substituting a placeholder would turn a visible failure into a plausible-looking
+record.
+
+**FHIR `Observation.interpretation` codes are carried through instead of flattened.** The importer
+mapped nine HL7 v3 codes onto four English words (H and L both to "abnormal", HH and LL both to
+"critical") and wrote `unknown` for everything else — which is where susceptibility (S/I/R),
+detection (POS/NEG/DET/ND), reactivity (RR/WR/NR) and change (B/D/U/W) results went. "The organism
+is resistant to this antibiotic" and "the source reported nothing" arrived as the same string.
+health 2.6 binds `health:interpretation` to that code system, so a code in the accepted set is now
+written verbatim, and `unknown` means one thing: the source Observation carried no interpretation. A
+code outside the accepted set keeps the previous nearest mapping and raises a warning naming the
+code. The accepted set is a copy of the `sh:in` list in the bundled shapes, and a test reads the
+shapes file and fails if the two ever disagree.
+
+### Changed
+
+`tests/known-shacl-gaps.ts` shrinks: the date-datatype gap it documented is closed by the emitter
+fix above, so the two suites that referenced it assert zero violations again. The file now records
+the one finding that remains — `clinical:ProcedureShape` requires `clinical:procedureName` while
+`sections/procedures.ts` writes the name to `health:procedureName`, so a procedure record violates
+the name constraint while carrying a name. Moving that predicate is a data change for every existing
+consumer and wants its own release note, so it is pinned rather than folded in here.
+
+### Verification
+
+Full suite 133 files / 619 suites / 1983 tests, 0 failed, 0 skipped (from 130 / 602 / 1931 before).
+Three synthetic C-CDA fixtures under `test-fixtures/` cover the date precisions, the resolvable
+narrative references and the unresolvable ones; the typed-date fixture converts, imports and
+validates through the CLI with zero violations.
+
 ## [0.14.0] - 2026-08-08
 
 ### Changed

--- a/src/lib/ccda-converter/dates.ts
+++ b/src/lib/ccda-converter/dates.ts
@@ -1,0 +1,122 @@
+/**
+ * The one place a C-CDA date becomes an RDF literal.
+ *
+ * WHY THIS IS A MODULE AND NOT A LINE IN EACH HANDLER
+ * ---------------------------------------------------
+ * Five section handlers each sliced `<effectiveTime value="20250311"/>` into
+ * `2025-03-11` with their own copy of the same three-line expression and wrote it
+ * with `literal(dateStr)` — a PLAIN literal, which is `xsd:string`. The shapes
+ * constrain those properties to `xsd:date` or `xsd:dateTime`, so every one of
+ * those records failed validation on a property the document had stated
+ * perfectly well. A correct helper (`tripleDateTime`) already existed in the FHIR
+ * converter and had been used at exactly one C-CDA site; four siblings never got
+ * it. Five copies of a rule is five chances to fix it in four places, so the rule
+ * lives here and the handlers call it.
+ *
+ * WHAT THE PRECISION RULE IS
+ * --------------------------
+ * HL7 v3 `TS` is `YYYYMMDDHHMMSS[.SSSS][±ZZzz]`, truncated on the right at
+ * whatever precision the system actually knows. FHIR's `dateTime` primitive is
+ * partial in the same way, and the shapes accept `xsd:date` OR `xsd:dateTime`
+ * for that reason. So:
+ *
+ *   20250311143000-0500  ->  "2025-03-11T14:30:00-05:00"^^xsd:dateTime
+ *   20250311             ->  "2025-03-11"^^xsd:date
+ *
+ * A day-precision value is NOT promoted to `T00:00:00`. Appending midnight would
+ * satisfy a datatype check by asserting a time of day the source never gave, and
+ * a fabricated 00:00 is indistinguishable downstream from a real midnight draw.
+ * The same reasoning applies to the zone: a time with no offset is left with no
+ * offset (`xsd:dateTime` permits that) rather than being stamped `Z`, because
+ * the document did not say UTC.
+ *
+ * Anything coarser than a calendar day (`2025`, `202503`) yields null and is not
+ * emitted. `xsd:date` is `YYYY-MM-DD` exactly, `xsd:gYearMonth` is not in the
+ * shapes' accepted list, and an untyped literal is the defect this file removes.
+ * Callers that need to notice the drop can check for null.
+ */
+
+import { NS } from '../fhir-converter/types.js';
+import { DataFactory } from 'n3';
+import type { Quad } from 'n3';
+
+const { namedNode, literal, quad: makeQuad } = DataFactory;
+
+const XSD_DATE = NS.xsd + 'date';
+const XSD_DATETIME = NS.xsd + 'dateTime';
+
+/** A lexical form plus the datatype IRI it is well-formed for. */
+export interface CcdaDateTerm {
+  value: string;
+  datatype: string;
+}
+
+/** `Z` or `±HHMM` / `±HH:MM` at the end of an HL7 TS value. */
+const ZONE = /(Z|[+-]\d{2}:?\d{2})$/;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?$/;
+
+/**
+ * Convert one C-CDA `effectiveTime`/`@value` to the literal that states it.
+ *
+ * Returns null when the value is absent, unparseable, or coarser than a day —
+ * i.e. whenever there is no honest `xsd:date` or `xsd:dateTime` to write.
+ */
+export function ccdaDateTerm(raw: unknown): CcdaDateTerm | null {
+  if (raw === null || raw === undefined) return null;
+  const s = String(raw).trim();
+  if (!s) return null;
+
+  // Some vendor shims hand back an already-normalized ISO value. Take it as it
+  // stands rather than round-tripping it through the digit parser.
+  if (ISO_DATE.test(s)) return { value: s, datatype: XSD_DATE };
+  if (ISO_DATETIME.test(s)) return { value: s, datatype: XSD_DATETIME };
+
+  const zoneMatch = s.match(ZONE);
+  let zone = zoneMatch ? zoneMatch[1] : '';
+  const withoutZone = zone ? s.slice(0, s.length - zone.length) : s;
+  // Fractional seconds carry no information either datatype needs here.
+  const digits = withoutZone.replace(/\.\d+$/, '');
+
+  if (!/^\d+$/.test(digits)) return null;
+  if (digits.length < 8) return null;
+
+  const day = `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+
+  // Day precision. Any zone the source attached is dropped: `2025-03-11` names
+  // the same calendar day in every zone, and carrying an offset on a date
+  // invites it to be read as a time.
+  if (digits.length === 8) return { value: day, datatype: XSD_DATE };
+
+  // Hour, minute or second precision. An odd length past the day means the value
+  // is malformed beyond the day; the day is still known and is what gets said.
+  if (digits.length !== 10 && digits.length !== 12 && digits.length < 14) {
+    return { value: day, datatype: XSD_DATE };
+  }
+
+  const hh = digits.slice(8, 10);
+  const mm = digits.length >= 12 ? digits.slice(10, 12) : '00';
+  const ss = digits.length >= 14 ? digits.slice(12, 14) : '00';
+
+  // xsd:dateTime writes the offset with a colon; HL7 writes it without.
+  if (/^[+-]\d{4}$/.test(zone)) zone = `${zone.slice(0, 3)}:${zone.slice(3)}`;
+
+  return { value: `${day}T${hh}:${mm}:${ss}${zone}`, datatype: XSD_DATETIME };
+}
+
+/**
+ * The quad for a C-CDA date property, or null when there is no date to state.
+ *
+ * Callers emit conditionally — `const q = ccdaDateQuad(...); if (q) quads.push(q)`
+ * — which is the same shape as the `if (dateStr)` guard they had before.
+ */
+export function ccdaDateQuad(subject: string, predicate: string, raw: unknown): Quad | null {
+  const term = ccdaDateTerm(raw);
+  if (!term) return null;
+  return makeQuad(
+    namedNode(subject),
+    namedNode(predicate),
+    literal(term.value, namedNode(term.datatype)),
+  );
+}

--- a/src/lib/ccda-converter/narrative-reference.ts
+++ b/src/lib/ccda-converter/narrative-reference.ts
@@ -1,0 +1,120 @@
+/**
+ * Resolving `<reference value="#id"/>` against a C-CDA section's own narrative.
+ *
+ * A C-CDA section's `<text>` block is the attested, human-readable rendering, and
+ * the structured entries are allowed to point INTO it rather than repeat what it
+ * says:
+ *
+ *   <text>…<content ID="labname1">Hemoglobin</content>…</text>
+ *   …
+ *   <code code="30313-1" codeSystem="…6.1">
+ *     <originalText><reference value="#labname1"/></originalText>
+ *   </code>
+ *
+ * There is no `@displayName` there, and the name is not missing — it is one
+ * dereference away. A handler that reads `@displayName` only concludes the record
+ * has no name and drops it, which is how lab results reached a pod with no
+ * `health:testName` (a `sh:minCount 1` property) despite the document naming
+ * every one of them.
+ *
+ * WHY THIS IS SHARED
+ * ------------------
+ * `medications.ts` already carried a private copy of this resolution, written for
+ * Epic's `#medNN` paragraphs, and `allergies.ts` carries a note asking for the
+ * same thing. That is the beginning of the pattern this repository keeps paying
+ * for: one correct implementation, copied to the site that needed it, and absent
+ * from the four that needed it later. The medications copy is now this module,
+ * moved rather than reimplemented, so its behaviour is unchanged and the other
+ * handlers call the same code.
+ *
+ * WHAT IT WILL NOT DO
+ * -------------------
+ * It never invents a name. An ID no element declares, and an element holding only
+ * whitespace, both resolve to the empty string, and callers emit nothing. The
+ * resulting `minCount` violation is a true statement about a document that did
+ * not name the record in any place this converter can read.
+ */
+
+/**
+ * Every narrative element that declares an `ID`, mapped to its flattened text.
+ *
+ * Only non-empty text is mapped, so a caller cannot tell an ID apart from a blank
+ * one — deliberately: both mean "no name here".
+ */
+export function buildNarrativeIdMap(sectionText: unknown): Record<string, string> {
+  const map: Record<string, string> = {};
+  const walk = (node: any): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    const id = node['@_ID'];
+    if (typeof id === 'string' && id) {
+      const text = collapseText(node);
+      if (text) map[id] = text;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('@_')) continue;
+      if (value && typeof value === 'object') walk(value);
+    }
+  };
+  walk(sectionText);
+  return map;
+}
+
+/** Collect all `#text` descendants of a parsed node into a single trimmed string. */
+export function collapseText(node: any): string {
+  if (node == null) return '';
+  if (typeof node === 'string') return node.trim();
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collapseText).filter(Boolean).join(' ').trim();
+  if (typeof node === 'object') {
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('@_')) continue;
+      const t = collapseText(value);
+      if (t) parts.push(t);
+    }
+    return parts.join(' ').replace(/\s+/g, ' ').trim();
+  }
+  return '';
+}
+
+/**
+ * The text a narrative CONTAINER stands for: the element it references, or the
+ * text it carries inline. Empty string when it stands for nothing.
+ *
+ * A container is any element that may hold `<reference value="#id"/>` — an
+ * `<originalText>`, an entry's `<text>`, a `<value>`'s `<originalText>`.
+ */
+export function narrativeTextFor(
+  container: any,
+  narrativeIdMap: Record<string, string>,
+): string {
+  if (container == null) return '';
+
+  const ref = container?.reference?.['@_value'] ?? container?.reference?.value ?? '';
+  if (typeof ref === 'string' && ref.startsWith('#')) {
+    const resolved = narrativeIdMap[ref.slice(1)];
+    if (resolved) return resolved;
+    // A dangling reference is not a name. Fall through to any inline text rather
+    // than returning early, then give up.
+  }
+
+  const inline = typeof container === 'string' ? container : container?.['#text'];
+  if (typeof inline === 'string') return inline.trim();
+  if (typeof inline === 'number') return String(inline);
+  return '';
+}
+
+/**
+ * The name a coded element states outside `@displayName`: its `<originalText>`,
+ * resolved through the narrative when that is a reference.
+ */
+export function resolveNarrativeName(
+  codeEl: any,
+  narrativeIdMap: Record<string, string>,
+): string {
+  return narrativeTextFor(codeEl?.originalText, narrativeIdMap);
+}

--- a/src/lib/ccda-converter/sections/immunizations.ts
+++ b/src/lib/ccda-converter/sections/immunizations.ts
@@ -6,6 +6,7 @@ import { NS } from '../../fhir-converter/types.js';
 import { firstOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
+import { ccdaDateQuad } from '../dates.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -69,9 +70,9 @@ export function extractImmunizationQuads(
     if (code && (codeSystem.includes('292') || codeSystem === cvxOid)) {
       quads.push(makeQuad(subj, namedNode(NS.health + 'cvxCode'), namedNode(resolveCodeUri(cvxOid, code))));
     }
-    if (dateStr) {
-      quads.push(makeQuad(subj, namedNode(NS.health + 'administrationDate'), literal(dateStr)));
-    }
+    // Typed from the raw effectiveTime; see `dates.ts`.
+    const administrationQuad = ccdaDateQuad(uri, NS.health + 'administrationDate', dateVal);
+    if (administrationQuad) quads.push(administrationQuad);
     if (sourceId) {
       quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
     }

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -46,6 +46,8 @@ import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { contentFingerprint, EMPTY_SEED } from '../../identity.js';
 import { resolveCodeUri } from '../code-systems.js';
+import { ccdaDateQuad } from '../dates.js';
+import { buildNarrativeIdMap, narrativeTextFor, resolveNarrativeName } from '../narrative-reference.js';
 import { buildEncounterRecord } from './encounters.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -117,6 +119,7 @@ interface LabObservation {
 function extractObservationQuads(
   obs: any,
   sourceSystem: string,
+  narrativeIdMap: Record<string, string>,
   warnings?: string[],
 ): LabObservation | null {
   if (!obs) return null;
@@ -126,6 +129,26 @@ function extractObservationQuads(
   const codeSystem = codeEl?.['@_codeSystem'] ?? codeEl?.codeSystem ?? '';
   const displayName = codeEl?.['@_displayName'] ?? codeEl?.displayName ?? '';
   const isLoinc = isLoincSystem(codeSystem);
+
+  // The test's name when the structured code does not carry one. C-CDA lets the
+  // entry point at the section narrative instead of repeating the name as an
+  // attribute — `<code><originalText><reference value="#result1"/></originalText>`
+  // — and this handler used to read `@displayName` only, so every such result
+  // reached the pod with NO `health:testName`. That property is `sh:minCount 1`,
+  // so the record was invalid for missing a name the document stated in plain
+  // words one dereference away.
+  //
+  // Two containers carry it: the code's `<originalText>` (which may also hold the
+  // text inline rather than behind a reference) and, in some exports, the
+  // observation's own `<text>`. Both resolve through the same narrative map.
+  //
+  // If neither resolves, this stays empty and NOTHING is emitted below. The
+  // minCount violation then fires and is true: no name for this record exists in
+  // what the converter can read. A placeholder would hide that.
+  const testName =
+    displayName ||
+    resolveNarrativeName(codeEl, narrativeIdMap) ||
+    narrativeTextFor(obs?.text, narrativeIdMap);
 
   // Extract effective date
   const effTime = obs?.effectiveTime;
@@ -161,6 +184,13 @@ function extractObservationQuads(
     sourceId,
     content: {
       loincCode: isLoinc ? code : undefined,
+      // The STRUCTURED name only, deliberately. A name recovered from the
+      // narrative is now emitted (above), but adding it to the key would re-mint
+      // every id-less result that gains one, i.e. duplicate them against any pod
+      // that already holds them. Widening the key is a defensible change with a
+      // migration attached; it is not this change, and
+      // `tests/ccda-narrative-names.test.ts` pins a golden IRI so the choice
+      // cannot drift silently.
       testName: displayName || undefined,
       // `dateVal` raw, NOT `dateStr`. `formatCcdaDate` truncates to a calendar
       // day, which merged a 07:00 draw with an 11:00 draw.
@@ -183,8 +213,12 @@ function extractObservationQuads(
   if (isLoinc && code) {
     quads.push(makeQuad(subj, namedNode(NS.health + 'testCode'), namedNode(resolveCodeUri(LOINC_OID, code))));
   }
-  if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'testName'), literal(displayName)));
-  if (dateStr) quads.push(makeQuad(subj, namedNode(NS.health + 'performedDate'), literal(dateStr)));
+  if (testName) quads.push(makeQuad(subj, namedNode(NS.health + 'testName'), literal(testName)));
+  // Typed from the RAW effectiveTime, not from the day-truncated `dateStr`: a
+  // source that stated a time keeps it, a source that stated a day gets no
+  // invented one. See `dates.ts`.
+  const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal);
+  if (performedQuad) quads.push(performedQuad);
   if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'resultValue'), literal(value)));
   if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'resultUnit'), literal(unit)));
   if (refRangeText) quads.push(makeQuad(subj, namedNode(NS.health + 'referenceRangeText'), literal(refRangeText)));
@@ -323,12 +357,16 @@ function buildPanelQuads(
 export function extractLabQuads(
   entries: any[],
   sourceSystem: string,
-  _sectionText?: any,
+  sectionText?: any,
   importedAt?: string,
   warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const stamp = importedAt ?? new Date().toISOString();
+  // The section's own narrative, indexed by element ID. `sectionText` was already
+  // being passed to every handler and this one ignored it (`_sectionText`), which
+  // is why the names sitting in it were unreachable.
+  const narrativeIdMap = buildNarrativeIdMap(sectionText);
   // Encounter records dedupe across the whole section: many organizers cite the
   // same visit, so a given encounter subject is emitted once even though each
   // panel that references it gets its own hasEncounter edge.
@@ -353,7 +391,7 @@ export function extractLabQuads(
         if (!comp?.observation) continue;
         const obsList = listOf<any>(comp.observation);
         for (const obs of obsList) {
-          const member = extractObservationQuads(obs, sourceSystem, warnings);
+          const member = extractObservationQuads(obs, sourceSystem, narrativeIdMap, warnings);
           if (!member) continue;
           quads.push(...member.quads);
           memberSubjects.push(member.subject);
@@ -396,7 +434,7 @@ export function extractLabQuads(
       // Standalone observation (no organizer): a plain lab result, no panel.
       const obsList = listOf<any>(entry.observation);
       for (const obs of obsList) {
-        const member = extractObservationQuads(obs, sourceSystem, warnings);
+        const member = extractObservationQuads(obs, sourceSystem, narrativeIdMap, warnings);
         if (member) quads.push(...member.quads);
       }
     }

--- a/src/lib/ccda-converter/sections/medications.ts
+++ b/src/lib/ccda-converter/sections/medications.ts
@@ -1,11 +1,21 @@
 /**
  * Extract medications from C-CDA section (templateId 2.16.840.1.113883.10.20.22.2.1.1)
+ *
+ * Epic medication entries put the human-readable drug name in the section
+ * narrative (e.g. `<paragraph ID="med12">cholecalciferol (VITAMIN D-3) …`) and
+ * reference it from
+ * `consumable/manufacturedMaterial/code/originalText/reference/@value="#med12"`.
+ * The resolver that recovers it used to live here. It now lives in
+ * `narrative-reference.ts`, unchanged, because the results, problems and
+ * procedures sections need the identical resolution and were each about to grow
+ * their own copy of it.
  */
 
 import { NS } from '../../fhir-converter/types.js';
 import { firstOf } from '../multivalued.js';
 import { ccdaMedicationRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
+import { buildNarrativeIdMap, resolveNarrativeName } from '../narrative-reference.js';
 import { lookupRxNormName } from '../rxnorm-lookup.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
@@ -14,69 +24,6 @@ const { namedNode, literal, quad: makeQuad } = DataFactory;
 
 export const MEDICATIONS_TEMPLATE_ID = '2.16.840.1.113883.10.20.22.2.1.1';
 export const MEDICATIONS_LOINC = '10160-0';
-
-/**
- * Build a map of narrative element ID -> plain text from a section's <text>
- * block. Epic medication entries put the human-readable drug name in the
- * narrative (e.g. <paragraph ID="med12">cholecalciferol (VITAMIN D-3) ...) and
- * reference it from the entry's
- * consumable/manufacturedMaterial/code/originalText/reference/@value="#med12".
- * Resolving the reference recovers the drug name the structured code omits.
- */
-function buildNarrativeIdMap(sectionText: any): Record<string, string> {
-  const map: Record<string, string> = {};
-  const walk = (node: any): void => {
-    if (!node || typeof node !== 'object') return;
-    if (Array.isArray(node)) {
-      for (const item of node) walk(item);
-      return;
-    }
-    const id = node['@_ID'];
-    if (typeof id === 'string' && id) {
-      const text = collapseText(node);
-      if (text) map[id] = text;
-    }
-    for (const [key, value] of Object.entries(node)) {
-      if (key.startsWith('@_')) continue;
-      if (value && typeof value === 'object') walk(value);
-    }
-  };
-  walk(sectionText);
-  return map;
-}
-
-/** Collect all #text descendants of a parsed node into a single trimmed string. */
-function collapseText(node: any): string {
-  if (node == null) return '';
-  if (typeof node === 'string') return node.trim();
-  if (typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(collapseText).filter(Boolean).join(' ').trim();
-  if (typeof node === 'object') {
-    const parts: string[] = [];
-    for (const [key, value] of Object.entries(node)) {
-      if (key.startsWith('@_')) continue;
-      const t = collapseText(value);
-      if (t) parts.push(t);
-    }
-    return parts.join(' ').replace(/\s+/g, ' ').trim();
-  }
-  return '';
-}
-
-/** Resolve a manufacturedMaterial code's originalText/reference/@value (#medNN). */
-function resolveNarrativeName(codeEl: any, narrativeIdMap: Record<string, string>): string {
-  const ref =
-    codeEl?.originalText?.reference?.['@_value'] ??
-    codeEl?.originalText?.reference?.value ?? '';
-  if (typeof ref === 'string' && ref.startsWith('#')) {
-    const name = narrativeIdMap[ref.slice(1)];
-    if (name) return name;
-  }
-  // originalText may carry the text inline rather than a reference.
-  const inline = codeEl?.originalText?.['#text'] ??
-    (typeof codeEl?.originalText === 'string' ? codeEl.originalText : '');
-  return typeof inline === 'string' ? inline.trim() : '';
-}
 
 export function extractMedicationQuads(
   entries: any[],

--- a/src/lib/ccda-converter/sections/problems.ts
+++ b/src/lib/ccda-converter/sections/problems.ts
@@ -6,6 +6,8 @@ import { NS } from '../../fhir-converter/types.js';
 import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
+import { ccdaDateQuad } from '../dates.js';
+import { buildNarrativeIdMap, resolveNarrativeName } from '../narrative-reference.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -17,13 +19,14 @@ export const PROBLEMS_LOINC = '11450-4';
 export function extractProblemQuads(
   entries: any[],
   sourceSystem: string,
-  _sectionText?: any,
+  sectionText?: any,
   _importedAt?: string,
   warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const snomedOid = '2.16.840.1.113883.6.96';
   const icd10Oid = '2.16.840.1.113883.6.90';
+  const narrativeIdMap = buildNarrativeIdMap(sectionText);
 
   for (const entry of entries) {
     // Conditions are inside an act/observation
@@ -48,6 +51,14 @@ export function extractProblemQuads(
       const displayName =
         valueEl?.['@_displayName'] ?? valueEl?.displayName ??
         firstTranslation?.['@_displayName'] ?? firstTranslation?.displayName ?? '';
+
+      // Same recovery as the results section: when neither the value nor its
+      // translations name the condition, the name is usually in the section
+      // narrative, referenced from `<value><originalText><reference value="#id"/>`.
+      // `health:conditionName` is `sh:minCount 1`, so reading `@displayName` only
+      // meant an invalid record for a problem the document named in words.
+      // Unresolvable stays empty and emits nothing.
+      const conditionName = displayName || resolveNarrativeName(valueEl, narrativeIdMap);
 
       const isSnomed = codeSystem.includes('6.96') || codeSystem === snomedOid;
       const isIcd10 = codeSystem.includes('6.90') || codeSystem === icd10Oid;
@@ -91,6 +102,9 @@ export function extractProblemQuads(
         content: {
           snomedCode: isSnomed ? code : undefined,
           icd10Code: isIcd10 ? code : undefined,
+          // The STRUCTURED name only. A narrative-recovered name is emitted but
+          // deliberately kept out of the key, for the reason spelled out in
+          // `labs.ts`: widening it re-mints every record that gains one.
           conditionName: displayName || undefined,
           onsetDate: onsetDate || undefined,
           // Serialized as health:status, so it belongs in the key: "active" and
@@ -110,9 +124,11 @@ export function extractProblemQuads(
 
       if (isSnomed && code) quads.push(makeQuad(subj, namedNode(NS.health + 'snomedCode'), namedNode(resolveCodeUri(snomedOid, code))));
       if (isIcd10 && code) quads.push(makeQuad(subj, namedNode(NS.health + 'icd10Code'), namedNode(resolveCodeUri(icd10Oid, code))));
-      if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'conditionName'), literal(displayName)));
+      if (conditionName) quads.push(makeQuad(subj, namedNode(NS.health + 'conditionName'), literal(conditionName)));
       if (status) quads.push(makeQuad(subj, namedNode(NS.health + 'status'), literal(status.toLowerCase())));
-      if (onsetDate) quads.push(makeQuad(subj, namedNode(NS.health + 'onsetDate'), literal(onsetDate)));
+      // Typed from the raw effectiveTime; see `dates.ts`.
+      const onsetQuad = ccdaDateQuad(uri, NS.health + 'onsetDate', onsetVal);
+      if (onsetQuad) quads.push(onsetQuad);
       if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
     }
   }

--- a/src/lib/ccda-converter/sections/procedures.ts
+++ b/src/lib/ccda-converter/sections/procedures.ts
@@ -6,6 +6,8 @@ import { NS } from '../../fhir-converter/types.js';
 import { firstOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
+import { ccdaDateQuad } from '../dates.js';
+import { buildNarrativeIdMap, resolveNarrativeName } from '../narrative-reference.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -17,13 +19,14 @@ export const PROCEDURES_LOINC = '47519-4';
 export function extractProcedureQuads(
   entries: any[],
   sourceSystem: string,
-  _sectionText?: any,
+  sectionText?: any,
   _importedAt?: string,
   warnings?: string[],
 ): Quad[] {
   const quads: Quad[] = [];
   const snomedOid = '2.16.840.1.113883.6.96';
   const cptOid = '2.16.840.1.113883.6.12';
+  const narrativeIdMap = buildNarrativeIdMap(sectionText);
 
   for (const entry of entries) {
     // `<procedure>` and `<act>` are both repeatable elements and are therefore
@@ -43,6 +46,10 @@ export function extractProcedureQuads(
     const code = codeEl?.['@_code'] ?? codeEl?.code ?? '';
     const codeSystem = codeEl?.['@_codeSystem'] ?? codeEl?.codeSystem ?? '';
     const displayName = codeEl?.['@_displayName'] ?? codeEl?.displayName ?? '';
+    // The same narrative recovery the results and problems sections do: a
+    // procedure whose code carries no `@displayName` normally names itself in the
+    // section narrative behind `<originalText><reference value="#id"/>`.
+    const procedureName = displayName || resolveNarrativeName(codeEl, narrativeIdMap);
 
     const effTime = proc?.effectiveTime ?? {};
     const dateVal =
@@ -69,8 +76,10 @@ export function extractProcedureQuads(
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Procedure')));
     quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
-    if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'procedureName'), literal(displayName)));
-    if (dateStr) quads.push(makeQuad(subj, namedNode(NS.health + 'performedDate'), literal(dateStr)));
+    if (procedureName) quads.push(makeQuad(subj, namedNode(NS.health + 'procedureName'), literal(procedureName)));
+    // Typed from the raw effectiveTime; see `dates.ts`.
+    const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal);
+    if (performedQuad) quads.push(performedQuad);
     if (code) {
       if (codeSystem.includes('6.96') || codeSystem === snomedOid) {
         quads.push(makeQuad(subj, namedNode(NS.health + 'snomedCode'), namedNode(resolveCodeUri(snomedOid, code))));

--- a/src/lib/ccda-converter/sections/vitals.ts
+++ b/src/lib/ccda-converter/sections/vitals.ts
@@ -14,6 +14,7 @@ import { NS, VITAL_LOINC_CODES } from '../../fhir-converter/types.js';
 import { firstOf, listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { resolveCodeUri } from '../code-systems.js';
+import { ccdaDateQuad } from '../dates.js';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
 
@@ -109,7 +110,7 @@ export function extractVitalQuads(
         // canonical enum). Preserve the value as a lab result rather than drop it.
         quads.push(...buildLabFallback({
           sourceSystem, loincCode, isLoinc, loincOid,
-          displayName, dateStr, value, unit, sourceId, source: obs, warnings,
+          displayName, dateStr, dateVal, value, unit, sourceId, source: obs, warnings,
         }));
         continue;
       }
@@ -161,7 +162,10 @@ function buildLabFallback(args: {
   isLoinc: boolean;
   loincOid: string;
   displayName: string;
+  /** Day-truncated. Identity key only — see `dateVal` for what gets emitted. */
   dateStr: string;
+  /** The raw `<effectiveTime>` value, at whatever precision the source stated. */
+  dateVal: string;
   value: string;
   unit: string;
   sourceId: string | undefined;
@@ -170,7 +174,7 @@ function buildLabFallback(args: {
   source: unknown;
   warnings: string[] | undefined;
 }): Quad[] {
-  const { sourceSystem, loincCode, isLoinc, loincOid, displayName, dateStr, value, unit, sourceId, source, warnings } = args;
+  const { sourceSystem, loincCode, isLoinc, loincOid, displayName, dateStr, dateVal, value, unit, sourceId, source, warnings } = args;
   const quads: Quad[] = [];
 
   const uri = ccdaRecordUri({
@@ -193,7 +197,9 @@ function buildLabFallback(args: {
   quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
   if (isLoinc && loincCode) quads.push(makeQuad(subj, namedNode(NS.health + 'testCode'), namedNode(resolveCodeUri(loincOid, loincCode))));
   if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'testName'), literal(displayName)));
-  if (dateStr) quads.push(makeQuad(subj, namedNode(NS.health + 'performedDate'), literal(dateStr)));
+  // Typed from the raw effectiveTime; see `dates.ts`.
+  const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal);
+  if (performedQuad) quads.push(performedQuad);
   if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'resultValue'), literal(String(value))));
   if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'resultUnit'), literal(String(unit))));
   if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -48,6 +48,7 @@ import {
   pushIndicationEdges,
   pushParsedIndicationCandidates,
 } from './reference-resolution.js';
+import { interpretationValue } from './interpretation.js';
 
 // ---------------------------------------------------------------------------
 // Medication converter
@@ -662,17 +663,17 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
     warnings.push('No result value found in Observation resource');
   }
 
-  if (resource.interpretation && Array.isArray(resource.interpretation) && resource.interpretation.length > 0) {
-    const interpCode = resource.interpretation[0]?.coding?.[0]?.code ?? 'unknown';
-    const interpMap: Record<string, string> = {
-      N: 'normal', H: 'abnormal', L: 'abnormal', A: 'abnormal',
-      HH: 'critical', LL: 'critical', AA: 'critical',
-      HU: 'critical', LU: 'critical',
-    };
-    quads.push(tripleStr(subjectUri, NS.health + 'interpretation', interpMap[interpCode] ?? 'unknown'));
-  } else {
-    quads.push(tripleStr(subjectUri, NS.health + 'interpretation', 'unknown'));
-  }
+  // The source's own ObservationInterpretation code, carried through. health v2.6
+  // binds health:interpretation to that code system, so there is nothing left to
+  // translate and no reason to collapse H and L onto one word. See
+  // `interpretation.ts` for what the accepted set is and what happens outside it.
+  quads.push(
+    tripleStr(
+      subjectUri,
+      NS.health + 'interpretation',
+      interpretationValue(resource.interpretation, warnings),
+    ),
+  );
 
   const effectiveDate = resource.effectiveDateTime ?? resource.effectivePeriod?.start ?? resource.issued;
   if (effectiveDate) {

--- a/src/lib/fhir-converter/interpretation.ts
+++ b/src/lib/fhir-converter/interpretation.ts
@@ -1,0 +1,95 @@
+/**
+ * What `health:interpretation` is allowed to say, and how a FHIR
+ * `Observation.interpretation` becomes one of those things.
+ *
+ * FHIR R4 binds `Observation.interpretation` to the HL7 v3
+ * ObservationInterpretation code system
+ * (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), and as of
+ * health v2.6 `health:interpretation` is bound to the same 49 selectable codes,
+ * plus the data-absent-reason code `unknown` and the ten English words the
+ * previous five-member enum used.
+ *
+ * So the importer's job is now to CARRY the code, not to translate it. It used to
+ * translate: H and L both became "abnormal", HH and LL both became "critical",
+ * and every code outside a nine-entry map — every susceptibility (S/I/R),
+ * detection (POS/NEG/DET/ND), reactivity (RR/WR/NR) and change (B/D/U/W) result —
+ * became "unknown". That made "the organism is resistant to this antibiotic"
+ * indistinguishable from "the source reported no interpretation", and no
+ * downstream reader could tell which had happened.
+ *
+ * `unknown` now means one thing: the source Observation carried no interpretation.
+ *
+ * THE LIST BELOW IS A COPY, AND A COPY DRIFTS
+ * -------------------------------------------
+ * `src/shapes/health.shapes.ttl` is the authority; `src/shapes/` is synced from
+ * `spec/` and is not editable here. This constant is the same list in the same
+ * order, and `tests/fhir-interpretation-passthrough.test.ts` reads the shapes file
+ * and fails if the two ever disagree — so the copy cannot quietly fall behind a
+ * vocabulary release.
+ */
+
+/**
+ * Every value `health:interpretation` accepts: the 49 selectable HL7 v3
+ * ObservationInterpretation codes, the data-absent-reason code `unknown`, and the
+ * ten retained health v2.5 words.
+ */
+export const ACCEPTED_INTERPRETATION_CODES: ReadonlySet<string> = new Set([
+  'EX', 'HM', 'OBX', 'CAR', 'Carrier', 'B', 'D', 'U', 'W',
+  '<', '>', 'AC', 'IE', 'QCF', 'TOX',
+  'A', 'N', 'I', 'MS', 'NCL', 'NS', 'R', 'S', 'VS',
+  'AA', 'H', 'L', 'HH', 'LL', 'HX', 'LX', 'H>', 'HU', 'E', 'L<', 'LU',
+  'ND', 'IND', 'NEG', 'POS', 'EXP', 'UNE', 'DET',
+  'SYN-R', 'NR', 'RR', 'WR', 'SDD', 'SYN-S',
+  'unknown',
+  'normal', 'high', 'low', 'abnormal', 'critical',
+  'Normal', 'High', 'Low', 'Abnormal', 'Critical',
+]);
+
+/** The value written when the source carried no interpretation at all. */
+export const INTERPRETATION_ABSENT = 'unknown';
+
+/**
+ * The pre-v2.6 flattening, kept only for codes the accepted set does not contain.
+ *
+ * Measured, because it reads as dead code otherwise: all nine of these keys ARE in
+ * the accepted set, so a source writing any of them now takes the verbatim path
+ * and never reaches this map. It is retained because dropping it would silently
+ * change behaviour for a code that is added to it later, and because a nearest
+ * mapping is a better answer than `unknown` if one ever applies.
+ */
+const NEAREST_LEGACY_MAPPING: Record<string, string> = {
+  N: 'normal', H: 'abnormal', L: 'abnormal', A: 'abnormal',
+  HH: 'critical', LL: 'critical', AA: 'critical',
+  HU: 'critical', LU: 'critical',
+};
+
+/**
+ * The `health:interpretation` value for one FHIR `Observation.interpretation`
+ * array.
+ *
+ * - No interpretation, or one carrying no code  -> `unknown`
+ * - A code the shapes accept                    -> that code, verbatim
+ * - Anything else                               -> nearest legacy mapping, else
+ *                                                  `unknown`, and a warning
+ *                                                  naming the code that was lost
+ */
+export function interpretationValue(
+  interpretation: unknown,
+  warnings?: string[],
+): string {
+  if (!Array.isArray(interpretation) || interpretation.length === 0) {
+    return INTERPRETATION_ABSENT;
+  }
+
+  const code = (interpretation[0] as any)?.coding?.[0]?.code;
+  if (typeof code !== 'string' || !code) return INTERPRETATION_ABSENT;
+
+  if (ACCEPTED_INTERPRETATION_CODES.has(code)) return code;
+
+  const nearest = NEAREST_LEGACY_MAPPING[code];
+  warnings?.push(
+    `Observation.interpretation code "${code}" is not in the ObservationInterpretation ` +
+      `set health:interpretation accepts; recorded as "${nearest ?? INTERPRETATION_ABSENT}"`,
+  );
+  return nearest ?? INTERPRETATION_ABSENT;
+}

--- a/test-fixtures/ccda-narrative-names-unresolved.xml
+++ b/test-fixtures/ccda-narrative-names-unresolved.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic C-CDA whose narrative references do NOT resolve. It exists to pin the
+  guard: the converter must not invent a name, and must not emit an empty one.
+
+    NR-LAB-DANGLING   originalText references #missing, which no narrative
+                      element declares
+    NR-LAB-BLANK      originalText references #blank, whose narrative element
+                      contains only whitespace
+
+  Both lab results must therefore carry NO health:testName, which makes the
+  LabResultRecordShape minCount violation TRUE and correct. A fixture that
+  validated cleanly here would mean the converter had made a name up.
+
+  Authored for this repository. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NARRATIVE-UNRESOLVED-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Unresolvable Narrative Reference Fixture</title>
+  <effectiveTime value="20260327120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.4.1" extension="000-00-0000"/>
+      <patient>
+        <name use="L"><given>Jane</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.3.88.11.32.1"/>
+        <name>Fixture Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>
+            <table>
+              <tbody>
+                <tr>
+                  <td><content ID="blank">   </content></td>
+                  <td>123 10*3/uL</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="NR-ORG-001"/>
+              <code code="58410-2" displayName="CBC panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250311"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NR-LAB-DANGLING"/>
+                  <code code="30313-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#missing"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="13.2" unit="g/dL"/>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NR-LAB-BLANK"/>
+                  <code code="26515-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#blank"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="123" unit="10*3/uL"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/ccda-narrative-names.xml
+++ b/test-fixtures/ccda-narrative-names.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic C-CDA in which the human-readable name of a record is written in the
+  section NARRATIVE and referenced from the structured entry, rather than being
+  carried on the code element as @displayName. This is ordinary C-CDA: the
+  narrative is the attested rendering, and <originalText><reference value="#id"/>
+  points at the element of it that names the concept.
+
+  Every reference here RESOLVES, so the whole document must validate with zero
+  violations. The unresolvable cases live in ccda-narrative-names-unresolved.xml
+  so that a fixture which is supposed to be clean cannot quietly stop being clean.
+
+  Cases covered:
+    LAB-NARRATIVE   code has no @displayName, originalText references #labname1
+    LAB-INLINE      code has no @displayName, originalText carries text inline
+    LAB-OBS-TEXT    code has nothing; the OBSERVATION's <text> references #labname3
+    LAB-DISPLAYNAME code has @displayName AND a reference — @displayName wins
+    PROB-NARRATIVE  condition <value> has no @displayName, references #prob1
+    PROC-NARRATIVE  procedure code has no @displayName, references #proc1
+
+  Authored for this repository. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NARRATIVE-NAMES-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Narrative Name Fixture</title>
+  <effectiveTime value="20260327120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.4.1" extension="000-00-0000"/>
+      <patient>
+        <name use="L"><given>Jane</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.3.88.11.32.1"/>
+        <name>Fixture Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <!-- Results -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>
+            <table>
+              <tbody>
+                <tr>
+                  <td><content ID="labname1">Hemoglobin</content></td>
+                  <td>13.2 g/dL</td>
+                </tr>
+                <tr>
+                  <td><content ID="labname3">Platelet count</content></td>
+                  <td>123 10*3/uL</td>
+                </tr>
+                <tr>
+                  <td><content ID="labname4">Potassium (narrative wording)</content></td>
+                  <td>4.1 mmol/L</td>
+                </tr>
+                <tr>
+                  <td><content ID="labname5">Sodium level</content></td>
+                  <td>140 mmol/L</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-ORG-001"/>
+              <code code="58410-2" displayName="CBC panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250311"/>
+              <component>
+                <!-- Name only in the narrative, referenced from code/originalText. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-LAB-NARRATIVE"/>
+                  <code code="30313-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#labname1"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="13.2" unit="g/dL"/>
+                </observation>
+              </component>
+              <component>
+                <!-- Name inline in originalText rather than behind a reference. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-LAB-INLINE"/>
+                  <code code="33765-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText>White blood cell count</originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="6.7" unit="10*3/uL"/>
+                </observation>
+              </component>
+              <component>
+                <!-- Reference on the observation's own <text>, not on the code. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-LAB-OBS-TEXT"/>
+                  <code code="26515-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <text><reference value="#labname3"/></text>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="123" unit="10*3/uL"/>
+                </observation>
+              </component>
+              <component>
+                <!-- @displayName present AND a narrative reference: the structured
+                     name is what the source coded, so it wins. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-LAB-DISPLAYNAME"/>
+                  <code code="2823-3" displayName="Potassium [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#labname4"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="4.1" unit="mmol/L"/>
+                </observation>
+              </component>
+              <component>
+                <!-- NO <id>: identity falls to the content tier. The name this
+                     observation gains from the narrative must not move its IRI,
+                     which the golden value in the test pins. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <code code="2951-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#labname5"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="140" unit="mmol/L"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Problems -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" displayName="Problem List" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Problems</title>
+          <text>
+            <list>
+              <item><content ID="prob1">Seasonal allergic rhinitis</content></item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-PROB-ACT"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              <statusCode code="active"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-PROB-OBS"/>
+                  <code code="55607006" displayName="Problem" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <low value="20200401"/>
+                  </effectiveTime>
+                  <value xsi:type="CD" code="21719001" codeSystem="2.16.840.1.113883.6.96">
+                    <originalText><reference value="#prob1"/></originalText>
+                  </value>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Procedures -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+          <code code="47519-4" displayName="History of Procedures" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Procedures</title>
+          <text>
+            <list>
+              <item><content ID="proc1">Colonoscopy</content></item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="NN-PROC-001"/>
+              <code code="73761001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                <originalText><reference value="#proc1"/></originalText>
+              </code>
+              <statusCode code="completed"/>
+              <effectiveTime value="20240612103000-0400"/>
+            </procedure>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/ccda-typed-dates.xml
+++ b/test-fixtures/ccda-typed-dates.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic C-CDA exercising every effectiveTime PRECISION the converter has to
+  serialize, so the emitted RDF literal can be checked against the precision the
+  source actually stated:
+
+    labs          - one timed observation (YYYYMMDDHHMMSS with a zone offset)
+                    and one date-precision observation (YYYYMMDD)
+    problems      - date-precision onset (effectiveTime/low)
+    immunizations - timed administration, zone offset +0000
+    vitals        - one enum vital and one non-enum vital (which the converter
+                    re-routes to a LabResultRecord, a second performedDate site)
+
+  Authored for this repository. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.3.88.11.32.1" extension="TYPED-DATES-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Typed Date Fixture</title>
+  <effectiveTime value="20260327120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.4.1" extension="000-00-0000"/>
+      <patient>
+        <name use="L"><given>Jane</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.3.88.11.32.1"/>
+        <name>Fixture Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <!-- Results -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>Glucose 95 mg/dL; Sodium 140 mmol/L</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-ORG-001"/>
+              <code code="24323-8" displayName="Comprehensive metabolic panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250311143000-0500"/>
+              <component>
+                <!-- Second-precision effectiveTime with a zone offset. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-OBS-TIMED"/>
+                  <code code="2345-7" displayName="Glucose [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311143000-0500"/>
+                  <value xsi:type="PQ" value="95" unit="mg/dL"/>
+                </observation>
+              </component>
+              <component>
+                <!-- Day-precision effectiveTime: the source states a calendar day. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-OBS-DAY"/>
+                  <code code="2951-2" displayName="Sodium [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="140" unit="mmol/L"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Problems -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" displayName="Problem List" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Problems</title>
+          <text>Asthma, onset 2007-01-03</text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-PROB-ACT"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              <statusCode code="active"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-PROB-OBS"/>
+                  <code code="55607006" displayName="Problem" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <low value="20070103"/>
+                  </effectiveTime>
+                  <value xsi:type="CD" code="195967001" displayName="Asthma" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Immunizations -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+          <code code="11369-6" displayName="History of Immunizations" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Immunizations</title>
+          <text>Influenza vaccine, 2024-10-02</text>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+              <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-IMM-001"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20241002091500+0000"/>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                  <manufacturedMaterial>
+                    <code code="141" displayName="Influenza, seasonal, injectable" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX"/>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Vital signs -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+          <code code="8716-3" displayName="Vital Signs" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Vital Signs</title>
+          <text>Heart rate 67; mean blood pressure 94</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-VIT-ORG"/>
+              <code code="46680005" displayName="Vital signs" codeSystem="2.16.840.1.113883.6.96"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250311143000-0500"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-VIT-HR"/>
+                  <code code="8867-4" displayName="Heart rate" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311143000-0500"/>
+                  <value xsi:type="PQ" value="67" unit="/min"/>
+                </observation>
+              </component>
+              <component>
+                <!-- Mean blood pressure is not in the VitalSignShape enum, so the
+                     converter re-routes it to a LabResultRecord: the second
+                     health:performedDate emission site in vitals.ts. -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                  <id root="2.16.840.1.113883.3.88.11.32.1" extension="TD-VIT-MBP"/>
+                  <code code="8478-0" displayName="Mean blood pressure" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250311"/>
+                  <value xsi:type="PQ" value="94" unit="mm[Hg]"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/tests/ccda-converter.test.ts
+++ b/tests/ccda-converter.test.ts
@@ -27,10 +27,6 @@ import { fileURLToPath } from 'node:url';
 import { Parser } from 'n3';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
 import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
-import {
-  assertOnlyKnownViolations,
-  expectKnownViolationsStillPresent,
-} from './known-shacl-gaps.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -189,7 +185,7 @@ describe('C-CDA converter — full summarization (P4-A)', () => {
     expect(result.output).toContain('"TestSystem"');
   });
 
-  it('output passes SHACL validation with no violation beyond the known date-datatype gap', async () => {
+  it('output passes SHACL validation with no violations', async () => {
     const xml = readFixture('full-summarization.xml');
     const result = await convertCcda(xml, { sourceSystem: 'TestSystem' });
 
@@ -203,17 +199,16 @@ describe('C-CDA converter — full summarization (P4-A)', () => {
     // filtered out.
     //
     // This asserted zero violations until health v2.5 gave the five health:*Record
-    // classes shapes. The converter's output is byte-identical; three predicates
-    // are simply now checked against the `xsd:dateTime` range they always had.
-    // See `known-shacl-gaps.ts` — that list is exact in both directions, so this
-    // still fails on any new violation AND once the gap is closed.
+    // classes shapes, at which point three date predicates started being checked
+    // and the converter's untyped literals started failing. Those emitters now
+    // type their literals from the precision the source stated (see
+    // `src/lib/ccda-converter/dates.ts`), so the assertion is back to zero — which
+    // is the only assertion that cannot quietly absorb a new defect.
     const violations = validation.results.filter((r) => r.severity === 'violation');
-    assertOnlyKnownViolations(violations);
-    expectKnownViolationsStillPresent(violations, [
-      'performedDate',
-      'onsetDate',
-      'administrationDate',
-    ]);
+    expect(
+      violations,
+      violations.map((v) => `  ${v.shape}: ${v.message} (${v.property})`).join('\n'),
+    ).toHaveLength(0);
   });
 });
 

--- a/tests/ccda-lab-identity.test.ts
+++ b/tests/ccda-lab-identity.test.ts
@@ -182,15 +182,20 @@ describe('C-CDA lab results that differ are two records', () => {
       .toEqual(subjectsOfType(convert(structuredClone(doc)), 'LabResultRecord'));
   });
 
-  it('the day-truncated date is still what the record REPORTS', () => {
-    // STABILITY PIN. Full precision moved into the identity key only; the
-    // emitted `health:performedDate` literal is unchanged, so no consumer that
-    // reads or queries the date sees a different value.
+  it('the record REPORTS the date at the precision the source stated', () => {
+    // This used to assert `['2026-08-02']`, and said so as a stability pin: full
+    // precision had moved into the identity key while the emitted literal stayed
+    // day-truncated. That is no longer the behaviour, deliberately. The emitters
+    // now type the literal, and typing it meant deciding WHICH type — which
+    // meant reading the precision the source stated instead of discarding it.
+    // A source that wrote 07:00 gets 07:00; the day-truncated string is still
+    // what the identity key uses, and `tests/ccda-typed-dates.test.ts` covers the
+    // day-precision case where no time is invented.
     const quads = convert([{ observation: labObs({ id: 'obs-1', time: '20260802070000-0500' }) }]);
     const dates = quads
       .filter((q: any) => q.predicate.value.endsWith('performedDate'))
       .map((q: any) => q.object.value);
-    expect(dates).toEqual(['2026-08-02']);
+    expect(dates).toEqual(['2026-08-02T07:00:00-05:00']);
   });
 });
 

--- a/tests/ccda-narrative-names.test.ts
+++ b/tests/ccda-narrative-names.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Recovering the name of a record from the section NARRATIVE when the structured
+ * code does not carry one.
+ *
+ * C-CDA lets an entry name its concept in the attested narrative and point at it
+ * from the structured data — `<code><originalText><reference value="#id"/>` —
+ * instead of repeating the name in a `@displayName` attribute. Handlers that read
+ * `@displayName` only therefore dropped the name entirely: `health:testName` and
+ * `health:conditionName` are `sh:minCount 1`, so every such record failed
+ * validation for missing a name the document plainly stated.
+ *
+ * `medications.ts` already resolved these references and `allergies.ts` carries a
+ * standing note asking for the same thing, so the resolver moved into
+ * `narrative-reference.ts` and the sites call it rather than each growing a copy.
+ *
+ * THE GUARD IS THE HALF THAT MATTERS. When a reference does not resolve — no
+ * element declares that ID, or the element it names is empty — nothing is
+ * emitted. The `minCount` violation then fires, and it is TRUE: the converter has
+ * no name for that record. Substituting a placeholder would convert a visible
+ * failure into a plausible-looking record, which is the worse outcome.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { parseCcdaXml } from '../src/lib/ccda-converter/parser.js';
+import {
+  buildNarrativeIdMap,
+  narrativeTextFor,
+  resolveNarrativeName,
+} from '../src/lib/ccda-converter/narrative-reference.js';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+import {
+  assertOnlyKnownViolations,
+  expectKnownViolationsStillPresent,
+} from './known-shacl-gaps.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FIXTURES = path.resolve(__dirname, '../test-fixtures');
+
+const HEALTH = 'https://ns.cascadeprotocol.org/health/v1#';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+
+async function convertFixture(name: string): Promise<Quad[]> {
+  const xml = fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
+  const result = await convertCcda(xml, {
+    sourceSystem: 'TestSystem',
+    importedAt: '2026-01-01T00:00:00Z',
+  });
+  expect(result.errors, `conversion errors: ${result.errors.join(', ')}`).toHaveLength(0);
+  return new Parser().parse(result.output);
+}
+
+/** The record whose cascade:sourceRecordId ends with `suffix`, as a predicate map. */
+function recordBySourceId(quads: Quad[], suffix: string): Record<string, string[]> {
+  const idQuad = quads.find(
+    (q) => q.predicate.value === CASCADE + 'sourceRecordId' && q.object.value.endsWith(suffix),
+  );
+  expect(idQuad, `no record with sourceRecordId ending "${suffix}"`).toBeDefined();
+  const out: Record<string, string[]> = {};
+  for (const q of quads) {
+    if (q.subject.value === idQuad!.subject.value) (out[q.predicate.value] ??= []).push(q.object.value);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The resolver
+// ---------------------------------------------------------------------------
+
+describe('narrative-reference — ID map and reference resolution', () => {
+  const sectionText = parseCcdaXml(
+    `<text><table><tbody>
+       <tr><td><content ID="a">Hemoglobin</content></td><td>13.2</td></tr>
+       <tr><td><content ID="blank">   </content></td><td>7</td></tr>
+       <tr><td><paragraph ID="nested">Serum <content>sodium</content></paragraph></td></tr>
+     </tbody></table></text>`,
+  ).text;
+
+  it('maps a narrative element ID to its text', () => {
+    expect(buildNarrativeIdMap(sectionText).a).toBe('Hemoglobin');
+  });
+
+  it('flattens nested markup under one ID into a single string', () => {
+    // Pinned as-is, not as it should read. The parser hands back mixed content as
+    // an object, so the flattener walks it in KEY order, and a bare text node
+    // interleaved with a child element does not come back in document order —
+    // here "Serum <content>sodium</content>" flattens to "sodium Serum". This
+    // behaviour is inherited unchanged from the medications resolver, and
+    // `clinical:drugName` feeds the medication identity key, so correcting the
+    // order would re-mint medication IRIs. That is a separate change with its own
+    // consequence; what matters here is that the text is not LOST.
+    expect(buildNarrativeIdMap(sectionText).nested).toBe('sodium Serum');
+  });
+
+  it('does not map an ID whose element holds only whitespace', () => {
+    expect(buildNarrativeIdMap(sectionText)).not.toHaveProperty('blank');
+  });
+
+  it('resolves a code originalText reference', () => {
+    const map = buildNarrativeIdMap(sectionText);
+    const codeEl = { originalText: { reference: { '@_value': '#a' } } };
+    expect(resolveNarrativeName(codeEl, map)).toBe('Hemoglobin');
+  });
+
+  it('returns empty string for a reference no element declares', () => {
+    const map = buildNarrativeIdMap(sectionText);
+    const codeEl = { originalText: { reference: { '@_value': '#nope' } } };
+    expect(resolveNarrativeName(codeEl, map)).toBe('');
+  });
+
+  it('returns empty string for a reference to a blank element', () => {
+    const map = buildNarrativeIdMap(sectionText);
+    const codeEl = { originalText: { reference: { '@_value': '#blank' } } };
+    expect(resolveNarrativeName(codeEl, map)).toBe('');
+  });
+
+  it('reads text carried inline in originalText instead of behind a reference', () => {
+    expect(resolveNarrativeName({ originalText: 'Troponin-T' }, {})).toBe('Troponin-T');
+    expect(resolveNarrativeName({ originalText: { '#text': 'Troponin-T' } }, {})).toBe('Troponin-T');
+  });
+
+  it('resolves a reference from any container, not just originalText', () => {
+    const map = buildNarrativeIdMap(sectionText);
+    expect(narrativeTextFor({ reference: { '@_value': '#a' } }, map)).toBe('Hemoglobin');
+  });
+
+  it('is empty, never undefined, for absent input', () => {
+    expect(resolveNarrativeName(undefined, {})).toBe('');
+    expect(narrativeTextFor(undefined, {})).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lab test names
+// ---------------------------------------------------------------------------
+
+describe('C-CDA lab testName from the section narrative', () => {
+  it('uses the referenced narrative text when the code has no displayName', async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(recordBySourceId(quads, 'NN-LAB-NARRATIVE')[HEALTH + 'testName']).toEqual(['Hemoglobin']);
+  });
+
+  it('uses originalText carried inline', async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(recordBySourceId(quads, 'NN-LAB-INLINE')[HEALTH + 'testName']).toEqual([
+      'White blood cell count',
+    ]);
+  });
+
+  it("resolves a reference on the observation's own <text>", async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(recordBySourceId(quads, 'NN-LAB-OBS-TEXT')[HEALTH + 'testName']).toEqual([
+      'Platelet count',
+    ]);
+  });
+
+  it('prefers the structured displayName over the narrative wording', async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(recordBySourceId(quads, 'NN-LAB-DISPLAYNAME')[HEALTH + 'testName']).toEqual([
+      'Potassium [Moles/volume] in Serum or Plasma',
+    ]);
+  });
+
+  it('emits no testName when the reference does not resolve', async () => {
+    const quads = await convertFixture('ccda-narrative-names-unresolved.xml');
+    expect(recordBySourceId(quads, 'NR-LAB-DANGLING')[HEALTH + 'testName']).toBeUndefined();
+  });
+
+  it('emits no testName when the referenced element is blank', async () => {
+    const quads = await convertFixture('ccda-narrative-names-unresolved.xml');
+    expect(recordBySourceId(quads, 'NR-LAB-BLANK')[HEALTH + 'testName']).toBeUndefined();
+  });
+
+  it('leaves the minCount violation standing for an unresolvable reference', async () => {
+    const xml = fs.readFileSync(path.join(FIXTURES, 'ccda-narrative-names-unresolved.xml'), 'utf-8');
+    const result = await convertCcda(xml, {
+      sourceSystem: 'TestSystem',
+      importedAt: '2026-01-01T00:00:00Z',
+    });
+    const { store, shapeFiles } = loadShapes();
+    const validation = validateTurtle(result.output, store, shapeFiles, 'unresolved');
+    const violations = validation.results.filter((r) => r.severity === 'violation');
+    // Two lab results, neither nameable from this document: two true violations
+    // and nothing else. If this ever reads zero, the converter started inventing
+    // names.
+    expect(violations.map((v) => v.property).sort()).toEqual(['testName', 'testName']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The same pattern in the other sections
+// ---------------------------------------------------------------------------
+
+describe('C-CDA condition and procedure names from the section narrative', () => {
+  it('problems: conditionName resolves from the value originalText reference', async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(recordBySourceId(quads, 'NN-PROB-OBS')[HEALTH + 'conditionName']).toEqual([
+      'Seasonal allergic rhinitis',
+    ]);
+  });
+
+  it('procedures: procedureName resolves from the code originalText reference', async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(recordBySourceId(quads, 'NN-PROC-001')[HEALTH + 'procedureName']).toEqual(['Colonoscopy']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Identity does not move
+// ---------------------------------------------------------------------------
+
+describe('C-CDA narrative names do not move record identity', () => {
+  it('an id-less lab keeps its content-tier IRI after gaining a narrative name', async () => {
+    // The content key still reads the STRUCTURED displayName only. Widening it to
+    // include a name recovered from narrative text is a separate decision with a
+    // separate consequence (every such record re-mints), so this change does not
+    // make it, and this golden value is what says so.
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    const named = quads.find(
+      (q) => q.predicate.value === HEALTH + 'testName' && q.object.value === 'Sodium level',
+    );
+    expect(named, 'the id-less lab result').toBeDefined();
+    expect(named!.subject.value).toBe('urn:uuid:225e19ec-c7b9-52de-93ae-419cbeedb1d5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHACL
+// ---------------------------------------------------------------------------
+
+describe('C-CDA narrative names — SHACL', () => {
+  it('leaves no testName or conditionName violation on the resolvable fixture', async () => {
+    const xml = fs.readFileSync(path.join(FIXTURES, 'ccda-narrative-names.xml'), 'utf-8');
+    const result = await convertCcda(xml, {
+      sourceSystem: 'TestSystem',
+      importedAt: '2026-01-01T00:00:00Z',
+    });
+    const { store, shapeFiles } = loadShapes();
+    const validation = validateTurtle(result.output, store, shapeFiles, 'ccda-narrative-names.xml');
+    const violations = validation.results.filter((r) => r.severity === 'violation');
+
+    // `procedureName` is a DIFFERENT, pre-existing defect: `clinical:ProcedureShape`
+    // requires `clinical:procedureName`, and `procedures.ts` writes the name to
+    // `health:procedureName`. Resolving the name from the narrative — which the
+    // test above proves happened — cannot satisfy a constraint on a predicate the
+    // handler does not write. It is documented in `known-shacl-gaps.ts` and
+    // asserted through that file's matchers, which fail both on a NEW violation
+    // and on this one silently disappearing.
+    assertOnlyKnownViolations(violations);
+    expectKnownViolationsStillPresent(violations, ['procedureName']);
+  });
+});

--- a/tests/ccda-provenance-required-fields.test.ts
+++ b/tests/ccda-provenance-required-fields.test.ts
@@ -15,10 +15,6 @@
 import { describe, it, expect } from 'vitest';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
 import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
-import {
-  assertOnlyKnownViolations,
-  expectKnownViolationsStillPresent,
-} from './known-shacl-gaps.js';
 
 // A minimal but realistic Epic-style C-CDA: custodian org, patient demographics,
 // a medication whose drug name lives in the narrative (originalText reference),
@@ -198,16 +194,19 @@ describe('C-CDA vital signs', () => {
 });
 
 describe('C-CDA full SHACL validation', () => {
-  it('produces no SHACL violation beyond the known date-datatype gap', async () => {
+  it('produces no SHACL violations', async () => {
     const { output } = await convert();
     const { store, shapeFiles } = loadShapes();
     const validation = validateTurtle(output, store, shapeFiles, 'ccda-provenance-test');
     const violations = validation.results.filter((r) => r.severity === 'violation');
 
-    // Was zero violations until health v2.5 shaped the health:*Record classes.
-    // This fixture exercises only the labs path, so it reaches one of the three
-    // affected predicates. See `known-shacl-gaps.ts`.
-    assertOnlyKnownViolations(violations);
-    expectKnownViolationsStillPresent(violations, ['performedDate']);
+    // Was zero violations until health v2.5 shaped the health:*Record classes, at
+    // which point this fixture's lab results failed on an untyped
+    // `health:performedDate`. The emitter types it now, so zero is the assertion
+    // again.
+    expect(
+      violations,
+      violations.map((v) => `  ${v.shape}: ${v.message} (${v.property})`).join('\n'),
+    ).toHaveLength(0);
   });
 });

--- a/tests/ccda-typed-dates.test.ts
+++ b/tests/ccda-typed-dates.test.ts
@@ -1,0 +1,270 @@
+/**
+ * The C-CDA converter must state a date at the precision the SOURCE stated it,
+ * and must say which kind of date it is.
+ *
+ * health v2.6 / clinical v1.14 constrain the source-carried date properties with
+ * `sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] )`. A plain RDF
+ * literal is `xsd:string`, which is neither, so every C-CDA-converted record
+ * carrying one of these properties failed validation on it. The five emitters
+ * now build the literal through one helper, `ccdaDateQuad`, which decides the
+ * datatype from the precision of the `<effectiveTime>` value:
+ *
+ *   <effectiveTime value="20250311143000-0500"/>  -> "2025-03-11T14:30:00-05:00"^^xsd:dateTime
+ *   <effectiveTime value="20250311"/>             -> "2025-03-11"^^xsd:date
+ *
+ * The second line is the point of the exercise. Satisfying an `xsd:dateTime`
+ * constraint by appending `T00:00:00` would have made the record claim a draw
+ * time the document never gave, so the shapes were widened instead and the
+ * converter says exactly what it was told.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { ccdaDateTerm } from '../src/lib/ccda-converter/dates.js';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FIXTURES = path.resolve(__dirname, '../test-fixtures');
+const CLI_PATH = path.resolve(__dirname, '../dist/index.js');
+const HAVE_DIST = fs.existsSync(CLI_PATH);
+
+const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
+const XSD_DATETIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
+
+const HEALTH = 'https://ns.cascadeprotocol.org/health/v1#';
+
+async function convertFixture(name: string): Promise<Quad[]> {
+  const xml = fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
+  const result = await convertCcda(xml, {
+    sourceSystem: 'TestSystem',
+    importedAt: '2026-01-01T00:00:00Z',
+  });
+  expect(result.errors, `conversion errors: ${result.errors.join(', ')}`).toHaveLength(0);
+  return new Parser().parse(result.output);
+}
+
+/** Every object of `predicate`, as {value, datatype}. */
+function objectsOf(quads: Quad[], predicate: string): { value: string; datatype: string }[] {
+  return quads
+    .filter((q) => q.predicate.value === predicate)
+    .map((q) => ({
+      value: q.object.value,
+      datatype: (q.object as any).datatype?.value ?? '(not a literal)',
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// The helper itself
+// ---------------------------------------------------------------------------
+
+describe('ccdaDateTerm — HL7 v3 TS precision to RDF datatype', () => {
+  it('types a second-precision value with a zone offset as xsd:dateTime', () => {
+    expect(ccdaDateTerm('20250311143000-0500')).toEqual({
+      value: '2025-03-11T14:30:00-05:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('types a day-precision value as xsd:date and invents no time', () => {
+    expect(ccdaDateTerm('20250311')).toEqual({
+      value: '2025-03-11',
+      datatype: XSD_DATE,
+    });
+  });
+
+  it('keeps a time that carries no zone unzoned rather than assuming UTC', () => {
+    expect(ccdaDateTerm('20250311143000')).toEqual({
+      value: '2025-03-11T14:30:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('zero-fills minutes and seconds for hour- and minute-precision values', () => {
+    expect(ccdaDateTerm('2025031114')).toEqual({
+      value: '2025-03-11T14:00:00',
+      datatype: XSD_DATETIME,
+    });
+    expect(ccdaDateTerm('202503111430')).toEqual({
+      value: '2025-03-11T14:30:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('drops fractional seconds, which neither datatype needs here', () => {
+    expect(ccdaDateTerm('20250311143000.000+0000')).toEqual({
+      value: '2025-03-11T14:30:00+00:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('returns null for a value coarser than a calendar day', () => {
+    // xsd:date is YYYY-MM-DD exactly; "2025-03" is xsd:gYearMonth, which the
+    // shapes do not accept. Emitting it typed either way would be a lie, and
+    // emitting it untyped is the defect this helper exists to remove.
+    expect(ccdaDateTerm('202503')).toBeNull();
+    expect(ccdaDateTerm('2025')).toBeNull();
+  });
+
+  it('returns null for absent, empty and non-numeric values', () => {
+    expect(ccdaDateTerm(undefined)).toBeNull();
+    expect(ccdaDateTerm(null)).toBeNull();
+    expect(ccdaDateTerm('')).toBeNull();
+    expect(ccdaDateTerm('   ')).toBeNull();
+    expect(ccdaDateTerm('not-a-date')).toBeNull();
+  });
+
+  it('passes an already-ISO value through with the matching datatype', () => {
+    expect(ccdaDateTerm('2025-03-11')).toEqual({ value: '2025-03-11', datatype: XSD_DATE });
+    expect(ccdaDateTerm('2025-03-11T14:30:00Z')).toEqual({
+      value: '2025-03-11T14:30:00Z',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('falls back to day precision when the digits past the day are malformed', () => {
+    // 9 digits: the calendar day is known, the time is not. Reporting the day is
+    // honest; reporting "T0:00:00" from a stray digit would not be.
+    expect(ccdaDateTerm('202503111')).toEqual({ value: '2025-03-11', datatype: XSD_DATE });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The five emission sites
+// ---------------------------------------------------------------------------
+
+describe('C-CDA date emitters — typed literals at every constrained site', () => {
+  it('labs: a timed effectiveTime becomes an xsd:dateTime carrying that time', async () => {
+    const quads = await convertFixture('ccda-typed-dates.xml');
+    const dates = objectsOf(quads, HEALTH + 'performedDate');
+    expect(dates).toContainEqual({
+      value: '2025-03-11T14:30:00-05:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('labs: a day-precision effectiveTime becomes an xsd:date with no time', async () => {
+    const quads = await convertFixture('ccda-typed-dates.xml');
+    const dates = objectsOf(quads, HEALTH + 'performedDate');
+    expect(dates).toContainEqual({ value: '2025-03-11', datatype: XSD_DATE });
+  });
+
+  it('problems: onsetDate is typed', async () => {
+    const quads = await convertFixture('ccda-typed-dates.xml');
+    expect(objectsOf(quads, HEALTH + 'onsetDate')).toEqual([
+      { value: '2007-01-03', datatype: XSD_DATE },
+    ]);
+  });
+
+  it('immunizations: administrationDate is typed', async () => {
+    const quads = await convertFixture('ccda-typed-dates.xml');
+    expect(objectsOf(quads, HEALTH + 'administrationDate')).toEqual([
+      { value: '2024-10-02T09:15:00+00:00', datatype: XSD_DATETIME },
+    ]);
+  });
+
+  it('vitals: the lab-result fallback path types performedDate too', async () => {
+    // Mean blood pressure is outside the VitalSignShape enum, so vitals.ts
+    // re-routes it to a LabResultRecord through a second, separate emitter.
+    const quads = await convertFixture('ccda-typed-dates.xml');
+    const mbp = quads.find(
+      (q) => q.predicate.value === HEALTH + 'testName' && q.object.value === 'Mean blood pressure',
+    );
+    expect(mbp, 'mean blood pressure lab fallback record').toBeDefined();
+    const dateQuad = quads.find(
+      (q) => q.subject.value === mbp!.subject.value && q.predicate.value === HEALTH + 'performedDate',
+    );
+    expect((dateQuad!.object as any).datatype.value).toBe(XSD_DATE);
+    expect(dateQuad!.object.value).toBe('2025-03-11');
+  });
+
+  it('procedures: performedDate is typed', async () => {
+    const quads = await convertFixture('ccda-narrative-names.xml');
+    expect(objectsOf(quads, HEALTH + 'performedDate')).toContainEqual({
+      value: '2024-06-12T10:30:00-04:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+
+  it('no date property is left as a plain (xsd:string) literal', async () => {
+    const quads = await convertFixture('ccda-typed-dates.xml');
+    const dateProps = [
+      HEALTH + 'performedDate',
+      HEALTH + 'onsetDate',
+      HEALTH + 'administrationDate',
+    ];
+    const untyped = quads
+      .filter((q) => dateProps.includes(q.predicate.value))
+      .filter((q) => {
+        const dt = (q.object as any).datatype?.value;
+        return dt !== XSD_DATE && dt !== XSD_DATETIME;
+      })
+      .map((q) => `${q.predicate.value} = ${q.object.value}`);
+    expect(untyped, `untyped date literals:\n${untyped.join('\n')}`).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHACL
+// ---------------------------------------------------------------------------
+
+describe('C-CDA typed dates — SHACL', () => {
+  it('the typed-date fixture validates with zero violations', async () => {
+    const xml = fs.readFileSync(path.join(FIXTURES, 'ccda-typed-dates.xml'), 'utf-8');
+    const result = await convertCcda(xml, {
+      sourceSystem: 'TestSystem',
+      importedAt: '2026-01-01T00:00:00Z',
+    });
+    const { store, shapeFiles } = loadShapes();
+    const validation = validateTurtle(result.output, store, shapeFiles, 'ccda-typed-dates.xml');
+    const violations = validation.results.filter((r) => r.severity === 'violation');
+    expect(
+      violations,
+      violations.map((v) => `  ${v.property}: ${v.message}`).join('\n'),
+    ).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end through the CLI a user actually runs
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!HAVE_DIST)('C-CDA typed dates — convert, import, validate', () => {
+  function cli(args: string[]): string {
+    return execFileSync('node', [CLI_PATH, ...args], { encoding: 'utf-8', timeout: 120000 });
+  }
+
+  it('a pod built from the fixture validates clean', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-typed-dates-'));
+    const podDir = path.join(dir, 'pod');
+    cli(['pod', 'init', podDir]);
+
+    const ttl = path.join(dir, 'typed-dates.ttl');
+    fs.writeFileSync(
+      ttl,
+      cli(['convert', '--from', 'c-cda', '--to', 'turtle', path.join(FIXTURES, 'ccda-typed-dates.xml')]),
+    );
+    cli(['pod', 'import', podDir, ttl]);
+
+    // `cascade validate` exits 1 on any violation, so a clean exit IS the
+    // assertion; the output is captured so a failure says which property broke.
+    let out = '';
+    let status = 0;
+    try {
+      out = cli(['validate', podDir]);
+    } catch (e: any) {
+      status = e.status ?? -1;
+      out = String(e.stdout ?? '');
+    }
+    expect(status, `cascade validate reported violations:\n${out}`).toBe(0);
+    expect(out).not.toMatch(/Property: (performedDate|onsetDate|administrationDate)/);
+  });
+});

--- a/tests/fhir-converter.test.ts
+++ b/tests/fhir-converter.test.ts
@@ -412,7 +412,10 @@ describe('FHIR -> Cascade converters', () => {
       expect(findQuadValue(quads, NS.health + 'testName')).toBe('Glucose');
       expect(findQuadValue(quads, NS.health + 'resultValue')).toBe('105');
       expect(findQuadValue(quads, NS.health + 'resultUnit')).toBe('mg/dL');
-      expect(findQuadValue(quads, NS.health + 'interpretation')).toBe('abnormal');
+      // "H", the code the fixture sends, not the word "abnormal" it used to be
+      // flattened onto. `tests/fhir-interpretation-passthrough.test.ts` covers
+      // the family.
+      expect(findQuadValue(quads, NS.health + 'interpretation')).toBe('H');
     });
 
     it('should handle referenceRange', () => {

--- a/tests/fhir-interpretation-passthrough.test.ts
+++ b/tests/fhir-interpretation-passthrough.test.ts
@@ -1,0 +1,160 @@
+/**
+ * A lab interpretation is a coded finding, and the FHIR importer used to throw
+ * most of it away.
+ *
+ * `Observation.interpretation` is bound in FHIR R4 to the HL7 v3
+ * ObservationInterpretation code system. The importer mapped nine of its codes
+ * onto four English words — H and L both became "abnormal", HH and LL both
+ * became "critical" — and wrote "unknown" for every other code, which is where
+ * susceptibility (S/I/R), detection (POS/NEG/DET/ND), reactivity (RR/WR/NR) and
+ * change (B/D/U/W) results went. "The organism is resistant to this antibiotic"
+ * and "the source said nothing" arrived in the pod as the same string.
+ *
+ * health v2.6 binds `health:interpretation` to that code system, so the codes
+ * can now be carried as the source wrote them. "unknown" keeps exactly one
+ * meaning: the source Observation carried no interpretation.
+ *
+ * The accepted set is the `sh:in` list in `src/shapes/health.shapes.ttl`, and
+ * `ACCEPTED_INTERPRETATION_CODES` is a copy of it. A copy drifts, so the last
+ * test here reads the shapes file and fails if the two disagree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { convertObservationLab } from '../src/lib/fhir-converter/converters-clinical.js';
+import { restoreLabResultRecord } from '../src/lib/fhir-converter/cascade-to-fhir-clinical.js';
+import { NS } from '../src/lib/fhir-converter/types.js';
+import { ACCEPTED_INTERPRETATION_CODES } from '../src/lib/fhir-converter/interpretation.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function labWith(interpretation: unknown): any {
+  const obs: any = {
+    resourceType: 'Observation',
+    id: 'interp-1',
+    code: { coding: [{ system: 'http://loinc.org', code: '2345-7', display: 'Glucose' }], text: 'Glucose' },
+    category: [{ coding: [{ code: 'laboratory' }] }],
+    valueQuantity: { value: 105, unit: 'mg/dL' },
+    effectiveDateTime: '2024-01-15T10:30:00Z',
+  };
+  if (interpretation !== undefined) obs.interpretation = interpretation;
+  return obs;
+}
+
+function interpretationOf(obs: any): string | undefined {
+  const q = convertObservationLab(obs)._quads.find(
+    (x: any) => x.predicate.value === NS.health + 'interpretation',
+  );
+  return q?.object.value;
+}
+
+describe('FHIR lab interpretation — codes pass through verbatim', () => {
+  it('keeps H as H rather than flattening it to "abnormal"', () => {
+    expect(interpretationOf(labWith([{ coding: [{ code: 'H' }] }]))).toBe('H');
+  });
+
+  it('keeps HH and LL distinct rather than merging them into "critical"', () => {
+    expect(interpretationOf(labWith([{ coding: [{ code: 'HH' }] }]))).toBe('HH');
+    expect(interpretationOf(labWith([{ coding: [{ code: 'LL' }] }]))).toBe('LL');
+  });
+
+  it('keeps H and L distinct', () => {
+    expect(interpretationOf(labWith([{ coding: [{ code: 'H' }] }]))).toBe('H');
+    expect(interpretationOf(labWith([{ coding: [{ code: 'L' }] }]))).toBe('L');
+  });
+
+  it('carries susceptibility results, which had no representation at all', () => {
+    for (const code of ['S', 'I', 'R', 'SDD', 'SYN-S', 'SYN-R']) {
+      expect(interpretationOf(labWith([{ coding: [{ code }] }])), code).toBe(code);
+    }
+  });
+
+  it('carries detection and reactivity results', () => {
+    for (const code of ['POS', 'NEG', 'DET', 'ND', 'IND', 'RR', 'WR', 'NR']) {
+      expect(interpretationOf(labWith([{ coding: [{ code }] }])), code).toBe(code);
+    }
+  });
+
+  it('carries change-over-time results', () => {
+    for (const code of ['B', 'D', 'U', 'W']) {
+      expect(interpretationOf(labWith([{ coding: [{ code }] }])), code).toBe(code);
+    }
+  });
+
+  it('reads the code from the first coding of the first interpretation', () => {
+    expect(
+      interpretationOf(
+        labWith([
+          {
+            coding: [
+              { system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation', code: 'A' },
+            ],
+          },
+        ]),
+      ),
+    ).toBe('A');
+  });
+});
+
+describe('FHIR lab interpretation — "unknown" means the source said nothing', () => {
+  it('writes unknown when the Observation carries no interpretation', () => {
+    expect(interpretationOf(labWith(undefined))).toBe('unknown');
+  });
+
+  it('writes unknown for an empty interpretation array', () => {
+    expect(interpretationOf(labWith([]))).toBe('unknown');
+  });
+
+  it('writes unknown when the interpretation carries no code', () => {
+    expect(interpretationOf(labWith([{ text: 'high' }]))).toBe('unknown');
+  });
+});
+
+describe('FHIR lab interpretation — a code outside the accepted set', () => {
+  it('falls back to the nearest previous mapping and says so in a warning', () => {
+    const result = convertObservationLab(labWith([{ coding: [{ code: 'ZZZ-not-a-code' }] }]));
+    const value = result._quads.find(
+      (x: any) => x.predicate.value === NS.health + 'interpretation',
+    )?.object.value;
+    expect(value).toBe('unknown');
+    expect(result.warnings.join(' ')).toContain('ZZZ-not-a-code');
+  });
+
+  it('does not silently drop the interpretation property', () => {
+    expect(interpretationOf(labWith([{ coding: [{ code: 'ZZZ-not-a-code' }] }]))).toBeDefined();
+  });
+});
+
+describe('FHIR lab interpretation — round trip', () => {
+  it('H survives Cascade and comes back as H', () => {
+    const quads = convertObservationLab(labWith([{ coding: [{ code: 'H' }] }]))._quads;
+    const pv = new Map<string, string[]>();
+    for (const q of quads as any[]) {
+      const arr = pv.get(q.predicate.value) ?? [];
+      arr.push(q.object.value);
+      pv.set(q.predicate.value, arr);
+    }
+    const restored: any = restoreLabResultRecord(pv as any, []);
+    expect(restored.interpretation[0].coding[0].code).toBe('H');
+  });
+});
+
+describe('FHIR lab interpretation — the accepted set matches the shapes', () => {
+  it('ACCEPTED_INTERPRETATION_CODES is exactly the health:interpretation sh:in list', () => {
+    const shapes = fs.readFileSync(
+      path.resolve(__dirname, '../src/shapes/health.shapes.ttl'),
+      'utf-8',
+    );
+    const block = shapes.slice(shapes.indexOf('sh:path health:interpretation'));
+    const inStart = block.indexOf('sh:in (');
+    const inEnd = block.indexOf(') ;', inStart);
+    expect(inStart, 'health:interpretation sh:in list not found in the shapes').toBeGreaterThan(-1);
+
+    const codes = [...block.slice(inStart, inEnd).matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+    expect(codes.length).toBeGreaterThan(50);
+    expect([...ACCEPTED_INTERPRETATION_CODES].sort()).toEqual([...new Set(codes)].sort());
+  });
+});

--- a/tests/fhir-standards-alignment.test.ts
+++ b/tests/fhir-standards-alignment.test.ts
@@ -321,12 +321,13 @@ describe('a conformant Epic-shaped FHIR bundle converts and validates', () => {
     expect(objects(`${NS.clinical}cptCode`)).toEqual(['0042T']);
   });
 
-  it('writes an interpretation the shapes accept for a code outside the old enum', () => {
-    // The converter has no mapping for the susceptibility code "I" and writes
-    // the data-absent-reason code `unknown`. That value is now IN the value
-    // set, which is the specific thing that used to fail. This asserts the
-    // value that is actually written rather than the one we wish were written;
-    // widening the converter's own HL7 mapping is a separate change.
-    expect(objects(`${NS.health}interpretation`)).toEqual(['unknown']);
+  it('carries the susceptibility code the source sent', () => {
+    // This used to assert `['unknown']`, with a note that the converter had no
+    // mapping for the susceptibility code "I" and that widening its HL7 mapping
+    // was a separate change. This is that change: `health:interpretation` is
+    // bound to the ObservationInterpretation code system, so the code is carried
+    // rather than translated, and "intermediate susceptibility" no longer arrives
+    // as "the source said nothing".
+    expect(objects(`${NS.health}interpretation`)).toEqual(['I']);
   });
 });

--- a/tests/known-shacl-gaps.ts
+++ b/tests/known-shacl-gaps.ts
@@ -2,82 +2,49 @@
  * SHACL violations that the C-CDA converter is currently known to produce, and
  * the rule that keeps the list from becoming a place to hide new ones.
  *
- * WHY THIS EXISTS
- * ---------------
- * health v2.5 defines and shapes five record classes that were emitted but
- * undefined. Records the validator previously reported as conforming — because
- * no shape selected them, and a conforming report over zero constraints is
- * indistinguishable from a conforming report over many — are now actually
- * checked. Everything below is a finding of that kind: the converter's output
- * did not change, the constraints did.
+ * THE DATE-DATATYPE GAP IS CLOSED
+ * -------------------------------
+ * This file used to document one finding: five section handlers sliced
+ * `<effectiveTime value="20250311"/>` to `2025-03-11` and wrote it with
+ * `literal(dateStr)` — a PLAIN literal, which is `xsd:string`, which is neither
+ * `xsd:date` nor `xsd:dateTime`. It has been fixed rather than re-described. The
+ * five sites now build the literal through `ccdaDateQuad` in
+ * `src/lib/ccda-converter/dates.ts`, which types it from the precision of the
+ * source value: `xsd:dateTime` when the document stated a time, `xsd:date` when
+ * it stated a calendar day, and NOT `T00:00:00` appended to make a datatype check
+ * pass. `tests/ccda-typed-dates.test.ts` carries the cases, including the
+ * fixture-wide assertion that no date property is left plain.
  *
- * WHAT CHANGED AT health v2.6 / clinical v1.14
- * --------------------------------------------
- * The vocabulary question this file said the emitter fix was blocked on has
- * been answered, in the direction this file argued for. The date properties
- * below are no longer `sh:datatype xsd:dateTime`; they are
- * `sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] )`, because
- * FHIR's `dateTime` primitive is explicitly partial-precision and a C-CDA
- * `<effectiveTime value="20250311"/>` states a calendar day and nothing more.
- * Appending `T00:00:00` to satisfy a validator would have fabricated precision
- * the source never had.
+ * That is why this file shrank instead of growing a "still known" entry. A list
+ * of known gaps that outlives the gap it describes is worse than no list, because
+ * the next reader trusts it.
  *
- * THE GAP DID NOT GO AWAY, AND IS NOW SMALLER AND SHARPER. The remaining
- * violation is no longer a disagreement about which datatype is right. It is
- * that the emitters write `literal(dateStr)` — a PLAIN literal, which is
- * `xsd:string` — and `xsd:string` is neither `xsd:date` nor `xsd:dateTime`. The
- * shapes now accept exactly what the source can honestly say; the converter
- * still has to say it, by typing the literal. `2025-03-11`^^`xsd:date`
- * validates today, with no invented time and no shape change.
+ * THE ONE FINDING THAT REMAINS
+ * ----------------------------
+ * `clinical:ProcedureShape` requires `clinical:procedureName` (`sh:minCount 1`).
+ * `sections/procedures.ts` writes the procedure's name to `health:procedureName`,
+ * which no shape targeting `clinical:Procedure` declares. So every C-CDA-converted
+ * procedure record violates the name constraint while CARRYING a name, and the
+ * name it carries is validated by nothing.
  *
- * That emitter fix is deliberately still not made here, for reason 1 below: a
- * change that syncs vocabulary and shapes must not also alter what the
- * converter writes. Reason 2 — "the correct fix is not obvious" — no longer
- * applies and has been struck.
+ * Measured against the public sample corpus this repository tests with: 2 of 2
+ * procedures in one transition-of-care sample, 7 of 7 in another, 1 of 1 in a
+ * third. It is not a fixture artefact and it is not rare.
  *
- * THE ONE FINDING, STATED PRECISELY
- * ---------------------------------
- * Four C-CDA section handlers read `<effectiveTime value="20250311"/>`, slice it
- * to `2025-03-11`, and write it with `literal(dateStr)` — a plain literal, so
- * `xsd:string`:
- *
- *   sections/procedures.ts    -> health:performedDate
- *   sections/vitals.ts        -> health:performedDate
- *   sections/labs.ts          -> health:performedDate
- *   sections/problems.ts      -> health:onsetDate
- *   sections/immunizations.ts -> health:administrationDate
- *
- * health v2.5 constrained all three predicates with `sh:datatype xsd:dateTime`;
- * health v2.6 widened them to `xsd:date` OR `xsd:dateTime`. Either way the
- * emitters disagree with the ratified vocabulary, because a plain literal is
- * `xsd:string` and always was. Nothing was checking until v2.5 shaped these
- * classes at all.
- *
- * `labs.ts:292` already writes `clinical:performedDate` through a
- * `tripleDateTime()` helper that types the literal correctly. The helper exists.
- * It was never propagated to the other sites — the same shape of defect as the
- * identity helpers that had to be pulled into a chokepoint.
- *
- * WHY THIS IS PINNED RATHER THAN FIXED HERE
- * -----------------------------------------
- * One reason now, not two.
- *
- * 1. This change syncs vocabulary and shapes; it deliberately alters no emission
- *    site. Fixing a converter here would mix a data-output change into a
- *    vocabulary sync, and the two need to be reviewed and released separately.
- *
- * 2. STRUCK at health v2.6. It read: "the correct fix is not obvious", because
- *    a single `sh:datatype` could not express FHIR's partial-precision
- *    `dateTime` and the emitter fix was therefore blocked on a vocabulary
- *    decision. That decision is made. The fix is now obvious and small: type
- *    the literal `xsd:date` at the five sites listed above, using the same
- *    kind of helper `labs.ts:292` already uses for `clinical:performedDate`.
+ * WHY IT IS PINNED HERE RATHER THAN FIXED
+ * ---------------------------------------
+ * Deciding which predicate a procedure's name lands on is not a converter detail:
+ * `health:procedureName` is what has been written to date, so anything already
+ * querying a pod for procedure names reads that predicate, and moving it (or
+ * emitting both) is a data change for every existing consumer. It wants its own
+ * change, with its own note about what to re-query. What it does NOT want is to
+ * be discovered again from scratch, which is what this entry prevents.
  *
  * HOW THIS STAYS HONEST
  * ---------------------
  * `assertOnlyKnownViolations` fails if a violation appears on any property not
- * listed here, and `expectKnownViolationsStillPresent` fails once they stop
- * being produced. So the list cannot silently absorb a new defect, and it cannot
+ * listed here, and `expectKnownViolationsStillPresent` fails once they stop being
+ * produced. So the list cannot silently absorb a new defect, and it cannot
  * outlive the defect it describes.
  */
 
@@ -91,47 +58,38 @@ export interface SeverityIssue {
 }
 
 /**
- * Local names of the properties whose date-datatype constraint the C-CDA
- * converter currently violates by emitting an untyped day-precision string.
+ * Local names of the properties the C-CDA converter is currently known to
+ * violate.
  */
-export const KNOWN_DATE_DATATYPE_PROPERTIES = new Set([
-  'performedDate',
-  'onsetDate',
-  'administrationDate',
-]);
+export const KNOWN_VIOLATION_PROPERTIES = new Set(['procedureName']);
 
 /**
- * The substring that identifies the date-datatype finding specifically.
+ * The substring that identifies the finding specifically.
  *
- * At health v2.5 this was the `xsd:dateTime` IRI, which appeared in the
- * `sh:datatype` report. health v2.6 replaced that constraint with an `sh:or`
- * over `xsd:date` and `xsd:dateTime`, and an `sh:or` report carries the
- * property shape's own `sh:message` instead. So the matcher keys on that
- * message. This is deliberately a phrase from the SHAPES, not a phrase invented
- * here: if `spec` reworded or dropped the message, the match stops and this
- * file is forced open rather than silently widening.
+ * Deliberately a phrase from the SHAPES, not one invented here: if `spec`
+ * reworded or dropped the message, the match stops and this file is forced open
+ * rather than silently widening to cover some other `procedureName` failure.
  */
-const DATE_DATATYPE_MESSAGE = 'must be an xsd:date or an xsd:dateTime';
+const PROCEDURE_NAME_MESSAGE = 'Procedure must have a name';
 
-function isKnownDateDatatypeViolation(v: SeverityIssue): boolean {
+function isKnownViolation(v: SeverityIssue): boolean {
   return (
-    KNOWN_DATE_DATATYPE_PROPERTIES.has(v.property) &&
-    v.message.includes(DATE_DATATYPE_MESSAGE)
+    KNOWN_VIOLATION_PROPERTIES.has(v.property) && v.message.includes(PROCEDURE_NAME_MESSAGE)
   );
 }
 
 /**
- * Assert that every violation present is one of the known date-datatype ones.
+ * Assert that every violation present is one of the known ones.
  *
- * The message check matters: without it, ANY violation on `performedDate` — a
- * missing value, a cardinality breach — would be swallowed by the property name
- * alone.
+ * The message check matters: without it, ANY violation on `procedureName` — a
+ * cardinality breach, a datatype mismatch — would be swallowed by the property
+ * name alone.
  */
 export function assertOnlyKnownViolations(violations: SeverityIssue[]): void {
-  const unexpected = violations.filter((v) => !isKnownDateDatatypeViolation(v));
+  const unexpected = violations.filter((v) => !isKnownViolation(v));
   expect(
     unexpected,
-    `Unexpected SHACL violations (not the known date-datatype gap):\n${unexpected
+    `Unexpected SHACL violations (not a known gap):\n${unexpected
       .map((v) => `  ${v.shape}: ${v.message} (${v.property})`)
       .join('\n')}`,
   ).toHaveLength(0);
@@ -142,8 +100,8 @@ export function assertOnlyKnownViolations(violations: SeverityIssue[]): void {
  *
  * Without this, `assertOnlyKnownViolations` would pass on output containing no
  * violations at all — including output where the converter had been fixed, or
- * where a shape had been dropped and stopped firing. Either of those should
- * force this file to be revisited rather than pass quietly.
+ * where a shape had been dropped and stopped firing. Either of those should force
+ * this file to be revisited rather than pass quietly.
  */
 export function expectKnownViolationsStillPresent(
   violations: SeverityIssue[],

--- a/tests/pod-import-importedat-reimport.test.ts
+++ b/tests/pod-import-importedat-reimport.test.ts
@@ -83,13 +83,12 @@ describe('pod import: re-import keeps exactly one importedAt (symptom 3)', () =>
     expect(out).not.toMatch(/exactly one importedAt/i);
     expect(out).not.toMatch(/Property: importedAt/);
 
-    // This used to assert `0 failed`. It no longer can, and the reason is not a
-    // regression in this fix: health v2.5 shapes `health:LabResultRecord`, so
-    // this fixture's day-precision `performedDate` literals are checked against
-    // `sh:datatype xsd:dateTime` for the first time and fail. Asserting the
-    // failing file's identity keeps this a real check — a new failure anywhere
-    // else in the pod still breaks it — without pinning it to a count that a
-    // separate, tracked defect controls. See `known-shacl-gaps.ts`.
+    // `0 failed` again. This asserted 1 failing file for a while: health v2.5
+    // shaped `health:LabResultRecord`, so this fixture's day-precision
+    // `performedDate` literals were checked for the first time and failed for
+    // being untyped. The emitters type them now, so the whole pod validates and
+    // the assertion goes back to the strongest form: any failure anywhere in the
+    // pod breaks it.
     // Per-FILE status lines start at column 0; per-ISSUE lines are indented two
     // spaces and carry no path, so matching on the bare word would count them
     // too and make the assertion mean nothing.
@@ -97,7 +96,6 @@ describe('pod import: re-import keeps exactly one importedAt (symptom 3)', () =>
       .split('\n')
       .map((l) => l.replace(/\[[0-9;]*m/g, ''))
       .filter((l) => /^FAIL\s/.test(l));
-    expect(failingFiles.length, out).toBe(1);
-    expect(failingFiles[0], out).toContain('clinical/lab-results.ttl');
+    expect(failingFiles, out).toEqual([]);
   });
 });


### PR DESCRIPTION
Three converter defects, all the same kind: the ratified shapes describe what the source documents already say, and the converters were saying something else. No shape file is touched here.

## 1. C-CDA dates were untyped literals

Five section handlers each sliced `<effectiveTime value="20250311"/>` down to `2025-03-11` with their own copy of the same expression and wrote it with `literal(dateStr)`. A plain RDF literal is `xsd:string`, and the shapes constrain these properties to `xsd:date` or `xsd:dateTime`, so every C-CDA-converted record carrying one failed validation on a date the document had stated perfectly well.

The five sites now build the literal through one helper, `src/lib/ccda-converter/dates.ts`, which reads the datatype off the precision of the source value:

- `<effectiveTime value="20250311143000-0500"/>` becomes `"2025-03-11T14:30:00-05:00"^^xsd:dateTime`
- `<effectiveTime value="20250311"/>` becomes `"2025-03-11"^^xsd:date`

A day-precision value is not promoted to `T00:00:00`. Appending midnight would pass the datatype check by asserting a time of day the source never gave, and a fabricated 00:00 is indistinguishable downstream from a real one. A value coarser than a calendar day is not emitted at all, because neither accepted datatype can express it.

Affects `health:performedDate` (results, procedures, and the vital-sign-to-lab-result fallback), `health:onsetDate` (problems), `health:administrationDate` (immunizations). Identity keys are untouched: they still read the day-truncated string, so no record IRI moves.

## 2. C-CDA record names were dropped when they lived in the narrative

C-CDA lets an entry name its concept in the attested narrative and point at it from the structured data, `<code><originalText><reference value="#result1"/></originalText>`, instead of repeating the name as a `@displayName` attribute. The results, problems and procedures handlers read `@displayName` only, so those records reached the pod with no name at all. `health:testName` and `health:conditionName` are `sh:minCount 1`, so each was invalid for missing a name the document stated one dereference away.

`medications.ts` already carried a private resolver for exactly this. It moved to `src/lib/ccda-converter/narrative-reference.ts` unchanged, and the three other sites call it rather than each growing a copy. A structured `@displayName` still wins where both are present.

The guard is the half that matters. When a reference does not resolve, because no element declares that ID or the element it names is blank, nothing is emitted and the `minCount` violation stands, because it is then a true statement about the document. `test-fixtures/ccda-narrative-names-unresolved.xml` exists to hold that behavior in place: it must keep producing exactly two `testName` violations.

## 3. FHIR interpretation was lossy

The importer mapped nine HL7 v3 codes onto four English words, H and L both to "abnormal", HH and LL both to "critical", and wrote `unknown` for every other code. That is where susceptibility (S/I/R), detection (POS/NEG/DET/ND), reactivity (RR/WR/NR) and change (B/D/U/W) results went, so "the organism is resistant to this antibiotic" and "the source reported nothing" arrived as the same string.

`health:interpretation` is now bound to that code system, so a code in the accepted set is carried verbatim, and `unknown` means one thing: the source Observation carried no interpretation. A code outside the accepted set keeps the previous nearest mapping and raises a warning naming the code. The accepted set is a copy of the `sh:in` list in the bundled shapes, and a test reads the shapes file and fails if the two ever disagree.

## known-shacl-gaps.ts

The date-datatype gap it documented is closed, so the two suites that referenced it assert zero violations again. The file now records the one finding that remains: `clinical:ProcedureShape` requires `clinical:procedureName` while `sections/procedures.ts` writes the name to `health:procedureName`, so a procedure record violates the name constraint while carrying a name. Moving that predicate is a data change for every existing consumer and wants its own change.

## Verification

Full suite, JSON reporter, dist built first:

| | files | suites | tests | failed | skipped |
| --- | --- | --- | --- | --- | --- |
| before (origin/main) | 130 | 602 | 1931 | 0 | 0 |
| after | 133 | 619 | 1983 | 0 | 0 |

`npx tsc --noEmit` clean. Three synthetic C-CDA fixtures added under `test-fixtures/`, covering the date precisions, the resolvable narrative references and the unresolvable ones. The typed-date fixture goes through `cascade convert`, `cascade pod init`, `cascade pod import` and `cascade validate` in the suite and reports zero violations.

Every new test was observed RED before the fix that turns it green (27 failing, 25 passing on the first run against the unmodified converters). Each load-bearing line was then reverted individually, with the diff confirmed non-empty, `npm run build` re-run, and the FULL suite re-run to observe RED before restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
