### PR TITLE
test(cli): pathology corpus and end-to-end import harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+**A regression corpus of real-world import pathologies, and an end-to-end harness that runs it.**
+`test-fixtures/pathology/` holds thirteen scenarios, each reproducing ONE named phenomenon that
+appears in real health-data exports: the dual-label split (one health system landing under two
+`clinical:sourceEHR` labels because the FHIR path reads an endpoint domain and the C-CDA path reads a
+custodian name), a single `<id>` reused across three distinct lab observations, narrative-only test
+names including one dangling reference, date-precision variety, HL7 interpretation codes across the
+accepted set plus one outside it, indication absence, cross-source exact lab duplicates, same-source
+repeat vitals with a clock-skew duplicate from a second source, medication chains (dose supersession
+and stale-active), allergy sentinels, panel display-name variants over shared results, and a set of
+vendor-shipped defects (an unsubstituted template placeholder used as a document id, a malformed
+nine-digit date, an empty `nullFlavor` section, and `nullFlavor` variety on values). Every fixture is
+100% synthetic: invented people, organizations, endpoints, identifiers, dates and values. What is
+reproduced is the shape of the phenomenon, never the content of any document.
+
+`tests/pathology-corpus.test.ts` runs each scenario through the pipeline a person actually runs —
+`cascade convert`, `pod init`, `pod import --reconcile-existing` once per batch, `pod conflicts`,
+`cascade validate` — and pins the census: records in, records out, merges, conflicts, edges,
+violations, warnings.
+
+Fixture tiers are directory-discovered: a tier is any directory containing a `scenarios.json`
+manifest, so an additional corpus arrives as a sibling directory and needs no change to the harness.
+Tiers that must not be committed are passed as absolute paths in `CASCADE_PATHOLOGY_TIERS`.
+
+Two gates run over the result. `tests/pathology-known-outcomes.ts` is a known-defect ledger built as
+a ratchet rather than a filter: each entry records what the pipeline does today AND what it must do
+once fixed, and the gate fails in both directions, so a new deviation is caught and a silently
+corrected one is caught too. The ledger can only shrink deliberately. It currently carries seventeen
+entries. `tests/pathology-reconciliation-baseline.json` is a report-only scorecard: for the
+scenarios that carry a constructed ground truth about which records denote the same clinical event,
+the harness measures the reconciler's precision and recall over merge pairs and compares them to a
+committed baseline. It does not assert the numbers are good — two of the recalls are 0. It asserts
+they are known, so a change to matching has to move the baseline on purpose.
+
+No converter or reconciler behaviour changes in this entry. The harness documents; fixes come
+separately.
+
+---
+
 ## [0.15.0] - 2026-08-09
 
 ### Fixed

--- a/test-fixtures/pathology/INVENTORY.md
+++ b/test-fixtures/pathology/INVENTORY.md
@@ -1,0 +1,64 @@
+# Pathology corpus
+
+A regression corpus of real-world health-data import pathologies, and the
+end-to-end harness that runs each one through the whole pipeline and records
+what actually happens.
+
+Every byte of every fixture is synthetic. The people, organizations, endpoints,
+medical record numbers, dates and values are invented. What is NOT invented is
+the SHAPE: each fixture reproduces one named phenomenon that appears in real
+exports, so that the import and reconciliation paths can be worked on without a
+real chart in the room.
+
+The vendor-structure reference used while authoring (how the major EHRs lay out
+a C-CDA: which templateIds appear, where ids and narrative references sit) is
+the publicly published sample-document corpora and the HL7 C-CDA R2.1
+implementation guide. No document from any corpus is vendored here; every
+fixture is an independently authored synthetic equivalent.
+
+## How to run it
+
+```sh
+npm run build          # the harness spawns dist/index.js
+npx vitest run tests/pathology-corpus.test.ts
+```
+
+The harness lives in `tests/pathology-corpus.test.ts`; the known-defect ledger
+it gates on lives in `tests/pathology-known-outcomes.ts`; the reconciliation
+scorecard baseline lives in `tests/pathology-reconciliation-baseline.json`.
+
+## Scenarios
+
+| ID | Fixture(s) | Pathology |
+|----|-----------|-----------|
+| P01 | `p01-dual-label-fhir.json`, `p01-dual-label-ccda.xml` | **Dual-label split.** One health system exports FHIR (whose `clinical:sourceEHR` is derived from the registrable domain of its endpoint) and a C-CDA (whose label is derived from the custodian organization name). One system, two rows on the pod's source axis. |
+| P02 | `p02-duplicate-source-id-ccda.xml` | **Duplicate source-id collision.** A single root-only `<id>` reused across three distinct lab observations, the shape the public HL7 CCD sample distributes. HL7 II says a root alone may be the whole identifier, so all three mint one IRI. |
+| P03 | `p03-narrative-names-ccda.xml` | **Narrative-only test names, one dangling.** Names live in the section narrative and are referenced from the entry. Three references resolve, one points at an element the narrative does not contain, and one observation is named nowhere at all. |
+| P04 | `p04-date-precision-ccda.xml` | **Date-precision variety.** Day precision, second precision with a zone offset, and a month-precision value that has no honest `xsd:date` or `xsd:dateTime` and must not be emitted. Carries the corpus's one procedure. |
+| P05 | `p05-interpretation-categories-fhir.json` | **Interpretation codes across the HL7 set, and multi-category labs.** H, S, POS, a code outside the accepted set, and an observation with no interpretation at all; plus observations carrying two `category` entries. |
+| P06 | `p06-indication-absence-fhir.json` | **Indication absence.** One MedicationRequest with `reasonReference`, one with a `reasonCode` that resolves, one with a `reasonCode` that does not, and two with neither. "The source never said" and "the source said and we could not match it" must not collapse. |
+| P07 | `p07a-crosssource-labs-alpha.json`, `p07b-crosssource-labs-beta.json` | **Cross-source exact lab duplicates.** Same LOINC codes, same values, byte-identical `effectiveDateTime`, two different systems, imported in two batches. The tier-0 reconciliation shape. |
+| P07-SHARED-LABEL | same two fixtures, one `--source-system` | **Same-source guard defeated by the transport label.** The two exports arrive under one import-batch label (the Apple Health shape), and the guard that exists to stop same-source records comparing stops the cross-source duplicates comparing too. |
+| P08 | `p08a-repeat-vitals-alpha.json`, `p08b-repeat-vitals-beta.json` | **Same-source repeat vitals plus a clock-skew duplicate.** Three blood-pressure readings hours apart on one day at one practice, which must never merge, and a fourth from a second system 17 minutes after the third, which is the same cuff reading and should. |
+| P09 | `p09a-med-chains-alpha.json`, `p09b-med-chains-beta.json` | **Medication chains.** Dose supersession (10 mg stopped / 20 mg active), stale-active (one active against two stopped from another prescriber), and the same dose disagreement asked twice: once through `MedicationStatement.dosage` and once through `MedicationRequest.dosageInstruction`. |
+| P10 | `p10-allergy-sentinels-fhir.json` | **Allergy sentinels.** A real allergen, a "No Known Allergies" negation, an "Unknown Allergen" data-absent marker, and a real allergen with sparse detail. Three different meanings, one record shape. |
+| P11 | `p11-panel-name-variants-fhir.json` | **Panel display-name variants over shared results.** One lipid draw reported three times as "Lipid Panel", "Lipid Profile" and "LIPID PROFILE - Final result", every report pointing at the same four Observations. |
+
+## What the harness asserts
+
+For each scenario, in order: `cascade convert` (records in), `cascade pod init`,
+`cascade pod import --reconcile-existing` once per batch (records out, merges,
+edges), `cascade pod conflicts` (conflicts), `cascade validate` (violations),
+and a census of the pod's record subjects by type.
+
+The expected numbers in the harness are the numbers this pipeline produces
+TODAY. Where today's number is WRONG, the wrongness is named in the
+`KNOWN_OUTCOMES` ledger with the outcome that must replace it, and the ledger is
+a gate in both directions: a new deviation fails the suite, and so does a
+silently corrected one. The ledger can only shrink deliberately.
+
+Two scenarios carry a constructed ground truth about which records denote the
+same clinical event (P07 and its shared-label variant, and P08). For those the
+harness measures the reconciler's per-scenario precision and recall over merge
+PAIRS and compares them against a committed baseline. It does not assert the
+numbers are good. It asserts they are known.

--- a/test-fixtures/pathology/p01-dual-label-ccda.xml
+++ b/test-fixtures/pathology/p01-dual-label-ccda.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  P01b - DUAL-LABEL SPLIT (C-CDA half).
+
+  The SAME synthetic health system as p01-dual-label-fhir.json, exporting a
+  Continuity of Care Document instead of FHIR resources. The C-CDA converter
+  derives clinical:sourceEHR from the custodian ORGANIZATION NAME, so these
+  records land under an organization-name label ("Meridian Health System")
+  while the FHIR half of the same system lands under the registrable domain of
+  its FHIR endpoint ("meridianhealth.example").
+
+  The pathology: one health system occupies two rows on the pod's source axis,
+  purely because of which transport the patient happened to download. Nothing
+  in either document is wrong; the two derivation rules simply do not meet.
+
+  Authored for this repository. Invented person, organization, identifiers,
+  dates and values. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+  <id root="2.16.840.1.113883.19.5.99991.1" extension="P01-CCDA-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Meridian Health System Continuity of Care Document</title>
+  <effectiveTime value="20250214081500-0800"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.99991.2" extension="MRN-4417"/>
+      <patient>
+        <name use="L"><given>Marisol</given><family>Quintaine</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19710418"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.99991.1"/>
+        <name>Meridian Health System</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <!-- Problems: the SAME condition the FHIR half carries. -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" displayName="Problem List" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Problems</title>
+          <text>Type 2 diabetes mellitus, onset 2019-06-02</text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+              <id root="2.16.840.1.113883.19.5.99991.3" extension="P01-PROB-ACT"/>
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+              <statusCode code="active"/>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                  <id root="2.16.840.1.113883.19.5.99991.3" extension="P01-PROB-OBS"/>
+                  <code code="55607006" displayName="Problem" codeSystem="2.16.840.1.113883.6.96"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime><low value="20190602"/></effectiveTime>
+                  <value xsi:type="CD" code="44054006" displayName="Type 2 diabetes mellitus" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Results: the SAME A1c the FHIR half carries, same day, same value. -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>Hemoglobin A1c 7.4 %</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.99991.4" extension="P01-ORG-A1C"/>
+              <code code="4548-4" displayName="Hemoglobin A1c panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250211091500-0800"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99991.4" extension="P01-OBS-A1C"/>
+                  <code code="4548-4" displayName="Hemoglobin A1c/Hemoglobin.total in Blood" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250211091500-0800"/>
+                  <value xsi:type="PQ" value="7.4" unit="%"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/pathology/p01-dual-label-fhir.json
+++ b/test-fixtures/pathology/p01-dual-label-fhir.json
@@ -1,0 +1,67 @@
+{
+  "_comment": "P01a - DUAL-LABEL SPLIT (FHIR half). One synthetic health system, Meridian Health System, exporting FHIR. Every reference is an absolute URL on the system's own FHIR endpoint, which is how a real patient-facing FHIR export identifies its origin. The converter derives clinical:sourceEHR from the registrable domain of that host, so these records land under a DOMAIN-STYLE label. The C-CDA half of this scenario (p01-dual-label-ccda.xml) is the SAME system exporting a document, where the label is derived from the custodian ORGANIZATION NAME instead. The pathology is that one health system therefore occupies two rows on any source axis. 100% synthetic: invented person, invented organization, invented endpoint, invented values.",
+  "resourceType": "Bundle",
+  "id": "p01-meridian-fhir",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.meridianhealth.example/api/FHIR/R4/Patient/pt-4417",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "pt-4417",
+        "name": [{ "use": "official", "family": "Quintaine", "given": ["Marisol"] }],
+        "gender": "female",
+        "birthDate": "1971-04-18"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.meridianhealth.example/api/FHIR/R4/Condition/cond-8801",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "cond-8801",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/condition-clinical", "code": "active" }] },
+        "code": {
+          "coding": [{ "system": "http://snomed.info/sct", "code": "44054006", "display": "Type 2 diabetes mellitus" }],
+          "text": "Type 2 diabetes mellitus"
+        },
+        "subject": { "reference": "https://fhir.meridianhealth.example/api/FHIR/R4/Patient/pt-4417" },
+        "onsetDateTime": "2019-06-02",
+        "recorder": { "display": "Meridian Health System" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.meridianhealth.example/api/FHIR/R4/Observation/obs-7712",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-7712",
+        "status": "final",
+        "category": [
+          {
+            "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory", "display": "Laboratory" }]
+          }
+        ],
+        "code": {
+          "coding": [{ "system": "http://loinc.org", "code": "4548-4", "display": "Hemoglobin A1c/Hemoglobin.total in Blood" }],
+          "text": "Hemoglobin A1c"
+        },
+        "subject": { "reference": "https://fhir.meridianhealth.example/api/FHIR/R4/Patient/pt-4417" },
+        "effectiveDateTime": "2025-02-11T09:15:00-08:00",
+        "valueQuantity": { "value": 7.4, "unit": "%", "system": "http://unitsofmeasure.org", "code": "%" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.meridianhealth.example/api/FHIR/R4/Immunization/imm-3390",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "imm-3390",
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [{ "system": "http://hl7.org/fhir/sid/cvx", "code": "141", "display": "Influenza, seasonal, injectable" }],
+          "text": "Influenza, seasonal, injectable"
+        },
+        "patient": { "reference": "https://fhir.meridianhealth.example/api/FHIR/R4/Patient/pt-4417" },
+        "occurrenceDateTime": "2024-10-14"
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p02-duplicate-source-id-ccda.xml
+++ b/test-fixtures/pathology/p02-duplicate-source-id-ccda.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  P02 - DUPLICATE SOURCE ID COLLISION.
+
+  One <id> value, reused verbatim across three DISTINCT laboratory observations
+  in the same organizer. This is not a malformed document invented to break
+  something: the public HL7 Continuity of Care Document sample distributes a
+  single root-only <id> across every result observation in its Results section,
+  and vendors that copied that sample inherited the shape. HL7 v3 II says a root
+  alone may be the entire instance identifier, so the converter takes the source
+  at its word and mints ONE subject IRI for all three.
+
+  The three observations disagree about everything a lab result is: different
+  LOINC code, different name, different value, different unit, different
+  reference range. So the collision is not a re-import; it is three records
+  claiming one identity.
+
+  The fourth observation in this organizer carries a DISTINCT id and is the
+  control: whatever happens to the first three must not happen to it.
+
+  Authored for this repository. Invented person, organization, identifiers,
+  dates and values. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5.99992.1" extension="P02-CCDA-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Northgate Regional Laboratory Results Summary</title>
+  <effectiveTime value="20250406101000-0500"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.99992.2" extension="MRN-6620"/>
+      <patient>
+        <name use="L"><given>Teodoro</given><family>Halvane</family></name>
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19580922"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.99992.1"/>
+        <name>Northgate Regional Laboratory</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>
+            <table>
+              <tbody>
+                <tr><td>Sodium</td><td>139 mmol/L</td></tr>
+                <tr><td>Potassium</td><td>4.2 mmol/L</td></tr>
+                <tr><td>Chloride</td><td>104 mmol/L</td></tr>
+                <tr><td>Creatinine</td><td>1.1 mg/dL</td></tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.99992.4" extension="P02-ORG-BMP"/>
+              <code code="51990-0" displayName="Basic metabolic panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250406094500-0500"/>
+
+              <!-- COLLIDING #1 - shares the root-only id below with #2 and #3. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="a1d84b70-5c31-11ef-9c1d-0800200c9a66"/>
+                  <code code="2951-2" displayName="Sodium [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250406094500-0500"/>
+                  <value xsi:type="PQ" value="139" unit="mmol/L"/>
+                  <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
+                  <referenceRange>
+                    <observationRange>
+                      <text>135 - 145 mmol/L</text>
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+
+              <!-- COLLIDING #2 -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="a1d84b70-5c31-11ef-9c1d-0800200c9a66"/>
+                  <code code="2823-3" displayName="Potassium [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250406094500-0500"/>
+                  <value xsi:type="PQ" value="4.2" unit="mmol/L"/>
+                  <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
+                  <referenceRange>
+                    <observationRange>
+                      <text>3.5 - 5.1 mmol/L</text>
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+
+              <!-- COLLIDING #3 -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="a1d84b70-5c31-11ef-9c1d-0800200c9a66"/>
+                  <code code="2075-0" displayName="Chloride [Moles/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250406094500-0500"/>
+                  <value xsi:type="PQ" value="104" unit="mmol/L"/>
+                  <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
+                  <referenceRange>
+                    <observationRange>
+                      <text>98 - 107 mmol/L</text>
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+
+              <!-- CONTROL - a distinct id, so it must survive as its own record. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99992.5" extension="P02-OBS-CREAT"/>
+                  <code code="2160-0" displayName="Creatinine [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250406094500-0500"/>
+                  <value xsi:type="PQ" value="1.1" unit="mg/dL"/>
+                  <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
+                  <referenceRange>
+                    <observationRange>
+                      <text>0.7 - 1.3 mg/dL</text>
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/pathology/p03-narrative-names-ccda.xml
+++ b/test-fixtures/pathology/p03-narrative-names-ccda.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  P03 - NARRATIVE-ONLY TEST NAMES, WITH ONE DANGLING REFERENCE.
+
+  In ordinary C-CDA the attested rendering is the section narrative, and the
+  structured entry points into it with <text><reference value="#id"/> rather
+  than repeating the name on the code element. A converter that reads only
+  @displayName therefore loses the name of every such test.
+
+  Four resolvable cases and one that does NOT resolve:
+
+    P03-RESOLVES-CODE   name behind code/originalText -> #p03name1
+    P03-RESOLVES-TEXT   name behind the observation's own <text> -> #p03name2
+    P03-RESOLVES-INLINE name inline in originalText, no reference at all
+    P03-DANGLING        reference to #p03missing, which the narrative does NOT
+                        contain. The pathology: a pointer into a rendering that
+                        was truncated, re-sectioned, or exported without the
+                        table it named. The record must still import, and must
+                        not acquire a fabricated name.
+    P03-NO-NAME-AT-ALL  no @displayName, no originalText, no <text>. The floor
+                        case: nothing anywhere names this test.
+
+  Authored for this repository. Invented person, organization, identifiers,
+  dates and values. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5.99993.1" extension="P03-CCDA-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Cascadia Valley Clinic Results</title>
+  <effectiveTime value="20250519134500-0700"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.99993.2" extension="MRN-8115"/>
+      <patient>
+        <name use="L"><given>Perrine</given><family>Odalric</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19880305"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.99993.1"/>
+        <name>Cascadia Valley Clinic</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>
+            <table>
+              <tbody>
+                <tr><td><content ID="p03name1">Thyroid stimulating hormone</content></td><td>2.10 mIU/L</td></tr>
+                <tr><td><content ID="p03name2">Free thyroxine</content></td><td>1.20 ng/dL</td></tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.99993.4" extension="P03-ORG-THY"/>
+              <code code="24348-5" displayName="Thyroid panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250519"/>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99993.5" extension="P03-RESOLVES-CODE"/>
+                  <code code="3016-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#p03name1"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250519"/>
+                  <value xsi:type="PQ" value="2.10" unit="mIU/L"/>
+                </observation>
+              </component>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99993.5" extension="P03-RESOLVES-TEXT"/>
+                  <code code="3024-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <text><reference value="#p03name2"/></text>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250519"/>
+                  <value xsi:type="PQ" value="1.20" unit="ng/dL"/>
+                </observation>
+              </component>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99993.5" extension="P03-RESOLVES-INLINE"/>
+                  <code code="3026-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText>Triiodothyronine</originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250519"/>
+                  <value xsi:type="PQ" value="110" unit="ng/dL"/>
+                </observation>
+              </component>
+
+              <!-- DANGLING: #p03missing is not in the narrative above. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99993.5" extension="P03-DANGLING"/>
+                  <code code="3051-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                    <originalText><reference value="#p03missing"/></originalText>
+                  </code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250519"/>
+                  <value xsi:type="PQ" value="3.9" unit="pg/mL"/>
+                </observation>
+              </component>
+
+              <!-- FLOOR: nothing names this test anywhere. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99993.5" extension="P03-NO-NAME-AT-ALL"/>
+                  <code code="3013-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250519"/>
+                  <value xsi:type="PQ" value="17" unit="ng/mL"/>
+                </observation>
+              </component>
+
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/pathology/p04-date-precision-ccda.xml
+++ b/test-fixtures/pathology/p04-date-precision-ccda.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  P04 - DATE PRECISION VARIETY.
+
+  HL7 v3 TS is truncated on the right at whatever precision the system actually
+  knows, so one Results section routinely mixes three precisions. The pathology
+  is what a converter does with the coarse end: promoting a month to a day, or a
+  day to T00:00:00, satisfies a datatype check by ASSERTING a time the source
+  never gave, and a fabricated midnight is indistinguishable downstream from a
+  real midnight draw.
+
+    P04-DAY      effectiveTime 20250703            -> a calendar day
+    P04-TIMED    effectiveTime 20250703142215-0400 -> a full instant with offset
+    P04-MONTH    effectiveTime 202507              -> coarser than a day. There
+                 is no honest xsd:date or xsd:dateTime for it, so NOTHING must
+                 be emitted for this record's performed date. The record itself
+                 must still import; only its date is absent.
+
+  This document also carries ONE procedure. It is here because a procedure has a
+  date of its own (a third emission site for the precision rule), and it is the
+  corpus's instance of the open procedure-name defect the harness ledger pins.
+
+  Authored for this repository. Invented person, organization, identifiers,
+  dates and values. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5.99994.1" extension="P04-CCDA-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Alder Point Medical Group Summary</title>
+  <effectiveTime value="20250801090000-0400"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.99994.2" extension="MRN-2043"/>
+      <patient>
+        <name use="L"><given>Ansel</given><family>Brightwater</family></name>
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19760711"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.99994.1"/>
+        <name>Alder Point Medical Group</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>Ferritin 88 ng/mL; Vitamin B12 410 pg/mL; Vitamin D 31 ng/mL</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.99994.4" extension="P04-ORG-NUTR"/>
+              <code code="24356-8" displayName="Nutritional panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250703"/>
+
+              <!-- DAY precision. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99994.5" extension="P04-DAY"/>
+                  <code code="2276-4" displayName="Ferritin [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250703"/>
+                  <value xsi:type="PQ" value="88" unit="ng/mL"/>
+                </observation>
+              </component>
+
+              <!-- SECOND precision with a zone offset. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99994.5" extension="P04-TIMED"/>
+                  <code code="2132-9" displayName="Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20250703142215-0400"/>
+                  <value xsi:type="PQ" value="410" unit="pg/mL"/>
+                </observation>
+              </component>
+
+              <!-- MONTH precision: coarser than xsd:date can state. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99994.5" extension="P04-MONTH"/>
+                  <code code="14635-7" displayName="25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="202507"/>
+                  <value xsi:type="PQ" value="31" unit="ng/mL"/>
+                </observation>
+              </component>
+
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+          <code code="47519-4" displayName="History of Procedures" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Procedures</title>
+          <text>Screening colonoscopy, 2024-11-19</text>
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+              <id root="2.16.840.1.113883.19.5.99994.6" extension="P04-PROC-001"/>
+              <code code="73761001" displayName="Colonoscopy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20241119081000-0500"/>
+            </procedure>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/pathology/p05-interpretation-categories-fhir.json
+++ b/test-fixtures/pathology/p05-interpretation-categories-fhir.json
@@ -1,0 +1,120 @@
+{
+  "_comment": "P05 - INTERPRETATION CODES ACROSS THE HL7 SET, AND MULTI-CATEGORY LABS. FHIR R4 binds Observation.interpretation to the HL7 v3 ObservationInterpretation code system, which is far wider than high/low: susceptibility (S/I/R), detection (POS/NEG/DET/ND), reactivity, and change all live there. A converter that flattens the system onto a handful of English words makes 'the organism is resistant to this antibiotic' and 'the source said nothing' arrive as the same string. This bundle carries H (a high value), S (a susceptibility result), POS (a detection result), an UNMAPPED code that is not in the accepted set at all, and one observation with NO interpretation, which is the only case that legitimately means 'unknown'. It also carries two multi-category observations: one tagged both laboratory and a second category (which must stay a lab), and one tagged both vital-signs and laboratory (where the category order decides the routing, and the routing decides which shape validates it). 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p05-interpretation",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:p05-patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "p05-pt",
+        "name": [{ "use": "official", "family": "Ferrowyn", "given": ["Lucienne"] }],
+        "gender": "female",
+        "birthDate": "1993-12-02"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-h",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-h",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2345-7", "display": "Glucose [Mass/volume] in Serum or Plasma" }], "text": "Glucose" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueQuantity": { "value": 168, "unit": "mg/dL" },
+        "interpretation": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", "code": "H", "display": "High" }] }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-s",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-s",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "18928-5", "display": "Ciprofloxacin [Susceptibility]" }], "text": "Ciprofloxacin susceptibility" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueString": "Susceptible",
+        "interpretation": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", "code": "S", "display": "Susceptible" }] }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-pos",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-pos",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "5195-3", "display": "Hepatitis B virus surface Ag [Presence] in Serum" }], "text": "Hepatitis B surface antigen" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueString": "Detected",
+        "interpretation": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", "code": "POS", "display": "Positive" }] }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-unmapped",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-unmapped",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "1751-7", "display": "Albumin [Mass/volume] in Serum or Plasma" }], "text": "Albumin" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueQuantity": { "value": 4.1, "unit": "g/dL" },
+        "interpretation": [{ "coding": [{ "system": "http://example.org/local-flags", "code": "ZQ7", "display": "Local laboratory flag" }] }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-none",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-none",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2160-0", "display": "Creatinine [Mass/volume] in Serum or Plasma" }], "text": "Creatinine" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueQuantity": { "value": 0.9, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-multicat-lab",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-multicat-lab",
+        "status": "final",
+        "category": [
+          { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] },
+          { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "procedure" }] }
+        ],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2093-3", "display": "Cholesterol [Mass/volume] in Serum or Plasma" }], "text": "Total cholesterol" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueQuantity": { "value": 202, "unit": "mg/dL" },
+        "interpretation": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", "code": "H" }] }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p05-multicat-vital",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p05-multicat-vital",
+        "status": "final",
+        "category": [
+          { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] },
+          { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }
+        ],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8310-5", "display": "Body temperature" }], "text": "Body temperature" },
+        "subject": { "reference": "urn:uuid:p05-patient" },
+        "effectiveDateTime": "2025-03-04T07:40:00-06:00",
+        "valueQuantity": { "value": 37.1, "unit": "Cel" }
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p06-indication-absence-fhir.json
+++ b/test-fixtures/pathology/p06-indication-absence-fhir.json
@@ -1,0 +1,123 @@
+{
+  "_comment": "P06 - INDICATION ABSENCE. 'What is this drug for?' is the question a patient most often brings to their own medication list, and FHIR answers it three different ways. reasonReference points at a Condition resource and becomes a real record-to-record edge. reasonCode carries a code or free text and becomes a candidate for literal lifting, which can only resolve if the named condition is somewhere in the pod. And a great many real MedicationRequests carry NEITHER, because the prescribing system never captured one. The pathology is that the third case is indistinguishable from the second-that-failed-to-resolve unless the pipeline keeps them apart: 'the source never said' and 'the source said, and we could not match it' are different answers and must not collapse into one silent blank. This bundle carries one of each, plus the Condition that the reasonReference case points at and the Condition that the reasonCode case names. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p06-indication",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:p06-patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "p06-pt",
+        "name": [{ "use": "official", "family": "Vashti", "given": ["Oberon"] }],
+        "gender": "male",
+        "birthDate": "1962-08-27"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-cond-htn",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "p06-cond-htn",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/condition-clinical", "code": "active" }] },
+        "code": { "coding": [{ "system": "http://snomed.info/sct", "code": "38341003", "display": "Hypertensive disorder" }], "text": "Hypertension" },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "onsetDateTime": "2016-03-01"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-cond-gerd",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "p06-cond-gerd",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/condition-clinical", "code": "active" }] },
+        "code": { "coding": [{ "system": "http://snomed.info/sct", "code": "235595009", "display": "Gastroesophageal reflux disease" }], "text": "Gastroesophageal reflux disease" },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "onsetDateTime": "2021-09-15"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-med-with-reference",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "p06-med-with-reference",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "197361", "display": "Amlodipine 5 MG Oral Tablet" }],
+          "text": "Amlodipine 5 mg oral tablet"
+        },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "authoredOn": "2024-01-08",
+        "reasonReference": [{ "reference": "urn:uuid:p06-cond-htn" }],
+        "dosageInstruction": [{ "text": "Take 1 tablet by mouth once daily", "timing": { "repeat": { "frequency": 1, "period": 1, "periodUnit": "d" } } }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-med-with-reasoncode",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "p06-med-with-reasoncode",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "198211", "display": "Omeprazole 20 MG Delayed Release Oral Capsule" }],
+          "text": "Omeprazole 20 mg delayed release capsule"
+        },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "authoredOn": "2024-02-19",
+        "reasonCode": [{ "text": "Gastroesophageal reflux disease" }],
+        "dosageInstruction": [{ "text": "Take 1 capsule by mouth once daily before breakfast" }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-med-no-indication",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "p06-med-no-indication",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "310798", "display": "Hydrochlorothiazide 25 MG Oral Tablet" }],
+          "text": "Hydrochlorothiazide 25 mg oral tablet"
+        },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "authoredOn": "2024-03-27",
+        "dosageInstruction": [{ "text": "Take 1 tablet by mouth every morning" }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-med-no-indication-2",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "p06-med-no-indication-2",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "617314", "display": "Atorvastatin 40 MG Oral Tablet" }],
+          "text": "Atorvastatin 40 mg oral tablet"
+        },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "authoredOn": "2024-04-02",
+        "dosageInstruction": [{ "text": "Take 1 tablet by mouth at bedtime" }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p06-med-unresolvable-reasoncode",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "p06-med-unresolvable-reasoncode",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "308136", "display": "Amoxicillin 500 MG Oral Capsule" }],
+          "text": "Amoxicillin 500 mg oral capsule"
+        },
+        "subject": { "reference": "urn:uuid:p06-patient" },
+        "authoredOn": "2024-05-11",
+        "reasonCode": [{ "text": "Acute sinusitis" }],
+        "dosageInstruction": [{ "text": "Take 1 capsule by mouth three times daily for 10 days" }]
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p07a-crosssource-labs-alpha.json
+++ b/test-fixtures/pathology/p07a-crosssource-labs-alpha.json
@@ -1,0 +1,83 @@
+{
+  "_comment": "P07a - CROSS-SOURCE EXACT LAB DUPLICATES (source A). The hospital that ran the panel and the primary-care office that received the report both export the same four results, with the same LOINC codes, the same values, and a byte-identical collection timestamp. This is the highest-confidence merge case there is: nothing about these records differs except which system handed them over. The pathology is that a patient importing both exports has every lab listed twice, and the duplicate looks like a second draw. This half is imported first; p07b-crosssource-labs-beta.json is imported second, so the merge has to happen ACROSS batches against records already on disk. The two files also carry one lab each that the OTHER does not, so a run that merged everything would be as wrong as one that merged nothing. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p07a-alpha",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.stonebridgehospital.example/r4/Patient/p07-pt",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "p07-pt",
+        "name": [{ "use": "official", "family": "Marchetti", "given": ["Ilona"] }],
+        "gender": "female",
+        "birthDate": "1984-01-30"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.stonebridgehospital.example/r4/Observation/p07a-sodium",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p07a-sodium",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2951-2", "display": "Sodium [Moles/volume] in Serum or Plasma" }], "text": "Sodium" },
+        "subject": { "reference": "https://fhir.stonebridgehospital.example/r4/Patient/p07-pt" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 141, "unit": "mmol/L" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.stonebridgehospital.example/r4/Observation/p07a-potassium",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p07a-potassium",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2823-3", "display": "Potassium [Moles/volume] in Serum or Plasma" }], "text": "Potassium" },
+        "subject": { "reference": "https://fhir.stonebridgehospital.example/r4/Patient/p07-pt" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 4.0, "unit": "mmol/L" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.stonebridgehospital.example/r4/Observation/p07a-bun",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p07a-bun",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "3094-0", "display": "Urea nitrogen [Mass/volume] in Serum or Plasma" }], "text": "BUN" },
+        "subject": { "reference": "https://fhir.stonebridgehospital.example/r4/Patient/p07-pt" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 14, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.stonebridgehospital.example/r4/Observation/p07a-calcium",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p07a-calcium",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "17861-6", "display": "Calcium [Mass/volume] in Serum or Plasma" }], "text": "Calcium" },
+        "subject": { "reference": "https://fhir.stonebridgehospital.example/r4/Patient/p07-pt" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 9.4, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.stonebridgehospital.example/r4/Observation/p07a-only-magnesium",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p07a-only-magnesium",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2601-3", "display": "Magnesium [Moles/volume] in Serum or Plasma" }], "text": "Magnesium" },
+        "subject": { "reference": "https://fhir.stonebridgehospital.example/r4/Patient/p07-pt" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 2.0, "unit": "mg/dL" }
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p07b-crosssource-labs-beta.json
+++ b/test-fixtures/pathology/p07b-crosssource-labs-beta.json
@@ -1,0 +1,83 @@
+{
+  "_comment": "P07b - CROSS-SOURCE EXACT LAB DUPLICATES (source B). The same four results as p07a, from a different health system's export: different resource ids, different endpoint host, identical LOINC codes, identical values, byte-identical effectiveDateTime. Plus one result the first export does not carry (phosphorus), which must survive as its own record. This is the tier-0 reconciliation shape: if anything merges, this does. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p07b-beta",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.larkfieldclinic.example/r4/Patient/lf-90021",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "lf-90021",
+        "name": [{ "use": "official", "family": "Marchetti", "given": ["Ilona"] }],
+        "gender": "female",
+        "birthDate": "1984-01-30"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.larkfieldclinic.example/r4/Observation/lf-na",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "lf-na",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2951-2", "display": "Sodium [Moles/volume] in Serum or Plasma" }], "text": "Sodium, serum" },
+        "subject": { "reference": "https://fhir.larkfieldclinic.example/r4/Patient/lf-90021" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 141, "unit": "mmol/L" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.larkfieldclinic.example/r4/Observation/lf-k",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "lf-k",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2823-3", "display": "Potassium [Moles/volume] in Serum or Plasma" }], "text": "Potassium, serum" },
+        "subject": { "reference": "https://fhir.larkfieldclinic.example/r4/Patient/lf-90021" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 4.0, "unit": "mmol/L" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.larkfieldclinic.example/r4/Observation/lf-bun",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "lf-bun",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "3094-0", "display": "Urea nitrogen [Mass/volume] in Serum or Plasma" }], "text": "Blood urea nitrogen" },
+        "subject": { "reference": "https://fhir.larkfieldclinic.example/r4/Patient/lf-90021" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 14, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.larkfieldclinic.example/r4/Observation/lf-ca",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "lf-ca",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "17861-6", "display": "Calcium [Mass/volume] in Serum or Plasma" }], "text": "Calcium, total" },
+        "subject": { "reference": "https://fhir.larkfieldclinic.example/r4/Patient/lf-90021" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 9.4, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.larkfieldclinic.example/r4/Observation/lf-only-phosphorus",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "lf-only-phosphorus",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2777-1", "display": "Phosphate [Mass/volume] in Serum or Plasma" }], "text": "Phosphorus" },
+        "subject": { "reference": "https://fhir.larkfieldclinic.example/r4/Patient/lf-90021" },
+        "effectiveDateTime": "2025-05-20T06:12:00-07:00",
+        "valueQuantity": { "value": 3.5, "unit": "mg/dL" }
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p08a-repeat-vitals-alpha.json
+++ b/test-fixtures/pathology/p08a-repeat-vitals-alpha.json
@@ -1,0 +1,96 @@
+{
+  "_comment": "P08a - SAME-SOURCE REPEAT VITALS (source A). Three blood-pressure readings taken hours apart on ONE day at ONE practice, each a separate clinical event: a morning reading, a midday recheck, and an evening reading after a dose change. Nothing about them is a duplicate. A matcher that keys on 'same LOINC + same calendar day' sees three identical keys, so the only thing standing between these and a merge is the guard that refuses to compare two records from the same source. The pathology this fixture exists to catch: that guard keys on the TRANSPORT label, not on the clinical source, so it can be defeated from outside (see p08b-repeat-vitals-beta.json, which introduces a fourth reading from a second system 17 minutes after the third). Systolic and diastolic are separate observations, which is how a great many real exports carry them. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p08a-alpha",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Patient/hv-551",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "hv-551",
+        "name": [{ "use": "official", "family": "Delacroix-Rue", "given": ["Bartholomew"] }],
+        "gender": "male",
+        "birthDate": "1955-07-09"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Observation/hv-sys-morning",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "hv-sys-morning",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6", "display": "Systolic blood pressure" }], "text": "Systolic blood pressure" },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-551" },
+        "effectiveDateTime": "2025-06-11T08:05:00-07:00",
+        "valueQuantity": { "value": 138, "unit": "mm[Hg]" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Observation/hv-dia-morning",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "hv-dia-morning",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8462-4", "display": "Diastolic blood pressure" }], "text": "Diastolic blood pressure" },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-551" },
+        "effectiveDateTime": "2025-06-11T08:05:00-07:00",
+        "valueQuantity": { "value": 86, "unit": "mm[Hg]" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Observation/hv-sys-midday",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "hv-sys-midday",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6", "display": "Systolic blood pressure" }], "text": "Systolic blood pressure" },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-551" },
+        "effectiveDateTime": "2025-06-11T12:40:00-07:00",
+        "valueQuantity": { "value": 129, "unit": "mm[Hg]" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Observation/hv-dia-midday",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "hv-dia-midday",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8462-4", "display": "Diastolic blood pressure" }], "text": "Diastolic blood pressure" },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-551" },
+        "effectiveDateTime": "2025-06-11T12:40:00-07:00",
+        "valueQuantity": { "value": 81, "unit": "mm[Hg]" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Observation/hv-sys-evening",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "hv-sys-evening",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6", "display": "Systolic blood pressure" }], "text": "Systolic blood pressure" },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-551" },
+        "effectiveDateTime": "2025-06-11T17:20:00-07:00",
+        "valueQuantity": { "value": 144, "unit": "mm[Hg]" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Observation/hv-dia-evening",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "hv-dia-evening",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8462-4", "display": "Diastolic blood pressure" }], "text": "Diastolic blood pressure" },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-551" },
+        "effectiveDateTime": "2025-06-11T17:20:00-07:00",
+        "valueQuantity": { "value": 90, "unit": "mm[Hg]" }
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p08b-repeat-vitals-beta.json
+++ b/test-fixtures/pathology/p08b-repeat-vitals-beta.json
@@ -1,0 +1,44 @@
+{
+  "_comment": "P08b - CLOCK-SKEW DUPLICATE FROM A SECOND SOURCE. One blood-pressure reading recorded by an urgent-care system 17 minutes after the third reading in p08a-repeat-vitals-alpha.json, with the same values. Clinically this is the SAME cuff reading: the patient walked next door and the receiving system stamped it with its own clock. So exactly one merge is correct here (this reading with the 17:20 reading), and every other pairing is wrong. Because this record arrives from a different source, the same-source guard does not apply to it, and 'same LOINC + same calendar day' matches it against ALL THREE of the day's readings at once. That is the pathology: a single cross-source arrival can pull apart-in-time same-source readings into one group that the guard alone would never have formed. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p08b-beta",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.ridgecresturgent.example/r4/Patient/rc-7788",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "rc-7788",
+        "name": [{ "use": "official", "family": "Delacroix-Rue", "given": ["Bartholomew"] }],
+        "gender": "male",
+        "birthDate": "1955-07-09"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecresturgent.example/r4/Observation/rc-sys-skew",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "rc-sys-skew",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6", "display": "Systolic blood pressure" }], "text": "Systolic blood pressure" },
+        "subject": { "reference": "https://fhir.ridgecresturgent.example/r4/Patient/rc-7788" },
+        "effectiveDateTime": "2025-06-11T17:37:00-07:00",
+        "valueQuantity": { "value": 144, "unit": "mm[Hg]" }
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecresturgent.example/r4/Observation/rc-dia-skew",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "rc-dia-skew",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8462-4", "display": "Diastolic blood pressure" }], "text": "Diastolic blood pressure" },
+        "subject": { "reference": "https://fhir.ridgecresturgent.example/r4/Patient/rc-7788" },
+        "effectiveDateTime": "2025-06-11T17:37:00-07:00",
+        "valueQuantity": { "value": 90, "unit": "mm[Hg]" }
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p09a-med-chains-alpha.json
+++ b/test-fixtures/pathology/p09a-med-chains-alpha.json
@@ -1,0 +1,84 @@
+{
+  "_comment": "P09a - MEDICATION CHAINS (source A: the primary-care practice). Four chains start here. DOSE SUPERSESSION: lisinopril 10 mg, stopped last year, whose successor at 20 mg lives in p09b. STALE-ACTIVE: metformin 500 mg, still marked active in this practice's list, which the specialist in p09b stopped twice over. DOSE DISAGREEMENT, DOSE CARRIED: levothyroxine 75 mcg as a MedicationStatement, whose dose text rides on the resource's own `dosage` array. DOSE DISAGREEMENT, DOSE ON THE ORDER: sertraline 50 mg as a MedicationRequest, whose dose text rides on `dosageInstruction` instead. The last two are the same clinical question asked through two ordinary FHIR shapes, and they exist to show whether the answer depends on which shape the source happened to use. Dose is deliberately stripped by the matcher's name normalization, so '10 mg' and '20 mg' are one drug with a dose disagreement rather than two drugs; the question the pipeline has to keep open is which one the patient is taking TODAY. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p09a-alpha",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/Patient/hv-903",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "hv-903",
+        "name": [{ "use": "official", "family": "Anselminho", "given": ["Rosalind"] }],
+        "gender": "female",
+        "birthDate": "1968-02-14"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/MedicationRequest/hv-lisinopril-10",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "hv-lisinopril-10",
+        "status": "stopped",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "314076", "display": "Lisinopril 10 MG Oral Tablet" }],
+          "text": "Lisinopril 10 mg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-903" },
+        "requester": { "display": "Adaeze Nwankwo-Barrett, MD" },
+        "authoredOn": "2023-05-02",
+        "dosageInstruction": [{ "text": "Take 1 tablet (10 mg) by mouth once daily" }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/MedicationRequest/hv-metformin-active",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "hv-metformin-active",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "861007", "display": "Metformin hydrochloride 500 MG Oral Tablet" }],
+          "text": "Metformin 500 mg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-903" },
+        "requester": { "display": "Adaeze Nwankwo-Barrett, MD" },
+        "authoredOn": "2022-11-04",
+        "dosageInstruction": [{ "text": "Take 1 tablet (500 mg) by mouth twice daily" }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/MedicationStatement/hv-levothyroxine-75",
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "hv-levothyroxine-75",
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "966221", "display": "Levothyroxine Sodium 0.075 MG Oral Tablet" }],
+          "text": "Levothyroxine 75 mcg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-903" },
+        "effectiveDateTime": "2023-01-19",
+        "dosage": [{ "text": "75 mcg by mouth every morning", "timing": { "repeat": { "frequency": 1, "period": 1, "periodUnit": "d" } } }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.harborviewfamily.example/r4/MedicationRequest/hv-sertraline-50",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "hv-sertraline-50",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "312940", "display": "Sertraline 50 MG Oral Tablet" }],
+          "text": "Sertraline 50 mg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.harborviewfamily.example/r4/Patient/hv-903" },
+        "requester": { "display": "Adaeze Nwankwo-Barrett, MD" },
+        "authoredOn": "2023-09-21",
+        "dosageInstruction": [{ "text": "50 mg by mouth every morning", "timing": { "repeat": { "frequency": 1, "period": 1, "periodUnit": "d" } } }]
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p09b-med-chains-beta.json
+++ b/test-fixtures/pathology/p09b-med-chains-beta.json
@@ -1,0 +1,101 @@
+{
+  "_comment": "P09b - MEDICATION CHAINS (source B: the specialist practice). The other end of all four chains from p09a-med-chains-alpha.json. DOSE SUPERSESSION: lisinopril 20 mg, active, authored a year after the 10 mg the primary-care list still carries as stopped. STALE-ACTIVE: metformin stopped twice by this prescriber (an immediate-release order and its extended-release replacement, both now stopped), against the primary-care list's still-active metformin. The second stopped metformin is the interesting one: it arrives after its sibling has already been paired with the active record, so whether it is examined at all is a property of iteration order rather than of clinical meaning. The levothyroxine and sertraline pairs raise the same dose disagreement (75 vs 100 mcg, 50 vs 100 mg) through two different FHIR shapes, so a divergence between them is a property of the transport and not of the medicine. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p09b-beta",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://fhir.ridgecrestcardiology.example/r4/Patient/rc-2210",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "rc-2210",
+        "name": [{ "use": "official", "family": "Anselminho", "given": ["Rosalind"] }],
+        "gender": "female",
+        "birthDate": "1968-02-14"
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecrestcardiology.example/r4/MedicationRequest/rc-lisinopril-20",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "rc-lisinopril-20",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "314077", "display": "Lisinopril 20 MG Oral Tablet" }],
+          "text": "Lisinopril 20 mg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.ridgecrestcardiology.example/r4/Patient/rc-2210" },
+        "requester": { "display": "Yusuf Oyelaran-Steed, MD" },
+        "authoredOn": "2024-08-15",
+        "dosageInstruction": [{ "text": "Take 1 tablet (20 mg) by mouth once daily" }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecrestcardiology.example/r4/MedicationRequest/rc-metformin-stopped-1",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "rc-metformin-stopped-1",
+        "status": "stopped",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "861007", "display": "Metformin hydrochloride 500 MG Oral Tablet" }],
+          "text": "Metformin 500 mg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.ridgecrestcardiology.example/r4/Patient/rc-2210" },
+        "requester": { "display": "Yusuf Oyelaran-Steed, MD" },
+        "authoredOn": "2023-06-01",
+        "dosageInstruction": [{ "text": "Take 1 tablet (500 mg) by mouth twice daily" }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecrestcardiology.example/r4/MedicationRequest/rc-metformin-stopped-2",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "rc-metformin-stopped-2",
+        "status": "stopped",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "861763", "display": "Metformin hydrochloride 500 MG Extended Release Oral Tablet" }],
+          "text": "Metformin 500 mg extended release oral tablet"
+        },
+        "subject": { "reference": "https://fhir.ridgecrestcardiology.example/r4/Patient/rc-2210" },
+        "requester": { "display": "Yusuf Oyelaran-Steed, MD" },
+        "authoredOn": "2024-02-10",
+        "dosageInstruction": [{ "text": "Take 1 tablet (500 mg) by mouth twice daily" }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecrestcardiology.example/r4/MedicationStatement/rc-levothyroxine-100",
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "rc-levothyroxine-100",
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "966224", "display": "Levothyroxine Sodium 0.1 MG Oral Tablet" }],
+          "text": "Levothyroxine 100 mcg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.ridgecrestcardiology.example/r4/Patient/rc-2210" },
+        "effectiveDateTime": "2024-10-03",
+        "dosage": [{ "text": "100 mcg by mouth every morning", "timing": { "repeat": { "frequency": 1, "period": 1, "periodUnit": "d" } } }]
+      }
+    },
+    {
+      "fullUrl": "https://fhir.ridgecrestcardiology.example/r4/MedicationRequest/rc-sertraline-100",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "rc-sertraline-100",
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "312941", "display": "Sertraline 100 MG Oral Tablet" }],
+          "text": "Sertraline 100 mg oral tablet"
+        },
+        "subject": { "reference": "https://fhir.ridgecrestcardiology.example/r4/Patient/rc-2210" },
+        "requester": { "display": "Yusuf Oyelaran-Steed, MD" },
+        "authoredOn": "2024-11-12",
+        "dosageInstruction": [{ "text": "100 mg by mouth every morning", "timing": { "repeat": { "frequency": 1, "period": 1, "periodUnit": "d" } } }]
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p10-allergy-sentinels-fhir.json
+++ b/test-fixtures/pathology/p10-allergy-sentinels-fhir.json
@@ -1,0 +1,83 @@
+{
+  "_comment": "P10 - ALLERGY SENTINELS. An allergy list carries three things that look alike in a record store and mean nothing alike in a clinic. A REAL allergen (penicillin G, with a criticality and a reaction) is a fact about the patient. 'No Known Allergies' (SNOMED 716186003) is an assertion ABOUT the list: someone asked, and the answer was none. An 'Unknown Allergen' entry is a data-absent marker: the source recorded that something was recorded, but not what. The pathology is that all three land as one record type with an allergen string, so a list view renders 'No known allergy' as though the patient were allergic to it, and 'Unknown Allergen' as though that were the name of a substance. A fourth entry is the sentinel's near-miss: a real allergen whose criticality and reaction are absent, which must NOT be confused with the data-absent case. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p10-allergy",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:p10-patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "p10-pt",
+        "name": [{ "use": "official", "family": "Sandoval-Ihejirika", "given": ["Cordelia"] }],
+        "gender": "female",
+        "birthDate": "1990-11-23"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p10-real-allergen",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "p10-real-allergen",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", "code": "active" }] },
+        "verificationStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", "code": "confirmed" }] },
+        "type": "allergy",
+        "category": ["medication"],
+        "criticality": "high",
+        "code": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "7980", "display": "Penicillin G" }],
+          "text": "Penicillin G"
+        },
+        "patient": { "reference": "urn:uuid:p10-patient" },
+        "recordedDate": "2018-04-12",
+        "reaction": [
+          {
+            "manifestation": [{ "coding": [{ "system": "http://snomed.info/sct", "code": "247472004", "display": "Hives" }], "text": "Hives" }],
+            "severity": "severe"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p10-no-known-allergies",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "p10-no-known-allergies",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", "code": "active" }] },
+        "verificationStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", "code": "confirmed" }] },
+        "code": {
+          "coding": [{ "system": "http://snomed.info/sct", "code": "716186003", "display": "No known allergy" }],
+          "text": "No Known Allergies"
+        },
+        "patient": { "reference": "urn:uuid:p10-patient" },
+        "recordedDate": "2024-01-05"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p10-unknown-allergen",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "p10-unknown-allergen",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", "code": "active" }] },
+        "verificationStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", "code": "unconfirmed" }] },
+        "patient": { "reference": "urn:uuid:p10-patient" },
+        "recordedDate": "2022-08-30",
+        "note": [{ "text": "Reaction reported by patient; substance not identified." }]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p10-real-allergen-sparse",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "p10-real-allergen-sparse",
+        "clinicalStatus": { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", "code": "active" }] },
+        "code": {
+          "coding": [{ "system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "5640", "display": "Ibuprofen" }],
+          "text": "Ibuprofen"
+        },
+        "patient": { "reference": "urn:uuid:p10-patient" },
+        "recordedDate": "2023-03-17"
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p11-panel-name-variants-fhir.json
+++ b/test-fixtures/pathology/p11-panel-name-variants-fhir.json
@@ -1,0 +1,127 @@
+{
+  "_comment": "P11 - PANEL DISPLAY-NAME VARIANTS OVER SHARED RESULTS. One lipid panel, drawn once, reported three times: as 'Lipid Panel' when the order was placed, as 'Lipid Profile' by the performing laboratory, and as 'LIPID PROFILE - Final result' by the results-delivery system that appended its own status wording to the name. All three reports point at the SAME four Observation resources, so the results underneath are identical by construction and only the panel NAME differs. The pathology: a panel whose identity is read off its display name fragments into three panels, each apparently carrying the same four results, and a patient sees their cholesterol reported three times. It is also where display-name normalization is tempting and dangerous, since 'Final result' is a status word and 'Profile' is not. 100% synthetic.",
+  "resourceType": "Bundle",
+  "id": "p11-panels",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:p11-patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "p11-pt",
+        "name": [{ "use": "official", "family": "Okonkwo-Lindqvist", "given": ["Emeka"] }],
+        "gender": "male",
+        "birthDate": "1979-05-16"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-chol",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p11-chol",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2093-3", "display": "Cholesterol [Mass/volume] in Serum or Plasma" }], "text": "Total cholesterol" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "valueQuantity": { "value": 214, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-hdl",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p11-hdl",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2085-9", "display": "Cholesterol in HDL [Mass/volume] in Serum or Plasma" }], "text": "HDL cholesterol" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "valueQuantity": { "value": 48, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-ldl",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p11-ldl",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "13457-7", "display": "Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation" }], "text": "LDL cholesterol (calculated)" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "valueQuantity": { "value": 138, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-trig",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "p11-trig",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2571-8", "display": "Triglyceride [Mass/volume] in Serum or Plasma" }], "text": "Triglycerides" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "valueQuantity": { "value": 141, "unit": "mg/dL" }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-report-ordered",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "p11-report-ordered",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v2-0074", "code": "LAB" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "57698-3", "display": "Lipid panel with direct LDL - Serum or Plasma" }], "text": "Lipid Panel" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "issued": "2025-04-09T14:02:00-05:00",
+        "result": [
+          { "reference": "urn:uuid:p11-chol" },
+          { "reference": "urn:uuid:p11-hdl" },
+          { "reference": "urn:uuid:p11-ldl" },
+          { "reference": "urn:uuid:p11-trig" }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-report-performed",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "p11-report-performed",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v2-0074", "code": "LAB" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "57698-3", "display": "Lipid panel with direct LDL - Serum or Plasma" }], "text": "Lipid Profile" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "issued": "2025-04-09T14:07:00-05:00",
+        "result": [
+          { "reference": "urn:uuid:p11-chol" },
+          { "reference": "urn:uuid:p11-hdl" },
+          { "reference": "urn:uuid:p11-ldl" },
+          { "reference": "urn:uuid:p11-trig" }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:p11-report-delivered",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "p11-report-delivered",
+        "status": "final",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v2-0074", "code": "LAB" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "57698-3", "display": "Lipid panel with direct LDL - Serum or Plasma" }], "text": "LIPID PROFILE - Final result" },
+        "subject": { "reference": "urn:uuid:p11-patient" },
+        "effectiveDateTime": "2025-04-09T07:55:00-05:00",
+        "issued": "2025-04-09T14:31:00-05:00",
+        "result": [
+          { "reference": "urn:uuid:p11-chol" },
+          { "reference": "urn:uuid:p11-hdl" },
+          { "reference": "urn:uuid:p11-ldl" },
+          { "reference": "urn:uuid:p11-trig" }
+        ]
+      }
+    }
+  ]
+}

--- a/test-fixtures/pathology/p12-vendor-defects-a-ccda.xml
+++ b/test-fixtures/pathology/p12-vendor-defects-a-ccda.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  P12a - VENDOR-SHIPPED DEFECTS (first document).
+
+  Four shapes that certified products have been observed to emit, all in one
+  document because they arrive together in one document:
+
+    1. AN UNSUBSTITUTED TEMPLATE PLACEHOLDER AS THE DOCUMENT ID. The <id> root
+       is the literal string "ClinicalDocumentGUID" — the variable name from the
+       vendor's template, never replaced at generation time. Every document that
+       product emits therefore claims the same document identifier, which is the
+       one thing a document identifier must not do. p12-vendor-defects-b-ccda.xml
+       is the same product's next document, carrying the same literal id and
+       different content, so the harness can see what two of them do to each
+       other.
+
+    2. A MALFORMED 9-DIGIT DATE. effectiveTime="201102013": nine digits, which is
+       neither the 8-digit calendar day nor the 10-digit hour precision. The
+       honest readings are "2011-02-01 with a stray digit" and "we cannot tell",
+       and they are not the same answer.
+
+    3. AN EMPTY SECTION CARRYING nullFlavor. The Allergies section states
+       nullFlavor="NI" and contains no entries: the source is saying "no
+       information", not "no allergies". A section that imports as silence is
+       indistinguishable from one that was never in the document.
+
+    4. nullFlavor VARIETY ON VALUES. UNK (unknown), NAV (temporarily
+       unavailable) and ASKU (asked but unknown) are three different statements
+       about why a value is missing, and HL7 v3 distinguishes them deliberately.
+
+  Authored for this repository from the C-CDA R2.1 specification. Invented
+  person, organization, identifiers, dates and values. No content is derived
+  from a real record or from any external document corpus.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="ClinicalDocumentGUID"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Thornfield Community Health Summary</title>
+  <effectiveTime value="20250912103000-0600"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.99995.2" extension="MRN-3372"/>
+      <patient>
+        <name use="L"><given>Yevgenia</given><family>Thorncastle</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19811104"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.99995.1"/>
+        <name>Thornfield Community Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <!-- Empty section carrying nullFlavor: "no information", not "none". -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+          <code code="48765-2" displayName="Allergies, Adverse Reactions, Alerts" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Allergies</title>
+          <text>No information available.</text>
+        </section>
+      </component>
+
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>Hematocrit 41 %; Lead, unknown; Cortisol, unavailable; Prolactin, asked but unknown</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.99995.4" extension="P12A-ORG"/>
+              <code code="58410-2" displayName="CBC panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20110201"/>
+
+              <!-- 9-digit effectiveTime: malformed past the calendar day. -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99995.5" extension="P12A-MALFORMED-DATE"/>
+                  <code code="4544-3" displayName="Hematocrit [Volume Fraction] of Blood by Automated count" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="201102013"/>
+                  <value xsi:type="PQ" value="41" unit="%"/>
+                </observation>
+              </component>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99995.5" extension="P12A-NULL-UNK"/>
+                  <code code="10368-9" displayName="Lead [Mass/volume] in Blood" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20110201"/>
+                  <value xsi:type="PQ" nullFlavor="UNK"/>
+                </observation>
+              </component>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99995.5" extension="P12A-NULL-NAV"/>
+                  <code code="2143-6" displayName="Cortisol [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20110201"/>
+                  <value xsi:type="PQ" nullFlavor="NAV"/>
+                </observation>
+              </component>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99995.5" extension="P12A-NULL-ASKU"/>
+                  <code code="2842-3" displayName="Prolactin [Mass/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20110201"/>
+                  <value xsi:type="PQ" nullFlavor="ASKU"/>
+                </observation>
+              </component>
+
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/pathology/p12-vendor-defects-b-ccda.xml
+++ b/test-fixtures/pathology/p12-vendor-defects-b-ccda.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  P12b - VENDOR-SHIPPED DEFECTS (second document, same product, same literal id).
+
+  The same unsubstituted template placeholder "ClinicalDocumentGUID" as the
+  document <id>, on a document that is not the same document: a different visit,
+  a different Results section, different analytes and values. Two documents, one
+  claimed identifier. Whatever the pipeline does with the second one is what it
+  does to every document after the first from a product with this defect.
+
+  Authored for this repository from the C-CDA R2.1 specification. Invented
+  person, organization, identifiers, dates and values. No content is derived
+  from a real record or from any external document corpus.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="ClinicalDocumentGUID"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Thornfield Community Health Summary</title>
+  <effectiveTime value="20251118141500-0700"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.99995.2" extension="MRN-3372"/>
+      <patient>
+        <name use="L"><given>Yevgenia</given><family>Thorncastle</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19811104"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.99995.1"/>
+        <name>Thornfield Community Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>Alanine aminotransferase 29 U/L; Alkaline phosphatase 74 U/L</text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.99995.6" extension="P12B-ORG"/>
+              <code code="24325-3" displayName="Hepatic function panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20251117"/>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99995.7" extension="P12B-ALT"/>
+                  <code code="1742-6" displayName="Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20251117"/>
+                  <value xsi:type="PQ" value="29" unit="U/L"/>
+                </observation>
+              </component>
+
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.99995.7" extension="P12B-ALP"/>
+                  <code code="6768-6" displayName="Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20251117"/>
+                  <value xsi:type="PQ" value="74" unit="U/L"/>
+                </observation>
+              </component>
+
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/pathology/scenarios.json
+++ b/test-fixtures/pathology/scenarios.json
@@ -1,0 +1,284 @@
+{
+  "tier": "authored-synthetic",
+  "description": "Import pathologies authored for this repository. Every fixture is 100% synthetic: invented people, organizations, endpoints, identifiers, dates and values. What is reproduced is the SHAPE of a phenomenon that appears in real exports, never the content of any document. See INVENTORY.md.",
+  "scenarios": [
+    {
+      "id": "P01",
+      "pathology": "dual-label split: one health system, two source labels",
+      "batches": [
+        { "file": "p01-dual-label-fhir.json", "from": "fhir" },
+        { "file": "p01-dual-label-ccda.xml", "from": "c-cda" }
+      ],
+      "expect": {
+        "convertedRecords": [4, 6],
+        "reportedResourceCount": [4, 3],
+        "podRecords": 8,
+        "podRecordsByType": {
+          "ClinicalDocument": 2,
+          "ConditionRecord": 1,
+          "ImmunizationRecord": 1,
+          "LaboratoryReport": 1,
+          "LabResultRecord": 2,
+          "PatientProfile": 1
+        },
+        "merges": 2,
+        "conflicts": 0,
+        "edgesInPod": 1,
+        "violations": 0,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P02",
+      "pathology": "duplicate source-id collision: one <id> across three distinct lab observations",
+      "batches": [{ "file": "p02-duplicate-source-id-ccda.xml", "from": "c-cda" }],
+      "expect": {
+        "convertedRecords": [5],
+        "reportedResourceCount": [2],
+        "podRecords": 5,
+        "podRecordsByType": {
+          "ClinicalDocument": 1,
+          "LaboratoryReport": 1,
+          "LabResultRecord": 2,
+          "PatientProfile": 1
+        },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 2,
+        "violations": 2,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P03",
+      "pathology": "narrative-only test names, one reference dangling",
+      "batches": [{ "file": "p03-narrative-names-ccda.xml", "from": "c-cda" }],
+      "expect": {
+        "convertedRecords": [8],
+        "reportedResourceCount": [2],
+        "podRecords": 8,
+        "podRecordsByType": {
+          "ClinicalDocument": 1,
+          "LaboratoryReport": 1,
+          "LabResultRecord": 5,
+          "PatientProfile": 1
+        },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 5,
+        "violations": 2,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P04",
+      "pathology": "date-precision variety: day, timed with offset, and a month that must not be emitted",
+      "batches": [{ "file": "p04-date-precision-ccda.xml", "from": "c-cda" }],
+      "expect": {
+        "convertedRecords": [8],
+        "reportedResourceCount": [3],
+        "podRecords": 8,
+        "podRecordsByType": {
+          "ClinicalDocument": 2,
+          "LaboratoryReport": 1,
+          "LabResultRecord": 3,
+          "PatientProfile": 1,
+          "Procedure": 1
+        },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 3,
+        "violations": 1,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P05",
+      "pathology": "HL7 interpretation codes across the set, and multi-category observations",
+      "batches": [{ "file": "p05-interpretation-categories-fhir.json", "from": "fhir" }],
+      "expect": {
+        "convertedRecords": [8],
+        "reportedResourceCount": [8],
+        "podRecords": 8,
+        "podRecordsByType": { "LabResultRecord": 6, "PatientProfile": 1, "VitalSign": 1 },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 0,
+        "violations": 0,
+        "importWarnings": 1
+      }
+    },
+    {
+      "id": "P06",
+      "pathology": "indication absence: reasonReference, resolvable reasonCode, unresolvable reasonCode, and neither",
+      "batches": [{ "file": "p06-indication-absence-fhir.json", "from": "fhir" }],
+      "expect": {
+        "convertedRecords": [8],
+        "reportedResourceCount": [8],
+        "podRecords": 8,
+        "podRecordsByType": { "ConditionRecord": 2, "Medication": 5, "PatientProfile": 1 },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 1,
+        "violations": 0,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P07",
+      "pathology": "cross-source exact lab duplicates across two import batches",
+      "batches": [
+        { "file": "p07a-crosssource-labs-alpha.json", "from": "fhir" },
+        { "file": "p07b-crosssource-labs-beta.json", "from": "fhir" }
+      ],
+      "expect": {
+        "convertedRecords": [6, 6],
+        "reportedResourceCount": [6, 6],
+        "podRecords": 7,
+        "podRecordsByType": { "LabResultRecord": 6, "PatientProfile": 1 },
+        "merges": 5,
+        "conflicts": 0,
+        "edgesInPod": 0,
+        "violations": 0,
+        "importWarnings": 0
+      },
+      "groundTruth": [
+        ["p07a-sodium", "lf-na"],
+        ["p07a-potassium", "lf-k"],
+        ["p07a-bun", "lf-bun"],
+        ["p07a-calcium", "lf-ca"],
+        ["p07a-only-magnesium"],
+        ["lf-only-phosphorus"]
+      ]
+    },
+    {
+      "id": "P07-SHARED-LABEL",
+      "pathology": "the same two exports under ONE import-batch label: the same-source guard suppresses every cross-source comparison",
+      "batches": [
+        { "file": "p07a-crosssource-labs-alpha.json", "from": "fhir", "sourceSystem": "Household export" },
+        { "file": "p07b-crosssource-labs-beta.json", "from": "fhir", "sourceSystem": "Household export" }
+      ],
+      "expect": {
+        "convertedRecords": [6, 6],
+        "reportedResourceCount": [6, 6],
+        "podRecords": 12,
+        "podRecordsByType": { "LabResultRecord": 10, "PatientProfile": 2 },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 0,
+        "violations": 0,
+        "importWarnings": 0
+      },
+      "groundTruth": [
+        ["p07a-sodium", "lf-na"],
+        ["p07a-potassium", "lf-k"],
+        ["p07a-bun", "lf-bun"],
+        ["p07a-calcium", "lf-ca"],
+        ["p07a-only-magnesium"],
+        ["lf-only-phosphorus"]
+      ]
+    },
+    {
+      "id": "P08",
+      "pathology": "three same-source readings hours apart that must never merge, plus a clock-skew duplicate from a second source that should",
+      "batches": [
+        { "file": "p08a-repeat-vitals-alpha.json", "from": "fhir" },
+        { "file": "p08b-repeat-vitals-beta.json", "from": "fhir" }
+      ],
+      "expect": {
+        "convertedRecords": [7, 3],
+        "reportedResourceCount": [7, 3],
+        "podRecords": 9,
+        "podRecordsByType": { "PatientProfile": 1, "VitalSign": 8 },
+        "merges": 1,
+        "conflicts": 0,
+        "edgesInPod": 0,
+        "violations": 0,
+        "importWarnings": 0
+      },
+      "groundTruth": [
+        ["hv-sys-morning"],
+        ["hv-dia-morning"],
+        ["hv-sys-midday"],
+        ["hv-dia-midday"],
+        ["hv-sys-evening", "rc-sys-skew"],
+        ["hv-dia-evening", "rc-dia-skew"]
+      ]
+    },
+    {
+      "id": "P09",
+      "pathology": "medication chains: dose supersession, stale-active, and one dose disagreement asked through two FHIR shapes",
+      "batches": [
+        { "file": "p09a-med-chains-alpha.json", "from": "fhir" },
+        { "file": "p09b-med-chains-beta.json", "from": "fhir" }
+      ],
+      "expect": {
+        "convertedRecords": [5, 6],
+        "reportedResourceCount": [5, 6],
+        "podRecords": 5,
+        "podRecordsByType": { "Medication": 4, "PatientProfile": 1 },
+        "merges": 2,
+        "conflicts": 3,
+        "edgesInPod": 0,
+        "violations": 0,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P10",
+      "pathology": "allergy sentinels: a real allergen, a No Known Allergies negation, and an Unknown Allergen data-absent marker",
+      "batches": [{ "file": "p10-allergy-sentinels-fhir.json", "from": "fhir" }],
+      "expect": {
+        "convertedRecords": [5],
+        "reportedResourceCount": [5],
+        "podRecords": 5,
+        "podRecordsByType": { "AllergyRecord": 4, "PatientProfile": 1 },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 0,
+        "violations": 0,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P11",
+      "pathology": "one lipid draw reported three times under three display names, over shared results",
+      "batches": [{ "file": "p11-panel-name-variants-fhir.json", "from": "fhir" }],
+      "expect": {
+        "convertedRecords": [8],
+        "reportedResourceCount": [8],
+        "podRecords": 8,
+        "podRecordsByType": { "LaboratoryReport": 3, "LabResultRecord": 4, "PatientProfile": 1 },
+        "merges": 0,
+        "conflicts": 0,
+        "edgesInPod": 12,
+        "violations": 0,
+        "importWarnings": 0
+      }
+    },
+    {
+      "id": "P12",
+      "pathology": "vendor-shipped defects: an unsubstituted template placeholder as the document id, a malformed 9-digit date, an empty nullFlavor section, and nullFlavor variety on values",
+      "batches": [
+        { "file": "p12-vendor-defects-a-ccda.xml", "from": "c-cda" },
+        { "file": "p12-vendor-defects-b-ccda.xml", "from": "c-cda" }
+      ],
+      "expect": {
+        "convertedRecords": [8, 5],
+        "reportedResourceCount": [2, 2],
+        "podRecords": 12,
+        "podRecordsByType": {
+          "ClinicalDocument": 3,
+          "LaboratoryReport": 2,
+          "LabResultRecord": 6,
+          "PatientProfile": 1
+        },
+        "merges": 1,
+        "conflicts": 0,
+        "edgesInPod": 6,
+        "violations": 0,
+        "importWarnings": 0
+      }
+    }
+  ]
+}

--- a/tests/pathology-corpus.test.ts
+++ b/tests/pathology-corpus.test.ts
@@ -1,0 +1,551 @@
+/**
+ * The end-to-end harness for the pathology corpus.
+ *
+ * WHAT THIS IS FOR
+ * ----------------
+ * `test-fixtures/pathology/` holds synthetic documents that each reproduce ONE
+ * named real-world import pathology. This file runs every one of them through
+ * the pipeline a person actually runs — `cascade convert`, `pod init`,
+ * `pod import --reconcile-existing` once per batch, `pod conflicts`,
+ * `cascade validate` — and pins the census that comes out: records in, records
+ * out, merges, conflicts, edges, violations.
+ *
+ * It exists so that import and reconciliation can be worked on iteratively
+ * WITHOUT a real chart in the room. Every number below was measured, not
+ * predicted, and several of them are wrong. The wrong ones are named in
+ * `pathology-known-outcomes.ts` with the outcome that must replace them.
+ *
+ * FIXTURE TIERS ARE DIRECTORY-DISCOVERED
+ * --------------------------------------
+ * A tier is any directory containing a `scenarios.json` manifest. This file
+ * scans `test-fixtures/` for them, so a second corpus arrives as a SIBLING
+ * DIRECTORY with its own manifest and needs no change here. Tiers that must not
+ * be committed (differently licensed corpora, or anything cloned locally) are
+ * passed as absolute paths in `CASCADE_PATHOLOGY_TIERS`, delimited the way PATH
+ * is, and are discovered identically.
+ *
+ * The manifest is JSON rather than TypeScript for the same reason: a tier can be
+ * added, or an expectation corrected, without anyone editing the harness.
+ *
+ * THE TWO GATES
+ * -------------
+ * 1. KNOWN_OUTCOMES (`pathology-known-outcomes.ts`) is a ratchet, not a filter.
+ *    A new deviation fails; a silently corrected one ALSO fails. The list can
+ *    only shrink deliberately.
+ *
+ * 2. The reconciliation scorecard (`pathology-reconciliation-baseline.json`) is
+ *    REPORT-ONLY. For the scenarios that carry a constructed ground truth about
+ *    which records denote the same clinical event, it measures precision and
+ *    recall over merge PAIRS and compares them to a committed baseline. It does
+ *    not assert the numbers are good — two of them are terrible. It asserts they
+ *    are known, so that a change to matching has to move the baseline on purpose.
+ *
+ * Every fixture is synthetic and authored for this repository.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import {
+  KNOWN_OUTCOMES,
+  assertEveryEntryWasExercised,
+  assertKnownOutcomesForScenario,
+  assertLedgerIsWellFormed,
+  type ImportReportLite,
+  type ScenarioObservation,
+} from './pathology-known-outcomes.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+const FIXTURE_ROOT = path.join(REPO, 'test-fixtures');
+const BASELINE_PATH = path.join(REPO, 'tests', 'pathology-reconciliation-baseline.json');
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+const MERGED_FROM = CASCADE + 'mergedFrom';
+/** Every predicate any importer uses to carry the source's own record id. */
+const SOURCE_RECORD_ID = [
+  CASCADE + 'sourceRecordId',
+  'https://ns.cascadeprotocol.org/health/v1#sourceRecordId',
+  'https://ns.cascadeprotocol.org/clinical/v1#sourceRecordId',
+];
+
+// ---------------------------------------------------------------------------
+// Manifest types (the on-disk contract a fixture tier implements)
+// ---------------------------------------------------------------------------
+
+interface Batch {
+  file: string;
+  /** `--from` value for `cascade convert`. */
+  from: string;
+  /** `--source-system` passed to BOTH convert and import, when present. */
+  sourceSystem?: string;
+}
+
+interface Expectations {
+  /** Typed record subjects the converter emitted, per batch. */
+  convertedRecords: number[];
+  /** `resourceCount` the converter REPORTED, per batch. Not always the same number. */
+  reportedResourceCount: number[];
+  /** Record subjects the pod holds when every batch has been imported. */
+  podRecords: number;
+  /** Those subjects by type local name. */
+  podRecordsByType: Record<string, number>;
+  /** exactDuplicatesRemoved + nearDuplicatesMerged on the final batch. */
+  merges: number;
+  /** Rows in `pod conflicts --format json`. */
+  conflicts: number;
+  /** `edgeResolution.totalInPod` on the final batch. */
+  edgesInPod: number;
+  /** `sh:Violation` results from `cascade validate` over the pod. */
+  violations: number;
+  /** Import-time warnings across every batch. */
+  importWarnings: number;
+}
+
+interface Scenario {
+  id: string;
+  pathology: string;
+  batches: Batch[];
+  expect: Expectations;
+  /**
+   * The complete partition of the records under evaluation into the clinical
+   * events they denote, by SOURCE record id. Present only for scenarios where a
+   * truth exists by construction. Records outside this universe (patient
+   * profiles, reports) are not scored.
+   */
+  groundTruth?: string[][];
+}
+
+interface Tier {
+  dir: string;
+  name: string;
+  scenarios: Scenario[];
+}
+
+// ---------------------------------------------------------------------------
+// Tier discovery
+// ---------------------------------------------------------------------------
+
+function discoverTiers(): Tier[] {
+  const candidates: string[] = [];
+  for (const entry of fs.readdirSync(FIXTURE_ROOT, { withFileTypes: true })) {
+    if (entry.isDirectory()) candidates.push(path.join(FIXTURE_ROOT, entry.name));
+  }
+  const external = process.env.CASCADE_PATHOLOGY_TIERS;
+  if (external) {
+    for (const p of external.split(path.delimiter).filter(Boolean)) candidates.push(p);
+  }
+
+  const tiers: Tier[] = [];
+  for (const dir of candidates) {
+    const manifest = path.join(dir, 'scenarios.json');
+    if (!fs.existsSync(manifest)) continue;
+    const parsed = JSON.parse(fs.readFileSync(manifest, 'utf-8')) as { tier: string; scenarios: Scenario[] };
+    tiers.push({ dir, name: parsed.tier, scenarios: parsed.scenarios });
+  }
+  return tiers.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const TIERS = discoverTiers();
+const ALL_SCENARIOS: Array<{ tier: Tier; scenario: Scenario }> = TIERS.flatMap((tier) =>
+  tier.scenarios.map((scenario) => ({ tier, scenario })),
+);
+
+// ---------------------------------------------------------------------------
+// CLI plumbing
+// ---------------------------------------------------------------------------
+
+function cli(args: string[]): { out: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 180000 });
+  return { out: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+interface PodQuad {
+  subject: string;
+  predicate: string;
+  object: string;
+}
+
+function parseTurtle(ttl: string): PodQuad[] {
+  return new Parser({ format: 'Turtle' })
+    .parse(ttl)
+    .map((q) => ({ subject: q.subject.value, predicate: q.predicate.value, object: q.object.value }));
+}
+
+function readPodQuads(podDir: string): PodQuad[] {
+  const quads: PodQuad[] = [];
+  for (const dir of ['clinical', 'wellness']) {
+    const dirPath = path.join(podDir, dir);
+    if (!fs.existsSync(dirPath)) continue;
+    for (const file of fs.readdirSync(dirPath).sort()) {
+      if (!file.endsWith('.ttl')) continue;
+      quads.push(...parseTurtle(fs.readFileSync(path.join(dirPath, file), 'utf-8')));
+    }
+  }
+  return quads;
+}
+
+function localName(iri: string): string {
+  return iri.includes('#') ? (iri.split('#').pop() ?? iri) : (iri.split('/').pop() ?? iri);
+}
+
+// ---------------------------------------------------------------------------
+// Running one scenario
+// ---------------------------------------------------------------------------
+
+interface RunResult {
+  observation: ScenarioObservation;
+  /** `resourceCount` as the converter REPORTED it, per batch. */
+  reportedResourceCount: number[];
+  /** Pre-reconciliation subject IRI -> the source's own record id, over all batches. */
+  iriToSourceId: Map<string, string>;
+  /** Final record subject -> every subject IRI merged into it (itself included). */
+  mergeGroups: string[][];
+}
+
+const tempRoots: string[] = [];
+
+function runScenario(tier: Tier, scenario: Scenario): RunResult {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `pathology-${scenario.id.toLowerCase()}-`));
+  tempRoots.push(root);
+  const podDir = path.join(root, 'pod');
+
+  const convertedRecords: number[] = [];
+  const reportedResourceCount: number[] = [];
+  const iriToSourceId = new Map<string, string>();
+
+  // 1. cascade convert, per batch. Run standalone so the per-record subject IRIs
+  //    are observed BEFORE reconciliation can merge any of them away — that map
+  //    is what makes the scorecard able to say which source records ended up
+  //    together.
+  for (const batch of scenario.batches) {
+    const file = path.join(tier.dir, batch.file);
+    const args = ['--json', 'convert', '--from', batch.from, '--to', 'cascade', file];
+    if (batch.sourceSystem) args.push('--source-system', batch.sourceSystem);
+    const r = cli(args);
+    expect(r.status, `convert failed for ${scenario.id}/${batch.file}:\n${r.out}`).toBe(0);
+    const parsed = JSON.parse(r.out) as { resourceCount: number; output: string };
+    reportedResourceCount.push(parsed.resourceCount);
+
+    const quads = parseTurtle(parsed.output);
+    const typed = new Set(quads.filter((q) => q.predicate === RDF_TYPE).map((q) => q.subject));
+    convertedRecords.push(typed.size);
+    for (const q of quads) {
+      if (SOURCE_RECORD_ID.includes(q.predicate)) iriToSourceId.set(q.subject, q.object);
+    }
+  }
+
+  // 2. pod init
+  const init = cli(['pod', 'init', podDir]);
+  expect(init.status, `pod init failed for ${scenario.id}:\n${init.out}`).toBe(0);
+
+  // 3. pod import --reconcile-existing, one batch at a time, so cross-batch
+  //    reconciliation is exercised against records already on disk.
+  const importReports: ImportReportLite[] = [];
+  scenario.batches.forEach((batch, i) => {
+    const file = path.join(tier.dir, batch.file);
+    const reportPath = path.join(root, `report-${i}.json`);
+    const args = ['pod', 'import', podDir, file, '--reconcile-existing', '--report', reportPath];
+    if (batch.sourceSystem) args.push('--source-system', batch.sourceSystem);
+    const r = cli(args);
+    expect(r.status, `pod import failed for ${scenario.id}/${batch.file}:\n${r.out}`).toBe(0);
+    importReports.push(JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as ImportReportLite);
+  });
+
+  // 4. pod conflicts. Exit 1 means "conflicts present" and is expected; exit 2
+  //    means the conflict store could not be READ, which is never acceptable.
+  const conflictsRun = cli(['pod', 'conflicts', podDir, '--format', 'json']);
+  expect(
+    conflictsRun.status,
+    `pod conflicts could not read the pod for ${scenario.id}:\n${conflictsRun.out}`,
+  ).not.toBe(2);
+  const conflicts = JSON.parse(conflictsRun.out) as Array<{ conflictId: string; recordType: string }>;
+
+  // 5. cascade validate
+  const validateRun = cli(['--json', 'validate', podDir]);
+  const validated = JSON.parse(validateRun.out) as Array<{
+    results: Array<{ severity: string; property: string; message: string }>;
+  }>;
+  const violations = validated
+    .flatMap((f) => f.results)
+    .filter((r) => r.severity === 'violation')
+    .map((r) => ({ property: r.property, message: r.message }));
+
+  // 6. Census
+  const quads = readPodQuads(podDir);
+  const typeOf = new Map<string, string>();
+  for (const q of quads) if (q.predicate === RDF_TYPE) typeOf.set(q.subject, q.object);
+
+  const podRecordsByType: Record<string, number> = {};
+  for (const t of typeOf.values()) {
+    const n = localName(t);
+    podRecordsByType[n] = (podRecordsByType[n] ?? 0) + 1;
+  }
+
+  const mergedFrom = new Map<string, Set<string>>();
+  for (const q of quads) {
+    if (q.predicate !== MERGED_FROM) continue;
+    const set = mergedFrom.get(q.subject) ?? new Set<string>();
+    set.add(q.object);
+    mergedFrom.set(q.subject, set);
+  }
+  const mergeGroups = [...typeOf.keys()].map((s) => [...new Set([s, ...(mergedFrom.get(s) ?? [])])]);
+
+  const importWarnings = importReports.flatMap((r) => r.warnings ?? []);
+
+  const valuesOn = (typeIri: string, predicateIri: string): string[] =>
+    quads
+      .filter((q) => q.predicate === predicateIri && typeOf.get(q.subject) === typeIri)
+      .map((q) => q.object)
+      .sort();
+
+  const observation: ScenarioObservation = {
+    id: scenario.id,
+    convertedRecords,
+    reportedResourceCount,
+    importReports,
+    importWarnings,
+    podRecords: typeOf.size,
+    podRecordsByType,
+    conflicts,
+    violations,
+    values: (predicateIri) =>
+      [...new Set(quads.filter((q) => q.predicate === predicateIri).map((q) => q.object))].sort(),
+    subjectsWith: (predicateIri) =>
+      [...new Set(quads.filter((q) => q.predicate === predicateIri).map((q) => q.subject))].sort(),
+    valuesOn,
+    countMissing: (typeIri, predicateIri) => {
+      const have = new Set(
+        quads.filter((q) => q.predicate === predicateIri).map((q) => q.subject),
+      );
+      return [...typeOf.entries()].filter(([s, t]) => t === typeIri && !have.has(s)).length;
+    },
+  };
+
+  return { observation, reportedResourceCount, iriToSourceId, mergeGroups };
+}
+
+// ---------------------------------------------------------------------------
+// The reconciliation scorecard (report-only)
+// ---------------------------------------------------------------------------
+
+interface Score {
+  /** Records under evaluation, from the scenario's ground truth. */
+  universe: number;
+  /** Pairs the truth says belong together. */
+  truthPairs: number;
+  /** Pairs the reconciler actually put together, within the universe. */
+  predictedPairs: number;
+  /** Predicted pairs that are also truth pairs. */
+  correctPairs: number;
+  precision: number;
+  recall: number;
+}
+
+function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+function pairsOf(group: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < group.length; i++) {
+    for (let j = i + 1; j < group.length; j++) out.push(pairKey(group[i], group[j]));
+  }
+  return out;
+}
+
+function score(scenario: Scenario, run: RunResult): Score {
+  const universe = new Set(scenario.groundTruth!.flat());
+  const truth = new Set(scenario.groundTruth!.flatMap(pairsOf));
+
+  const predicted = new Set<string>();
+  for (const group of run.mergeGroups) {
+    const ids = group
+      .map((iri) => run.iriToSourceId.get(iri))
+      .filter((id): id is string => !!id && universe.has(id));
+    for (const p of pairsOf([...new Set(ids)])) predicted.add(p);
+  }
+
+  const correct = [...predicted].filter((p) => truth.has(p)).length;
+  return {
+    universe: universe.size,
+    truthPairs: truth.size,
+    predictedPairs: predicted.size,
+    correctPairs: correct,
+    // An empty prediction set asserts nothing wrong, so precision is 1 by
+    // convention. Recall is what exposes it, and does.
+    precision: predicted.size === 0 ? 1 : round(correct / predicted.size),
+    recall: truth.size === 0 ? 1 : round(correct / truth.size),
+  };
+}
+
+function round(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+const runs = new Map<string, RunResult>();
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing — run `npm run build` before `npm test`.');
+  }
+  for (const { tier, scenario } of ALL_SCENARIOS) {
+    runs.set(scenario.id, runScenario(tier, scenario));
+  }
+}, 900000);
+
+afterAll(() => {
+  for (const r of tempRoots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+describe('pathology corpus', () => {
+  it('discovers at least the committed authored-synthetic tier', () => {
+    expect(TIERS.map((t) => t.name)).toContain('authored-synthetic');
+  });
+
+  it('gives every scenario across every tier a unique id', () => {
+    const ids = ALL_SCENARIOS.map((s) => s.scenario.id);
+    expect(new Set(ids).size, `duplicate scenario ids: ${ids.join(', ')}`).toBe(ids.length);
+  });
+
+  it('names an existing fixture file for every batch of every scenario', () => {
+    for (const { tier, scenario } of ALL_SCENARIOS) {
+      for (const batch of scenario.batches) {
+        expect(
+          fs.existsSync(path.join(tier.dir, batch.file)),
+          `${scenario.id} names ${batch.file}, which is not in ${tier.dir}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('keeps the known-outcome ledger well formed', () => {
+    assertLedgerIsWellFormed(ALL_SCENARIOS.map((s) => s.scenario.id));
+  });
+});
+
+describe.each(ALL_SCENARIOS)('$scenario.id  $scenario.pathology', ({ scenario }) => {
+  const obs = () => runs.get(scenario.id)!.observation;
+
+  it('converts the expected number of records per batch', () => {
+    expect(obs().convertedRecords).toEqual(scenario.expect.convertedRecords);
+  });
+
+  it('reports the resource count it reports', () => {
+    // Separate from the assertion above ON PURPOSE: for C-CDA the two numbers
+    // disagree, and pinning both is what makes the disagreement visible instead
+    // of a matter of which one a caller happened to read.
+    expect(runs.get(scenario.id)!.reportedResourceCount).toEqual(
+      scenario.expect.reportedResourceCount,
+    );
+  });
+
+  it('leaves the expected record census in the pod', () => {
+    expect(obs().podRecords).toBe(scenario.expect.podRecords);
+    expect(obs().podRecordsByType).toEqual(scenario.expect.podRecordsByType);
+  });
+
+  it('performs the expected number of merges on the final batch', () => {
+    const summary = obs().importReports[obs().importReports.length - 1].reconciliation?.summary;
+    const merges = summary ? summary.exactDuplicatesRemoved + summary.nearDuplicatesMerged : 0;
+    expect(merges).toBe(scenario.expect.merges);
+  });
+
+  it('raises the expected number of unresolved conflicts', () => {
+    expect(obs().conflicts.length).toBe(scenario.expect.conflicts);
+  });
+
+  it('holds the expected number of record-to-record edges', () => {
+    const last = obs().importReports[obs().importReports.length - 1];
+    expect(last.edgeResolution.totalInPod).toBe(scenario.expect.edgesInPod);
+  });
+
+  it('validates with the expected number of violations', () => {
+    expect(
+      obs().violations.length,
+      `violations:\n${obs()
+        .violations.map((v) => `  ${v.property}: ${v.message}`)
+        .join('\n')}`,
+    ).toBe(scenario.expect.violations);
+  });
+
+  it('emits the expected number of import warnings', () => {
+    expect(obs().importWarnings.length, obs().importWarnings.join('\n')).toBe(
+      scenario.expect.importWarnings,
+    );
+  });
+
+  it('matches every known-outcome entry recorded against it', () => {
+    assertKnownOutcomesForScenario(obs());
+  });
+});
+
+describe('reconciliation scorecard (report-only)', () => {
+  it('matches the committed baseline exactly', () => {
+    const scored: Record<string, Score> = {};
+    for (const { scenario } of ALL_SCENARIOS) {
+      if (!scenario.groundTruth) continue;
+      scored[scenario.id] = score(scenario, runs.get(scenario.id)!);
+    }
+
+    const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf-8')) as {
+      scores: Record<string, Score>;
+    };
+
+    // Deliberately NOT an assertion that precision and recall are good. Two of
+    // these recalls are 0 and that is the point: the numbers are recorded so a
+    // change to matching has to move them ON PURPOSE, with the baseline edited
+    // in the same commit as the change that moved it.
+    expect(
+      scored,
+      'The reconciler scored differently than the committed baseline. If the change was\n' +
+        'intended, update tests/pathology-reconciliation-baseline.json in the same commit\n' +
+        'and say in the message which scenario moved and why.',
+    ).toEqual(baseline.scores);
+  });
+
+  it('scores every scenario that carries a ground truth, and only those', () => {
+    const withTruth = ALL_SCENARIOS.filter((s) => s.scenario.groundTruth).map((s) => s.scenario.id);
+    const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf-8')) as {
+      scores: Record<string, Score>;
+    };
+    expect(Object.keys(baseline.scores).sort()).toEqual(withTruth.sort());
+  });
+
+  it('evaluates every ground-truth record id against a record the converter actually produced', () => {
+    // Without this a typo in a ground-truth id silently shrinks the universe and
+    // flatters the score, because an id nothing maps to can never be in a wrong pair.
+    for (const { scenario } of ALL_SCENARIOS) {
+      if (!scenario.groundTruth) continue;
+      const produced = new Set(runs.get(scenario.id)!.iriToSourceId.values());
+      for (const id of scenario.groundTruth.flat()) {
+        expect(produced, `${scenario.id} ground truth names "${id}", which no record carries`).toContain(id);
+      }
+    }
+  });
+});
+
+describe('known-outcome ledger coverage', () => {
+  it('records at least one open defect', () => {
+    // A ledger that emptied itself without anyone noticing would mean either
+    // every defect is fixed (worth a person confirming) or the gate stopped
+    // running (worth a person fixing).
+    expect(KNOWN_OUTCOMES.length).toBeGreaterThan(0);
+  });
+
+  it('evaluated every entry in this run', () => {
+    // Pins the gate CALL, not just the gate. Deleting
+    // `assertKnownOutcomesForScenario` from the per-scenario block leaves every
+    // other test in this file green; it does not leave this one green.
+    assertEveryEntryWasExercised();
+  });
+});

--- a/tests/pathology-known-outcomes.ts
+++ b/tests/pathology-known-outcomes.ts
@@ -1,0 +1,540 @@
+/**
+ * The known-defect ledger for the pathology corpus, and the rule that stops it
+ * becoming a place to hide things.
+ *
+ * WHY A LEDGER AND NOT A LIST OF SKIPS
+ * ------------------------------------
+ * The corpus in `test-fixtures/pathology/` is built out of import pathologies
+ * that real exports contain, so a harness that runs it end to end trips over
+ * defects that are open today. There are two dishonest ways to land such a
+ * harness green: assert the wrong numbers with no comment (which makes the wrong
+ * behaviour look intended), or skip the cases that fail (which makes the corpus
+ * decorative). This file is the third way.
+ *
+ * Each entry names ONE deviation, states what the pipeline does today and what
+ * it must do once fixed, and carries a probe that reads the measurement out of
+ * the scenario's observed run. The gate is two-sided:
+ *
+ *   - the probe returns something OTHER than `current`   -> FAIL. Either a new
+ *     defect appeared, or this one changed shape. Both want a person.
+ *   - the probe returns `fixed`                          -> FAIL, loudly, with
+ *     "this appears to be FIXED". A ledger entry that outlives its defect is
+ *     worse than no ledger, because the next reader trusts it. Removing the
+ *     entry and folding the expectation into the scenario is the intended
+ *     response, and it has to be deliberate.
+ *
+ * So the list cannot silently absorb a new defect and it cannot silently keep a
+ * dead one. It only shrinks on purpose.
+ *
+ * WHAT DOES NOT BELONG HERE
+ * -------------------------
+ * Anything the pipeline already gets right. If a scenario's numbers are correct,
+ * they are asserted in the scenario itself and this file says nothing about it.
+ *
+ * `current` and `fixed` are compared with `toEqual`, so they may be any
+ * JSON-shaped value; they MUST differ from each other, which `assertLedgerIsWellFormed`
+ * enforces — an entry whose two states are the same is a no-op that would pass
+ * forever.
+ */
+
+import { expect } from 'vitest';
+
+/** Everything the harness measured for one scenario, as the probes see it. */
+export interface ScenarioObservation {
+  id: string;
+  /** Typed record subjects the converter actually emitted, one per batch. */
+  convertedRecords: number[];
+  /** `resourceCount` as `cascade convert --json` REPORTED it, one per batch. */
+  reportedResourceCount: number[];
+  /** Parsed `--report` JSON from `cascade pod import`, one per batch. */
+  importReports: ImportReportLite[];
+  /** Every `--report` warning across every batch. */
+  importWarnings: string[];
+  /** Record subjects (those carrying an rdf:type) in clinical/ + wellness/. */
+  podRecords: number;
+  /** Those subjects counted by their type's local name. */
+  podRecordsByType: Record<string, number>;
+  /** `cascade pod conflicts --format json`. */
+  conflicts: Array<{ conflictId: string; recordType: string }>;
+  /** Every `sh:Violation` from `cascade --json validate <pod>`. */
+  violations: Array<{ property: string; message: string }>;
+  /** Object values of one predicate across the pod, deduplicated and sorted. */
+  values(predicateIri: string): string[];
+  /** Subjects carrying `predicateIri` at all. */
+  subjectsWith(predicateIri: string): string[];
+  /** Every object value of `predicateIri` on subjects of `typeIri`, sorted. */
+  valuesOn(typeIri: string, predicateIri: string): string[];
+  /** How many subjects of `typeIri` carry no `predicateIri` at all. */
+  countMissing(typeIri: string, predicateIri: string): number;
+}
+
+export interface ImportReportLite {
+  totalRecordsImported: number;
+  recordsNew: number;
+  recordsAlreadyPresent: number;
+  sourceBreakdown: Record<string, number>;
+  warnings: string[];
+  edgeResolution: { resolved: number; unresolved: number; totalInPod: number };
+  reconciliation?: {
+    enabled: boolean;
+    summary?: {
+      exactDuplicatesRemoved: number;
+      nearDuplicatesMerged: number;
+      conflictsUnresolved: number;
+      identityCollisionsSplit: number;
+      finalRecordCount: number;
+    };
+  };
+  sectionCensus: Array<{ label: string; entriesIn: number; recordsOut: number }>;
+}
+
+export interface KnownOutcome {
+  /** Stable id. Referenced in failure messages; never reused after removal. */
+  id: string;
+  /** The scenario whose observation the probe reads. */
+  scenario: string;
+  /** What the pipeline does today, and why that is wrong. */
+  currentWrongOutcome: string;
+  /** What must be true instead once this is fixed. */
+  expectedOnceFixed: string;
+  probe: (o: ScenarioObservation) => unknown;
+  /** What `probe` returns today. */
+  current: unknown;
+  /** What `probe` must return once fixed. Must differ from `current`. */
+  fixed: unknown;
+}
+
+const NS = {
+  cascade: 'https://ns.cascadeprotocol.org/core/v1#',
+  health: 'https://ns.cascadeprotocol.org/health/v1#',
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+};
+
+/** Total merges the last batch of a scenario performed. */
+function merges(o: ScenarioObservation): number {
+  const s = o.importReports[o.importReports.length - 1]?.reconciliation?.summary;
+  if (!s) return 0;
+  return s.exactDuplicatesRemoved + s.nearDuplicatesMerged;
+}
+
+export const KNOWN_OUTCOMES: KnownOutcome[] = [
+  {
+    id: 'P01-one-system-two-source-labels',
+    scenario: 'P01',
+    currentWrongOutcome:
+      'One health system occupies two rows on the pod source axis. The FHIR path derives ' +
+      'clinical:sourceEHR from the registrable domain of the first absolute reference URL ' +
+      '("meridianhealth.example"); the C-CDA path derives it from the custodian organization ' +
+      'name ("Meridian Health System"). Both are defensible readings of their own document and ' +
+      'neither knows about the other, so a patient who downloaded both transports from one ' +
+      'system sees two sources.',
+    expectedOnceFixed:
+      'One system yields ONE label. Which label wins (organization name, endpoint domain, or a ' +
+      'user-visible alias resolved from both) is the open design question; the invariant the ' +
+      'harness holds is that the count of distinct labels for one system is 1, whichever is chosen.',
+    probe: (o) => ({ distinctSourceEhrLabels: o.values(NS.clinical + 'sourceEHR').length }),
+    current: { distinctSourceEhrLabels: 2 },
+    fixed: { distinctSourceEhrLabels: 1 },
+  },
+  {
+    id: 'P02-duplicate-source-id-collision-undetected',
+    scenario: 'P02',
+    currentWrongOutcome:
+      'Three lab observations that share one root-only <id> mint one subject IRI, and because ' +
+      'they are one subject inside a single converted document there is no second record for the ' +
+      'reconciler to compare: splitIdentityCollisions only ever sees ONE parsed record. So the ' +
+      'three results pile onto one subject as multi-valued testCode/testName/resultValue, the pod ' +
+      'holds 2 lab records where the document stated 4, `pod conflicts` reports nothing, and the ' +
+      'only trace is two SHACL maxCount violations that name the symptom rather than the cause.',
+    expectedOnceFixed:
+      'The four observations become four lab records with zero violations, either by minting ' +
+      'distinct IRIs when a shared id is contradicted by the entry content, or by raising the ' +
+      'collision as a conflict the way the reconciler already does for records that arrive ' +
+      'separately. The failure mode to avoid is a fix that silences the SHACL violations without ' +
+      'recovering the two lost results.',
+    probe: (o) => ({
+      labRecords: o.podRecordsByType['LabResultRecord'] ?? 0,
+      conflicts: o.conflicts.length,
+      violations: o.violations.length,
+    }),
+    current: { labRecords: 2, conflicts: 0, violations: 2 },
+    fixed: { labRecords: 4, conflicts: 0, violations: 0 },
+  },
+  {
+    id: 'P03-dangling-narrative-reference-is-silent',
+    scenario: 'P03',
+    currentWrongOutcome:
+      'An <originalText><reference value="#id"/> pointing at an element the narrative does not ' +
+      'contain resolves to nothing, the record imports with no testName, and the import reports ' +
+      'no warning. In the pod it is byte-indistinguishable from the observation that carried no ' +
+      'name anywhere, so "the rendering we were given was incomplete" and "this test was never ' +
+      'named" arrive as the same absence.',
+    expectedOnceFixed:
+      'The record still gains NO name — inventing one from the LOINC code would be fabricating ' +
+      'the attested rendering — but the import emits one warning naming the unresolved reference, ' +
+      'so the two absences are told apart at the point where the information still exists.',
+    probe: (o) => ({
+      importWarnings: o.importWarnings.length,
+      labsWithoutTestName: o.countMissing(NS.health + 'LabResultRecord', NS.health + 'testName'),
+    }),
+    current: { importWarnings: 0, labsWithoutTestName: 2 },
+    fixed: { importWarnings: 1, labsWithoutTestName: 2 },
+  },
+  {
+    id: 'P04-procedure-name-written-off-shape',
+    scenario: 'P04',
+    currentWrongOutcome:
+      'The C-CDA procedures handler writes the procedure name to health:procedureName, which no ' +
+      'shape targeting clinical:Procedure declares, while clinical:ProcedureShape requires ' +
+      'clinical:procedureName. So the record CARRIES a name, validates as though it had none, and ' +
+      'the name it carries is validated by nothing.',
+    expectedOnceFixed:
+      'The name lands on clinical:procedureName and the violation goes away. Moving it is a data ' +
+      'change for every consumer already querying health:procedureName, which is why it wants its ' +
+      'own change with its own note about what to re-query.',
+    probe: (o) => ({
+      violations: o.violations.filter((v) => v.property === 'procedureName').length,
+      onHealth: o.valuesOn(NS.clinical + 'Procedure', NS.health + 'procedureName'),
+      onClinical: o.valuesOn(NS.clinical + 'Procedure', NS.clinical + 'procedureName'),
+    }),
+    current: { violations: 1, onHealth: ['Colonoscopy'], onClinical: [] },
+    fixed: { violations: 0, onHealth: [], onClinical: ['Colonoscopy'] },
+  },
+  {
+    id: 'P04-lab-report-date-promoted-to-midnight',
+    scenario: 'P04',
+    currentWrongOutcome:
+      'The lab ORGANIZER states a day ("20250703"), and the LaboratoryReport it becomes carries ' +
+      'clinical:documentDate "2025-07-03T00:00:00Z"^^xsd:dateTime — a midnight, in UTC, that the ' +
+      'document never gave. This is precisely the fabrication the observation-level date rule ' +
+      'refuses to make: the sibling lab records from the same organizer correctly carry ' +
+      '"2025-07-03"^^xsd:date. Two date paths, one document, opposite answers.',
+    expectedOnceFixed:
+      'The report date states the precision the source stated: "2025-07-03"^^xsd:date, through the ' +
+      'same typed-date helper the observation path uses. A fabricated 00:00 is indistinguishable ' +
+      'downstream from a real midnight draw, so promoting is not a harmless normalization.',
+    probe: (o) => ({
+      reportDates: o.valuesOn(NS.clinical + 'LaboratoryReport', NS.clinical + 'documentDate'),
+      observationDates: o.valuesOn(NS.health + 'LabResultRecord', NS.health + 'performedDate'),
+    }),
+    current: {
+      reportDates: ['2025-07-03T00:00:00Z'],
+      observationDates: ['2025-07-03', '2025-07-03T14:22:15-04:00'],
+    },
+    fixed: {
+      reportDates: ['2025-07-03'],
+      observationDates: ['2025-07-03', '2025-07-03T14:22:15-04:00'],
+    },
+  },
+  {
+    id: 'P05-unmapped-interpretation-collapses-onto-absent',
+    scenario: 'P05',
+    currentWrongOutcome:
+      'An Observation.interpretation code outside the set health:interpretation accepts is written ' +
+      'as "unknown" — the SAME value that means "the source carried no interpretation at all". The ' +
+      'import does warn, but a warning is transient and the pod is what survives, so two different ' +
+      'facts are stored as one string.',
+    expectedOnceFixed:
+      'The pod distinguishes "the source stated an interpretation this vocabulary cannot express" ' +
+      'from "the source stated none", so exactly ONE record in this scenario reads as absent. The ' +
+      'import warning stays either way; it is the pod that has to stop losing the distinction.',
+    probe: (o) => ({
+      unknownInterpretations: o
+        .valuesOn(NS.health + 'LabResultRecord', NS.health + 'interpretation')
+        .filter((v) => v === 'unknown').length,
+      warnings: o.importWarnings.filter((w) => w.includes('ZQ7')).length,
+    }),
+    current: { unknownInterpretations: 2, warnings: 1 },
+    fixed: { unknownInterpretations: 1, warnings: 1 },
+  },
+  {
+    id: 'P05-multi-category-observation-keeps-one-category',
+    scenario: 'P05',
+    currentWrongOutcome:
+      'An Observation categorised BOTH laboratory and procedure records health:labCategory ' +
+      '"procedure" only: the last category wins and the category that DECIDED the routing is the ' +
+      'one dropped. A pod filtered by labCategory therefore omits a record that is filed as a lab.',
+    expectedOnceFixed:
+      'Every category the source stated is carried, so the record is findable under the category it ' +
+      'was routed by as well as the one it also claims.',
+    probe: (o) => o.valuesOn(NS.health + 'LabResultRecord', NS.health + 'labCategory'),
+    current: ['procedure'],
+    fixed: ['laboratory', 'procedure'],
+  },
+  {
+    id: 'P05-records-without-a-derivable-ehr-leave-the-source-axis',
+    scenario: 'P05',
+    currentWrongOutcome:
+      'A bundle whose references are all urn:uuid: gives the provenance pass no host to read and no ' +
+      'institution-looking display, so no clinical:sourceEHR is written at all and the import ' +
+      "report's sourceBreakdown is empty. Eight records were imported and the source axis accounts " +
+      'for none of them, which reads as "this pod has no data" rather than "we could not tell where ' +
+      'this came from". The ClinicalDocument path already solves this with the ratified ' +
+      'data-absent token.',
+    expectedOnceFixed:
+      'Every imported record appears in sourceBreakdown, with the ratified "unknown" token where the ' +
+      'EHR of origin genuinely cannot be determined — never the import-batch label, which is how the ' +
+      'data got in rather than where it came from.',
+    probe: (o) => ({
+      imported: o.importReports[0].totalRecordsImported,
+      accountedFor: Object.values(o.importReports[0].sourceBreakdown).reduce((a, b) => a + b, 0),
+    }),
+    current: { imported: 8, accountedFor: 0 },
+    fixed: { imported: 8, accountedFor: 8 },
+  },
+  {
+    id: 'P07-shared-transport-label-blocks-cross-source-dedup',
+    scenario: 'P07-SHARED-LABEL',
+    currentWrongOutcome:
+      'The guard that stops two records from the same source being compared keys on ' +
+      'cascade:sourceSystem — the IMPORT-BATCH label, set by --source-system. Give two different ' +
+      "health systems' exports one batch label (the Apple Health shape, where one export carries " +
+      'several connected accounts) and the guard suppresses every cross-source comparison: none of ' +
+      'the four byte-identical duplicates merges, and the pod ends up holding two patient profiles ' +
+      'and twelve records where the same data under distinct labels yields seven.',
+    expectedOnceFixed:
+      'The guard keys on the CLINICAL source (clinical:sourceEHR, or an explicit per-record source ' +
+      'identity), not on how the records were transported, so the shared-label run reconciles ' +
+      'identically to the distinct-label run: 7 records, 5 merges.',
+    probe: (o) => ({ podRecords: o.podRecords, merges: merges(o) }),
+    current: { podRecords: 12, merges: 0 },
+    fixed: { podRecords: 7, merges: 5 },
+  },
+  {
+    id: 'P08-vital-matcher-reads-predicates-the-converter-never-writes',
+    scenario: 'P08',
+    currentWrongOutcome:
+      'matchVitalSigns reads health:testCode, health:effectiveDate / health:performedDate and ' +
+      'health:value. The converter writes clinical:loincCode, clinical:effectiveDate and ' +
+      'clinical:value. All three lookups return undefined, the date guard fails, and the function ' +
+      'returns no-match for EVERY pair — so no two vital signs in any pod have ever matched. The ' +
+      '"three same-day readings must never merge" property holds here for the wrong reason, and ' +
+      'the price is the clock-skew duplicate 17 minutes later, which is the same cuff reading and ' +
+      'is kept as a second record.',
+    expectedOnceFixed:
+      'The matcher reads the predicates the converter emits. The clock-skew pair (systolic and ' +
+      'diastolic) merges and nothing else does, leaving 6 vital records. Restoring the matcher ' +
+      'without a time-proximity rule would instead merge all four same-day readings, which is why ' +
+      'this scenario carries three readings hours apart rather than one.',
+    probe: (o) => ({ vitalRecords: o.podRecordsByType['VitalSign'] ?? 0, merges: merges(o) }),
+    current: { vitalRecords: 8, merges: 1 },
+    fixed: { vitalRecords: 6, merges: 3 },
+  },
+  {
+    id: 'P09-medicationrequest-dose-is-dropped-then-silently-merged',
+    scenario: 'P09',
+    currentWrongOutcome:
+      'The medication converter reads dose text from resource.dosage (the MedicationStatement ' +
+      'field) and never from resource.dosageInstruction (the MedicationRequest field). So ' +
+      'sertraline 50 mg and sertraline 100 mg arrive carrying no dose, the dose-conflict check ' +
+      'compares two absent values, finds no disagreement, and merges them into ONE record with no ' +
+      'conflict raised — a dose change silently disappears. The levothyroxine pair, the same ' +
+      'disagreement expressed as MedicationStatement, does raise its conflict, so the outcome ' +
+      'depends on which FHIR shape the source used.',
+    expectedOnceFixed:
+      'dosageInstruction is read the way dosage is, both pairs carry their dose, and both raise a ' +
+      'dose conflict: 4 unresolved conflicts, and 2 medication records carrying clinical:dosage.',
+    probe: (o) => ({
+      conflicts: o.conflicts.length,
+      medsCarryingDosage: o.subjectsWith(NS.clinical + 'dosage').length,
+    }),
+    current: { conflicts: 3, medsCarryingDosage: 1 },
+    fixed: { conflicts: 4, medsCarryingDosage: 2 },
+  },
+  {
+    id: 'P10-negation-and-data-absent-sentinels-stored-as-allergens',
+    scenario: 'P10',
+    currentWrongOutcome:
+      'A "No Known Allergies" assertion (SNOMED 716186003, a statement ABOUT the list) and a ' +
+      'code-less entry (a data-absent marker) both become health:AllergyRecord with an ' +
+      'health:allergen string, shape-identical to the penicillin allergy beside them. A list view ' +
+      'renders the patient as allergic to "No Known Allergies" and to "Unknown Allergen".',
+    expectedOnceFixed:
+      'Only substances the patient is actually allergic to appear as allergens. The negation is ' +
+      'carried as an assertion about the list (which is what makes "we asked and the answer was ' +
+      'none" different from "nobody asked"), and the data-absent entry is marked as such rather ' +
+      'than given a placeholder substance name.',
+    probe: (o) => o.valuesOn(NS.health + 'AllergyRecord', NS.health + 'allergen'),
+    current: ['Ibuprofen', 'No Known Allergies', 'Penicillin G', 'Unknown Allergen'],
+    fixed: ['Ibuprofen', 'Penicillin G'],
+  },
+  {
+    id: 'P11-panel-name-variants-are-never-reconciled',
+    scenario: 'P11',
+    currentWrongOutcome:
+      'clinical:LaboratoryReport is not a reconcilable type, so it passes through untouched. One ' +
+      'lipid draw reported three times under three display names stays three reports, each ' +
+      'carrying the same four hasLabResult edges: 3 reports, 12 edges into 4 results. The results ' +
+      'themselves are correctly stored once, which is what makes the duplication visible — the ' +
+      'edges fan in.',
+    expectedOnceFixed:
+      'The three reports reconcile to one (same LOINC, same performed instant, identical result ' +
+      'set), leaving 1 report and 4 edges. The display names are evidence for the match, not the ' +
+      'match key: "Final result" is a status word appended by a delivery system and normalizing it ' +
+      'away is not the same as normalizing "Profile" to "Panel".',
+    probe: (o) => ({
+      reports: o.podRecordsByType['LaboratoryReport'] ?? 0,
+      edges: o.importReports[0].edgeResolution.totalInPod,
+    }),
+    current: { reports: 3, edges: 12 },
+    fixed: { reports: 1, edges: 4 },
+  },
+  {
+    id: 'P12-malformed-nine-digit-date-accepted-silently',
+    scenario: 'P12',
+    currentWrongOutcome:
+      'effectiveTime="201102013" is nine digits: neither the 8-digit calendar day nor the 10-digit ' +
+      'hour precision, so the value is malformed past the day. The date rule takes the first eight ' +
+      'digits and emits "2011-02-01"^^xsd:date with no warning, which states a calendar day with ' +
+      'full confidence on the strength of a value the source got wrong. The guess is a REASONABLE ' +
+      'one — the defect is that it is indistinguishable from a well-formed day.',
+    expectedOnceFixed:
+      'The day is still emitted (throwing the record\'s date away over a stray digit would lose more ' +
+      'than it saves), but the import warns that the source value was malformed, so a reader can ' +
+      'tell a stated date from a salvaged one.',
+    probe: (o) => ({
+      malformedDateWarnings: o.importWarnings.filter((w) => w.includes('201102013')).length,
+      dates: o
+        .valuesOn(NS.health + 'LabResultRecord', NS.health + 'performedDate')
+        .filter((d) => d.startsWith('2011')),
+    }),
+    current: { malformedDateWarnings: 0, dates: ['2011-02-01', '2011-02-01', '2011-02-01', '2011-02-01'] },
+    fixed: { malformedDateWarnings: 1, dates: ['2011-02-01', '2011-02-01', '2011-02-01', '2011-02-01'] },
+  },
+  {
+    id: 'P12-nullflavor-variety-collapses-to-one-absence',
+    scenario: 'P12',
+    currentWrongOutcome:
+      'UNK ("unknown"), NAV ("temporarily unavailable") and ASKU ("asked but unknown") are three ' +
+      'different statements about WHY a value is missing, and HL7 v3 separates them deliberately: ' +
+      'the third one means somebody asked the patient. All three produce a lab record with no ' +
+      'health:resultValue and nothing else, so the three become one indistinguishable blank and the ' +
+      'reason the source took the trouble to state is discarded.',
+    expectedOnceFixed:
+      'The nullFlavor is carried, so "we never measured it", "the result is coming" and "we asked ' +
+      'and were not told" stay three different answers. The records still carry no resultValue — ' +
+      'inventing one is not the fix.',
+    probe: (o) => ({
+      labsWithoutValue: o.countMissing(NS.health + 'LabResultRecord', NS.health + 'resultValue'),
+      dataAbsentReasons: o.values(NS.health + 'dataAbsentReason').length,
+    }),
+    current: { labsWithoutValue: 3, dataAbsentReasons: 0 },
+    fixed: { labsWithoutValue: 3, dataAbsentReasons: 3 },
+  },
+  {
+    id: 'P12-nullflavor-empty-section-queued-for-extraction',
+    scenario: 'P12',
+    currentWrongOutcome:
+      'An Allergies section carrying nullFlavor="NI" and no entries becomes a ClinicalDocument ' +
+      'narrative record with cascade:requiresLLMExtraction true. The section has already said, in ' +
+      'the ratified way, that it holds no information; queueing it for extraction offers a model ' +
+      'the sentence "No information available." and asks what allergies it contains.',
+    expectedOnceFixed:
+      'A section whose nullFlavor says there is no information is not queued for extraction. ' +
+      'Whether it should produce a record at all (an explicit "this section was empty" is more than ' +
+      'the pod knows otherwise) is the open question; not asking a model to read it is not.',
+    probe: (o) => o.valuesOn(NS.clinical + 'ClinicalDocument', NS.cascade + 'requiresLLMExtraction'),
+    current: ['false', 'false', 'true'],
+    fixed: ['false', 'false', 'false'],
+  },
+  {
+    id: 'P12-ccda-convert-under-reports-what-it-produced',
+    scenario: 'P12',
+    currentWrongOutcome:
+      '`cascade convert --json --from c-cda` reports resourceCount 2 for a document from which it ' +
+      'emits 8 record subjects, because the C-CDA importer counts documents-and-sections where the ' +
+      'FHIR importer counts records. A caller reading resourceCount to decide whether an import is ' +
+      'worth running, or to show "N records found", is told a number four times too small, and the ' +
+      'two importers disagree about what the field means.',
+    expectedOnceFixed:
+      'resourceCount means the same thing for every importer: the number of records the conversion ' +
+      'produced. For this document that is 8 and 5.',
+    probe: (o) => ({ reported: o.reportedResourceCount, produced: o.convertedRecords }),
+    current: { reported: [2, 2], produced: [8, 5] },
+    fixed: { reported: [8, 5], produced: [8, 5] },
+  },
+];
+
+/**
+ * Structural checks on the ledger itself, run as a test.
+ *
+ * The `current` / `fixed` inequality is the load-bearing one: an entry whose two
+ * states are equal can never fail in either direction, so it would sit here
+ * forever asserting nothing.
+ */
+export function assertLedgerIsWellFormed(scenarioIds: string[]): void {
+  const ids = KNOWN_OUTCOMES.map((k) => k.id);
+  expect(new Set(ids).size, `duplicate KNOWN_OUTCOMES ids: ${ids.join(', ')}`).toBe(ids.length);
+
+  for (const k of KNOWN_OUTCOMES) {
+    expect(
+      scenarioIds,
+      `KNOWN_OUTCOMES entry "${k.id}" names scenario "${k.scenario}", which is not in the corpus`,
+    ).toContain(k.scenario);
+    expect(
+      JSON.stringify(k.current),
+      `KNOWN_OUTCOMES entry "${k.id}" has current === fixed, so it can never fail and asserts nothing`,
+    ).not.toBe(JSON.stringify(k.fixed));
+    expect(k.currentWrongOutcome.length, `"${k.id}" must say what is wrong today`).toBeGreaterThan(40);
+    expect(k.expectedOnceFixed.length, `"${k.id}" must say what must be true once fixed`).toBeGreaterThan(40);
+  }
+}
+
+/**
+ * Ids the gate has actually evaluated this run.
+ *
+ * Without this the gate itself is unpinned: delete the
+ * `assertKnownOutcomesForScenario` call from the harness and every entry in this
+ * file stops being checked while the suite stays green, which is the exact
+ * failure mode a ledger is supposed to prevent. `assertEveryEntryWasExercised`
+ * turns that deletion into a red test.
+ */
+const exercised = new Set<string>();
+
+/** Fails if any ledger entry was never evaluated. Run after all scenarios. */
+export function assertEveryEntryWasExercised(): void {
+  const missed = KNOWN_OUTCOMES.filter((k) => !exercised.has(k.id)).map((k) => k.id);
+  expect(
+    missed,
+    `these KNOWN_OUTCOMES entries were never evaluated, so nothing in this run held them:\n` +
+      `  ${missed.join('\n  ')}\n` +
+      `Either their scenario is missing from the corpus, or the gate is no longer being called.`,
+  ).toEqual([]);
+}
+
+/**
+ * The gate. Run once per scenario, over the entries that name it.
+ *
+ * Both directions fail. That is the entire point: a ledger that only caught
+ * regressions would let a fix rot the documentation, and a ledger that only
+ * caught fixes would let a new defect hide behind an existing entry.
+ */
+export function assertKnownOutcomesForScenario(o: ScenarioObservation): void {
+  for (const k of KNOWN_OUTCOMES.filter((e) => e.scenario === o.id)) {
+    exercised.add(k.id);
+    const actual = k.probe(o);
+    const actualJson = JSON.stringify(actual);
+
+    if (actualJson === JSON.stringify(k.fixed)) {
+      throw new Error(
+        `KNOWN_OUTCOMES "${k.id}" appears to be FIXED.\n\n` +
+          `  Observed: ${actualJson}\n` +
+          `  which is the entry's declared post-fix outcome.\n\n` +
+          `  Remove the entry from tests/pathology-known-outcomes.ts and fold the corrected\n` +
+          `  expectation into scenario ${k.scenario}. The ledger is allowed to shrink; it is not\n` +
+          `  allowed to shrink by accident.\n\n` +
+          `  What it recorded: ${k.expectedOnceFixed}`,
+      );
+    }
+
+    expect(
+      actual,
+      `KNOWN_OUTCOMES "${k.id}" (scenario ${k.scenario}) deviated from the recorded behaviour.\n` +
+        `  Recorded today: ${JSON.stringify(k.current)}\n` +
+        `  Observed now:   ${actualJson}\n` +
+        `  Neither matches the declared post-fix outcome ${JSON.stringify(k.fixed)}, so this is a\n` +
+        `  NEW deviation, not a fix. What the entry documents:\n` +
+        `  ${k.currentWrongOutcome}`,
+    ).toEqual(k.current);
+  }
+}

--- a/tests/pathology-reconciliation-baseline.json
+++ b/tests/pathology-reconciliation-baseline.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Baseline reconciliation scorecard for the pathology-corpus scenarios that carry a constructed ground truth. REPORT-ONLY: nothing here asserts these numbers are good, and two of the recalls are 0. The harness asserts they are KNOWN, so a change to matching has to move this file on purpose, in the same commit as the change that moved it. Scored over merge PAIRS: precision = correctPairs / predictedPairs (1 when the reconciler predicted nothing, since predicting nothing asserts nothing wrong), recall = correctPairs / truthPairs.",
+  "scores": {
+    "P07": {
+      "universe": 10,
+      "truthPairs": 4,
+      "predictedPairs": 4,
+      "correctPairs": 4,
+      "precision": 1,
+      "recall": 1
+    },
+    "P07-SHARED-LABEL": {
+      "universe": 10,
+      "truthPairs": 4,
+      "predictedPairs": 0,
+      "correctPairs": 0,
+      "precision": 1,
+      "recall": 0
+    },
+    "P08": {
+      "universe": 8,
+      "truthPairs": 2,
+      "predictedPairs": 0,
+      "correctPairs": 0,
+      "precision": 1,
+      "recall": 0
+    }
+  }
+}


### PR DESCRIPTION
A regression corpus of real-world import pathologies, and the end-to-end harness that runs it. Standing instrument, so import and reconciliation can be worked on iteratively without needing a real chart in the room.

No converter or reconciler behaviour changes here. `src/` is untouched. The harness documents what the pipeline does today; fixes come separately.

## The corpus

`test-fixtures/pathology/`, 19 fixture files across 13 scenarios. Every fixture is 100% synthetic: invented people, organizations, endpoints, identifiers, dates and values. What is reproduced is the SHAPE of a phenomenon that appears in real exports, never the content of any document. Nothing is vendored from any external corpus.

| Scenario | Pathology |
|---|---|
| P01 | Dual-label split: one health system under two `clinical:sourceEHR` labels, because the FHIR path reads an endpoint domain and the C-CDA path reads a custodian name |
| P02 | One root-only `<id>` reused across three distinct lab observations |
| P03 | Narrative-only test names, including one dangling reference and one test named nowhere |
| P04 | Date precision: day, second-with-offset, and a month that has no honest typed literal |
| P05 | HL7 interpretation codes H / S / POS / one outside the accepted set / none; multi-category observations |
| P06 | Indication absence: `reasonReference`, resolvable `reasonCode`, unresolvable `reasonCode`, and neither |
| P07 | Cross-source exact lab duplicates across two import batches |
| P07-SHARED-LABEL | The same two exports under ONE `--source-system` label |
| P08 | Three same-source readings hours apart that must never merge, plus a clock-skew duplicate from a second source 17 minutes later |
| P09 | Medication chains: dose supersession, stale-active, and one dose disagreement asked through two FHIR shapes |
| P10 | Allergy sentinels: a real allergen, a No Known Allergies negation, an Unknown Allergen data-absent marker |
| P11 | One lipid draw reported three times under three display names, over shared results |
| P12 | Vendor-shipped defects: an unsubstituted template placeholder as document id, a malformed 9-digit date, an empty `nullFlavor` section, `nullFlavor` variety on values |

## The harness

`tests/pathology-corpus.test.ts` runs each scenario through the commands a person actually runs: `cascade convert`, `pod init`, `pod import --reconcile-existing` once per batch, `pod conflicts`, `cascade validate`, then a record and edge census. It pins records in, records out per type, merges, conflicts, edges, violations and warnings.

Fixture tiers are directory-discovered: a tier is any directory containing a `scenarios.json` manifest, so a further corpus arrives as a sibling directory and needs no change to the harness. Tiers that must not be committed are passed as absolute paths in `CASCADE_PATHOLOGY_TIERS`.

## Two gates

**Known-outcome ledger** (`tests/pathology-known-outcomes.ts`, 17 entries) is a ratchet, not a filter. Each entry records what the pipeline does today AND what must be true once fixed, and the gate fails in both directions: a new deviation fails, and a silently corrected one fails too, with a message saying so. The ledger can only shrink deliberately. A separate test asserts every entry was actually evaluated, so deleting the gate call is red rather than green.

**Reconciliation scorecard** (`tests/pathology-reconciliation-baseline.json`) is report-only. For the three scenarios carrying a constructed truth about which records denote the same clinical event, precision and recall are measured over merge pairs and compared to a committed baseline. Nothing asserts the numbers are good. Two of the recalls are 0. The gate asserts they are KNOWN, so a change to matching has to move the baseline on purpose.

| Scenario | universe | truth pairs | predicted | correct | precision | recall |
|---|---|---|---|---|---|---|
| P07 | 10 | 4 | 4 | 4 | 1.0 | 1.0 |
| P07-SHARED-LABEL | 10 | 4 | 0 | 0 | 1.0 | 0.0 |
| P08 | 8 | 2 | 0 | 0 | 1.0 | 0.0 |

## Verification

Full suite, JSON reporter, after `npm run build`: 2109 tests across 636 suites, 2109 passed, 0 failed, 0 skipped, 0 pending. 126 of those tests are new.

Mutation-checked in 8 places, each applied with a confirmed non-empty diff, built, run against the FULL suite, and reverted:

| Mutation | Result |
|---|---|
| Ledger `current` moved to a third value | RED, per-scenario gate |
| Ledger `current` set to the declared post-fix outcome | RED, "appears to be FIXED" plus well-formedness |
| Ledger entry whose two states are identical | RED, well-formedness |
| Gate call deleted from the per-scenario block | RED, ledger-coverage test |
| A scenario expectation edited | RED, violations assertion |
| Scorecard baseline edited | RED, baseline drift gate |
| A batch naming a fixture that is not present | RED, suite-level failure in setup |
| The P02 pathology removed from the fixture itself | RED, 5 assertions |

Note on the last two: when a fixture is missing, setup throws and all 126 tests report as `pending`, not `failed`. A skip audit that reads the aggregate `numPendingTests` misses it; the audit above counts per assertion.

Lint is unchanged: the repo's 12 pre-existing `eslint src/` errors are untouched, and this branch modifies no file under `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
