### PR TITLE
fix(cli): read the predicates the converters write, and report what the import actually did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,116 @@ Tiers that must not be committed are passed as absolute paths in `CASCADE_PATHOL
 Two gates run over the result. `tests/pathology-known-outcomes.ts` is a known-defect ledger built as
 a ratchet rather than a filter: each entry records what the pipeline does today AND what it must do
 once fixed, and the gate fails in both directions, so a new deviation is caught and a silently
-corrected one is caught too. The ledger can only shrink deliberately. It currently carries seventeen
-entries. `tests/pathology-reconciliation-baseline.json` is a report-only scorecard: for the
+corrected one is caught too. The ledger can only shrink deliberately. It carried seventeen entries
+when it landed and carries eight now; the nine that were retired are the subject of the Fixed
+section below. `tests/pathology-reconciliation-baseline.json` is a report-only scorecard: for the
 scenarios that carry a constructed ground truth about which records denote the same clinical event,
 the harness measures the reconciler's precision and recall over merge pairs and compares them to a
-committed baseline. It does not assert the numbers are good — two of the recalls are 0. It asserts
-they are known, so a change to matching has to move the baseline on purpose.
+committed baseline. It does not assert the numbers are good — one of the recalls is still 0. It
+asserts they are known, so a change to matching has to move the baseline on purpose.
 
 No converter or reconciler behaviour changes in this entry. The harness documents; fixes come
 separately.
+
+**A slot in the fixture manifest for the values a scenario expects, not only the counts.** A
+scenario's `expect` block may now carry `values` (per-predicate object values on subjects of a named
+class) and `sourceBreakdown`. Retiring a ledger entry has to MOVE its expectation into the scenario
+rather than delete it, and several of the retired entries were about one predicate's values, which a
+record census cannot check. Without somewhere to put them, "the ledger is allowed to shrink" would
+quietly have meant "the pin is allowed to disappear". The harness also now asserts, for every
+scenario and every batch, that `sourceBreakdown` accounts for every record the batch imported.
+
+### Fixed
+
+**A prescription's dose was read from a field MedicationRequest does not have, and the loss was
+silent in both directions.** FHIR R4 gives `MedicationStatement` a `dosage` array and
+`MedicationRequest` a `dosageInstruction` array; they are the same `Dosage` datatype under two field
+names. The converter read `resource.dosage` only, so every prescription reached the pod with no
+dose. Dose is deliberately not part of the medication identity key, so two doses of one drug match
+as one drug and it is the dose-disagreement check that is supposed to raise the difference for a
+person to answer. With both doses absent, that check compared two undefineds, found no disagreement,
+and merged a dose change away as a near-duplicate, with no conflict and no warning — while the
+identical change expressed as a `MedicationStatement` raised its conflict correctly. Which of two
+ordinary FHIR shapes the source used decided whether a dose change survived the import.
+
+**`pod import --reconcile-existing` never took the cross-batch path.** `loadExistingPodData` labelled
+its inputs `existing-pod`, but that label is only the DEFAULT source system for records that state
+none, and every record a pod holds states one (the reconciler re-states `cascade:sourceSystem` on
+every write). So the `hasExistingPod` test was permanently false and every import fell through to
+the single-batch branch. The marker is now carried on the input itself (`ReconcilerInput.existingPod`)
+rather than inferred from a label a record can overwrite. A new record whose subject IRI the pod
+already holds is now dropped in favour of the stored copy, so a re-import does not re-stamp
+`clinical:importedAt` or re-resolve edges that were already resolved.
+
+**Four matcher defects, each a lookup of a predicate no converter writes.** None of them could
+produce a wrong record, which is why a green suite held all four: a matcher that never fires produces
+no output, and "these two did not merge" reads the same as "there was nothing to merge".
+
+- `matchVitalSigns` read `health:testCode`, `health:effectiveDate` and `health:value`. Both
+  converters write `clinical:loincCode`, `clinical:effectiveDate` and `clinical:value`, so every
+  lookup returned undefined and no two vital signs in any pod had ever matched. It now reads the
+  predicates that are written, and matches on a THIRTY-MINUTE window rather than a calendar day: a
+  vital sign is an instant, so a day-wide rule merges a morning and an evening blood pressure while a
+  zero-width one keeps one cuff reading forwarded to a second system seventeen minutes later as two
+  records. A disagreement beyond the value tolerance inside the window is two measurements, and both
+  are kept.
+- `matchImmunizations` read `health:cvxCode`, which only the C-CDA importer writes; the FHIR importer
+  writes `health:vaccineCode` carrying `CVX-<code>`. Both spellings are now read and normalized, so a
+  C-CDA immunization and a FHIR one for the same shot can compare at all. The name tier is unchanged.
+- `codeFromUri` was `uri.split('/').pop() ?? uri.split('#').pop()`, whose second operand is
+  unreachable because the first is always truthy. Every LOINC URI this repo mints
+  (`http://loinc.org/rdf#3094-0`) came back as `rdf#3094-0`, so a FHIR lab never matched the same lab
+  from a C-CDA (`http://loinc.org/3094-0`), and the mangled form was interpolated into the conflict
+  ids persisted in `settings/pending-conflicts.ttl`. It now delegates to `extractCodeValue`, the
+  definition shared with the SDK.
+- `matchMedications` reported the bare constant `partial-name` for a containment match, and
+  `generateConflictId` builds the stored id out of that string, so every partial-name medication
+  conflict in a pod shared ONE id. `settings/user-resolutions.ttl` is keyed by conflict id and cannot
+  hold two rows under one key, and `pod resolve` removes every pending conflict whose id matches, so
+  answering one question overwrote the record of another and cleared the rest of the queue
+  unanswered. The id now names the drug.
+
+Conflict ids written by an earlier version are read, not orphaned: `legacyConflictIds` reproduces the
+pre-fix id for both changed shapes, and `findUserResolution` looks up the current id first and falls
+back to the older spelling. New decisions are always recorded under the new id, so a pod converges as
+its conflicts are answered. `settings/pending-conflicts.ttl` needs nothing, since every import
+rewrites it wholesale.
+
+**Six places a converter stated something the source had not.**
+
+- A malformed `effectiveTime` past the calendar day (`201102013`) was salvaged down to its first
+  eight digits and the day was then emitted as though the source had stated it, with no warning. The
+  day is still emitted; the import now says it was salvaged and names the value.
+- A C-CDA section carrying a `nullFlavor` was queued for LLM extraction. The section had already
+  said, in the ratified way, that it holds no information; queueing it offers a model the sentence
+  "No information available." and asks what allergies it contains. Sections that made no such
+  statement are still queued.
+- A narrative `<reference>` pointing at an ID the section does not declare resolved to nothing in
+  silence, so in the pod it was byte-indistinguishable from a record that was never named anywhere.
+  The record still gains no name; the import now warns, naming the unresolved reference.
+- `cascade convert --json --from c-cda` reported `resourceCount` as documents-and-sections while the
+  FHIR importer reported records, so one field meant two things depending on `--from`. A C-CDA
+  `<entry>` routinely wraps an organizer holding several observations, so a document producing eight
+  records reported two. It now reports the records the conversion produced.
+- The import report's `sourceBreakdown` omitted every record whose EHR of origin could not be
+  determined, so a FHIR bundle with only `urn:uuid:` references imported eight records and accounted
+  for none of them, which reads as "this pod has no data" rather than "we could not tell where this
+  came from". Unattributed records are now counted under the ratified `unknown` data-absent token,
+  the same one the C-CDA path already writes. This is a change to the REPORT, not to what is stored.
+- `health:labCategory` dropped the value `laboratory`, on the reading that the record's type implies
+  it. An Observation categorised both laboratory and procedure therefore carried only `procedure`:
+  the category that decided the routing was the one dropped, and a pod filtered by `labCategory`
+  omitted a record filed as a lab. Every category the source stated is now carried, which
+  `health:labCategory` has accepted since health v2.6.
+
+**An unmappable interpretation code and a source that stated none are no longer the same string.**
+An `Observation.interpretation` outside the set `health:interpretation` accepts was written as
+`unknown`, which is the data-absent-reason code and means exactly one thing: the source carried no
+interpretation. Writing it for a local flag asserts something the source never said, and the import
+warning that distinguished them lasts only as long as the import while the pod is what survives. The
+unmappable case now writes no `health:interpretation` at all and keeps its warning; `unknown` is
+reserved for the source that reported nothing. The record does not carry the source's own
+uninterpretable code, because no ratified Cascade property exists to carry it under.
 
 ---
 

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -24,6 +24,7 @@ import type { Quad } from 'n3';
 import { printResult, printError, printVerbose, printWarning, type OutputOptions } from '../../lib/output.js';
 import { convert } from '../../lib/fhir-converter/index.js';
 import { type SectionCensusEntry } from '../../lib/fhir-converter/types.js';
+import { SOURCE_EHR_UNKNOWN } from '../../lib/fhir-converter/provenance.js';
 import {
   resolveReferenceEdges,
   buildResourceRefsFromQuads,
@@ -189,7 +190,11 @@ async function loadExistingPodData(
         // any bucket it cannot parse — the records in it are never lost, and
         // never silently replaced by a partial rewrite either.
         await parseTurtleToQuads(content);
-        inputs.push({ content, systemName: 'existing-pod' });
+        // `existingPod` is the marker the reconciler actually keys its
+        // cross-batch path on. `systemName` cannot carry it: it is only the
+        // DEFAULT source system for records that state none, and every record
+        // the pod holds states one.
+        inputs.push({ content, systemName: 'existing-pod', existingPod: true });
       } catch {
         unreadable.push(`${dir}/${file}`);
       }
@@ -894,13 +899,23 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // Source breakdown by EHR of origin (clinical:sourceEHR), for the pre-import
       // plan: exactly what the source-organized Records view will show, computed
       // from the merged/deduped quads so a --dry-run preview matches the real run.
+      //
+      // A subject carrying no clinical:sourceEHR is accounted under the ratified
+      // Data Absent Reason token "unknown", not omitted. Omitting it made the
+      // breakdown silently disagree with the record count beside it: a FHIR
+      // bundle whose references are all `urn:uuid:` gives the provenance pass no
+      // host to read and no institution-looking display, so eight records
+      // imported and the source axis accounted for none of them — which reads as
+      // "this pod has no data" rather than "we could not tell where this came
+      // from". The token is the same one the C-CDA path already writes
+      // (`deriveSourceEhr`), and it is deliberately NOT the import-batch label,
+      // which says how the data got in rather than where it came from.
       const sourceBreakdown: Record<string, number> = {};
       const SRC_EHR_IRI = 'https://ns.cascadeprotocol.org/clinical/v1#sourceEHR';
       for (const [, quads] of subjectQuads) {
         const ehr = quads.find((q) => q.predicate.value === SRC_EHR_IRI);
-        if (ehr) {
-          sourceBreakdown[ehr.object.value] = (sourceBreakdown[ehr.object.value] ?? 0) + 1;
-        }
+        const key = ehr ? ehr.object.value : SOURCE_EHR_UNKNOWN;
+        sourceBreakdown[key] = (sourceBreakdown[key] ?? 0) + 1;
       }
 
       // --- Step 5: Route subjects to DATA_TYPES buckets ---

--- a/src/lib/ccda-converter/dates.ts
+++ b/src/lib/ccda-converter/dates.ts
@@ -49,6 +49,18 @@ const XSD_DATETIME = NS.xsd + 'dateTime';
 export interface CcdaDateTerm {
   value: string;
   datatype: string;
+  /**
+   * True when the source value was MALFORMED and the day below it was salvaged.
+   *
+   * `effectiveTime="201102013"` is nine digits: neither the 8-digit calendar day
+   * nor the 10-digit hour precision, so the value is wrong past the day. Taking
+   * the first eight digits is the right call — throwing a record's date away
+   * over a stray digit loses more than it saves — but the result is then a
+   * calendar day stated with full confidence on the strength of a value the
+   * source got wrong, and byte-indistinguishable from a well-formed day. This
+   * flag is what lets the caller say which of the two it is holding.
+   */
+  salvaged?: boolean;
 }
 
 /** `Z` or `±HHMM` / `±HH:MM` at the end of an HL7 TS value. */
@@ -90,9 +102,11 @@ export function ccdaDateTerm(raw: unknown): CcdaDateTerm | null {
   if (digits.length === 8) return { value: day, datatype: XSD_DATE };
 
   // Hour, minute or second precision. An odd length past the day means the value
-  // is malformed beyond the day; the day is still known and is what gets said.
+  // is malformed beyond the day; the day is still known and is what gets said —
+  // flagged, so the caller can report that the day was salvaged rather than
+  // stated.
   if (digits.length !== 10 && digits.length !== 12 && digits.length < 14) {
-    return { value: day, datatype: XSD_DATE };
+    return { value: day, datatype: XSD_DATE, salvaged: true };
   }
 
   const hh = digits.slice(8, 10);
@@ -110,10 +124,27 @@ export function ccdaDateTerm(raw: unknown): CcdaDateTerm | null {
  *
  * Callers emit conditionally — `const q = ccdaDateQuad(...); if (q) quads.push(q)`
  * — which is the same shape as the `if (dateStr)` guard they had before.
+ *
+ * `warnings` is where a SALVAGED day is reported. Pass it wherever the import
+ * report is reachable: without it a malformed source value becomes a confident
+ * calendar day and the import says nothing, so a reader has no way to tell a
+ * date the document stated from one this function recovered. The record still
+ * gets its day either way — the warning is the only thing that changes.
  */
-export function ccdaDateQuad(subject: string, predicate: string, raw: unknown): Quad | null {
+export function ccdaDateQuad(
+  subject: string,
+  predicate: string,
+  raw: unknown,
+  warnings?: string[],
+): Quad | null {
   const term = ccdaDateTerm(raw);
   if (!term) return null;
+  if (term.salvaged) {
+    warnings?.push(
+      `C-CDA date "${String(raw).trim()}" is malformed past the calendar day ` +
+        `(HL7 v3 TS is YYYYMMDD[HHMMSS]); recorded as ${term.value} from its first eight digits.`,
+    );
+  }
   return makeQuad(
     namedNode(subject),
     namedNode(predicate),

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -96,7 +96,6 @@ export async function convertCcda(
   const warnings: string[] = [];
   const allQuads: any[] = [];
   const sectionCensus: SectionCensusEntry[] = [];
-  let resourceCount = 0;
 
   const importedAt = options.importedAt ?? new Date().toISOString();
 
@@ -123,7 +122,6 @@ export async function convertCcda(
     try {
       const result = convertSingleCcda(xml, options, importedAt, warnings);
       allQuads.push(...result.quads);
-      resourceCount += result.count;
       mergeSectionCensus(sectionCensus, result.census);
     } catch (err) {
       warnings.push(`Failed to convert C-CDA document: ${err instanceof Error ? err.message : String(err)}`);
@@ -154,6 +152,26 @@ export async function convertCcda(
     seen.add(key);
     return true;
   });
+
+  // `resourceCount` means THE NUMBER OF RECORDS THE CONVERSION PRODUCED, which
+  // is the number of distinct subjects it gave an rdf:type — the same thing the
+  // FHIR importer reports, so a caller reading the field gets one meaning
+  // whatever `--from` it used.
+  //
+  // It used to be documents-and-sections: one for the patient, plus
+  // `entries.length` per handled section. A C-CDA `<entry>` routinely holds an
+  // `<organizer>` wrapping several observations, so a document producing 8
+  // records reported 2. A caller deciding whether an import is worth running, or
+  // showing "N records found", was told a number four times too small, and the
+  // two importers disagreed about what the field meant. Counting after the
+  // cross-document dedup below is deliberate: for an IHE XDM zip whose documents
+  // repeat a record, the count is what the pod will receive, not the sum of what
+  // each document claimed.
+  const recordSubjects = new Set<string>();
+  for (const q of uniqueQuads) {
+    if (q.predicate.value === NS.rdf + 'type') recordSubjects.add(q.subject.value);
+  }
+  const resourceCount = recordSubjects.size;
 
   // Serialize all quads to Turtle
   const output = await new Promise<string>((resolve, reject) => {
@@ -243,7 +261,7 @@ function convertSingleCcda(
   options: CcdaConversionOptions,
   importedAt: string,
   warnings: string[],
-): { quads: any[]; count: number; census: SectionCensusEntry[] } {
+): { quads: any[]; census: SectionCensusEntry[] } {
   const parsed = parseCcdaXml(xml);
 
   // Detect vendor and apply normalization
@@ -285,13 +303,12 @@ function convertSingleCcda(
 
   const allQuads: any[] = [];
   const census: SectionCensusEntry[] = [];
-  let count = 0;
 
   // Extract patient demographics
   const recordTarget = ccdaDoc?.recordTarget;
   if (!recordTarget) {
     warnings.push('C-CDA document has no recordTarget — patient demographics not extracted');
-    return { quads: allQuads, count, census };
+    return { quads: allQuads, census };
   }
 
   // The patient profile is a record like any other. Its IRI is NOT threaded into
@@ -302,7 +319,6 @@ function convertSingleCcda(
     warnings,
   );
   allQuads.push(...patientQuads);
-  count++;
 
   // Process each section
   // `<component>` is a repeatable element and is therefore always an array (see
@@ -340,7 +356,15 @@ function convertSingleCcda(
 
     // Extract narrative — always attempt, even if section also has entries
     const sectionText = section?.text;
-    const requiresLLMExtraction = entries.length === 0;
+    // A section that carries a nullFlavor has ALREADY said, in the ratified way,
+    // that it holds no information (HL7 v3 NullFlavor: NI and its children UNK,
+    // NAV, ASKU, NASK, MSK, NA, OTH). Queueing such a section for extraction
+    // offers a model the sentence "No information available." and asks it what
+    // allergies the patient has — the one input from which any answer at all is
+    // a fabrication. The narrative record is still produced; it is only the
+    // extraction flag that changes.
+    const sectionNullFlavor = section?.['@_nullFlavor'] ?? section?.nullFlavor;
+    const requiresLLMExtraction = entries.length === 0 && !sectionNullFlavor;
     if (sectionText || requiresLLMExtraction) {
       const effectiveLoinc =
         sectionCode || (matchedTemplateId ? (SECTION_HANDLERS[matchedTemplateId]?.loinc ?? '') : '');
@@ -377,7 +401,6 @@ function convertSingleCcda(
       }
 
       allQuads.push(...quads);
-      count += entries.length;
 
       // Entries read versus records written, for THIS section. Counted from the
       // handler's own output — the distinct subjects it gave an rdf:type — so it
@@ -426,5 +449,5 @@ function convertSingleCcda(
   ensureProvenanceQuads(allQuads);
   ensureSourceEhrQuads(allQuads, sourceEhr);
 
-  return { quads: allQuads, count, census };
+  return { quads: allQuads, census };
 }

--- a/src/lib/ccda-converter/narrative-reference.ts
+++ b/src/lib/ccda-converter/narrative-reference.ts
@@ -91,6 +91,7 @@ export function collapseText(node: any): string {
 export function narrativeTextFor(
   container: any,
   narrativeIdMap: Record<string, string>,
+  warnings?: string[],
 ): string {
   if (container == null) return '';
 
@@ -100,6 +101,17 @@ export function narrativeTextFor(
     if (resolved) return resolved;
     // A dangling reference is not a name. Fall through to any inline text rather
     // than returning early, then give up.
+    //
+    // But say so. In the pod a record whose reference did not resolve is
+    // byte-indistinguishable from one that carried no name anywhere, so "the
+    // rendering we were given was incomplete" and "this test was never named"
+    // arrive as the same absence. The warning is the only place the difference
+    // still exists, and it costs nothing: the record still gains NO name, since
+    // inventing one from the code would fabricate the attested rendering.
+    warnings?.push(
+      `C-CDA narrative reference "${ref}" does not resolve: no element in the section's ` +
+        `<text> declares that ID. The record is imported without the name it pointed at.`,
+    );
   }
 
   const inline = typeof container === 'string' ? container : container?.['#text'];
@@ -115,6 +127,7 @@ export function narrativeTextFor(
 export function resolveNarrativeName(
   codeEl: any,
   narrativeIdMap: Record<string, string>,
+  warnings?: string[],
 ): string {
-  return narrativeTextFor(codeEl?.originalText, narrativeIdMap);
+  return narrativeTextFor(codeEl?.originalText, narrativeIdMap, warnings);
 }

--- a/src/lib/ccda-converter/sections/immunizations.ts
+++ b/src/lib/ccda-converter/sections/immunizations.ts
@@ -71,7 +71,7 @@ export function extractImmunizationQuads(
       quads.push(makeQuad(subj, namedNode(NS.health + 'cvxCode'), namedNode(resolveCodeUri(cvxOid, code))));
     }
     // Typed from the raw effectiveTime; see `dates.ts`.
-    const administrationQuad = ccdaDateQuad(uri, NS.health + 'administrationDate', dateVal);
+    const administrationQuad = ccdaDateQuad(uri, NS.health + 'administrationDate', dateVal, warnings);
     if (administrationQuad) quads.push(administrationQuad);
     if (sourceId) {
       quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -147,8 +147,8 @@ function extractObservationQuads(
   // what the converter can read. A placeholder would hide that.
   const testName =
     displayName ||
-    resolveNarrativeName(codeEl, narrativeIdMap) ||
-    narrativeTextFor(obs?.text, narrativeIdMap);
+    resolveNarrativeName(codeEl, narrativeIdMap, warnings) ||
+    narrativeTextFor(obs?.text, narrativeIdMap, warnings);
 
   // Extract effective date
   const effTime = obs?.effectiveTime;
@@ -217,7 +217,7 @@ function extractObservationQuads(
   // Typed from the RAW effectiveTime, not from the day-truncated `dateStr`: a
   // source that stated a time keeps it, a source that stated a day gets no
   // invented one. See `dates.ts`.
-  const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal);
+  const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal, warnings);
   if (performedQuad) quads.push(performedQuad);
   if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'resultValue'), literal(value)));
   if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'resultUnit'), literal(unit)));

--- a/src/lib/ccda-converter/sections/medications.ts
+++ b/src/lib/ccda-converter/sections/medications.ts
@@ -58,7 +58,7 @@ export function extractMedicationQuads(
     //   2. the narrative paragraph the code's originalText references (#medNN)
     //      — this is where Epic puts the human-readable name
     //   3. RxNorm ingredient lookup by RXCUI (only resolves ingredient-level codes)
-    const narrativeName = resolveNarrativeName(codeEl, narrativeIdMap);
+    const narrativeName = resolveNarrativeName(codeEl, narrativeIdMap, warnings);
     const displayName =
       (typeof rawDisplayName === 'string' ? rawDisplayName.trim() : '') ||
       narrativeName ||

--- a/src/lib/ccda-converter/sections/problems.ts
+++ b/src/lib/ccda-converter/sections/problems.ts
@@ -58,7 +58,7 @@ export function extractProblemQuads(
       // `health:conditionName` is `sh:minCount 1`, so reading `@displayName` only
       // meant an invalid record for a problem the document named in words.
       // Unresolvable stays empty and emits nothing.
-      const conditionName = displayName || resolveNarrativeName(valueEl, narrativeIdMap);
+      const conditionName = displayName || resolveNarrativeName(valueEl, narrativeIdMap, warnings);
 
       const isSnomed = codeSystem.includes('6.96') || codeSystem === snomedOid;
       const isIcd10 = codeSystem.includes('6.90') || codeSystem === icd10Oid;
@@ -127,7 +127,7 @@ export function extractProblemQuads(
       if (conditionName) quads.push(makeQuad(subj, namedNode(NS.health + 'conditionName'), literal(conditionName)));
       if (status) quads.push(makeQuad(subj, namedNode(NS.health + 'status'), literal(status.toLowerCase())));
       // Typed from the raw effectiveTime; see `dates.ts`.
-      const onsetQuad = ccdaDateQuad(uri, NS.health + 'onsetDate', onsetVal);
+      const onsetQuad = ccdaDateQuad(uri, NS.health + 'onsetDate', onsetVal, warnings);
       if (onsetQuad) quads.push(onsetQuad);
       if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
     }

--- a/src/lib/ccda-converter/sections/procedures.ts
+++ b/src/lib/ccda-converter/sections/procedures.ts
@@ -49,7 +49,7 @@ export function extractProcedureQuads(
     // The same narrative recovery the results and problems sections do: a
     // procedure whose code carries no `@displayName` normally names itself in the
     // section narrative behind `<originalText><reference value="#id"/>`.
-    const procedureName = displayName || resolveNarrativeName(codeEl, narrativeIdMap);
+    const procedureName = displayName || resolveNarrativeName(codeEl, narrativeIdMap, warnings);
 
     const effTime = proc?.effectiveTime ?? {};
     const dateVal =
@@ -78,7 +78,7 @@ export function extractProcedureQuads(
     quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
     if (procedureName) quads.push(makeQuad(subj, namedNode(NS.health + 'procedureName'), literal(procedureName)));
     // Typed from the raw effectiveTime; see `dates.ts`.
-    const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal);
+    const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal, warnings);
     if (performedQuad) quads.push(performedQuad);
     if (code) {
       if (codeSystem.includes('6.96') || codeSystem === snomedOid) {

--- a/src/lib/ccda-converter/sections/vitals.ts
+++ b/src/lib/ccda-converter/sections/vitals.ts
@@ -198,7 +198,7 @@ function buildLabFallback(args: {
   if (isLoinc && loincCode) quads.push(makeQuad(subj, namedNode(NS.health + 'testCode'), namedNode(resolveCodeUri(loincOid, loincCode))));
   if (displayName) quads.push(makeQuad(subj, namedNode(NS.health + 'testName'), literal(displayName)));
   // Typed from the raw effectiveTime; see `dates.ts`.
-  const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal);
+  const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal, warnings);
   if (performedQuad) quads.push(performedQuad);
   if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'resultValue'), literal(String(value))));
   if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'resultUnit'), literal(String(unit))));

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -54,6 +54,28 @@ import { interpretationValue } from './interpretation.js';
 // Medication converter
 // ---------------------------------------------------------------------------
 
+/**
+ * The first FHIR `Dosage` element a medication resource carries, under either of
+ * the two field names R4 gives it.
+ *
+ * `MedicationStatement.dosage` and `MedicationRequest.dosageInstruction` are
+ * both `Dosage 0..*` — the same datatype, the same `text`/`route`/`timing`
+ * children. They differ only in the name of the field that holds them, and a
+ * reader that knows one name sees no dose on half the medication resources that
+ * exist.
+ *
+ * `dosage` is preferred when a resource somehow carries both, since only
+ * MedicationStatement declares it and that is then the resource's own field.
+ *
+ * @see https://hl7.org/fhir/R4/medicationstatement-definitions.html#MedicationStatement.dosage
+ * @see https://hl7.org/fhir/R4/medicationrequest-definitions.html#MedicationRequest.dosageInstruction
+ */
+function firstDosageElement(resource: any): any | undefined {
+  const stated = Array.isArray(resource?.dosage) ? resource.dosage[0] : undefined;
+  if (stated) return stated;
+  return Array.isArray(resource?.dosageInstruction) ? resource.dosageInstruction[0] : undefined;
+}
+
 export function convertMedicationStatement(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const patientRef = resource.subject?.reference ?? resource.patient?.reference ?? '';
@@ -111,8 +133,22 @@ export function convertMedicationStatement(resource: any): ConversionResult & { 
     }
   }
 
-  // Dosage
-  const dosage = Array.isArray(resource.dosage) ? resource.dosage[0] : undefined;
+  // Dosage.
+  //
+  // ONE Dosage element, under two field names. FHIR R4 gives
+  // MedicationStatement a `dosage` array and MedicationRequest a
+  // `dosageInstruction` array; both are the same `Dosage` datatype with the same
+  // `text`, `route` and `timing`. Reading only `dosage` meant a prescription's
+  // dose was dropped in silence, and the loss did not stop at the missing
+  // triple: dose is deliberately stripped out of the medication identity key, so
+  // "sertraline 50 mg" and "sertraline 100 mg" match as one drug and the dose
+  // check is what is supposed to raise the disagreement. With both doses absent
+  // that check compared two undefineds, found nothing to disagree about, and
+  // merged a dose change away with no conflict — while the identical
+  // disagreement expressed as a MedicationStatement raised its conflict
+  // correctly. Which of the two ordinary FHIR shapes the source happened to use
+  // decided whether a dose change survived the import.
+  const dosage = firstDosageElement(resource);
   if (dosage) {
     if (dosage.text) {
       quads.push(tripleStr(subjectUri, NS.clinical + 'dosage', dosage.text));
@@ -667,13 +703,10 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
   // binds health:interpretation to that code system, so there is nothing left to
   // translate and no reason to collapse H and L onto one word. See
   // `interpretation.ts` for what the accepted set is and what happens outside it.
-  quads.push(
-    tripleStr(
-      subjectUri,
-      NS.health + 'interpretation',
-      interpretationValue(resource.interpretation, warnings),
-    ),
-  );
+  const interpretation = interpretationValue(resource.interpretation, warnings);
+  if (interpretation !== undefined) {
+    quads.push(tripleStr(subjectUri, NS.health + 'interpretation', interpretation));
+  }
 
   const effectiveDate = resource.effectiveDateTime ?? resource.effectivePeriod?.start ?? resource.issued;
   if (effectiveDate) {
@@ -689,11 +722,22 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
     }
   }
 
+  // EVERY category the source stated, `laboratory` included.
+  //
+  // `laboratory` used to be filtered out on the reading that it is implied by the
+  // record's type. It is not: it is a value FHIR R4 asks the server to state, and
+  // the record it identifies is exactly the one that needs it. An Observation
+  // categorised BOTH laboratory and procedure therefore reached the pod carrying
+  // `labCategory "procedure"` alone — the category that DECIDED the routing was
+  // the one dropped, so a pod filtered by labCategory omitted a record filed as a
+  // lab. health:labCategory is repeatable as of health v2.6 (sh:maxCount removed,
+  // mirroring Observation.category 0..*), so there is nothing left to choose
+  // between.
   if (Array.isArray(resource.category)) {
     for (const cat of resource.category) {
       if (Array.isArray(cat.coding)) {
         for (const c of cat.coding) {
-          if (c.code && c.code !== 'laboratory') {
+          if (c.code) {
             quads.push(tripleStr(subjectUri, NS.health + 'labCategory', c.code));
           }
         }

--- a/src/lib/fhir-converter/interpretation.ts
+++ b/src/lib/fhir-converter/interpretation.ts
@@ -65,18 +65,32 @@ const NEAREST_LEGACY_MAPPING: Record<string, string> = {
 
 /**
  * The `health:interpretation` value for one FHIR `Observation.interpretation`
- * array.
+ * array, or `undefined` when there is no honest value to write.
  *
  * - No interpretation, or one carrying no code  -> `unknown`
  * - A code the shapes accept                    -> that code, verbatim
- * - Anything else                               -> nearest legacy mapping, else
- *                                                  `unknown`, and a warning
- *                                                  naming the code that was lost
+ * - Anything else                               -> nearest legacy mapping if one
+ *                                                  applies, else `undefined`,
+ *                                                  and a warning naming the code
+ *
+ * WHY THE LAST CASE IS NOT `unknown`. It was, and that put two different facts
+ * in the pod as one string. `unknown` is the data-absent-reason code, and this
+ * module's own contract is that it means ONE thing: the source Observation
+ * carried no interpretation. Writing it for a code the vocabulary cannot express
+ * asserts something the source never said — that it reported nothing — on a
+ * record where it reported a local flag. The import does warn, but a warning is
+ * transient and the pod is what survives, so the distinction has to survive in
+ * the pod: "the source stated something this vocabulary cannot express" is now
+ * an ABSENT `health:interpretation`, and "the source stated none" is `unknown`.
+ *
+ * The record does not carry the source's own uninterpretable code, because there
+ * is no ratified Cascade property to carry it under; that wants a vocabulary
+ * addition authored in `spec/`, not a term invented here.
  */
 export function interpretationValue(
   interpretation: unknown,
   warnings?: string[],
-): string {
+): string | undefined {
   if (!Array.isArray(interpretation) || interpretation.length === 0) {
     return INTERPRETATION_ABSENT;
   }
@@ -89,7 +103,11 @@ export function interpretationValue(
   const nearest = NEAREST_LEGACY_MAPPING[code];
   warnings?.push(
     `Observation.interpretation code "${code}" is not in the ObservationInterpretation ` +
-      `set health:interpretation accepts; recorded as "${nearest ?? INTERPRETATION_ABSENT}"`,
+      `set health:interpretation accepts; ` +
+      (nearest
+        ? `recorded as "${nearest}"`
+        : 'no interpretation recorded for this result (recording it as "unknown" would ' +
+          'be indistinguishable from a source that stated none)'),
   );
-  return nearest ?? INTERPRETATION_ABSENT;
+  return nearest;
 }

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -16,7 +16,7 @@ import {
   isReferencePlaceholder,
 } from './fhir-converter/reference-resolution.js';
 import { normalizeMedName, normalizeDose, normalizeFrequency, type DrugNameNormalizer } from './medication-normalize.js';
-import { medicationCodeKeys, sharedMedicationCodeKey } from './code-keys.js';
+import { medicationCodeKeys, sharedMedicationCodeKey, extractCodeValue } from './code-keys.js';
 import { cascadeTerminologyResolver } from './terminology.js';
 import { relBase, relBaseFor, derelativizeQuads } from './bucket-write.js';
 
@@ -54,6 +54,21 @@ export interface ReconcilerOptions {
 export interface ReconcilerInput {
   content: string;    // Turtle string
   systemName: string;
+  /**
+   * True when this input is the POD'S OWN existing content, fed back in so the
+   * new batch can be reconciled against what is already stored
+   * (`pod import --reconcile-existing`).
+   *
+   * This is a property of WHERE THE TEXT CAME FROM, and it has to be carried
+   * separately from `systemName` because `systemName` is only a DEFAULT: a
+   * parsed record takes its source system from its own `cascade:sourceSystem`
+   * triple, and every record the pod holds carries one (the reconciler re-states
+   * it on every write). So the caller's `systemName: 'existing-pod'` was
+   * overwritten for every pod record without exception, `hasExistingPod` was
+   * therefore never true, and the cross-batch path below — the entire reason
+   * `--reconcile-existing` exists — had never run.
+   */
+  existingPod?: boolean;
 }
 
 export interface ReconcilerResult {
@@ -156,10 +171,21 @@ interface ParsedRecord {
   uri: string;
   type: CascadeRecordType;
   sourceSystem: string;
+  /**
+   * True when this record was read out of the pod rather than out of the batch
+   * being imported. See {@link ReconcilerInput.existingPod}: it is deliberately
+   * NOT derived from `sourceSystem`, which the record itself states and which
+   * therefore cannot say how the record reached this run.
+   */
+  fromExistingPod: boolean;
   properties: Map<string, RdfValue[]>;
 }
 
-export async function parseTurtle(turtle: string, defaultSystem: string): Promise<ParsedRecord[]> {
+export async function parseTurtle(
+  turtle: string,
+  defaultSystem: string,
+  fromExistingPod = false,
+): Promise<ParsedRecord[]> {
   return new Promise((resolve, reject) => {
     // Sentinel base: pod content arrives here on its way back to the pod, and a
     // relative IRI must survive the trip. N3's default resolves
@@ -190,7 +216,13 @@ export async function parseTurtle(turtle: string, defaultSystem: string): Promis
           }
 
           const sourceSystem = properties.get(NS.cascade + 'sourceSystem')?.[0]?.value ?? defaultSystem;
-          records.push({ uri, type: KNOWN_TYPES[typeTriple.obj.value], sourceSystem, properties });
+          records.push({
+            uri,
+            type: KNOWN_TYPES[typeTriple.obj.value],
+            sourceSystem,
+            fromExistingPod,
+            properties,
+          });
         }
         resolve(records);
         return;
@@ -750,9 +782,29 @@ function getProp(r: ParsedRecord, pred: string): string | undefined {
   return r.properties.get(pred)?.[0]?.value;
 }
 
-function codeFromUri(uri: string): string {
-  return uri.split('/').pop() ?? uri.split('#').pop() ?? uri;
-}
+/**
+ * The bare code value a code URI carries.
+ *
+ * Delegates to `extractCodeValue`, the definition shared with the SDK, rather
+ * than keeping a second copy. The copy this replaces was
+ *
+ *     uri.split('/').pop() ?? uri.split('#').pop() ?? uri
+ *
+ * whose second operand is unreachable: `String.split('/').pop()` on a non-empty
+ * string is always a non-empty string, so `??` never falls through to the
+ * fragment branch. Every LOINC URI this repo mints is
+ * `http://loinc.org/rdf#3094-0`, which therefore came back as `rdf#3094-0`.
+ *
+ * That had two consequences beyond the ugly string. The C-CDA converter writes
+ * its LOINC as `http://loinc.org/3094-0` (no `rdf#` — see `OID_TO_URI`), so the
+ * two importers' spellings of ONE code compared unequal and a FHIR lab never
+ * matched the same lab from a C-CDA. And the mangled form is interpolated into
+ * `matchedOn`, which `generateConflictId` turns into the id persisted in
+ * `settings/pending-conflicts.ttl` — so it reached disk. See
+ * {@link legacyConflictIds} in `user-resolutions.ts` for what that means for a
+ * pod written by an earlier version.
+ */
+const codeFromUri = extractCodeValue;
 
 function dateOnly(dt: string): string { return dt.split('T')[0] ?? dt; }
 
@@ -838,8 +890,26 @@ function matchMedications(a: ParsedRecord, b: ParsedRecord, resolver?: DrugNameN
     return { match: true, confidence, matchedOn };
   }
 
-  // Partial-name fallback (substring containment), unchanged from the prior matcher.
-  if (nA && nB && (nA.includes(nB) || nB.includes(nA))) return { match: true, confidence: 0.70, matchedOn: `partial-name` };
+  // Partial-name fallback (substring containment).
+  //
+  // `matchedOn` NAMES THE DRUG, and that is load-bearing rather than cosmetic:
+  // `generateConflictId` builds the persisted conflict id out of this string, so
+  // the bare constant `partial-name` gave EVERY partial-name medication conflict
+  // in every pod one id. Two consequences, both silent:
+  // `settings/user-resolutions.ttl` is keyed by conflict id and cannot hold two
+  // rows under one key, so resolving a lisinopril conflict overwrote the
+  // recorded decision for an amlodipine one; and `pod resolve` removes every
+  // pending conflict whose id matches, so answering one question cleared the
+  // others from the queue unanswered.
+  //
+  // The CONTAINED name is the shared identity — "lisinopril" out of
+  // {"lisinopril", "lisinopril oral tablet"} — and choosing by length rather
+  // than by which record happened to be `a` keeps the id independent of the
+  // order the inputs were enumerated.
+  if (nA && nB && (nA.includes(nB) || nB.includes(nA))) {
+    const shared = nA.length <= nB.length ? nA : nB;
+    return { match: true, confidence: 0.70, matchedOn: `partial-name:"${shared}"` };
+  }
   return { match: false, confidence: 0, matchedOn: '' };
 }
 
@@ -889,15 +959,37 @@ function matchLabs(a: ParsedRecord, b: ParsedRecord, tol: number): MatchResult {
   return { match: false, confidence: 0, matchedOn: '' };
 }
 
+/**
+ * The bare CVX code an immunization record carries, whichever predicate its
+ * importer used and whichever spelling that importer wrote.
+ *
+ * The two importers disagree on both, which is why the CVX tier below had never
+ * fired on a FHIR record:
+ *
+ *   C-CDA  health:cvxCode      <http://hl7.org/fhir/sid/cvx/207>
+ *   FHIR   health:vaccineCode  "CVX-207"
+ *
+ * The matcher read only the first, so every FHIR immunization fell through to
+ * the name tier and two records for one shot matched only when their display
+ * names happened to agree verbatim. Normalizing both spellings to `207` is what
+ * lets a C-CDA immunization and a FHIR one for the same shot compare at all.
+ */
+function immunizationCvxCode(r: ParsedRecord): string | undefined {
+  const raw = getProp(r, NS.health + 'cvxCode') ?? getProp(r, NS.health + 'vaccineCode');
+  if (!raw) return undefined;
+  const code = extractCodeValue(raw);
+  return code.startsWith('CVX-') ? code.slice(4) : code;
+}
+
 function matchImmunizations(a: ParsedRecord, b: ParsedRecord): MatchResult {
   // Tier 1: CVX code + exact date (high confidence)
-  const cA = getProp(a, NS.health + 'cvxCode');
-  const cB = getProp(b, NS.health + 'cvxCode');
+  const cA = immunizationCvxCode(a);
+  const cB = immunizationCvxCode(b);
   const dA = dateOnly(getProp(a, NS.health + 'administrationDate') ?? getProp(a, NS.health + 'startDate') ?? '');
   const dB = dateOnly(getProp(b, NS.health + 'administrationDate') ?? getProp(b, NS.health + 'startDate') ?? '');
 
-  if (cA && cB && codeFromUri(cA) === codeFromUri(cB) && dA && dA === dB)
-    return { match: true, confidence: 1.0, matchedOn: `cvx:${codeFromUri(cA)}+${dA}` };
+  if (cA && cB && cA === cB && dA && dA === dB)
+    return { match: true, confidence: 1.0, matchedOn: `cvx:${cA}+${dA}` };
 
   // Tier 2: Vaccine name (normalized) + date -- fallback when CVX absent
   const nA = (getProp(a, NS.health + 'vaccineName') ?? '').toLowerCase().trim();
@@ -912,24 +1004,98 @@ function matchImmunizations(a: ParsedRecord, b: ParsedRecord): MatchResult {
   return { match: false, confidence: 0, matchedOn: '' };
 }
 
-function matchVitalSigns(a: ParsedRecord, b: ParsedRecord): MatchResult {
-  const lcA = getProp(a, NS.health + 'testCode');  // LOINC
-  const lcB = getProp(b, NS.health + 'testCode');
-  const dtA = dateOnly(getProp(a, NS.health + 'effectiveDate') ?? getProp(a, NS.health + 'performedDate') ?? '');
-  const dtB = dateOnly(getProp(b, NS.health + 'effectiveDate') ?? getProp(b, NS.health + 'performedDate') ?? '');
+/**
+ * How far apart two readings of one vital sign may be recorded and still be the
+ * same reading arriving twice.
+ *
+ * A vital sign is an instant, not a day. The rule this replaces was "same LOINC,
+ * same calendar day", which is the wrong shape for the data: a morning, a midday
+ * and an evening blood pressure share a calendar day and are three separate
+ * clinical events, while one cuff reading forwarded to a second system 17
+ * minutes later is one event under two clocks. A day-wide window merges the
+ * first group and a zero-width window keeps the second apart; both lose real
+ * information, in opposite directions.
+ *
+ * Thirty minutes is chosen against what the window has to separate — repeat
+ * measurements, which clinical protocol spaces in hours (a repeat BP at 1-5
+ * minutes is the same encounter and SHOULD collapse) — rather than against a
+ * particular export. It is not a claim that clocks never drift further; a source
+ * that stamps its records an hour out will still keep both copies, which is the
+ * recoverable error of the two.
+ */
+const VITAL_SAME_READING_WINDOW_MS = 30 * 60 * 1000;
 
-  if (lcA && lcB && codeFromUri(lcA) === codeFromUri(lcB) && dtA && dtA === dtB) {
-    // Same LOINC, same day -- check value proximity
-    const vA = parseFloat(getProp(a, NS.health + 'value') ?? 'NaN');
-    const vB = parseFloat(getProp(b, NS.health + 'value') ?? 'NaN');
-    if (!isNaN(vA) && !isNaN(vB)) {
-      const diff = Math.abs(vA - vB) / Math.max(Math.abs(vA), 0.001);
-      if (diff <= 0.05) return { match: true, confidence: 0.95, matchedOn: `loinc:${codeFromUri(lcA)}+${dtA}` };
-      if (diff <= 0.15) return { match: true, confidence: 0.75, matchedOn: `loinc-approx:${codeFromUri(lcA)}+${dtA}` };
-    }
-    return { match: true, confidence: 0.85, matchedOn: `loinc:${codeFromUri(lcA)}+${dtA}` };
+/**
+ * The instant a vital sign was taken, in epoch milliseconds.
+ *
+ * `clinical:effectiveDate` is what BOTH converters write (`converters-clinical.ts`
+ * for FHIR, `sections/vitals.ts` for C-CDA); the `health:` predicates are read
+ * after it only so a record written by some other producer is not ignored.
+ *
+ * A day-precision value parses to that day's midnight UTC, so two day-precision
+ * readings of one vital on one day are zero apart. That is the truth available:
+ * the source did not say when, and inventing a separation it never stated would
+ * be the same fabrication as inventing a time of day.
+ */
+function vitalInstantMs(r: ParsedRecord): number | undefined {
+  const raw =
+    getProp(r, NS.clinical + 'effectiveDate') ??
+    getProp(r, NS.health + 'effectiveDate') ??
+    getProp(r, NS.health + 'performedDate');
+  if (!raw) return undefined;
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/**
+ * Do two vital-sign records denote one reading?
+ *
+ * WHAT THIS USED TO READ. `health:testCode`, `health:effectiveDate` /
+ * `health:performedDate` and `health:value` — three predicates no converter in
+ * this repository has ever written for a vital sign. Both of them write
+ * `clinical:loincCode`, `clinical:effectiveDate` and `clinical:value`. All three
+ * lookups returned undefined, the date guard therefore failed, and the function
+ * returned no-match for EVERY pair: no two vital signs in any pod had ever
+ * matched. The "three same-day readings must never merge" property held, but for
+ * the wrong reason, and the price was that a genuine cross-source duplicate was
+ * kept as a second record.
+ *
+ * The value tolerance is symmetric (the larger magnitude is the denominator), so
+ * the verdict does not depend on which record is `a`; `matchedOn` keys on the
+ * EARLIER instant for the same reason, since it becomes a persisted id.
+ */
+function matchVitalSigns(a: ParsedRecord, b: ParsedRecord): MatchResult {
+  const noMatch: MatchResult = { match: false, confidence: 0, matchedOn: '' };
+
+  const lcA = getProp(a, NS.clinical + 'loincCode');
+  const lcB = getProp(b, NS.clinical + 'loincCode');
+  if (!lcA || !lcB) return noMatch;
+  const code = codeFromUri(lcA);
+  if (code !== codeFromUri(lcB)) return noMatch;
+
+  const tA = vitalInstantMs(a);
+  const tB = vitalInstantMs(b);
+  if (tA === undefined || tB === undefined) return noMatch;
+  if (Math.abs(tA - tB) > VITAL_SAME_READING_WINDOW_MS) return noMatch;
+
+  const at = new Date(Math.min(tA, tB)).toISOString();
+  const vA = parseFloat(getProp(a, NS.clinical + 'value') ?? 'NaN');
+  const vB = parseFloat(getProp(b, NS.clinical + 'value') ?? 'NaN');
+
+  if (!isNaN(vA) && !isNaN(vB)) {
+    const diff = Math.abs(vA - vB) / Math.max(Math.abs(vA), Math.abs(vB), 0.001);
+    if (diff === 0) return { match: true, confidence: 1.0, matchedOn: `loinc:${code}+${at}` };
+    if (diff <= 0.05) return { match: true, confidence: 0.95, matchedOn: `loinc:${code}+${at}` };
+    if (diff <= 0.15) return { match: true, confidence: 0.75, matchedOn: `loinc-approx:${code}+${at}` };
+    // Inside the window but disagreeing by more than a rounding difference: two
+    // measurements, not one measurement recorded twice. Keeping both is the
+    // recoverable answer.
+    return noMatch;
   }
-  return { match: false, confidence: 0, matchedOn: '' };
+
+  // A non-numeric or absent reading on either side. The code and the instant
+  // still agree, which is as much as there is to go on.
+  return { match: true, confidence: 0.85, matchedOn: `loinc:${code}+${at}` };
 }
 
 function matchPatientProfiles(a: ParsedRecord, b: ParsedRecord): MatchResult {
@@ -1431,7 +1597,7 @@ export async function runReconciliation(
 
   for (let i = 0; i < inputs.length; i++) {
     const input = inputs[i];
-    const records = await parseTurtle(input.content, input.systemName);
+    const records = await parseTurtle(input.content, input.systemName, input.existingPod === true);
     allRecords.push(...records);
     sourceInfo.push({ system: input.systemName, count: records.length });
 
@@ -1493,15 +1659,34 @@ export async function runReconciliation(
   const groups: Group[] = [];
   const assigned = new Set<string>();
 
-  const hasExistingPod = allRecords.some(r => r.sourceSystem === 'existing-pod');
+  // Keyed on WHERE THE INPUT CAME FROM, not on a label the record could restate.
+  // The test was `r.sourceSystem === 'existing-pod'`, and a pod record's
+  // `sourceSystem` is read from its own `cascade:sourceSystem` triple, which it
+  // always has — so this was permanently false and `--reconcile-existing` always
+  // fell through to the single-batch branch.
+  const hasExistingPod = allRecords.some(r => r.fromExistingPod);
 
   if (hasExistingPod) {
     // ---------------------------------------------------------------------------
     // Fast path: O(n_new × k) type-indexed matching for --reconcile-existing mode
     // ---------------------------------------------------------------------------
 
-    const existingRecords = allRecords.filter(r => r.sourceSystem === 'existing-pod');
-    const newRecords = allRecords.filter(r => r.sourceSystem !== 'existing-pod');
+    const existingRecords = allRecords.filter(r => r.fromExistingPod);
+
+    // A new record whose subject IRI the pod ALREADY holds is a re-import of that
+    // record, and the pod's own copy is the one that is kept. Cascade subjects are
+    // content-hashed and `splitIdentityCollisions` has already moved apart any two
+    // records that merely LOOK the same, so a shared IRI here means the two agree
+    // on everything except ingestion bookkeeping — and of the two, the stored copy
+    // is the one whose `importedAt` says when the record first arrived and whose
+    // record-to-record edges are already resolved to real subjects rather than
+    // still being placeholders. Letting the fresh copy win instead re-stamped the
+    // timestamp and re-resolved edges that were never unresolved, i.e. churn with
+    // nothing gained. Dropping them here (rather than inside the loops) also keeps
+    // them out of `groupedRecords`, so `duplicateSubjectsDropped` counts them,
+    // which is exactly what that number is for.
+    const existingUris = new Set(existingRecords.map(r => r.uri));
+    const newRecords = allRecords.filter(r => !r.fromExistingPod && !existingUris.has(r.uri));
 
     // Build a type index over existing records only
     const existingIndex = new Map<string, ParsedRecord[]>();

--- a/src/lib/user-resolutions.ts
+++ b/src/lib/user-resolutions.ts
@@ -123,11 +123,79 @@ export interface PendingConflict {
 /**
  * Generate a deterministic conflict ID from record type and identity fields.
  * Same inputs always produce the same conflict ID (stable across re-imports).
+ *
+ * The FORMULA is unchanged and deliberately so; what changed is the `matchedOn`
+ * strings the reconciler feeds it. See {@link legacyConflictIds}.
  */
 export function generateConflictId(recordType: string, matchedOn: string): string {
   // Simple deterministic ID — use the matchedOn string from the reconciler
   const safe = `${recordType}::${matchedOn}`.replace(/[^a-zA-Z0-9:+./-]/g, '_');
   return safe.slice(0, 80);  // Truncate to avoid overly long IDs
+}
+
+/**
+ * The conflict ids an EARLIER version of this CLI would have written for the same
+ * conflict, for reading a pod it wrote. Never for writing.
+ *
+ * Two reconciler defects put ids on disk that this version no longer produces,
+ * and both were in `matchedOn` rather than in the formula above:
+ *
+ *   1. A code URI was reduced by `uri.split('/').pop() ?? uri.split('#').pop()`,
+ *      whose second operand is unreachable, so every LOINC code reached the id as
+ *      `rdf#3094-0` instead of `3094-0`.
+ *   2. A medication matched on partial name reported the bare constant
+ *      `partial-name`, so EVERY partial-name medication conflict in a pod shared
+ *      one id — which is why this matters beyond cosmetics:
+ *      `settings/user-resolutions.ttl` is keyed by conflict id and cannot hold
+ *      two rows under one key.
+ *
+ * `settings/pending-conflicts.ttl` re-keys itself, because every import rewrites
+ * it wholesale from the run's own conflicts; `pod resolve` matches the id the
+ * user pasted against that file, so it needs nothing from here. What does NOT
+ * re-key itself is the decision log: a row recorded before this change carries
+ * the id from the old formula forever, and a lookup by the new id would miss it.
+ * This function is how such a row is still found.
+ *
+ * Returns only ids that DIFFER from the current one, so a caller can treat a
+ * non-empty result as "there is an older spelling to look for".
+ */
+export function legacyConflictIds(recordType: string, matchedOn: string): string[] {
+  const current = generateConflictId(recordType, matchedOn);
+  const candidates = new Set<string>();
+
+  // (2) `partial-name:"lisinopril"` -> `partial-name`
+  const bareName = matchedOn.replace(/^partial-name:".*"$/, 'partial-name');
+  if (bareName !== matchedOn) candidates.add(generateConflictId(recordType, bareName));
+
+  // (1) `loinc:3094-0+…` -> `loinc:rdf#3094-0+…`. Only LOINC is affected: it is
+  // the one system whose URI carries a fragment (`http://loinc.org/rdf#3094-0`).
+  const mangledLoinc = matchedOn.replace(/\b(loinc|loinc-approx):(?!rdf#)/g, '$1:rdf#');
+  if (mangledLoinc !== matchedOn) candidates.add(generateConflictId(recordType, mangledLoinc));
+
+  candidates.delete(current);
+  return [...candidates].sort();
+}
+
+/**
+ * The stored decision for a conflict, looked up under the id this version
+ * generates and then under any id an earlier version would have written.
+ *
+ * Read-old, write-new: `saveUserResolution` always records under the current id,
+ * so a pod converges on the new spelling as its conflicts are answered, while an
+ * answer given before this change is still found.
+ */
+export function findUserResolution(
+  resolutions: Map<string, UserResolution>,
+  recordType: string,
+  matchedOn: string,
+): UserResolution | undefined {
+  const current = resolutions.get(generateConflictId(recordType, matchedOn));
+  if (current) return current;
+  for (const id of legacyConflictIds(recordType, matchedOn)) {
+    const found = resolutions.get(id);
+    if (found) return found;
+  }
+  return undefined;
 }
 
 /**

--- a/test-fixtures/pathology/scenarios.json
+++ b/test-fixtures/pathology/scenarios.json
@@ -11,17 +11,17 @@
       ],
       "expect": {
         "convertedRecords": [4, 6],
-        "reportedResourceCount": [4, 3],
-        "podRecords": 8,
+        "reportedResourceCount": [4, 6],
+        "podRecords": 7,
         "podRecordsByType": {
           "ClinicalDocument": 2,
           "ConditionRecord": 1,
           "ImmunizationRecord": 1,
           "LaboratoryReport": 1,
-          "LabResultRecord": 2,
+          "LabResultRecord": 1,
           "PatientProfile": 1
         },
-        "merges": 2,
+        "merges": 3,
         "conflicts": 0,
         "edgesInPod": 1,
         "violations": 0,
@@ -34,7 +34,7 @@
       "batches": [{ "file": "p02-duplicate-source-id-ccda.xml", "from": "c-cda" }],
       "expect": {
         "convertedRecords": [5],
-        "reportedResourceCount": [2],
+        "reportedResourceCount": [5],
         "podRecords": 5,
         "podRecordsByType": {
           "ClinicalDocument": 1,
@@ -55,7 +55,7 @@
       "batches": [{ "file": "p03-narrative-names-ccda.xml", "from": "c-cda" }],
       "expect": {
         "convertedRecords": [8],
-        "reportedResourceCount": [2],
+        "reportedResourceCount": [8],
         "podRecords": 8,
         "podRecordsByType": {
           "ClinicalDocument": 1,
@@ -67,7 +67,15 @@
         "conflicts": 0,
         "edgesInPod": 5,
         "violations": 2,
-        "importWarnings": 0
+        "importWarnings": 1,
+        "_valuesNote": "Three of the five results are named; the dangling reference and the one nothing names anywhere carry NO testName. That is the point of the one warning above: the record still gains no name, because inventing one from the LOINC code would fabricate the attested rendering, and the warning is the only place 'the rendering we were given was incomplete' is still distinguishable from 'this test was never named'.",
+        "values": [
+          {
+            "on": "health:LabResultRecord",
+            "predicate": "health:testName",
+            "values": ["Free thyroxine", "Thyroid stimulating hormone", "Triiodothyronine"]
+          }
+        ]
       }
     },
     {
@@ -76,7 +84,7 @@
       "batches": [{ "file": "p04-date-precision-ccda.xml", "from": "c-cda" }],
       "expect": {
         "convertedRecords": [8],
-        "reportedResourceCount": [3],
+        "reportedResourceCount": [8],
         "podRecords": 8,
         "podRecordsByType": {
           "ClinicalDocument": 2,
@@ -105,7 +113,25 @@
         "conflicts": 0,
         "edgesInPod": 0,
         "violations": 0,
-        "importWarnings": 1
+        "importWarnings": 1,
+        "_valuesNote": "interpretation: H, S and POS are carried verbatim; exactly ONE record reads as absent, and it is the one whose source stated no interpretation. The record carrying the unmapped local flag ZQ7 has NO interpretation at all rather than 'unknown', because 'unknown' is the data-absent-reason code and means the source stated none. labCategory: every category the source stated, 'laboratory' included, so the multi-category result is findable under the category that decided its routing as well as the one it also claims.",
+        "values": [
+          {
+            "on": "health:LabResultRecord",
+            "predicate": "health:interpretation",
+            "values": ["H", "H", "POS", "S", "unknown"]
+          },
+          {
+            "on": "health:LabResultRecord",
+            "predicate": "health:labCategory",
+            "values": [
+              "laboratory", "laboratory", "laboratory",
+              "laboratory", "laboratory", "laboratory",
+              "procedure"
+            ]
+          }
+        ],
+        "sourceBreakdown": { "unknown": 8 }
       }
     },
     {
@@ -188,9 +214,9 @@
       "expect": {
         "convertedRecords": [7, 3],
         "reportedResourceCount": [7, 3],
-        "podRecords": 9,
-        "podRecordsByType": { "PatientProfile": 1, "VitalSign": 8 },
-        "merges": 1,
+        "podRecords": 7,
+        "podRecordsByType": { "PatientProfile": 1, "VitalSign": 6 },
+        "merges": 3,
         "conflicts": 0,
         "edgesInPod": 0,
         "violations": 0,
@@ -215,13 +241,27 @@
       "expect": {
         "convertedRecords": [5, 6],
         "reportedResourceCount": [5, 6],
-        "podRecords": 5,
-        "podRecordsByType": { "Medication": 4, "PatientProfile": 1 },
-        "merges": 2,
-        "conflicts": 3,
+        "podRecords": 6,
+        "podRecordsByType": { "Medication": 5, "PatientProfile": 1 },
+        "merges": 1,
+        "conflicts": 4,
         "edgesInPod": 0,
         "violations": 0,
-        "importWarnings": 0
+        "importWarnings": 0,
+        "_valuesNote": "Every medication carries the dose its source stated, whether that rode on MedicationStatement.dosage or on MedicationRequest.dosageInstruction. Both dose disagreements (levothyroxine 75/100 mcg, sertraline 50/100 mg) therefore raise a conflict, so the outcome no longer depends on which FHIR shape the source used. The list has five entries and four drugs because the two stopped metformin orders are different products (immediate and extended release, different RxNorm codes) and are kept apart.",
+        "values": [
+          {
+            "on": "clinical:Medication",
+            "predicate": "clinical:dosage",
+            "values": [
+              "100 mcg by mouth every morning",
+              "100 mg by mouth every morning",
+              "Take 1 tablet (20 mg) by mouth once daily",
+              "Take 1 tablet (500 mg) by mouth twice daily",
+              "Take 1 tablet (500 mg) by mouth twice daily"
+            ]
+          }
+        ]
       }
     },
     {
@@ -265,7 +305,7 @@
       ],
       "expect": {
         "convertedRecords": [8, 5],
-        "reportedResourceCount": [2, 2],
+        "reportedResourceCount": [8, 5],
         "podRecords": 12,
         "podRecordsByType": {
           "ClinicalDocument": 3,
@@ -273,11 +313,19 @@
           "LabResultRecord": 6,
           "PatientProfile": 1
         },
-        "merges": 1,
+        "merges": 0,
         "conflicts": 0,
         "edgesInPod": 6,
         "violations": 0,
-        "importWarnings": 0
+        "importWarnings": 1,
+        "_valuesNote": "The one warning is the malformed 9-digit effectiveTime: the day is still emitted, so no record loses its date, but the import says the value was salvaged rather than stated. requiresLLMExtraction is false on all three narrative documents, including the Allergies section carrying nullFlavor=\"NI\": a section that has already said in the ratified way that it holds no information is not offered to a model with the question of what allergies it contains.",
+        "values": [
+          {
+            "on": "clinical:ClinicalDocument",
+            "predicate": "cascade:requiresLLMExtraction",
+            "values": ["false", "false", "false"]
+          }
+        ]
       }
     }
   ]

--- a/tests/ccda-converter-honesty.test.ts
+++ b/tests/ccda-converter-honesty.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Three places the C-CDA path answered a question it had not been asked, and one
+ * where it under-reported what it had done.
+ *
+ * Each is a case where the OUTPUT looked fine and the STATEMENT about it did not
+ * match. None of them is a crash, a violation or a dropped record, which is why
+ * a green suite could hold all four:
+ *
+ *   - A malformed `effectiveTime` was salvaged down to its calendar day and the
+ *     day was then reported as though the source had stated it, with no warning.
+ *   - A section carrying `nullFlavor="NI"` — the ratified way of saying "no
+ *     information" — was queued for LLM extraction, i.e. a model was to be handed
+ *     the sentence "No information available." and asked what it contained.
+ *   - A narrative `<reference>` pointing at an ID the section does not declare
+ *     resolved to nothing in silence, so in the pod it is indistinguishable from
+ *     a record that was never named anywhere.
+ *   - `resourceCount` counted documents-and-sections while the FHIR importer
+ *     counted records, so one field meant two things depending on `--from`.
+ *
+ * Every document below is authored for this test: invented people,
+ * organizations, identifiers, dates and values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { ccdaDateQuad } from '../src/lib/ccda-converter/dates.js';
+import {
+  buildNarrativeIdMap,
+  narrativeTextFor,
+} from '../src/lib/ccda-converter/narrative-reference.js';
+import { parseCcdaXml } from '../src/lib/ccda-converter/parser.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+const HEALTH = 'https://ns.cascadeprotocol.org/health/v1#';
+
+/**
+ * A minimal but conformant C-CDA carrying one Results section whose organizer
+ * holds `observations`, plus whatever extra sections `extraSections` adds.
+ */
+function document(observations: string, extraSections = ''): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5.77771.1" extension="HONESTY-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Fernbrook Health Summary</title>
+  <effectiveTime value="20250704091500-0500"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.19.5.77771.2" extension="MRN-4402"/>
+      <patient>
+        <name use="L"><given>Ottoline</given><family>Vasquez-Hale</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19750618"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5.77771.1"/>
+        <name>Fernbrook Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" displayName="Relevant Diagnostic Tests and/or Laboratory Data" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Results</title>
+          <text>
+            <table><tbody>
+              <tr><td><content ID="fbname1">Sodium</content></td><td>140 mmol/L</td></tr>
+            </tbody></table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+              <id root="2.16.840.1.113883.19.5.77771.4" extension="FB-ORG"/>
+              <code code="24323-8" displayName="Comprehensive metabolic panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="20250704"/>
+${observations}
+            </organizer>
+          </entry>
+        </section>
+      </component>
+${extraSections}
+    </structuredBody>
+  </component>
+</ClinicalDocument>`;
+}
+
+/** One lab observation inside the organizer above. */
+function observation(extension: string, code: string, effectiveTime: string, codeBody = ''): string {
+  return `              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                  <id root="2.16.840.1.113883.19.5.77771.5" extension="${extension}"/>
+                  <code code="${code}" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">${codeBody}</code>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="${effectiveTime}"/>
+                  <value xsi:type="PQ" value="140" unit="mmol/L"/>
+                </observation>
+              </component>`;
+}
+
+const ALLERGIES_NULLFLAVOR = `      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+          <code code="48765-2" displayName="Allergies, Adverse Reactions, Alerts" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Allergies</title>
+          <text>No information available.</text>
+        </section>
+      </component>`;
+
+/** The same section WITHOUT the nullFlavor: genuinely narrative-only. */
+const ALLERGIES_NARRATIVE_ONLY = ALLERGIES_NULLFLAVOR.replace(' nullFlavor="NI"', '');
+
+function objectsOf(turtle: string, predicate: string): string[] {
+  return new Parser({ format: 'Turtle' })
+    .parse(turtle)
+    .filter((q) => q.predicate.value === predicate)
+    .map((q) => q.object.value)
+    .sort();
+}
+
+function recordSubjects(turtle: string): Set<string> {
+  return new Set(
+    new Parser({ format: 'Turtle' })
+      .parse(turtle)
+      .filter((q) => q.predicate.value === RDF_TYPE)
+      .map((q) => q.subject.value),
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('a salvaged date is reported as salvaged', () => {
+  it('warns, names the offending value, and still emits the day', async () => {
+    const result = await convertCcda(
+      document(observation('FB-BAD-DATE', '2951-2', '202507041')),
+    );
+
+    // The day survives — throwing a record's date away over a stray digit loses
+    // more than it saves.
+    expect(objectsOf(result.output, HEALTH + 'performedDate')).toContain('2025-07-04');
+    // And the value the source got wrong is named, so a reader can tell a stated
+    // date from a recovered one.
+    const salvaged = result.warnings.filter((w) => w.includes('202507041'));
+    expect(salvaged).toHaveLength(1);
+  });
+
+  it('says nothing about a well-formed day', async () => {
+    const result = await convertCcda(document(observation('FB-GOOD-DATE', '2951-2', '20250704')));
+    expect(result.warnings.filter((w) => w.includes('malformed'))).toEqual([]);
+  });
+
+  it('carries the warning through the quad helper, which is where callers get it', () => {
+    // Pins the ARGUMENT: the helper only warns because a `warnings` array was
+    // passed to it. Every section handler passes one, and a handler that stops
+    // doing so goes silent again without changing a single emitted triple.
+    const warnings: string[] = [];
+    const quad = ccdaDateQuad('urn:x', HEALTH + 'performedDate', '202507041', warnings);
+    expect(quad?.object.value).toBe('2025-07-04');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('202507041');
+
+    const silent: string[] = [];
+    ccdaDateQuad('urn:x', HEALTH + 'performedDate', '20250704', silent);
+    expect(silent).toEqual([]);
+  });
+});
+
+describe('a section that says it holds no information is not queued for extraction', () => {
+  it('leaves requiresLLMExtraction false for a nullFlavor section', async () => {
+    const result = await convertCcda(
+      document(observation('FB-1', '2951-2', '20250704'), ALLERGIES_NULLFLAVOR),
+    );
+    expect(objectsOf(result.output, CASCADE + 'requiresLLMExtraction')).toEqual(['false', 'false']);
+  });
+
+  it('still queues an entry-less section that made no such statement', async () => {
+    // The contrast is the whole point: a narrative-only section IS worth
+    // reading, and a fix that stopped queueing everything would be a different,
+    // larger change.
+    const result = await convertCcda(
+      document(observation('FB-1', '2951-2', '20250704'), ALLERGIES_NARRATIVE_ONLY),
+    );
+    expect(objectsOf(result.output, CASCADE + 'requiresLLMExtraction')).toEqual(['false', 'true']);
+  });
+});
+
+describe('a narrative reference that resolves to nothing says so', () => {
+  it('warns naming the reference, and still invents no name', async () => {
+    const dangling = '<originalText><reference value="#fbmissing"/></originalText>';
+    const result = await convertCcda(
+      document(observation('FB-DANGLING', '2951-2', '20250704', dangling)),
+    );
+
+    expect(result.warnings.filter((w) => w.includes('#fbmissing'))).toHaveLength(1);
+    // No fabricated name: naming it from the LOINC code would invent the
+    // attested rendering, which is the thing the reference pointed at.
+    expect(objectsOf(result.output, HEALTH + 'testName')).toEqual([]);
+  });
+
+  it('says nothing when the reference resolves', async () => {
+    const resolvable = '<originalText><reference value="#fbname1"/></originalText>';
+    const result = await convertCcda(
+      document(observation('FB-RESOLVES', '2951-2', '20250704', resolvable)),
+    );
+
+    expect(objectsOf(result.output, HEALTH + 'testName')).toEqual(['Sodium']);
+    expect(result.warnings.filter((w) => w.includes('does not resolve'))).toEqual([]);
+  });
+
+  it('warns from the resolver itself only when a warnings array is passed', () => {
+    const section = parseCcdaXml(
+      `<section><text><content ID="a">Sodium</content></text></section>`,
+    ).section;
+    const map = buildNarrativeIdMap(section.text);
+
+    const warnings: string[] = [];
+    expect(narrativeTextFor({ reference: { '@_value': '#nope' } }, map, warnings)).toBe('');
+    expect(warnings).toHaveLength(1);
+
+    // Resolvable: no warning, and the resolved text.
+    const quiet: string[] = [];
+    expect(narrativeTextFor({ reference: { '@_value': '#a' } }, map, quiet)).toBe('Sodium');
+    expect(quiet).toEqual([]);
+  });
+});
+
+describe('resourceCount means the same thing for every importer', () => {
+  it('counts the records produced, not the entries read', async () => {
+    // ONE <entry>, whose organizer holds three observations. The old count was
+    // 1 (patient) + entries.length (1) = 2, for a document that produces the
+    // patient, the Results section's narrative document, the laboratory report
+    // and three results: six records, reported as two.
+    const result = await convertCcda(
+      document(
+        [
+          observation('FB-1', '2951-2', '20250704'),
+          observation('FB-2', '2823-3', '20250704'),
+          observation('FB-3', '2075-0', '20250704'),
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.resourceCount).toBe(recordSubjects(result.output).size);
+    expect(result.resourceCount).toBe(6);
+  });
+});

--- a/tests/ccda-typed-dates.test.ts
+++ b/tests/ccda-typed-dates.test.ts
@@ -130,10 +130,22 @@ describe('ccdaDateTerm — HL7 v3 TS precision to RDF datatype', () => {
     });
   });
 
-  it('falls back to day precision when the digits past the day are malformed', () => {
+  it('falls back to day precision when the digits past the day are malformed, and says it salvaged it', () => {
     // 9 digits: the calendar day is known, the time is not. Reporting the day is
     // honest; reporting "T0:00:00" from a stray digit would not be.
-    expect(ccdaDateTerm('202503111')).toEqual({ value: '2025-03-11', datatype: XSD_DATE });
+    //
+    // `salvaged` is what stops the day being reported as if the source had
+    // stated it. Without it the term is byte-identical to a well-formed
+    // 8-digit day, so a reader has no way to tell a stated date from a
+    // recovered one, and the import has nothing to warn about. The pair of
+    // assertions below is the whole distinction: the flag must be on the
+    // recovered day and off the stated one.
+    expect(ccdaDateTerm('202503111')).toEqual({
+      value: '2025-03-11',
+      datatype: XSD_DATE,
+      salvaged: true,
+    });
+    expect(ccdaDateTerm('20250311')).toEqual({ value: '2025-03-11', datatype: XSD_DATE });
   });
 });
 

--- a/tests/fhir-interpretation-passthrough.test.ts
+++ b/tests/fhir-interpretation-passthrough.test.ts
@@ -26,7 +26,10 @@ import { fileURLToPath } from 'node:url';
 import { convertObservationLab } from '../src/lib/fhir-converter/converters-clinical.js';
 import { restoreLabResultRecord } from '../src/lib/fhir-converter/cascade-to-fhir-clinical.js';
 import { NS } from '../src/lib/fhir-converter/types.js';
-import { ACCEPTED_INTERPRETATION_CODES } from '../src/lib/fhir-converter/interpretation.js';
+import {
+  ACCEPTED_INTERPRETATION_CODES,
+  interpretationValue,
+} from '../src/lib/fhir-converter/interpretation.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -114,17 +117,37 @@ describe('FHIR lab interpretation — "unknown" means the source said nothing', 
 });
 
 describe('FHIR lab interpretation — a code outside the accepted set', () => {
-  it('falls back to the nearest previous mapping and says so in a warning', () => {
+  it('drops the property rather than writing "unknown", and warns naming the code', () => {
+    // The property is absent, and that is the POINT rather than an oversight.
+    // Writing "unknown" here was the defect: "unknown" is the data-absent-reason
+    // code, and this module's contract is that it means the source carried NO
+    // interpretation. Using it for a code the vocabulary cannot express asserts
+    // something the source never said, and stores two different facts as one
+    // string — while the warning that distinguishes them lasts only as long as
+    // the import.
     const result = convertObservationLab(labWith([{ coding: [{ code: 'ZZZ-not-a-code' }] }]));
     const value = result._quads.find(
       (x: any) => x.predicate.value === NS.health + 'interpretation',
     )?.object.value;
-    expect(value).toBe('unknown');
+    expect(value).toBeUndefined();
     expect(result.warnings.join(' ')).toContain('ZZZ-not-a-code');
   });
 
-  it('does not silently drop the interpretation property', () => {
-    expect(interpretationOf(labWith([{ coding: [{ code: 'ZZZ-not-a-code' }] }]))).toBeDefined();
+  it('is distinguishable in the pod from an Observation that stated none', () => {
+    // The whole distinction, in one assertion: the two cases must not produce
+    // the same triple. Absent for the code this vocabulary cannot express;
+    // "unknown" for the source that reported nothing.
+    expect(interpretationOf(labWith([{ coding: [{ code: 'ZZZ-not-a-code' }] }]))).toBeUndefined();
+    expect(interpretationOf(labWith(undefined))).toBe('unknown');
+  });
+
+  it('still uses the nearest legacy mapping where one applies', () => {
+    // The fallback map is not dead: a code IN it is mapped rather than dropped.
+    // Reached through the function directly, since every key of that map is also
+    // in the accepted set and so takes the verbatim path from a real resource.
+    const warnings: string[] = [];
+    expect(interpretationValue([{ coding: [{ code: 'N' }] }], warnings)).toBe('N');
+    expect(warnings).toEqual([]);
   });
 });
 

--- a/tests/fhir-medication-dosage-instruction.test.ts
+++ b/tests/fhir-medication-dosage-instruction.test.ts
@@ -1,0 +1,159 @@
+/**
+ * A prescribed dose is a dose, and the FHIR importer used to read only half of
+ * the resources that state one.
+ *
+ * FHIR R4 gives `MedicationStatement` a `dosage` array and `MedicationRequest` a
+ * `dosageInstruction` array. They are the SAME `Dosage` datatype with the same
+ * `text`, `route` and `timing` children; only the field name differs. The
+ * converter read `resource.dosage` alone, so every MedicationRequest — every
+ * prescription — reached the pod with no dose at all.
+ *
+ * WHY THAT IS WORSE THAN A MISSING TRIPLE. Dose is deliberately stripped out of
+ * the medication identity key, so "sertraline 50 mg" and "sertraline 100 mg" are
+ * one drug as far as matching is concerned; what is supposed to keep the two
+ * apart is the dose-disagreement check, which raises a conflict a person answers.
+ * With both doses absent that check compared two undefineds, found nothing to
+ * disagree about, and merged the pair as a near-duplicate. A dose change
+ * disappeared with no conflict, no warning and no trace — while the identical
+ * change expressed as a MedicationStatement raised its conflict correctly. Which
+ * of two ordinary FHIR shapes the source used decided whether the change
+ * survived the import.
+ *
+ * All fixtures are synthetic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Quad } from 'n3';
+import { convertMedicationStatement } from '../src/lib/fhir-converter/converters-clinical.js';
+import { runReconciliation } from '../src/lib/reconciler.js';
+import { NS } from '../src/lib/fhir-converter/types.js';
+
+/** A MedicationRequest whose dose rides on `dosageInstruction`. */
+function request(id: string, doseText: string): any {
+  return {
+    resourceType: 'MedicationRequest',
+    id,
+    status: 'active',
+    intent: 'order',
+    medicationCodeableConcept: {
+      coding: [
+        {
+          system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+          code: '312940',
+          display: 'Sertraline 50 MG Oral Tablet',
+        },
+      ],
+      text: 'Sertraline oral tablet',
+    },
+    subject: { reference: 'urn:uuid:patient-1' },
+    authoredOn: '2025-02-11',
+    dosageInstruction: [
+      {
+        text: doseText,
+        route: { text: 'Oral' },
+        timing: { repeat: { frequency: 1, period: 1, periodUnit: 'd' } },
+      },
+    ],
+  };
+}
+
+/** The same drug as a MedicationStatement, whose dose rides on `dosage`. */
+function statement(id: string, doseText: string): any {
+  const r = request(id, doseText);
+  r.resourceType = 'MedicationStatement';
+  r.dosage = r.dosageInstruction;
+  delete r.dosageInstruction;
+  delete r.intent;
+  return r;
+}
+
+function objectOf(quads: Quad[], predicate: string): string | undefined {
+  return quads.find((q) => q.predicate.value === predicate)?.object.value;
+}
+
+describe('MedicationRequest.dosageInstruction is read like MedicationStatement.dosage', () => {
+  it('carries the dose text, route and frequency off dosageInstruction', () => {
+    const { _quads } = convertMedicationStatement(request('mr-1', '50 mg by mouth every morning'));
+    expect(objectOf(_quads, NS.clinical + 'dosage')).toBe('50 mg by mouth every morning');
+    expect(objectOf(_quads, NS.clinical + 'route')).toBe('Oral');
+    expect(objectOf(_quads, NS.clinical + 'frequency')).toBe('once daily');
+  });
+
+  it('produces the same dose triple whichever of the two shapes stated it', () => {
+    // The invariant the defect broke: the answer must not depend on the
+    // transport. Compared as a triple rather than as "both are truthy", so a
+    // reader that found the field but mangled the value still fails.
+    const fromRequest = convertMedicationStatement(request('mr-1', '50 mg by mouth every morning'));
+    const fromStatement = convertMedicationStatement(
+      statement('ms-1', '50 mg by mouth every morning'),
+    );
+    expect(objectOf(fromRequest._quads, NS.clinical + 'dosage')).toBe(
+      objectOf(fromStatement._quads, NS.clinical + 'dosage'),
+    );
+  });
+
+  it('prefers the resource\'s own `dosage` when a resource somehow carries both', () => {
+    const both = statement('ms-2', 'from dosage');
+    both.dosageInstruction = [{ text: 'from dosageInstruction' }];
+    const { _quads } = convertMedicationStatement(both);
+    expect(objectOf(_quads, NS.clinical + 'dosage')).toBe('from dosage');
+  });
+
+  it('writes no dose triple when the resource states none', () => {
+    const bare = request('mr-3', '');
+    delete bare.dosageInstruction;
+    const { _quads } = convertMedicationStatement(bare);
+    expect(objectOf(_quads, NS.clinical + 'dosage')).toBeUndefined();
+  });
+});
+
+describe('a dose change stated on an order raises a conflict rather than merging away', () => {
+  const PREFIXES = `
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+`;
+
+  /** Serialize a converted MedicationRequest as the pod would hold it. */
+  function turtleFor(uri: string, doseText: string): string {
+    const { _quads } = convertMedicationStatement(request('mr', doseText));
+    const dose = objectOf(_quads, NS.clinical + 'dosage');
+    return `${PREFIXES}
+<${uri}> a clinical:Medication ;
+  clinical:drugName "Sertraline oral tablet" ;
+  clinical:rxNormCode <http://www.nlm.nih.gov/research/umls/rxnorm/312940> ;
+  clinical:status "active" ;
+${dose === undefined ? '' : `  clinical:dosage "${dose}" ;\n`}  clinical:provenanceClass "imported" .
+`;
+  }
+
+  it('reports a clinical:dosage conflict for 50 mg against 100 mg', async () => {
+    const result = await runReconciliation([
+      { content: turtleFor('urn:m:a', '50 mg by mouth every morning'), systemName: 'Harborview' },
+      { content: turtleFor('urn:m:b', '100 mg by mouth every morning'), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.conflictsUnresolved).toBe(1);
+    const [t] = result.report.transformations as Array<{ conflictField?: string; resolved?: boolean }>;
+    expect(t.conflictField).toBe('clinical:dosage');
+    expect(t.resolved).toBe(false);
+  });
+
+  it('still merges silently when neither record states a dose, which is why the read matters', async () => {
+    // The pre-fix outcome, reproduced deliberately: with no dose on either side
+    // there is nothing to disagree about and the pair collapses. Reading
+    // dosageInstruction is what moves a real prescription out of this branch.
+    const noDose = (uri: string) => `${PREFIXES}
+<${uri}> a clinical:Medication ;
+  clinical:drugName "Sertraline oral tablet" ;
+  clinical:rxNormCode <http://www.nlm.nih.gov/research/umls/rxnorm/312940> ;
+  clinical:status "active" .
+`;
+    const result = await runReconciliation([
+      { content: noDose('urn:m:a'), systemName: 'Harborview' },
+      { content: noDose('urn:m:b'), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.conflictsUnresolved).toBe(0);
+    expect(result.report.summary.finalRecordCount).toBe(1);
+  });
+});

--- a/tests/fhir-standards-alignment.test.ts
+++ b/tests/fhir-standards-alignment.test.ts
@@ -306,9 +306,16 @@ describe('a conformant Epic-shaped FHIR bundle converts and validates', () => {
   it('preserves every category and code the source sent', () => {
     // Pins CONVERTER behaviour. Widening a shape and dropping the values that
     // used to trip it produce the same green suite; this separates them.
+    //
+    // `laboratory` is in the list because the source sent it. It used to be
+    // filtered out on the reading that the record's type implies it, which cost
+    // nothing here but dropped the ONLY category of a result categorised both
+    // laboratory and something else — so a pod filtered by labCategory omitted a
+    // record filed as a lab.
     expect(objects(`${NS.health}labCategory`)).toEqual([
       'Antimicrobial Susceptibility',
       'MICROBIOLOGY',
+      'laboratory',
     ]);
     expect(objects(`${NS.health}testCode`)).toHaveLength(2);
     expect(objects(`${NS.health}icd10Code`)).toEqual([

--- a/tests/pathology-corpus.test.ts
+++ b/tests/pathology-corpus.test.ts
@@ -67,6 +67,24 @@ const BASELINE_PATH = path.join(REPO, 'tests', 'pathology-reconciliation-baselin
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
 const MERGED_FROM = CASCADE + 'mergedFrom';
+
+/** Prefixes a manifest may use in a `values` expectation. */
+const PREFIXES: Record<string, string> = {
+  cascade: CASCADE,
+  health: 'https://ns.cascadeprotocol.org/health/v1#',
+  clinical: 'https://ns.cascadeprotocol.org/clinical/v1#',
+  coverage: 'https://ns.cascadeprotocol.org/coverage/v1#',
+};
+
+/** `health:labCategory` -> the full IRI. Throws on an unknown prefix. */
+function expandPrefixed(name: string): string {
+  const [prefix, local] = name.split(':', 2);
+  const ns = PREFIXES[prefix];
+  if (!ns || local === undefined) {
+    throw new Error(`scenario names "${name}", whose prefix the harness does not know`);
+  }
+  return ns + local;
+}
 /** Every predicate any importer uses to carry the source's own record id. */
 const SOURCE_RECORD_ID = [
   CASCADE + 'sourceRecordId',
@@ -84,6 +102,26 @@ interface Batch {
   from: string;
   /** `--source-system` passed to BOTH convert and import, when present. */
   sourceSystem?: string;
+}
+
+/**
+ * One predicate's object values, as the pod must hold them.
+ *
+ * The count fields below say how many records came out; this says WHAT THEY SAY.
+ * It exists because retiring a KNOWN_OUTCOMES entry has to move its expectation
+ * into the scenario rather than delete it: several of those entries were about a
+ * single predicate's values (which categories a lab carries, which interpretation
+ * codes reached the pod, which doses a medication states), and a record census
+ * cannot tell whether those are right. Without a slot for them, "the ledger is
+ * allowed to shrink" would quietly mean "the pin is allowed to disappear".
+ */
+interface ValueExpectation {
+  /** Prefixed class name whose subjects are read (`health:LabResultRecord`). */
+  on: string;
+  /** Prefixed predicate name (`health:labCategory`). */
+  predicate: string;
+  /** Every object value, sorted, duplicates included. */
+  values: string[];
 }
 
 interface Expectations {
@@ -105,6 +143,14 @@ interface Expectations {
   violations: number;
   /** Import-time warnings across every batch. */
   importWarnings: number;
+  /** Object values the pod must hold, per predicate. Optional. */
+  values?: ValueExpectation[];
+  /**
+   * `sourceBreakdown` on the FIRST batch's import report. Optional, and present
+   * where WHICH source label the records land under is the point rather than
+   * merely how many there are.
+   */
+  sourceBreakdown?: Record<string, number>;
 }
 
 interface Scenario {
@@ -482,6 +528,29 @@ describe.each(ALL_SCENARIOS)('$scenario.id  $scenario.pathology', ({ scenario })
     expect(obs().importWarnings.length, obs().importWarnings.join('\n')).toBe(
       scenario.expect.importWarnings,
     );
+  });
+
+  it('holds the expected object values for every pinned predicate', () => {
+    for (const v of scenario.expect.values ?? []) {
+      const actual = obs().valuesOn(expandPrefixed(v.on), expandPrefixed(v.predicate));
+      expect(actual, `${v.on} ${v.predicate}`).toEqual(v.values);
+    }
+  });
+
+  it('accounts every imported record on the source axis', () => {
+    // The invariant behind the retired P05 entry, held for EVERY scenario rather
+    // than only the one that tripped over it: a record that reached the pod
+    // appears in sourceBreakdown, under the ratified "unknown" token when its EHR
+    // of origin cannot be determined. A breakdown that silently omits what it
+    // could not attribute reads as "this pod has no data".
+    for (const [i, report] of obs().importReports.entries()) {
+      const accountedFor = Object.values(report.sourceBreakdown).reduce((a, b) => a + b, 0);
+      expect(accountedFor, `batch ${i} sourceBreakdown: ${JSON.stringify(report.sourceBreakdown)}`)
+        .toBe(report.totalRecordsImported);
+    }
+    if (scenario.expect.sourceBreakdown) {
+      expect(obs().importReports[0].sourceBreakdown).toEqual(scenario.expect.sourceBreakdown);
+    }
   });
 
   it('matches every known-outcome entry recorded against it', () => {

--- a/tests/pathology-known-outcomes.ts
+++ b/tests/pathology-known-outcomes.ts
@@ -161,26 +161,6 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
     fixed: { labRecords: 4, conflicts: 0, violations: 0 },
   },
   {
-    id: 'P03-dangling-narrative-reference-is-silent',
-    scenario: 'P03',
-    currentWrongOutcome:
-      'An <originalText><reference value="#id"/> pointing at an element the narrative does not ' +
-      'contain resolves to nothing, the record imports with no testName, and the import reports ' +
-      'no warning. In the pod it is byte-indistinguishable from the observation that carried no ' +
-      'name anywhere, so "the rendering we were given was incomplete" and "this test was never ' +
-      'named" arrive as the same absence.',
-    expectedOnceFixed:
-      'The record still gains NO name — inventing one from the LOINC code would be fabricating ' +
-      'the attested rendering — but the import emits one warning naming the unresolved reference, ' +
-      'so the two absences are told apart at the point where the information still exists.',
-    probe: (o) => ({
-      importWarnings: o.importWarnings.length,
-      labsWithoutTestName: o.countMissing(NS.health + 'LabResultRecord', NS.health + 'testName'),
-    }),
-    current: { importWarnings: 0, labsWithoutTestName: 2 },
-    fixed: { importWarnings: 1, labsWithoutTestName: 2 },
-  },
-  {
     id: 'P04-procedure-name-written-off-shape',
     scenario: 'P04',
     currentWrongOutcome:
@@ -227,62 +207,6 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
     },
   },
   {
-    id: 'P05-unmapped-interpretation-collapses-onto-absent',
-    scenario: 'P05',
-    currentWrongOutcome:
-      'An Observation.interpretation code outside the set health:interpretation accepts is written ' +
-      'as "unknown" — the SAME value that means "the source carried no interpretation at all". The ' +
-      'import does warn, but a warning is transient and the pod is what survives, so two different ' +
-      'facts are stored as one string.',
-    expectedOnceFixed:
-      'The pod distinguishes "the source stated an interpretation this vocabulary cannot express" ' +
-      'from "the source stated none", so exactly ONE record in this scenario reads as absent. The ' +
-      'import warning stays either way; it is the pod that has to stop losing the distinction.',
-    probe: (o) => ({
-      unknownInterpretations: o
-        .valuesOn(NS.health + 'LabResultRecord', NS.health + 'interpretation')
-        .filter((v) => v === 'unknown').length,
-      warnings: o.importWarnings.filter((w) => w.includes('ZQ7')).length,
-    }),
-    current: { unknownInterpretations: 2, warnings: 1 },
-    fixed: { unknownInterpretations: 1, warnings: 1 },
-  },
-  {
-    id: 'P05-multi-category-observation-keeps-one-category',
-    scenario: 'P05',
-    currentWrongOutcome:
-      'An Observation categorised BOTH laboratory and procedure records health:labCategory ' +
-      '"procedure" only: the last category wins and the category that DECIDED the routing is the ' +
-      'one dropped. A pod filtered by labCategory therefore omits a record that is filed as a lab.',
-    expectedOnceFixed:
-      'Every category the source stated is carried, so the record is findable under the category it ' +
-      'was routed by as well as the one it also claims.',
-    probe: (o) => o.valuesOn(NS.health + 'LabResultRecord', NS.health + 'labCategory'),
-    current: ['procedure'],
-    fixed: ['laboratory', 'procedure'],
-  },
-  {
-    id: 'P05-records-without-a-derivable-ehr-leave-the-source-axis',
-    scenario: 'P05',
-    currentWrongOutcome:
-      'A bundle whose references are all urn:uuid: gives the provenance pass no host to read and no ' +
-      'institution-looking display, so no clinical:sourceEHR is written at all and the import ' +
-      "report's sourceBreakdown is empty. Eight records were imported and the source axis accounts " +
-      'for none of them, which reads as "this pod has no data" rather than "we could not tell where ' +
-      'this came from". The ClinicalDocument path already solves this with the ratified ' +
-      'data-absent token.',
-    expectedOnceFixed:
-      'Every imported record appears in sourceBreakdown, with the ratified "unknown" token where the ' +
-      'EHR of origin genuinely cannot be determined — never the import-batch label, which is how the ' +
-      'data got in rather than where it came from.',
-    probe: (o) => ({
-      imported: o.importReports[0].totalRecordsImported,
-      accountedFor: Object.values(o.importReports[0].sourceBreakdown).reduce((a, b) => a + b, 0),
-    }),
-    current: { imported: 8, accountedFor: 0 },
-    fixed: { imported: 8, accountedFor: 8 },
-  },
-  {
     id: 'P07-shared-transport-label-blocks-cross-source-dedup',
     scenario: 'P07-SHARED-LABEL',
     currentWrongOutcome:
@@ -299,47 +223,6 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
     probe: (o) => ({ podRecords: o.podRecords, merges: merges(o) }),
     current: { podRecords: 12, merges: 0 },
     fixed: { podRecords: 7, merges: 5 },
-  },
-  {
-    id: 'P08-vital-matcher-reads-predicates-the-converter-never-writes',
-    scenario: 'P08',
-    currentWrongOutcome:
-      'matchVitalSigns reads health:testCode, health:effectiveDate / health:performedDate and ' +
-      'health:value. The converter writes clinical:loincCode, clinical:effectiveDate and ' +
-      'clinical:value. All three lookups return undefined, the date guard fails, and the function ' +
-      'returns no-match for EVERY pair — so no two vital signs in any pod have ever matched. The ' +
-      '"three same-day readings must never merge" property holds here for the wrong reason, and ' +
-      'the price is the clock-skew duplicate 17 minutes later, which is the same cuff reading and ' +
-      'is kept as a second record.',
-    expectedOnceFixed:
-      'The matcher reads the predicates the converter emits. The clock-skew pair (systolic and ' +
-      'diastolic) merges and nothing else does, leaving 6 vital records. Restoring the matcher ' +
-      'without a time-proximity rule would instead merge all four same-day readings, which is why ' +
-      'this scenario carries three readings hours apart rather than one.',
-    probe: (o) => ({ vitalRecords: o.podRecordsByType['VitalSign'] ?? 0, merges: merges(o) }),
-    current: { vitalRecords: 8, merges: 1 },
-    fixed: { vitalRecords: 6, merges: 3 },
-  },
-  {
-    id: 'P09-medicationrequest-dose-is-dropped-then-silently-merged',
-    scenario: 'P09',
-    currentWrongOutcome:
-      'The medication converter reads dose text from resource.dosage (the MedicationStatement ' +
-      'field) and never from resource.dosageInstruction (the MedicationRequest field). So ' +
-      'sertraline 50 mg and sertraline 100 mg arrive carrying no dose, the dose-conflict check ' +
-      'compares two absent values, finds no disagreement, and merges them into ONE record with no ' +
-      'conflict raised — a dose change silently disappears. The levothyroxine pair, the same ' +
-      'disagreement expressed as MedicationStatement, does raise its conflict, so the outcome ' +
-      'depends on which FHIR shape the source used.',
-    expectedOnceFixed:
-      'dosageInstruction is read the way dosage is, both pairs carry their dose, and both raise a ' +
-      'dose conflict: 4 unresolved conflicts, and 2 medication records carrying clinical:dosage.',
-    probe: (o) => ({
-      conflicts: o.conflicts.length,
-      medsCarryingDosage: o.subjectsWith(NS.clinical + 'dosage').length,
-    }),
-    current: { conflicts: 3, medsCarryingDosage: 1 },
-    fixed: { conflicts: 4, medsCarryingDosage: 2 },
   },
   {
     id: 'P10-negation-and-data-absent-sentinels-stored-as-allergens',
@@ -380,28 +263,6 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
     fixed: { reports: 1, edges: 4 },
   },
   {
-    id: 'P12-malformed-nine-digit-date-accepted-silently',
-    scenario: 'P12',
-    currentWrongOutcome:
-      'effectiveTime="201102013" is nine digits: neither the 8-digit calendar day nor the 10-digit ' +
-      'hour precision, so the value is malformed past the day. The date rule takes the first eight ' +
-      'digits and emits "2011-02-01"^^xsd:date with no warning, which states a calendar day with ' +
-      'full confidence on the strength of a value the source got wrong. The guess is a REASONABLE ' +
-      'one — the defect is that it is indistinguishable from a well-formed day.',
-    expectedOnceFixed:
-      'The day is still emitted (throwing the record\'s date away over a stray digit would lose more ' +
-      'than it saves), but the import warns that the source value was malformed, so a reader can ' +
-      'tell a stated date from a salvaged one.',
-    probe: (o) => ({
-      malformedDateWarnings: o.importWarnings.filter((w) => w.includes('201102013')).length,
-      dates: o
-        .valuesOn(NS.health + 'LabResultRecord', NS.health + 'performedDate')
-        .filter((d) => d.startsWith('2011')),
-    }),
-    current: { malformedDateWarnings: 0, dates: ['2011-02-01', '2011-02-01', '2011-02-01', '2011-02-01'] },
-    fixed: { malformedDateWarnings: 1, dates: ['2011-02-01', '2011-02-01', '2011-02-01', '2011-02-01'] },
-  },
-  {
     id: 'P12-nullflavor-variety-collapses-to-one-absence',
     scenario: 'P12',
     currentWrongOutcome:
@@ -413,45 +274,20 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
     expectedOnceFixed:
       'The nullFlavor is carried, so "we never measured it", "the result is coming" and "we asked ' +
       'and were not told" stay three different answers. The records still carry no resultValue — ' +
-      'inventing one is not the fix.',
+      'inventing one is not the fix. BLOCKED ON VOCABULARY, deliberately: the predicate this entry ' +
+      'names, health:dataAbsentReason, does not exist. No property in health, clinical or core ' +
+      'carries a reason-for-absence today, and vocabulary is authored in `spec/` and synced into ' +
+      'src/shapes/ — emitting a term the ontology does not define would put an unvalidatable ' +
+      'predicate in every pod and is not a smaller change than adding it properly. So the CONVERTER ' +
+      'fix waits on a spec addition binding health:dataAbsentReason to the HL7 v3 NullFlavor / FHIR ' +
+      'data-absent-reason value set, and this entry stays open to say so rather than being answered ' +
+      'with an invented term.',
     probe: (o) => ({
       labsWithoutValue: o.countMissing(NS.health + 'LabResultRecord', NS.health + 'resultValue'),
       dataAbsentReasons: o.values(NS.health + 'dataAbsentReason').length,
     }),
     current: { labsWithoutValue: 3, dataAbsentReasons: 0 },
     fixed: { labsWithoutValue: 3, dataAbsentReasons: 3 },
-  },
-  {
-    id: 'P12-nullflavor-empty-section-queued-for-extraction',
-    scenario: 'P12',
-    currentWrongOutcome:
-      'An Allergies section carrying nullFlavor="NI" and no entries becomes a ClinicalDocument ' +
-      'narrative record with cascade:requiresLLMExtraction true. The section has already said, in ' +
-      'the ratified way, that it holds no information; queueing it for extraction offers a model ' +
-      'the sentence "No information available." and asks what allergies it contains.',
-    expectedOnceFixed:
-      'A section whose nullFlavor says there is no information is not queued for extraction. ' +
-      'Whether it should produce a record at all (an explicit "this section was empty" is more than ' +
-      'the pod knows otherwise) is the open question; not asking a model to read it is not.',
-    probe: (o) => o.valuesOn(NS.clinical + 'ClinicalDocument', NS.cascade + 'requiresLLMExtraction'),
-    current: ['false', 'false', 'true'],
-    fixed: ['false', 'false', 'false'],
-  },
-  {
-    id: 'P12-ccda-convert-under-reports-what-it-produced',
-    scenario: 'P12',
-    currentWrongOutcome:
-      '`cascade convert --json --from c-cda` reports resourceCount 2 for a document from which it ' +
-      'emits 8 record subjects, because the C-CDA importer counts documents-and-sections where the ' +
-      'FHIR importer counts records. A caller reading resourceCount to decide whether an import is ' +
-      'worth running, or to show "N records found", is told a number four times too small, and the ' +
-      'two importers disagree about what the field means.',
-    expectedOnceFixed:
-      'resourceCount means the same thing for every importer: the number of records the conversion ' +
-      'produced. For this document that is 8 and 5.',
-    probe: (o) => ({ reported: o.reportedResourceCount, produced: o.convertedRecords }),
-    current: { reported: [2, 2], produced: [8, 5] },
-    fixed: { reported: [8, 5], produced: [8, 5] },
   },
 ];
 

--- a/tests/pathology-reconciliation-baseline.json
+++ b/tests/pathology-reconciliation-baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Baseline reconciliation scorecard for the pathology-corpus scenarios that carry a constructed ground truth. REPORT-ONLY: nothing here asserts these numbers are good, and two of the recalls are 0. The harness asserts they are KNOWN, so a change to matching has to move this file on purpose, in the same commit as the change that moved it. Scored over merge PAIRS: precision = correctPairs / predictedPairs (1 when the reconciler predicted nothing, since predicting nothing asserts nothing wrong), recall = correctPairs / truthPairs.",
+  "_comment": "Baseline reconciliation scorecard for the pathology-corpus scenarios that carry a constructed ground truth. REPORT-ONLY: nothing here asserts these numbers are good, and one of the recalls is 0. The harness asserts they are KNOWN, so a change to matching has to move this file on purpose, in the same commit as the change that moved it. Scored over merge PAIRS: precision = correctPairs / predictedPairs (1 when the reconciler predicted nothing, since predicting nothing asserts nothing wrong), recall = correctPairs / truthPairs. P08 moved from recall 0 to recall 1 when the vital-sign matcher was pointed at the predicates the converters actually write and given a time-proximity rule: it now merges the clock-skew pair (systolic and diastolic, 17 minutes apart across two sources) and nothing else, so it predicts exactly the two pairs the truth names. P07-SHARED-LABEL's recall of 0 belongs to the same-source guard and is unchanged.",
   "scores": {
     "P07": {
       "universe": 10,
@@ -20,10 +20,10 @@
     "P08": {
       "universe": 8,
       "truthPairs": 2,
-      "predictedPairs": 0,
-      "correctPairs": 0,
+      "predictedPairs": 2,
+      "correctPairs": 2,
       "precision": 1,
-      "recall": 0
+      "recall": 1
     }
   }
 }

--- a/tests/reconciler-matcher-sweep.test.ts
+++ b/tests/reconciler-matcher-sweep.test.ts
@@ -1,0 +1,358 @@
+/**
+ * The reconciler matchers, pinned against the predicates the CONVERTERS actually
+ * write, and against the strings that reach persisted conflict ids.
+ *
+ * WHY THESE FOUR TESTS EXIST TOGETHER
+ * ----------------------------------
+ * They are one defect wearing four costumes: a matcher reading a name nothing
+ * writes. None of them could be caught by a green suite, because a matcher that
+ * never fires produces no wrong output — it produces no output, and "these two
+ * records did not merge" is the same observation as "there was nothing to merge".
+ *
+ *   - `matchVitalSigns` read `health:testCode`, `health:effectiveDate` and
+ *     `health:value`. Both converters write `clinical:loincCode`,
+ *     `clinical:effectiveDate` and `clinical:value`, so every lookup returned
+ *     undefined and no two vital signs in any pod had ever matched.
+ *   - `matchImmunizations` read `health:cvxCode`, which only the C-CDA importer
+ *     writes; the FHIR importer writes `health:vaccineCode` with a `CVX-` prefix.
+ *   - `codeFromUri` was `uri.split('/').pop() ?? uri.split('#').pop()`, whose
+ *     second operand is unreachable, so a FHIR LOINC (`http://loinc.org/rdf#…`)
+ *     and a C-CDA LOINC (`http://loinc.org/…`) for ONE code compared unequal, and
+ *     the mangled `rdf#3094-0` reached `settings/pending-conflicts.ttl`.
+ *   - `matchMedications` reported the bare constant `partial-name`, from which
+ *     `generateConflictId` built ONE id for every partial-name medication
+ *     conflict in a pod.
+ *
+ * Each test therefore asserts the ARGUMENT and not just the outcome: which
+ * predicate was read, which string was produced. An assertion that two records
+ * merged would stay green if the matcher started keying on something else.
+ *
+ * All fixtures are synthetic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runReconciliation } from '../src/lib/reconciler.js';
+import { generateConflictId, legacyConflictIds } from '../src/lib/user-resolutions.js';
+
+const PREFIXES = `
+@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+`;
+
+interface Transformation {
+  type: string;
+  recordType: string;
+  matchedOn?: string;
+  conflictField?: string;
+}
+
+const transformations = (r: { report: { transformations: object[] } }): Transformation[] =>
+  r.report.transformations as Transformation[];
+
+// ---------------------------------------------------------------------------
+// Vital signs
+// ---------------------------------------------------------------------------
+
+/**
+ * A vital sign exactly as `convertObservationVital` emits one: LOINC under
+ * `clinical:loincCode`, instant under `clinical:effectiveDate`, reading under
+ * `clinical:value`.
+ */
+function vital(uri: string, loinc: string, effective: string, value: number): string {
+  return `${PREFIXES}
+<${uri}> a clinical:VitalSign ;
+  clinical:vitalType "bloodPressureSystolic" ;
+  clinical:loincCode <http://loinc.org/rdf#${loinc}> ;
+  clinical:effectiveDate "${effective}" ;
+  clinical:value "${value}" .
+`;
+}
+
+describe('vital-sign matcher: reads the predicates the converters write', () => {
+  it('merges a clock-skew duplicate recorded 17 minutes later by a second system', async () => {
+    const result = await runReconciliation([
+      { content: vital('urn:v:evening', '8480-6', '2025-06-11T17:20:00-07:00', 144), systemName: 'Harborview' },
+      { content: vital('urn:v:skew', '8480-6', '2025-06-11T17:37:00-07:00', 144), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(1);
+
+    // The ARGUMENT, not just the outcome: matched on the LOINC code (unmangled)
+    // and the earlier of the two instants. Keying on the earlier one is what
+    // makes the id independent of which record was enumerated first.
+    const [t] = transformations(result);
+    expect(t.matchedOn).toBe('loinc:8480-6+2025-06-12T00:20:00.000Z');
+  });
+
+  it('never merges two readings of the same vital taken hours apart', async () => {
+    // 08:05 and 12:40 the same day, same LOINC, values within 7%. Under the
+    // "same LOINC + same calendar day" rule these are one record; they are three
+    // hours of clinical change. Note both come from DIFFERENT sources, so the
+    // same-source guard is not what is keeping them apart here.
+    const result = await runReconciliation([
+      { content: vital('urn:v:morning', '8480-6', '2025-06-11T08:05:00-07:00', 138), systemName: 'Harborview' },
+      { content: vital('urn:v:midday', '8480-6', '2025-06-11T12:40:00-07:00', 129), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(2);
+    expect(transformations(result)).toEqual([]);
+  });
+
+  it('keeps both readings when two sources disagree by more than a rounding difference', async () => {
+    // Inside the window, same code, but 138 and 172 are two measurements rather
+    // than one measurement recorded twice. Keeping both is the recoverable answer.
+    const result = await runReconciliation([
+      { content: vital('urn:v:a', '8480-6', '2025-06-11T17:20:00-07:00', 138), systemName: 'Harborview' },
+      { content: vital('urn:v:b', '8480-6', '2025-06-11T17:25:00-07:00', 172), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(2);
+  });
+
+  it('does not merge two different vitals recorded at the same instant', async () => {
+    // Systolic and diastolic, one cuff, one timestamp. Only the code tells them
+    // apart, so this is what fails if the code read is dropped from the key.
+    const result = await runReconciliation([
+      { content: vital('urn:v:sys', '8480-6', '2025-06-11T17:20:00-07:00', 90), systemName: 'Harborview' },
+      { content: vital('urn:v:dia', '8462-4', '2025-06-11T17:20:00-07:00', 90), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Immunizations
+// ---------------------------------------------------------------------------
+
+describe('immunization matcher: both importers spell the CVX code differently', () => {
+  it('matches a FHIR "CVX-141" against a C-CDA cvx code URI for the same shot', async () => {
+    // Two names that do NOT match as strings, so the name tier cannot rescue
+    // this: only reading the code both importers wrote can.
+    const fhirShape = `${PREFIXES}
+<urn:imm:fhir> a health:ImmunizationRecord ;
+  health:vaccineName "Influenza, seasonal, injectable" ;
+  health:vaccineCode "CVX-141" ;
+  health:administrationDate "2024-10-02" .
+`;
+    const ccdaShape = `${PREFIXES}
+<urn:imm:ccda> a health:ImmunizationRecord ;
+  health:vaccineName "Influenza vaccine" ;
+  health:cvxCode <http://hl7.org/fhir/sid/cvx/141> ;
+  health:administrationDate "2024-10-02" .
+`;
+    const result = await runReconciliation([
+      { content: fhirShape, systemName: 'Meridian FHIR' },
+      { content: ccdaShape, systemName: 'Meridian C-CDA' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(1);
+    expect(transformations(result)[0].matchedOn).toBe('cvx:141+2024-10-02');
+  });
+
+  it('keeps the name tier for records that carry no code at all', async () => {
+    const named = (uri: string) => `${PREFIXES}
+<${uri}> a health:ImmunizationRecord ;
+  health:vaccineName "Tetanus toxoid" ;
+  health:administrationDate "2023-04-11" .
+`;
+    const result = await runReconciliation([
+      { content: named('urn:imm:a'), systemName: 'Meridian' },
+      { content: named('urn:imm:b'), systemName: 'Ridgecrest' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(1);
+    expect(transformations(result)[0].matchedOn).toBe('name:"tetanus toxoid"+2023-04-11');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Code extraction, and what reaches a persisted conflict id
+// ---------------------------------------------------------------------------
+
+function lab(uri: string, loincUri: string, value: string): string {
+  return `${PREFIXES}
+<${uri}> a health:LabResultRecord ;
+  health:testName "Glucose" ;
+  health:testCode <${loincUri}> ;
+  health:performedDate "2025-03-04" ;
+  health:resultValue "${value}" .
+`;
+}
+
+describe('code extraction: one LOINC, two importer spellings, one key', () => {
+  it('matches a FHIR loinc/rdf# URI against a C-CDA loinc/ URI for the same code', async () => {
+    const result = await runReconciliation([
+      { content: lab('urn:lab:fhir', 'http://loinc.org/rdf#3094-0', '18'), systemName: 'Meridian FHIR' },
+      { content: lab('urn:lab:ccda', 'http://loinc.org/3094-0', '18'), systemName: 'Meridian C-CDA' },
+    ]);
+    expect(result.report.summary.finalRecordCount).toBe(1);
+  });
+
+  it('puts the bare code in matchedOn, which is what a conflict id is built from', async () => {
+    const result = await runReconciliation([
+      { content: lab('urn:lab:a', 'http://loinc.org/rdf#3094-0', '18'), systemName: 'Meridian' },
+      { content: lab('urn:lab:b', 'http://loinc.org/rdf#3094-0', '44'), systemName: 'Ridgecrest' },
+    ]);
+
+    const [t] = transformations(result);
+    expect(t.matchedOn).toBe('loinc:3094-0+2025-03-04');
+    // The string in the pod, not just in memory: `rdf#3094-0` is what used to
+    // land in settings/pending-conflicts.ttl and stay there.
+    expect(generateConflictId(t.recordType, t.matchedOn!)).toBe(
+      'health:LabResultRecord::loinc:3094-0+2025-03-04',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Medication partial-name conflict ids
+// ---------------------------------------------------------------------------
+
+function med(uri: string, drugName: string, dose: string, status = 'active'): string {
+  return `${PREFIXES}
+<${uri}> a clinical:Medication ;
+  clinical:drugName "${drugName}" ;
+  clinical:dosage "${dose}" ;
+  clinical:status "${status}" .
+`;
+}
+
+describe('medication partial-name conflicts: one id per drug, not one id total', () => {
+  it('names the drug in matchedOn so two drugs cannot share a conflict id', async () => {
+    // Two independent conflicts in one run, both matched by name containment.
+    // Under the bare `partial-name` constant these produced one id, and
+    // user-resolutions.ttl is keyed by id and cannot hold two rows under one key.
+    // "metoprolol succinate" contains "metoprolol" after normalization without
+    // equalling it, which is the containment case the name tier cannot answer.
+    const result = await runReconciliation([
+      { content: med('urn:m:a1', 'metoprolol', '25 mg'), systemName: 'Harborview' },
+      { content: med('urn:m:a2', 'metoprolol succinate', '50 mg'), systemName: 'Ridgecrest' },
+      { content: med('urn:m:b1', 'insulin', '10 units'), systemName: 'Harborview' },
+      { content: med('urn:m:b2', 'insulin glargine', '20 units'), systemName: 'Ridgecrest' },
+    ]);
+
+    const matched = transformations(result)
+      .filter((t) => t.matchedOn?.startsWith('partial-name'))
+      .map((t) => t.matchedOn!);
+    expect(matched.sort()).toEqual(['partial-name:"insulin"', 'partial-name:"metoprolol"']);
+
+    const ids = matched.map((m) => generateConflictId('clinical:Medication', m));
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('picks the contained name, so the id does not depend on input order', async () => {
+    const forward = await runReconciliation([
+      { content: med('urn:m:1', 'metoprolol', '25 mg'), systemName: 'Harborview' },
+      { content: med('urn:m:2', 'metoprolol succinate', '50 mg'), systemName: 'Ridgecrest' },
+    ]);
+    const reversed = await runReconciliation([
+      { content: med('urn:m:2', 'metoprolol succinate', '50 mg'), systemName: 'Ridgecrest' },
+      { content: med('urn:m:1', 'metoprolol', '25 mg'), systemName: 'Harborview' },
+    ]);
+
+    expect(transformations(forward)[0].matchedOn).toBe('partial-name:"metoprolol"');
+    expect(transformations(reversed)[0].matchedOn).toBe('partial-name:"metoprolol"');
+  });
+});
+
+describe('conflict ids an earlier version wrote are still findable', () => {
+  it('reproduces the pre-fix id for both changed shapes, and only when it differs', () => {
+    expect(legacyConflictIds('clinical:Medication', 'partial-name:"lisinopril"')).toEqual([
+      'clinical:Medication::partial-name',
+    ]);
+    expect(legacyConflictIds('health:LabResultRecord', 'loinc:3094-0+2025-03-04')).toEqual([
+      'health:LabResultRecord::loinc:rdf_3094-0+2025-03-04',
+    ]);
+    // An id no defect ever mangled has no older spelling to look for.
+    expect(legacyConflictIds('clinical:Medication', 'rxnorm:861007')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The cross-batch path
+// ---------------------------------------------------------------------------
+
+describe('cross-batch reconciliation runs on the existing-pod marker, not on a label', () => {
+  /**
+   * Two records the pod ALREADY holds that match each other, plus one new
+   * record. The pod is settled state: its records are not re-compared against
+   * each other, only against what is arriving. So the marker is observable as a
+   * merge that does NOT happen.
+   */
+  const podRecordA = `${PREFIXES}
+<urn:pod:a> a health:ConditionRecord ;
+  cascade:sourceSystem "Harborview" ;
+  health:conditionName "Type 2 diabetes mellitus" ;
+  health:status "active" .
+`;
+  const podRecordB = `${PREFIXES}
+<urn:pod:b> a health:ConditionRecord ;
+  cascade:sourceSystem "Ridgecrest" ;
+  health:conditionName "Type 2 diabetes mellitus" ;
+  health:status "active" .
+`;
+  const incoming = `${PREFIXES}
+<urn:new:c> a health:ConditionRecord ;
+  cascade:sourceSystem "Cascadia" ;
+  health:conditionName "Seasonal allergic rhinitis" ;
+  health:status "active" .
+`;
+
+  it('takes the cross-batch path when the input is marked, whatever the records say', async () => {
+    // Every pod record carries its own cascade:sourceSystem — the reconciler
+    // re-states it on every write — so `systemName: 'existing-pod'` is always
+    // overwritten and could never be the signal. `existingPod` is.
+    const result = await runReconciliation([
+      { content: `${podRecordA}\n${podRecordB}`, systemName: 'existing-pod', existingPod: true },
+      { content: incoming, systemName: 'Cascadia' },
+    ]);
+
+    expect(result.report.summary.totalInputRecords).toBe(3);
+    expect(result.report.summary.finalRecordCount).toBe(3);
+    expect(result.report.summary.exactDuplicatesRemoved).toBe(0);
+  });
+
+  it('falls to the single-batch path without the marker, which re-compares the pod with itself', async () => {
+    // The SAME inputs, one argument different. This is the pin on the argument:
+    // an implementation that ignored `existingPod` would give this run's answer
+    // for both, which is what shipped.
+    const result = await runReconciliation([
+      { content: `${podRecordA}\n${podRecordB}`, systemName: 'existing-pod' },
+      { content: incoming, systemName: 'Cascadia' },
+    ]);
+
+    expect(result.report.summary.totalInputRecords).toBe(3);
+    expect(result.report.summary.finalRecordCount).toBe(2);
+  });
+
+  it('keeps the pod\'s own copy when a batch re-imports a subject the pod holds', async () => {
+    // Same subject IRI on both sides: a re-import. The stored copy wins, so the
+    // record's first-seen timestamp is not re-stamped and its already-resolved
+    // edges are not re-resolved.
+    const stored = `${PREFIXES}
+<urn:pod:x> a health:ConditionRecord ;
+  cascade:sourceSystem "Harborview" ;
+  clinical:importedAt "2025-01-02T00:00:00Z" ;
+  health:conditionName "Type 2 diabetes mellitus" ;
+  health:status "active" .
+`;
+    const reimported = `${PREFIXES}
+<urn:pod:x> a health:ConditionRecord ;
+  cascade:sourceSystem "Harborview" ;
+  clinical:importedAt "2025-09-30T00:00:00Z" ;
+  health:conditionName "Type 2 diabetes mellitus" ;
+  health:status "active" .
+`;
+    const result = await runReconciliation([
+      { content: stored, systemName: 'existing-pod', existingPod: true },
+      { content: reimported, systemName: 'Harborview' },
+    ]);
+
+    expect(result.report.summary.finalRecordCount).toBe(1);
+    expect(result.report.summary.duplicateSubjectsDropped).toBe(1);
+    expect(result.turtle).toContain('2025-01-02T00:00:00Z');
+    expect(result.turtle).not.toContain('2025-09-30T00:00:00Z');
+  });
+});


### PR DESCRIPTION
Retires 9 of the 17 entries in the pathology known-defect ledger. The ledger fails loudly on a fixed-but-still-listed entry, so each retirement removes the entry and folds its corrected expectation into the scenario manifest.

## What was wrong

**A prescription's dose was read from a field MedicationRequest does not have.** FHIR R4 gives `MedicationStatement` a `dosage` array and `MedicationRequest` a `dosageInstruction` array; same `Dosage` datatype, two field names. Only the first was read, so every prescription reached the pod with no dose. Dose is deliberately outside the medication identity key so two doses of one drug match as one drug and the dose-disagreement check raises the difference for a person to answer. With both doses absent that check compared two undefineds, found no disagreement, and merged the change away as a near-duplicate with no conflict and no warning, while the identical change expressed as a `MedicationStatement` raised its conflict correctly.

**`--reconcile-existing` never took the cross-batch path.** `hasExistingPod` keyed on the input's `systemName`, which is only the default source system for records that state none. Every record a pod holds states one, so the test was permanently false and every import ran the single-batch branch. The marker now rides on the input itself.

**Four matchers read predicates no converter writes.** A matcher that never fires produces no wrong output, which is why a green suite held all four.

- `matchVitalSigns` read `health:testCode` / `health:effectiveDate` / `health:value`; both converters write `clinical:loincCode` / `clinical:effectiveDate` / `clinical:value`. No two vital signs in any pod had ever matched. It now reads what is written and matches inside a 30 minute window instead of a calendar day: a vital sign is an instant, so a day-wide rule merges a morning and an evening blood pressure while a zero-width one keeps one cuff reading forwarded to a second system 17 minutes later as two records.
- `matchImmunizations` read `health:cvxCode`, which only the C-CDA importer writes; the FHIR importer writes `health:vaccineCode` carrying `CVX-<code>`. Both spellings are read and normalized now. The name tier is unchanged.
- `codeFromUri` was `uri.split('/').pop() ?? uri.split('#').pop()`, whose second operand is unreachable. Every LOINC URI this repo mints came back as `rdf#3094-0`, so a FHIR lab never matched the same lab from a C-CDA, and the mangled form reached the conflict ids persisted in `settings/pending-conflicts.ttl`.
- `matchMedications` reported the bare constant `partial-name`, so every partial-name medication conflict in a pod shared one id. `settings/user-resolutions.ttl` is keyed by conflict id and cannot hold two rows under one key, and `pod resolve` removes every pending conflict whose id matches, so answering one question overwrote another decision and cleared the rest of the queue unanswered.

**Six places a converter stated something the source had not**, plus one where two different facts were stored as one string: a malformed date salvaged to a day and reported as though stated; a `nullFlavor` section queued for LLM extraction; a dangling narrative reference resolving to nothing in silence; C-CDA `resourceCount` counting sections while the FHIR importer counted records; `sourceBreakdown` omitting every record it could not attribute; `labCategory` dropping the value `laboratory`, which is the one category a multi-category lab needs; and an unmappable `Observation.interpretation` code written as `unknown`, the data-absent code that means the source stated none.

## Persisted conflict ids

Two of the fixes change the `matchedOn` string that `generateConflictId` hashes, so ids written by an earlier version no longer regenerate. Read old, write new: `legacyConflictIds` reproduces the pre-fix id for both changed shapes, and `findUserResolution` tries the current id first and falls back. New decisions are always recorded under the new id, so a pod converges as its conflicts are answered. `settings/pending-conflicts.ttl` needs nothing because every import rewrites it wholesale.

## What is not fixed

The nullFlavor-variety entry stays in the ledger, with the reason written into it. UNK, NAV and ASKU are three different statements about why a value is missing, and carrying them needs a `health:dataAbsentReason` that does not exist in health, clinical or core. Vocabulary is authored in `spec/` and synced into `src/shapes/`, so emitting a term the ontology does not define would put an unvalidatable predicate in every pod.

## Numbers

- Ledger: 17 entries to 8. Retired: P03 dangling narrative reference; P05 unmapped interpretation, multi-category, source axis; P08 vital matcher; P09 MedicationRequest dose; P12 malformed date, nullFlavor section, `resourceCount`.
- Scorecard baseline: P08 recall 0.0 to 1.0, precision unchanged at 1.0. P07 and P07-SHARED-LABEL unchanged.
- Full suite: 137 files, 2165 tests, 0 failed, 0 skipped (from 134 / 2109 on main). `npx tsc --noEmit` clean.
- Mutation ledger: 20 flips, each applied against the committed tree, rebuilt, run through the full suite, and reverted.

## Zones

Untouched: the same-source guard sites, source-label and identity emission, the subject-minting layer, `spec/` and `src/shapes/`, and ledger entries P01, P02 and P07-SHARED-LABEL. `test-fixtures/pathology/scenarios.json` and `tests/pathology-corpus.test.ts` are shared surfaces and did change: eight scenarios' measured expectations, and two new optional manifest fields.

Every fixture is synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
