### PR TITLE
feat(cli): declare each record's origin once, and read it where origin matters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,76 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+**A record's source identity is declared, canonical across transports, and never the transport label.**
+Cascade records carried two source-shaped properties and needed three, and both of the two were being
+read as the third. `clinical:sourceEHR` is a display LABEL. `cascade:sourceSystem` is the INGESTION
+batch, which defaults to the file name. Neither is an origin, and using either as one fails in a
+different direction, both measured on the pathology corpus:
+
+- The reconciler's same-source guard keyed on `cascade:sourceSystem`, so on a pod imported under ONE
+  batch label no pair of records was ever compared. Scenario `P07-SHARED-LABEL` — two health systems'
+  exports under one label, the ordinary shape when a consumer health app exports several connected
+  accounts — held **12 records and performed 0 merges** where 7 and 5 are right. On one real corpus the
+  same defect hid 148 cross-source duplicates.
+- The two converters derived the display label by different rules, so ONE health system rendered as
+  TWO sources the moment a patient downloaded both transports. Scenario `P01`.
+
+`cascade:sourceIdentity` (core v3.5) is the ORIGIN axis: a canonical, transport-independent identity
+for the organization a record came from, minted at ONE chokepoint (`src/lib/source-identity.ts`) that
+both converters call. Its value is scheme-prefixed so a consumer can always tell how much the producer
+knew — `org:{slug}` when an organization was derivable, `ns:{namespace}` when only an identifier
+assigning authority was (the FHIR server base URL, or the C-CDA `<id>` root OID), and
+`transport:{label}` as an honestly-labelled last resort that is explicitly not an origin claim. The
+slug normalization reduces an organization name or a registrable domain to its leading distinctive
+token, so `Meridian Health System` and `meridianhealth.example` both give `org:meridian`. It is
+deliberately biased toward collapsing two organizations rather than splitting one: a collapse leaves
+duplicates in the pod, visible and recoverable, while a split lets records an organization
+deliberately kept apart be compared and merged.
+
+### Changed
+
+**The reconciler's same-source guard reads the ORIGIN and the ingestion together.** Two records are
+held apart from comparison only when they are two things ONE organization stated in ONE ingestion,
+which is what the guard was always for: three blood-pressure readings hours apart in one download are
+three readings. One organization's two exports, or its two transports, are the re-sync case
+reconciliation exists to handle. The new rule suppresses a STRICT SUBSET of what the old one
+suppressed, so nothing that merged before stops merging; the only pairs newly admitted are those with
+different KNOWN origins under one batch label. A record with no origin, or one whose origin honestly
+landed on the `transport:` tier, falls back to the batch label alone — the pre-v3.5 behaviour — so a
+pod written by an older CLI reconciles exactly as it did.
+
+**Both converters emit the origin, and the FHIR path derives its display label per BUNDLE.** The FHIR
+converter previously derived `clinical:sourceEHR` per resource from whatever each one carried, so a
+single export produced two labels depending on which resources happened to have a `recorder.display`.
+It is now derived once for the whole input, preferring a stated organization NAME over the endpoint
+host — which is the rule the C-CDA path already used, and what makes one system resolve to one label
+across both transports. `cascade:sourceSystem` and `clinical:sourceEHR` keep their meanings.
+
+### Fixed
+
+**A C-CDA `<id>` contradicted by the document's own content stops identifying.** The public HL7
+Continuity of Care Document sample distributes ONE root-only `<id>` across every observation in its
+Results section, and vendors that copied it inherited the shape. Believing the id outright folded
+three observations that disagree about their LOINC code, name, value, unit and reference range onto one
+subject: scenario `P02` held **2 lab records where the document stated 4**, with two SHACL maxCount
+violations naming the symptom and two results simply gone. When one id is claimed by entries whose
+content contradicts, each claimant now mints `{type}:{id}#{fingerprint}`. Entries that share an id and
+are content-identical still mint one subject, because those are one act restated. The scope is built
+by pre-scanning the parsed document rather than by disambiguating the second and later claimants, so an
+IRI never depends on the position of an entry in the document. `deterministicUuid` is untouched: this
+composes around minting by choosing what to hash.
+
+**Corpus outcomes.** `P01` resolves to one origin and one label across two transports while keeping its
+2 merges; `P02` yields 4 lab records, 4 edges and 0 violations; `P07-SHARED-LABEL` yields 7 records and
+5 merges, and its reconciliation-scorecard recall moves 0.0 to 1.0. The three corresponding
+`KNOWN_OUTCOMES` entries are removed and their expectations folded into the scenarios, which is the
+ledger's designed retirement path. The ledger now carries five entries.
+
+**Vocabulary.** `src/shapes/core.ttl` and `core.shapes.ttl` synced to spec core v3.5 /
+core.shapes.ttl v1.5; `VOCAB_VERSIONS` `core=3.5`. Absence of `cascade:sourceIdentity` is not a
+validation finding at any severity, so every pod written before v3.5 validates unchanged.
+
+
 **A regression corpus of real-world import pathologies, and an end-to-end harness that runs it.**
 `test-fixtures/pathology/` holds thirteen scenarios, each reproducing ONE named phenomenon that
 appears in real health-data exports: the dual-label split (one health system landing under two

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -81,7 +81,21 @@
 #   2026-08-03 Validation Profile release and are unrelated to this change; they
 #   are left for their own sync so a genomics sh:class semantics change is not
 #   folded into a clinical alignment.
-core=3.4
+# Updated 2026-08-09: core v3.5 — cascade:sourceIdentity, the ORIGIN axis.
+#   A canonical, transport-independent identity for the organization a record
+#   came from, scheme-prefixed org: / ns: / transport:. cascade:sourceSystem is
+#   narrowed to say what it is NOT (the ingestion batch, never a reconciliation
+#   key) and clinical:sourceEHR is unchanged as the display label.
+#   core.shapes.ttl v1.5 adds cascade:SourceIdentityShape, an open-world
+#   sh:targetSubjectsOf shape: it constrains the VALUE wherever the property
+#   appears and never requires its presence, so every pod written before v3.5
+#   validates unchanged.
+#   spec PR the-cascade-protocol/spec#17; tag vocab/core-v3.5.
+#   NOT synced in this pass, again: the draft evidence.ttl and
+#   genomics.shapes.ttl diffs the sync script also produces are the same
+#   pre-existing drift the 2026-08-08 entry names, unrelated to this change, and
+#   left for their own sync.
+core=3.5
 health=2.6
 clinical=1.14
 coverage=1.4

--- a/src/lib/ccda-converter/index.ts
+++ b/src/lib/ccda-converter/index.ts
@@ -39,8 +39,16 @@ import { extractFamilyHistoryQuads, FAMILY_HISTORY_TEMPLATE_ID } from './section
 import { extractDeviceQuads, DEVICES_TEMPLATE_ID } from './sections/devices.js';
 import { extractSocialHistoryQuads, SOCIAL_HISTORY_TEMPLATE_ID } from './sections/social-history.js';
 import { extractNarrativeQuads } from './narrative.js';
-import { deriveSourceEhr, ensureProvenanceQuads, ensureSourceEhrQuads } from './provenance.js';
+import {
+  deriveCcdaIdNamespace,
+  deriveSourceEhr,
+  ensureProvenanceQuads,
+  ensureSourceEhrQuads,
+  ensureSourceIdentityQuads,
+} from './provenance.js';
 import { identityKey } from '../identity.js';
+import { beginCcdaIdScope, endCcdaIdScope } from './record-identity.js';
+import { sourceIdentity } from '../source-identity.js';
 
 // Map templateId → extractor function and LOINC code.
 //
@@ -256,6 +264,17 @@ function censusForwardEdges(quads: any[]): EdgeResolutionSummary {
   return stats;
 }
 
+/**
+ * Convert one C-CDA document, with the id-collision scope open for its whole
+ * conversion.
+ *
+ * The scope is module state in `record-identity.ts` and is opened and closed
+ * here, around a synchronous body, so no second document's scope can interleave
+ * with this one's. The `finally` matters: a document that throws mid-conversion
+ * (the caller catches and records a warning, then converts the next file of an
+ * IHE XDM zip) must not leave the previous document's contradicted-id set in
+ * place for its successor.
+ */
 function convertSingleCcda(
   xml: string,
   options: CcdaConversionOptions,
@@ -271,12 +290,40 @@ function convertSingleCcda(
     warnings.push(`Detected EHR vendor: ${vendor}`);
   }
 
+  // The scope is opened over the NORMALIZED document, because that is the tree
+  // the section handlers hand to the identity door: pre-scanning the raw parse
+  // would fingerprint objects the mint never sees.
+  beginCcdaIdScope(normalizedDoc?.ClinicalDocument ?? normalizedDoc);
+  try {
+    return convertNormalizedCcda(normalizedDoc, options, importedAt, warnings);
+  } finally {
+    endCcdaIdScope();
+  }
+}
+
+function convertNormalizedCcda(
+  normalizedDoc: any,
+  options: CcdaConversionOptions,
+  importedAt: string,
+  warnings: string[],
+): { quads: any[]; census: SectionCensusEntry[] } {
   const ccdaDoc = normalizedDoc?.ClinicalDocument ?? normalizedDoc;
   const sourceSystem = options.sourceSystem ?? getSourceSystemName(normalizedDoc);
   const documentType = detectDocumentType(normalizedDoc);
   // The EHR of origin is the document's custodian organization (ratified CDA
   // signal), independent of the import-batch label that drives `sourceSystem`.
   const sourceEhr = deriveSourceEhr(ccdaDoc);
+  // The ORIGIN axis, derived once per document through the shared door. The
+  // custodian organization NAME is the input, not the label: the label is what
+  // this document called the organization, and the identity is the canonical
+  // form the FHIR path independently arrives at from the endpoint host. If the
+  // custodian named nobody, the document's own id namespace is the next-best
+  // fact, and the import-batch label is the last resort and says so.
+  const documentOrigin = sourceIdentity({
+    organizationName: sourceEhr,
+    idNamespace: deriveCcdaIdNamespace(ccdaDoc),
+    transportLabel: sourceSystem,
+  });
 
   // Document ID for narrative linking
   const docIdEl = firstOf<any>(ccdaDoc?.id);
@@ -448,6 +495,7 @@ function convertSingleCcda(
   // Both are additive + idempotent: they never overwrite a value a handler set.
   ensureProvenanceQuads(allQuads);
   ensureSourceEhrQuads(allQuads, sourceEhr);
+  ensureSourceIdentityQuads(allQuads, documentOrigin);
 
   return { quads: allQuads, census };
 }

--- a/src/lib/ccda-converter/provenance.ts
+++ b/src/lib/ccda-converter/provenance.ts
@@ -24,6 +24,8 @@ import {
   commonTriples,
 } from '../fhir-converter/types.js';
 import { SOURCE_EHR_UNKNOWN } from '../fhir-converter/provenance.js';
+import { SOURCE_IDENTITY_PREDICATE, type SourceIdentity } from '../source-identity.js';
+import { firstOf, listOf } from './multivalued.js';
 
 const { namedNode } = DataFactory;
 
@@ -121,6 +123,72 @@ export function ensureSourceEhrQuads(quads: Quad[], sourceEhr: string): void {
         ),
       );
     }
+  }
+}
+
+/**
+ * The assigning authority for this document's identifiers, for the `ns:` tier of
+ * `cascade:sourceIdentity`.
+ *
+ * Preference order, and each is the same KIND of fact — an OID root that a
+ * particular organization was allocated:
+ *   1. the custodian organization's own `<id root>`. It names the organization
+ *      that holds the legal record, which is exactly the thing the origin axis
+ *      is trying to identify;
+ *   2. the document's `<id root>`;
+ *   3. the patient role's `<id root>` (the MRN's assigning authority).
+ *
+ * Returns `undefined` when the document carries none, in which case the caller
+ * falls through to the transport tier and says so honestly.
+ */
+export function deriveCcdaIdNamespace(ccdaDoc: any): string | undefined {
+  // `<id>` and `<recordTarget>` are both repeatable, so both are arrays on every
+  // document (see multivalued.ts, and tests/ccda-multivalued-shape.test.ts, which
+  // fails the build for reading one raw).
+  const custodianOrg = ccdaDoc?.custodian?.assignedCustodian?.representedCustodianOrganization;
+  const patientRole = firstOf<any>(ccdaDoc?.recordTarget)?.patientRole;
+  const idSets: any[][] = [
+    listOf<any>(custodianOrg?.id),
+    listOf<any>(ccdaDoc?.id),
+    listOf<any>(patientRole?.id),
+  ];
+  for (const ids of idSets) {
+    for (const el of ids) {
+      const root = el?.['@_root'] ?? el?.root;
+      if (typeof root === 'string' && root.trim()) return root.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Stamp `cascade:sourceIdentity` (the ORIGIN axis) onto every record subject
+ * that does not already carry one.
+ *
+ * Document-level, exactly like {@link ensureSourceEhrQuads}: a C-CDA has one
+ * custodian, so every record it yields has one origin. The two are deliberately
+ * separate predicates carrying different things — the label is what the document
+ * called the organization, the identity is the canonical form both transports
+ * agree on. See `src/lib/source-identity.ts`.
+ */
+export function ensureSourceIdentityQuads(quads: Quad[], identity: SourceIdentity | undefined): void {
+  if (!identity) return;
+  const subjects = new Set<string>();
+  const hasIdentity = new Set<string>();
+  for (const q of quads) {
+    const p = q.predicate.value;
+    if (p === NS.rdf + 'type') subjects.add(q.subject.value);
+    else if (p === SOURCE_IDENTITY_PREDICATE) hasIdentity.add(q.subject.value);
+  }
+  for (const subject of subjects) {
+    if (hasIdentity.has(subject)) continue;
+    quads.push(
+      DataFactory.quad(
+        namedNode(subject),
+        namedNode(SOURCE_IDENTITY_PREDICATE),
+        DataFactory.literal(identity.value, namedNode(NS.xsd + 'string')),
+      ),
+    );
   }
 }
 

--- a/src/lib/ccda-converter/record-identity.ts
+++ b/src/lib/ccda-converter/record-identity.ts
@@ -86,6 +86,7 @@ import {
   deterministicUuid,
   medicationUri,
 } from '../fhir-converter/types.js';
+import { contentFingerprint, EMPTY_SEED } from '../identity.js';
 
 /**
  * The single medication identity type, shared by every importer. Medication
@@ -193,6 +194,134 @@ function str(value: unknown): string {
   return '';
 }
 
+// ---------------------------------------------------------------------------
+// The id-collision scope
+// ---------------------------------------------------------------------------
+
+/**
+ * WHEN THE SOURCE'S OWN ID IS CONTRADICTED BY THE SOURCE'S OWN CONTENT
+ * --------------------------------------------------------------------
+ * `ccdaSourceId`'s header takes a root-only `<id>` at the source's word, because
+ * HL7 v3 II says a root alone may be the whole instance identifier, and it names
+ * the cost of doing so: "if a vendor misuses a shared assigning-authority OID as
+ * a root-only id, the cost is a merge; it is filed rather than guarded against
+ * by heuristic".
+ *
+ * That cost has now been measured, and it is not a merge of two similar records.
+ * The public HL7 Continuity of Care Document sample distributes ONE root-only
+ * `<id>` across every observation in its Results section, and vendors that
+ * copied the sample inherited the shape. Run the corpus fixture
+ * `p02-duplicate-source-id-ccda.xml` through the importer on `main`: three lab
+ * observations that disagree about their LOINC code, their name, their value,
+ * their unit and their reference range all mint one subject, so the pod holds 2
+ * lab records where the document stated 4, and the only trace is two SHACL
+ * maxCount violations naming the symptom.
+ *
+ * So the source's id is still believed — but only as far as the source's own
+ * content lets it be. When one id is claimed by entries whose content
+ * CONTRADICTS, the id has stopped identifying anything, and each claimant gets
+ * `{type}:{id}#{fingerprint}` instead of `{type}:{id}`.
+ *
+ * WHY A PRE-SCAN AND NOT A RUNNING REGISTRY
+ * -----------------------------------------
+ * A registry that disambiguated the SECOND and later claimants would make an
+ * IRI depend on the position of an entry in the document, so the same three
+ * observations in a different order would mint different subjects. This repo has
+ * an identity-determinism incident class and does not need a fourth entry in it.
+ * The scope is therefore built by walking the parsed document BEFORE any section
+ * runs, so "is this id contradicted?" is a property of the document, and every
+ * claimant of a contradicted id is disambiguated including the first.
+ *
+ * The `deterministicUuid` hash is untouched. This composes AROUND minting by
+ * choosing what to hash, which is the only layer that can see two entries at
+ * once.
+ *
+ * WHAT IT DOES NOT DO
+ * -------------------
+ * It does not disambiguate entries that share an id and are content-identical:
+ * those are one act restated, they mint one subject as they always have, and
+ * splitting them would recreate the duplicate-on-every-import defect.
+ *
+ * It does not look across documents. Two documents that reuse one id are a
+ * genuine cross-document collision, and the reconciler's `splitIdentityCollisions`
+ * already owns that case — it can see both records, which this layer cannot.
+ * The two are complementary: this one covers WITHIN a document, where there is
+ * no second record for the reconciler to compare because both were folded onto
+ * one subject before it ever ran.
+ */
+let contradictedIds: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Collect every (sourceId, content fingerprint) pair in a parsed C-CDA, at any
+ * depth. Keyed on the id alone rather than on (type, id): a caller's `type` is
+ * not knowable here, and treating a cross-type id clash as contradicted splits
+ * rather than merges, which is the recoverable direction.
+ */
+function collectIdClaims(node: unknown, into: Map<string, Set<string>>, seen: Set<unknown>): void {
+  if (node == null || typeof node !== 'object') return;
+  if (seen.has(node)) return;
+  seen.add(node);
+  if (Array.isArray(node)) {
+    for (const item of node) collectIdClaims(item, into, seen);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  if ('id' in obj) {
+    const sourceId = ccdaSourceId(obj);
+    if (sourceId) {
+      const fingerprint = contentFingerprint(obj);
+      // An element with no hashable content cannot be told apart from another
+      // one, so recording it would claim a contradiction nothing can resolve.
+      if (fingerprint !== EMPTY_SEED) {
+        const bucket = into.get(sourceId) ?? new Set<string>();
+        bucket.add(fingerprint);
+        into.set(sourceId, bucket);
+      }
+    }
+  }
+  for (const value of Object.values(obj)) collectIdClaims(value, into, seen);
+}
+
+/**
+ * Open the id-collision scope for ONE parsed document.
+ *
+ * Module-level state, which is safe here and only here: `convertSingleCcda` is
+ * synchronous from `beginCcdaIdScope` to `endCcdaIdScope`, so no second
+ * document's conversion can interleave with a first one's. `convertCcda` loops
+ * over the XML files of an IHE XDM zip synchronously for the same reason.
+ */
+export function beginCcdaIdScope(ccdaDoc: unknown): void {
+  const claims = new Map<string, Set<string>>();
+  collectIdClaims(ccdaDoc, claims, new Set<unknown>());
+  const contradicted = new Set<string>();
+  for (const [sourceId, fingerprints] of claims) {
+    if (fingerprints.size > 1) contradicted.add(sourceId);
+  }
+  contradictedIds = contradicted;
+}
+
+/** Close the scope. Always call from a `finally`, so a throw cannot leak it. */
+export function endCcdaIdScope(): void {
+  contradictedIds = new Set<string>();
+}
+
+/**
+ * The disambiguator to append to a tier-1 key, or `''` when the id identifies.
+ *
+ * Empty for the ordinary case, which is what keeps every id-bearing IRI this
+ * importer has already written exactly where it is: a document whose ids are
+ * used as ids produces byte-identical keys to before this existed.
+ */
+function idDisambiguator(sourceId: string, source: unknown): string {
+  if (!contradictedIds.has(sourceId)) return '';
+  const fingerprint = contentFingerprint(source);
+  // Nothing distinguishes this claimant from the others, so splitting it would
+  // mint an identity out of nothing. Fall back to the shared subject and let the
+  // shape violations stand: they are true.
+  if (fingerprint === EMPTY_SEED) return '';
+  return `#${fingerprint}`;
+}
+
 /**
  * THE DOOR. Mint the subject IRI for one C-CDA record.
  *
@@ -229,7 +358,11 @@ export function ccdaRecordUri(opts: {
   // `contentHashedUri(type, {}, id)` that the C-CDA lab observation path already
   // ships — so no id-bearing lab IRI moves for this reason.
   if (typeof sourceId === 'string' && sourceId.trim().length > 0) {
-    return `urn:uuid:${deterministicUuid(`${type}:${sourceId}`)}`;
+    // …unless the source's own content contradicts its own id, in which case the
+    // id has stopped identifying and the content decides which claimant this is.
+    // See "THE ID-COLLISION SCOPE" above. Empty for every document whose ids are
+    // used as ids, so no existing id-bearing IRI moves.
+    return `urn:uuid:${deterministicUuid(`${type}:${sourceId}${idDisambiguator(sourceId, source)}`)}`;
   }
 
   // Tiers 2-4 — the curated key, then the raw element, then a loud collapse.
@@ -259,7 +392,9 @@ export function ccdaMedicationRecordUri(opts: {
   const { sourceId, fields, source, warnings, label } = opts;
 
   if (typeof sourceId === 'string' && sourceId.trim().length > 0) {
-    return `urn:uuid:${deterministicUuid(`${MEDICATION_IDENTITY_TYPE}:${sourceId}`)}`;
+    return `urn:uuid:${deterministicUuid(
+      `${MEDICATION_IDENTITY_TYPE}:${sourceId}${idDisambiguator(sourceId, source)}`,
+    )}`;
   }
 
   // `undefined` in the fallbackId slot, for the same reason as above.

--- a/src/lib/fhir-converter/index.ts
+++ b/src/lib/fhir-converter/index.ts
@@ -57,7 +57,8 @@ const { namedNode, literal, quad: makeQuad } = DataFactory;
 import { convertFhirResourceToQuads } from './fhir-to-cascade.js';
 import { convertCascadeToFhir } from './cascade-to-fhir.js';
 import { EXCLUDED_TYPES } from './converters-passthrough.js';
-import { SOURCE_EHR_UNKNOWN } from './provenance.js';
+import { SOURCE_EHR_UNKNOWN, deriveBundleOrigin } from './provenance.js';
+import { SOURCE_IDENTITY_PREDICATE } from '../source-identity.js';
 import { resolveReferenceEdges, type ConvertedResourceRef } from './reference-resolution.js';
 import { liftTrappedLiterals, type LiteralLiftSummary } from '../literal-lifting.js';
 
@@ -225,16 +226,31 @@ export async function convert(
         );
       }
     }
-    // Authoritative per-record source override (e.g. the Apple Health export.xml
-    // <ClinicalRecord sourceName> the container adapter recovered). The container
-    // knows the EHR/account of origin even when the FHIR payload does not (Epic
-    // records carry only relative references + OID identifiers, no absolute org
-    // host), so this label is authoritative for EVERY record from the input: it is
-    // what the user sees in the Health app and it is consistent across the account.
-    // It REPLACES any host-derived sourceEHR (so one account groups under one name
-    // instead of splitting "Swedish" vs "swedish.org") and pre-empts the "unknown"
-    // fallback below. The import-batch tag stays separately on cascade:sourceSystem.
-    if (sourceEhrOverride) {
+    // THE SOURCE AXES, derived once for the whole input.
+    //
+    // `sourceEhrOverride` is the container adapter's authoritative account name
+    // (Apple Health's export.xml <ClinicalRecord sourceName>). The container knows
+    // the EHR/account of origin even when the FHIR payload does not — Epic records
+    // carry only relative references and OID identifiers, no absolute org host —
+    // so it beats anything derivable from the resources themselves.
+    //
+    // Absent an override, the bundle's own organization name beats its endpoint
+    // host, which is the P01 fix: the C-CDA path already labels records with the
+    // custodian ORGANIZATION NAME, so a system exporting both transports was
+    // rendering as "meridianhealth.example" here and "Meridian Health System"
+    // there. Deriving it per BUNDLE rather than per resource matters just as much:
+    // per-resource, one export produced two labels depending on which resources
+    // happened to carry a `recorder.display`.
+    //
+    // Whatever wins REPLACES the per-resource host-derived clinical:sourceEHR and
+    // pre-empts the "unknown" fallback below, so one input groups under one label.
+    // The import-batch tag stays separately on cascade:sourceSystem, and the
+    // canonical ORIGIN goes on cascade:sourceIdentity.
+    const bundleOrigin = deriveBundleOrigin(fhirResources, {
+      override: sourceEhrOverride,
+      transportLabel: sourceSystem,
+    });
+    if (bundleOrigin.label) {
       for (let i = allQuads.length - 1; i >= 0; i--) {
         const q = allQuads[i];
         if (
@@ -249,7 +265,18 @@ export async function convert(
           makeQuad(
             namedNode(subjectUri),
             namedNode(NS.clinical + 'sourceEHR'),
-            literal(sourceEhrOverride),
+            literal(bundleOrigin.label),
+          ),
+        );
+      }
+    }
+    if (bundleOrigin.identity) {
+      for (const subjectUri of recordSubjects) {
+        allQuads.push(
+          makeQuad(
+            namedNode(subjectUri),
+            namedNode(SOURCE_IDENTITY_PREDICATE),
+            literal(bundleOrigin.identity.value),
           ),
         );
       }

--- a/src/lib/fhir-converter/provenance.ts
+++ b/src/lib/fhir-converter/provenance.ts
@@ -30,6 +30,7 @@
 import type { Quad } from 'n3';
 
 import { NS, tripleStr } from './types.js';
+import { sourceIdentity, type SourceIdentity } from '../source-identity.js';
 
 /**
  * The ratified "value is expected but not known" token, from the FHIR/HL7
@@ -162,6 +163,93 @@ export function extractSourceEhr(resource: any): string | undefined {
     return display;
   }
   return undefined;
+}
+
+/**
+ * The organization NAME a bundle states about itself, if any.
+ *
+ * An `Organization` resource's `name` first (the source saying who it is
+ * outright), then the first institution-looking provider display. Both go
+ * through the same institution / person filters `extractSourceEhr` uses, so a
+ * clinician's name can never become the bundle's organization.
+ *
+ * Document order, first match wins. A patient-facing export is one system's
+ * export; a bundle that genuinely aggregates several organizations is out of
+ * scope for a single document-level origin, and taking the first is at worst the
+ * collapsing failure, which is the recoverable one.
+ */
+export function extractBundleOrganizationName(resources: readonly any[]): string | undefined {
+  for (const res of resources) {
+    if (res?.resourceType === 'Organization' && typeof res.name === 'string' && res.name.trim()) {
+      return res.name.trim();
+    }
+  }
+  for (const res of resources) {
+    const display = extractProviderName(res);
+    if (display && INSTITUTION_KEYWORDS.test(display) && !PERSON_ROLE.test(display)) return display;
+  }
+  return undefined;
+}
+
+/** The first absolute-reference host anywhere in a bundle, as a registrable domain. */
+export function extractBundleHost(resources: readonly any[]): string | undefined {
+  for (const res of resources) {
+    const host = sourceHost(res);
+    if (host) return host;
+  }
+  return undefined;
+}
+
+/**
+ * The assigning authority for a bundle's identifiers, for the `ns:` tier: the
+ * first `identifier.system` any resource carries. Reached only when no
+ * organization was derivable, which in practice means a bundle whose references
+ * are all `urn:uuid:` and which therefore states no host either.
+ */
+export function extractBundleIdNamespace(resources: readonly any[]): string | undefined {
+  for (const res of resources) {
+    const identifiers = Array.isArray(res?.identifier) ? res.identifier : res?.identifier ? [res.identifier] : [];
+    for (const ident of identifiers) {
+      const system = ident?.system;
+      if (typeof system === 'string' && system.trim()) return system.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * THE BUNDLE'S ORIGIN, and its display label, derived ONCE for the whole input.
+ *
+ * DOCUMENT-LEVEL ON PURPOSE, and this is the P01 half of the fix. The per-record
+ * derivation below reads whatever each resource happens to carry, so within ONE
+ * bundle a Condition with a `recorder.display` of "Meridian Health System" and an
+ * Observation with only a subject reference produced TWO different sourceEHR
+ * values for one export. A source axis cannot be built out of a value that
+ * varies by which field a resource happened to populate.
+ *
+ * The label prefers the organization NAME over the endpoint host, which is what
+ * makes it agree with the C-CDA path: that path already derives its label from
+ * the custodian organization name, and a system exporting both transports was
+ * rendering as "meridianhealth.example" and "Meridian Health System". The host
+ * remains the fallback, and remains what most Apple Health-shaped exports land
+ * on, because they name no organization anywhere.
+ *
+ * `override` is the container adapter's authoritative account name (Apple
+ * Health's `export.xml` `<ClinicalRecord sourceName>`), which beats both.
+ */
+export function deriveBundleOrigin(
+  resources: readonly any[],
+  opts: { override?: string; transportLabel?: string } = {},
+): { label?: string; identity?: SourceIdentity } {
+  const organizationName = opts.override?.trim() || extractBundleOrganizationName(resources);
+  const endpointHost = extractBundleHost(resources);
+  const identity = sourceIdentity({
+    organizationName,
+    endpointHost,
+    idNamespace: extractBundleIdNamespace(resources),
+    transportLabel: opts.transportLabel,
+  });
+  return { label: organizationName ?? endpointHost, identity };
 }
 
 /**

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -19,6 +19,7 @@ import { normalizeMedName, normalizeDose, normalizeFrequency, type DrugNameNorma
 import { medicationCodeKeys, sharedMedicationCodeKey, extractCodeValue } from './code-keys.js';
 import { cascadeTerminologyResolver } from './terminology.js';
 import { relBase, relBaseFor, derelativizeQuads } from './bucket-write.js';
+import { SOURCE_IDENTITY_PREDICATE, isKnownOrigin } from './source-identity.js';
 
 // Re-export so existing consumers of the reconciler's normalizeMedName keep
 // working. The canonical definition now lives in ./medication-normalize.ts
@@ -170,6 +171,7 @@ interface RdfValue {
 interface ParsedRecord {
   uri: string;
   type: CascadeRecordType;
+  /** INGESTION axis: the import batch this record arrived in. Never an origin. */
   sourceSystem: string;
   /**
    * True when this record was read out of the pod rather than out of the batch
@@ -178,6 +180,12 @@ interface ParsedRecord {
    * therefore cannot say how the record reached this run.
    */
   fromExistingPod: boolean;
+  /**
+   * ORIGIN axis: `cascade:sourceIdentity`, the canonical organization identity.
+   * Undefined for a record written before core v3.5 — see {@link sameSourceStatement},
+   * which is the only thing that reads it and which falls back safely.
+   */
+  sourceIdentity?: string;
   properties: Map<string, RdfValue[]>;
 }
 
@@ -216,10 +224,12 @@ export async function parseTurtle(
           }
 
           const sourceSystem = properties.get(NS.cascade + 'sourceSystem')?.[0]?.value ?? defaultSystem;
+          const sourceIdentity = properties.get(SOURCE_IDENTITY_PREDICATE)?.[0]?.value;
           records.push({
             uri,
             type: KNOWN_TYPES[typeTriple.obj.value],
             sourceSystem,
+            sourceIdentity,
             fromExistingPod,
             properties,
           });
@@ -551,6 +561,13 @@ const COLLISION_IGNORED_PREDICATES: ReadonlySet<string> = new Set<string>([
   NS.clinical + 'sourceRecordId',
   NS.health + 'sourceRecordId',
   NS.clinical + 'sourceEHR',
+  // The ORIGIN axis, for the same reason as the display label directly above:
+  // two copies of ONE result retrieved from two organizations differ here while
+  // saying the same clinical thing. Where they differ is exactly what the
+  // same-source guard reads to decide they are worth comparing at all, so
+  // treating the difference ALSO as evidence of a collision would raise a
+  // conflict on every cross-source duplicate the guard just admitted.
+  SOURCE_IDENTITY_PREDICATE,
 ]);
 
 /**
@@ -1255,7 +1272,7 @@ interface Resolution {
 }
 
 function completeness(r: ParsedRecord): number {
-  const skip = new Set([NS.rdf + 'type', NS.cascade + 'dataProvenance', NS.cascade + 'schemaVersion', NS.cascade + 'sourceSystem']);
+  const skip = new Set([NS.rdf + 'type', NS.cascade + 'dataProvenance', NS.cascade + 'schemaVersion', NS.cascade + 'sourceSystem', SOURCE_IDENTITY_PREDICATE]);
   let n = 0;
   for (const [p] of r.properties) if (!skip.has(p)) n++;
   return n;
@@ -1345,7 +1362,11 @@ function resolveGroup(
   let canonical: ParsedRecord = winner;
   if (strategy === 'merge_values') {
     const mergedProps = new Map(winner.properties);
-    const metaPreds = new Set([NS.rdf + 'type', NS.cascade + 'dataProvenance', NS.cascade + 'schemaVersion', NS.cascade + 'sourceSystem']);
+    // Provenance bookkeeping, not content. sourceIdentity in particular must NOT
+    // be filled in from a loser: a winner that carries no origin has no origin,
+    // and inheriting the loser's would attribute it to an organization it never
+    // came from.
+    const metaPreds = new Set([NS.rdf + 'type', NS.cascade + 'dataProvenance', NS.cascade + 'schemaVersion', NS.cascade + 'sourceSystem', SOURCE_IDENTITY_PREDICATE]);
     for (const src of losers) {
       for (const [pred, vals] of src.properties) {
         if (!metaPreds.has(pred) && !mergedProps.has(pred)) mergedProps.set(pred, vals);
@@ -1655,6 +1676,64 @@ export async function runReconciliation(
     return ga !== undefined && ga === split.collisionGroupByUri.get(b.uri);
   };
 
+  /**
+   * THE SAME-SOURCE GUARD. True when two records must NOT be compared, because
+   * they are two things ONE organization stated in ONE ingestion.
+   *
+   * WHAT THE GUARD IS ACTUALLY FOR
+   * ------------------------------
+   * A source does not restate the same record twice inside one export. Three
+   * blood-pressure readings hours apart in one download are three readings, and
+   * a matcher let loose on them merges away two real measurements. That is what
+   * the guard protects.
+   *
+   * It is NOT for holding apart two exports. One organization exporting FHIR in
+   * January and a C-CDA in March is the re-sync case that reconciliation exists
+   * to handle, and the same is true of the same system's two transports.
+   *
+   * WHY KEYING ON `sourceSystem` ALONE WAS WRONG
+   * --------------------------------------------
+   * `sourceSystem` is the INGESTION axis — the import-batch label, which defaults
+   * to the file name and is set by `--source-system`. It answers neither half of
+   * the question. Measured on the pathology corpus (P07-SHARED-LABEL): give two
+   * different health systems' exports ONE batch label, which is the ordinary
+   * shape when a consumer health app exports several connected accounts, and the
+   * guard suppresses every cross-source comparison. None of four byte-identical
+   * duplicates merges, and the pod holds 12 records where 7 is right. On one real
+   * corpus the same defect hid 148 cross-source duplicates.
+   *
+   * WHY IT IS NOT KEYED ON THE ORIGIN ALONE EITHER
+   * ----------------------------------------------
+   * Because that breaks the other half. Corpus scenario P01 is one health system
+   * exporting FHIR and a C-CDA; both halves now correctly carry ONE origin, so an
+   * origin-only guard would stop the two transports from ever being compared and
+   * the duplicate condition and lab would both survive. Measured: P01 falls from
+   * 2 merges to 0 and from 8 records to 10.
+   *
+   * So both axes, and the AND is the load-bearing part. This suppresses a STRICT
+   * SUBSET of what the old guard suppressed: nothing that merges today stops
+   * merging, and the only pairs newly admitted are those with DIFFERENT known
+   * origins under one batch label — exactly the defect.
+   *
+   * ABSENT OR UNKNOWN ORIGIN BEHAVES CONSERVATIVELY
+   * -----------------------------------------------
+   * `isKnownOrigin` is false for a record written before core v3.5 (no value at
+   * all) and for one whose origin honestly landed on the `transport:` tier
+   * (nothing in the document named or located an organization). In both cases the
+   * origin is UNKNOWN, and two unknowns are not evidence of two different
+   * organizations. So the guard declines to use the axis and falls back to the
+   * batch label, which is the pre-v3.5 behaviour: it suppresses MORE comparison,
+   * leaving duplicates in the pod, which is the recoverable direction. A pod
+   * imported by an older CLI therefore reconciles exactly as it did before.
+   */
+  const sameSourceStatement = (a: ParsedRecord, b: ParsedRecord): boolean => {
+    if (a.sourceSystem !== b.sourceSystem) return false;
+    if (isKnownOrigin(a.sourceIdentity) && isKnownOrigin(b.sourceIdentity)) {
+      return a.sourceIdentity === b.sourceIdentity;
+    }
+    return true;
+  };
+
   // Match and group
   const groups: Group[] = [];
   const assigned = new Set<string>();
@@ -1711,7 +1790,7 @@ export async function runReconciliation(
 
       const candidates = existingIndex.get(a.type) ?? [];
       for (const b of candidates) {
-        if (assigned.has(b.uri) || a.sourceSystem === b.sourceSystem || sameCollision(a, b)) continue;
+        if (assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -1731,7 +1810,8 @@ export async function runReconciliation(
     }
 
     // Within-batch pass: pairwise loop over newRecords only (existing-pod records
-    // from the same sourceSystem never match each other)
+    // that are the same organization's same ingestion never match each other; see
+    // sameSourceStatement)
     for (let i = 0; i < newRecords.length; i++) {
       const a = newRecords[i];
       if (assigned.has(a.uri)) continue;
@@ -1746,7 +1826,7 @@ export async function runReconciliation(
 
       for (let j = i + 1; j < newRecords.length; j++) {
         const b = newRecords[j];
-        if (assigned.has(b.uri) || a.sourceSystem === b.sourceSystem || sameCollision(a, b)) continue;
+        if (assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -1800,7 +1880,7 @@ export async function runReconciliation(
 
       const candidates = typeIndex.get(a.type) ?? [];
       for (const b of candidates) {
-        if (b === a || assigned.has(b.uri) || a.sourceSystem === b.sourceSystem || sameCollision(a, b)) continue;
+        if (b === a || assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {

--- a/src/lib/source-identity.ts
+++ b/src/lib/source-identity.ts
@@ -1,0 +1,302 @@
+/**
+ * Source identity: ONE door every record's ORIGIN goes through.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * A record carries three source-shaped facts, and this codebase had two of them
+ * and used both as if they were the third.
+ *
+ *   ORIGIN      `cascade:sourceIdentity`  WHICH ORGANIZATION the record came
+ *                                         from, canonically, whatever transport
+ *                                         carried it. The only one of the three
+ *                                         that may be a reconciliation key.
+ *   LABEL       `clinical:sourceEHR`      what to CALL that organization on
+ *                                         screen. Source-worded, so two
+ *                                         spellings of one organization are two
+ *                                         labels.
+ *   INGESTION   `cascade:sourceSystem`    the import batch: how and when data
+ *                                         entered the pod. Never an origin.
+ *
+ * Both misuses were MEASURED, and they fail in opposite directions.
+ *
+ *   Keying the reconciler's same-source guard on the INGESTION label means that
+ *   on a pod imported under one label, every pair of records looks same-source
+ *   and NOTHING is ever compared. On one real corpus that hid 148 cross-source
+ *   duplicates. The pathology corpus reproduces it as P07-SHARED-LABEL: two
+ *   health systems' exports under one batch tag, 12 records where 7 is right.
+ *
+ *   Reading the display LABEL as an origin fails the other way. The FHIR path
+ *   derives it from the registrable domain of the endpoint and the C-CDA path
+ *   from the custodian organization name, so ONE system renders as TWO sources
+ *   the moment a patient downloads both transports. Corpus scenario P01.
+ *
+ * So the origin has to be a THIRD, declared thing, derived by a rule both
+ * transports implement identically. That rule is `sourceIdentity()` below, and
+ * it lives in one module for the reason `identity.ts` gives at length: this repo
+ * has a history of a correct derivation existing in one converter, being
+ * enforced nowhere, and being re-invented wrongly in the next one. A per-site
+ * derivation is how the two transports came to disagree in the first place.
+ *
+ * THE VALUE IS SCHEME-PREFIXED, AND THAT IS LOAD-BEARING
+ * -----------------------------------------------------
+ * `org:` / `ns:` / `transport:`. A consumer can always tell how much the
+ * producer actually knew, and in particular can tell that it knew NOTHING:
+ *
+ *   org:{slug}        an organization was derivable. {slug} is {@link orgSlug}.
+ *   ns:{namespace}    no organization, but the record's identifiers have an
+ *                     assigning authority: the FHIR server base URL, or the
+ *                     C-CDA <id> root OID.
+ *   transport:{label} LAST RESORT. Nothing named or located an organization, so
+ *                     the value restates the ingestion label, honestly
+ *                     prefixed. It is NOT an origin claim.
+ *
+ * The unprefixed spelling is banned by `cascade:SourceIdentityShape`, because an
+ * unprefixed value is exactly what a producer writes when it has stamped a
+ * display label or a batch tag into the origin axis — the confusion the axis
+ * exists to end.
+ *
+ * @see core v3.5 `cascade:sourceIdentity` in `src/shapes/core.ttl` for the
+ *      normative statement of the value form and the normalization.
+ */
+
+/** The predicate this module's values are written under. */
+export const SOURCE_IDENTITY_PREDICATE = 'https://ns.cascadeprotocol.org/core/v1#sourceIdentity';
+
+/** Which tier of the cascade produced an identity. Mirrors the value's scheme. */
+export type SourceIdentityTier = 'organization' | 'namespace' | 'transport';
+
+export interface SourceIdentity {
+  /** The value to write to `cascade:sourceIdentity`, scheme prefix included. */
+  value: string;
+  /** Which tier produced it. Callers that report provenance branch on this, not on the string. */
+  tier: SourceIdentityTier;
+}
+
+/**
+ * Institution-or-specialty vocabulary that names no particular organization.
+ *
+ * Dropped from both derivation paths, which is what lets a NAME and a HOST for
+ * one organization agree: "Meridian Health System" and "meridianhealth.example"
+ * both reduce to "meridian" only because `health` and `system` are here.
+ *
+ * Kept to words that are generic in an ORGANIZATION name. Geography is
+ * deliberately absent — "Valley", "Harborview", "Northgate" are what
+ * distinguishes one organization from the next, and stripping them would merge
+ * organizations that share nothing but a suffix.
+ */
+const GENERIC_ORG_WORDS: ReadonlySet<string> = new Set([
+  // institution
+  'health', 'healthcare', 'system', 'systems', 'service', 'services',
+  'medical', 'medicine', 'center', 'centre', 'centers', 'centres',
+  'hospital', 'hospitals', 'clinic', 'clinics', 'care', 'group',
+  'associates', 'association', 'network', 'partners', 'partnership',
+  'physicians', 'physician', 'practice', 'practices', 'regional',
+  'community', 'memorial', 'university', 'institute', 'foundation',
+  'laboratory', 'laboratories', 'labs', 'lab', 'diagnostics', 'imaging',
+  'radiology', 'pathology', 'family', 'urgent', 'primary', 'specialty',
+  // specialty names that qualify a system rather than name one
+  'cardiology', 'oncology', 'orthopedic', 'orthopedics', 'pediatric', 'pediatrics',
+  // legal form
+  'inc', 'llc', 'llp', 'ltd', 'plc', 'corp', 'corporation', 'co', 'pc', 'pa', 'pllc',
+  // stopwords
+  'of', 'and', 'the', 'for', 'at', 'in', 'on', 'a', 'an',
+]);
+
+/**
+ * Multi-label public suffixes worth knowing about, so `nhs.uk` style hosts do
+ * not reduce to the suffix. Deliberately short: this is not a Public Suffix List
+ * implementation, and does not pretend to be. A suffix it does not know costs
+ * one extra label in the registrable name, which the generic-word strip below
+ * usually removes anyway.
+ */
+const MULTI_LABEL_SUFFIXES: ReadonlySet<string> = new Set([
+  'co.uk', 'org.uk', 'nhs.uk', 'ac.uk', 'gov.uk',
+  'com.au', 'net.au', 'org.au', 'gov.au',
+  'co.nz', 'co.za', 'co.jp', 'or.jp', 'com.br', 'com.mx',
+]);
+
+/** True when a string looks like a bare hostname rather than an organization name. */
+function looksLikeHost(raw: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*(\.[a-z0-9][a-z0-9-]*)+\.?$/i.test(raw.trim());
+}
+
+/** Fold accents to ASCII so "Hôpital" and "Hopital" cannot be two organizations. */
+function foldDiacritics(s: string): string {
+  return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/**
+ * The registrable NAME label of a host: the label immediately left of the public
+ * suffix. `fhir.meridianhealth.example` -> `meridianhealth`.
+ */
+function registrableName(host: string): string {
+  const labels = foldDiacritics(host.trim().toLowerCase())
+    .replace(/\.$/, '')
+    .split('.')
+    .filter(Boolean);
+  if (labels.length === 0) return '';
+  if (labels[0] === 'www' && labels.length > 1) labels.shift();
+  if (labels.length === 1) return labels[0];
+  const lastTwo = labels.slice(-2).join('.');
+  const suffixLabels = MULTI_LABEL_SUFFIXES.has(lastTwo) ? 2 : 1;
+  const kept = labels.slice(0, labels.length - suffixLabels);
+  // Everything was suffix (e.g. the bare string "co.uk"): keep the first label
+  // rather than returning nothing.
+  return kept.length > 0 ? kept[kept.length - 1] : labels[0];
+}
+
+/**
+ * Repeatedly strip any generic organization word forming a whole prefix or
+ * suffix of a single concatenated label. `meridianhealth` -> `meridian`,
+ * `stonebridgehospital` -> `stonebridge`.
+ *
+ * Never strips below three characters. Two-letter registrable names exist
+ * ("kp.org") and reducing one to nothing or to a single letter would produce an
+ * identity that collides with everything.
+ */
+function stripGenericAffixes(label: string): string {
+  let out = label;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const word of GENERIC_ORG_WORDS) {
+      if (word.length < 3) continue;
+      if (out.length - word.length < 3) continue;
+      if (out.startsWith(word)) {
+        out = out.slice(word.length);
+        changed = true;
+        break;
+      }
+      if (out.endsWith(word)) {
+        out = out.slice(0, out.length - word.length);
+        changed = true;
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * THE NORMALIZATION. An organization NAME or a HOST reduced to one canonical
+ * token, such that both spellings of one organization give the same answer.
+ *
+ * Returns `undefined` for input that carries no organization at all (empty, or
+ * the ratified data-absent token), so a caller cannot accidentally mint
+ * `org:unknown` and have every unattributed record on a pod look like one
+ * organization.
+ *
+ * WHY THE LEADING TOKEN AND NOT ALL OF THEM
+ * -----------------------------------------
+ * Because the two failure directions are not symmetric, and this is the whole
+ * argument for the rule:
+ *
+ *   COLLAPSING two different organizations onto one identity suppresses
+ *   comparisons between their records. The duplicates stay in the pod: visible,
+ *   and recoverable by a later pass or a person.
+ *
+ *   SPLITTING one organization across two identities lets records that
+ *   organization deliberately kept apart be compared and merged. That destroys
+ *   content, and nothing downstream can know it happened.
+ *
+ * So the rule is biased toward collapsing. Regional and specialty qualifiers get
+ * dropped rather than being allowed to split a system: "Providence Health and
+ * Services Washington and Montana" and "providence.org" both give "providence",
+ * which is what makes a C-CDA custodian and a FHIR endpoint of one system agree.
+ * The cost — "Mercy Hospital St. Louis" and "Mercy Medical Center Des Moines"
+ * both giving "mercy" — is the recoverable failure, and it is taken knowingly.
+ *
+ * This is not a registry. It canonicalizes what the documents themselves state,
+ * and cannot resolve two organizations that share no token ("Kaiser Permanente"
+ * against "kp.org").
+ */
+export function orgSlug(raw: string | undefined | null): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  // The ratified data-absent token is the source saying it does not know. Minting
+  // an identity from it would make every unattributed record one organization.
+  if (/^(unknown|unavailable|asked-unknown|not-asked|masked|temp-unknown)$/i.test(trimmed)) {
+    return undefined;
+  }
+
+  let tokens: string[];
+  if (looksLikeHost(trimmed)) {
+    const name = registrableName(trimmed);
+    if (!name) return undefined;
+    tokens = [stripGenericAffixes(name)].filter(Boolean);
+  } else {
+    tokens = foldDiacritics(trimmed)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim()
+      .split(' ')
+      .filter(Boolean);
+  }
+
+  const distinctive = tokens.filter((t) => !GENERIC_ORG_WORDS.has(t) && !/^\d+$/.test(t));
+  if (distinctive.length > 0) return distinctive[0];
+
+  // Every token was generic ("Regional Medical Center"). Falling through to
+  // undefined would file the organization under "origin unknown", which is worse
+  // than a low-information but STABLE identity, so use the whole normalized form.
+  const joined = tokens.join('');
+  return joined || undefined;
+}
+
+/**
+ * THE DOOR. Resolve one record set's source identity.
+ *
+ * Every caller passes what its transport can see and takes what comes back; no
+ * caller composes the value itself. The cascade is strict, and each tier is a
+ * weaker claim than the one above it:
+ *
+ *   1. ORGANIZATION — a name or a host reduced through {@link orgSlug}.
+ *      `organizationName` is tried before `endpointHost` because a name is what
+ *      the source CALLS itself, and the two normalize into the same space
+ *      anyway, so the order only decides tie-breaks.
+ *   2. NAMESPACE — no organization, but the record's identifiers have an
+ *      assigning authority. Two records agree on origin only if they agree here.
+ *   3. TRANSPORT — nothing. Restate the ingestion label, prefixed so a reader
+ *      knows this is an absence and not an answer.
+ *
+ * Returns `undefined` only when even the transport label is absent, which means
+ * the caller has nothing to say and must write no triple rather than an empty
+ * one.
+ */
+export function sourceIdentity(opts: {
+  /** An organization NAME the source stated: C-CDA custodian, FHIR Organization.name, an institution-looking display. */
+  organizationName?: string;
+  /** The host of the source FHIR endpoint, or any absolute reference on it. */
+  endpointHost?: string;
+  /** The assigning authority for this record set's identifiers: server base URL, or C-CDA <id> root OID. */
+  idNamespace?: string;
+  /** The import-batch label. Used ONLY as the last resort, and prefixed when it is. */
+  transportLabel?: string;
+}): SourceIdentity | undefined {
+  const { organizationName, endpointHost, idNamespace, transportLabel } = opts;
+
+  const slug = orgSlug(organizationName) ?? orgSlug(endpointHost);
+  if (slug) return { value: `org:${slug}`, tier: 'organization' };
+
+  const ns = typeof idNamespace === 'string' ? idNamespace.trim() : '';
+  if (ns) return { value: `ns:${ns}`, tier: 'namespace' };
+
+  const label = typeof transportLabel === 'string' ? transportLabel.trim() : '';
+  if (label) return { value: `transport:${label}`, tier: 'transport' };
+
+  return undefined;
+}
+
+/**
+ * Whether a stored value names a real organization, as opposed to being an
+ * honest statement that the origin is unknown.
+ *
+ * The reconciler's same-source guard needs this: two records that both landed on
+ * `transport:` share a batch tag, not a source, and must not be treated as
+ * having the same origin on that basis. Reading the prefix is why the prefix
+ * exists.
+ */
+export function isKnownOrigin(value: string | undefined): boolean {
+  return typeof value === 'string' && (value.startsWith('org:') || value.startsWith('ns:'));
+}

--- a/src/shapes/core.shapes.ttl
+++ b/src/shapes/core.shapes.ttl
@@ -7,11 +7,12 @@
 # ============================================================================
 # Cascade Protocol -- Core Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.1 (2026-08-03)
+# Version: 1.5 (2026-08-09)
 # Validates: cascade:PatientProfile, cascade:Address, cascade:EmergencyContact,
 #            cascade:PharmacyInfo, cascade:AdvanceDirectives, cascade:ProxyAgent,
 #            cascade:ExportManifest, cascade:RecordSummary,
-#            cascade:InteractionScenario
+#            cascade:InteractionScenario, and the value of cascade:sourceIdentity
+#            wherever it appears
 #
 # Severity levels:
 #   sh:Violation -- Must fix (blocks operations)
@@ -610,8 +611,61 @@ cascade:AdvisoryApplicationActivityShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Source Identity (core v3.5)
+# ============================================================================
+# The ORIGIN axis. See cascade:sourceIdentity in core.ttl for the value form and
+# the slug normalization; this shape checks that a producer wrote a well-formed
+# one.
+#
+# WHY sh:targetSubjectsOf AND NOT sh:targetClass, AND WHY ABSENCE IS UNCHECKED
+# ---------------------------------------------------------------------------
+# This is an open-world property shape: it evaluates a record only if that record
+# ALREADY carries cascade:sourceIdentity. A pod written before core v3.5 carries
+# it nowhere, so this shape reports nothing on one, and every previously-valid
+# pod stays valid.
+#
+# That is a deliberate choice over the alternative, sh:minCount 1 at sh:Warning
+# on each record shape in health: and clinical:. Requiring presence the moment
+# the property is defined turns every existing pod amber for a property no
+# producer has yet had the opportunity to write, and a warning that fires on
+# correct historical data is a warning readers learn to skip. The ratchet is
+# stated in core.ttl's v3.5 changelog rather than left to judgement: presence
+# becomes a Warning on the record shapes once the reference producers emit it,
+# and a Violation only after a release in which that Warning is observably absent
+# from conforming output.
+#
+# What IS checked, whenever the property is present: exactly one value, a string,
+# and one of the three declared schemes. An unprefixed value is the specific
+# error this catches, because it is what a producer writes when it has stamped a
+# display label or an import-batch label into the origin axis, which is the
+# confusion the axis exists to end.
+
+cascade:SourceIdentityShape a sh:NodeShape ;
+    sh:targetSubjectsOf cascade:sourceIdentity ;
+    rdfs:label "Source Identity Shape"@en ;
+    rdfs:comment "Constrains the ORIGIN axis on any record that carries it. Open-world: absence is not a finding in core v3.5."@en ;
+
+    sh:property [
+        sh:path cascade:sourceIdentity ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^(org:[a-z0-9]+|ns:.+|transport:.+)$" ;
+        sh:name "Source Identity"@en ;
+        sh:message "cascade:sourceIdentity must be a single scheme-prefixed token: 'org:{slug}' for a derivable organization, 'ns:{namespace}' for an identifier assigning authority, or 'transport:{label}' as the honestly-labelled last resort. An unprefixed value is usually a display label or an import-batch label written into the origin axis."@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.5 (2026-08-09)
+# - Added SourceIdentityShape for core v3.5's cascade:sourceIdentity.
+#   sh:targetSubjectsOf, so it constrains the VALUE wherever the property
+#   appears and never requires its presence; pods written before v3.5 validate
+#   unchanged. VIOLATION for a non-string, a repeated value, or a value that
+#   does not carry one of the org: / ns: / transport: schemes.
 #
 # Version 1.4 (2026-05-06)
 # - Added cascade:appliedTriplesCount Info-severity property shape on

--- a/src/shapes/core.ttl
+++ b/src/shapes/core.ttl
@@ -19,8 +19,8 @@
     dct:description "Core vocabulary for schema versioning, data provenance, identity management, and patient demographics across all Cascade Protocol applications"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-10-31"^^xsd:date ;
-    dct:modified "2026-08-03"^^xsd:date ;
-    owl:versionInfo "3.4" ;
+    dct:modified "2026-08-09"^^xsd:date ;
+    owl:versionInfo "3.5" ;
     rdfs:comment "This vocabulary defines cross-cutting concepts used by all Cascade Protocol health data applications: schema versioning, data provenance, patient demographics (PatientProfile), and supporting identity classes (Address, PharmacyInfo, AdvanceDirectives). Domain-specific vocabularies (e.g., pots:, ecg:, glucose:) import this core vocabulary."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/core/v1.0/> .
 
@@ -550,11 +550,66 @@ cascade:advanceDirectiveNotes a owl:DatatypeProperty ;
 # Used by the Cascade reconciliation pipeline to annotate merged records with
 # provenance and conflict resolution metadata.
 
+# ----------------------------------------------------------------------------
+# THE THREE SOURCE AXES (v3.5)
+# ----------------------------------------------------------------------------
+# A record carries three different answers to three different questions, and
+# collapsing any two of them is a defect that has been measured on real pods.
+#
+#   ORIGIN      cascade:sourceIdentity  WHICH ORGANIZATION the record came from,
+#                                       as a canonical token that is the SAME
+#                                       whatever transport carried it. This is
+#                                       the only one of the three that may be
+#                                       used as a reconciliation key.
+#
+#   LABEL       clinical:sourceEHR      what to CALL that organization on screen.
+#                                       Human-readable, source-worded, and not an
+#                                       identity: two spellings of one
+#                                       organization are two labels.
+#
+#   INGESTION   cascade:sourceSystem    HOW AND WHEN the data entered the Pod:
+#                                       the import batch. Explicitly NEVER an
+#                                       origin. One batch routinely carries
+#                                       several organizations (a consumer health
+#                                       app exports every connected account under
+#                                       one label), and one organization
+#                                       routinely arrives in many batches.
+#
+# The failure this section exists to end: a reconciler that keys "are these two
+# records from the same source?" on the INGESTION axis answers "yes" for every
+# pair on a single-batch Pod, so no duplicate is ever compared, and answers "no"
+# for two exports of one organization, so one organization occupies two rows of
+# any source view.
+
 cascade:sourceSystem a owl:DatatypeProperty ;
     rdfs:label "Source System"@en ;
-    rdfs:comment "The name of the EHR or health system that originally held this record (e.g. 'primary-care', 'hospital'). Added during cross-system conversion to enable reconciliation."@en ;
+    rdfs:comment "INGESTION AXIS. The import batch a record entered the Pod through (e.g. 'Apple Health export', 'primary-care'). It records HOW AND WHEN data arrived, NOT where it came from, and it MUST NOT be used as a source identity: one batch commonly carries records from several organizations, and one organization commonly arrives in many batches. Use cascade:sourceIdentity for origin."@en ;
     rdfs:domain owl:Thing ;
     rdfs:range xsd:string .
+
+cascade:sourceIdentity a owl:DatatypeProperty ;
+    rdfs:label "Source Identity"@en ;
+    rdfs:comment """ORIGIN AXIS. The canonical, transport-independent identity of the organization a record came from. Two records that a FHIR export and a C-CDA document of the SAME health system produced carry the same value here, which is what makes it usable as a reconciliation key where clinical:sourceEHR (a display label) and cascade:sourceSystem (an ingestion batch) are not.
+
+VALUE FORM. A scheme-prefixed token, so a consumer can always tell how much the producer actually knew:
+  org:{slug}       an organization was derivable. {slug} is the normalized form below.
+  ns:{namespace}   no organization was derivable, but the record's identifiers have an assigning authority: the FHIR server base URL, or the C-CDA <id> root OID. Records agree on origin only if they agree on the namespace.
+  transport:{label}  LAST RESORT. Nothing in the document named or located an organization, so the value restates cascade:sourceSystem, honestly prefixed. It is not an origin claim, and a consumer must treat two transport: values as 'origin unknown' rather than as evidence of a shared source.
+
+THE SLUG NORMALIZATION, which both transports must implement identically:
+  1. The input is either an organization NAME (a C-CDA custodian/author organization name, a FHIR Organization.name or an institution-looking performer display) or a HOST (the registrable domain of the source FHIR endpoint).
+  2. HOST: lowercase; drop a leading 'www.'; drop the public-suffix label(s), keeping the registrable name label ('fhir.meridianhealth.example' -> 'meridianhealth'). Then repeatedly strip any generic organization word that forms a whole prefix or suffix of that label ('meridianhealth' -> 'meridian'), never stripping to fewer than three characters.
+  3. NAME: lowercase; fold diacritics to ASCII; replace every run of non-alphanumeric characters with a single space; split on spaces.
+  4. Drop generic organization words, legal-form words and pure-number tokens from the token list. Generic means institution-or-specialty vocabulary that names no particular organization: health, healthcare, system(s), service(s), medical, medicine, center/centre, hospital(s), clinic(s), care, group, associates, association, network, partners, physicians, practice, regional, community, memorial, university, institute, foundation, laboratory/laboratories/lab(s), diagnostics, imaging, radiology, pathology, family, urgent, primary, specialty, and the specialty names cardiology, oncology, orthopedics, pediatrics; legal-form means inc, llc, llp, ltd, plc, corp, corporation, co, pc, pa, pllc; and the English stopwords of, and, the, for, at, in, on, a, an.
+  5. If no token survives step 4, use the whole normalized string with separators removed, so an organization named only in generic words still gets a stable identity.
+  6. The slug is the FIRST surviving token. 'Meridian Health System' and 'meridianhealth.example' both give 'meridian'; 'Providence Health and Services Washington and Montana' and 'providence.org' both give 'providence'.
+
+WHY THE LEADING TOKEN AND NOT ALL OF THEM. The two failure directions are not symmetric. Collapsing two different organizations onto one identity suppresses comparisons between their records, so duplicates simply remain in the Pod: visible, and recoverable later. Splitting ONE organization across two identities lets records the organization deliberately kept apart be compared and merged, which destroys content. So the normalization is deliberately biased toward collapsing, and regional and specialty qualifiers ('... Washington and Montana', '... Cardiology') are dropped rather than being allowed to split a system.
+
+WHAT IT IS NOT. It is not a registry key and does not attempt to resolve two organizations that name themselves differently in different documents with no shared token; it canonicalizes what the documents themselves state. It is not a display value: show clinical:sourceEHR. It is not the transport: that is cascade:sourceSystem."""@en ;
+    rdfs:domain owl:Thing ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.5" .
 
 cascade:reconciliationStatus a owl:ObjectProperty ;
     rdfs:label "Reconciliation Status"@en ;
@@ -677,6 +732,40 @@ cascade:forSystem a owl:DatatypeProperty ;
 
 # ============================================================================
 # Changelog
+#
+# Version 3.5 (2026-08-09)
+# - Added cascade:sourceIdentity (owl:DatatypeProperty, range xsd:string): the
+#   ORIGIN axis. A canonical, transport-independent identity for the
+#   organization a record came from, so that a FHIR export and a C-CDA document
+#   of one health system agree. The full value form and the slug normalization
+#   both transports must implement are stated on the property itself; the short
+#   version is a scheme-prefixed token, org: / ns: / transport:, where
+#   transport: is an honestly-labelled last resort and NOT an origin claim.
+# - Stated the three source axes explicitly in this file, because two of them
+#   were already here and being used interchangeably: ORIGIN
+#   (cascade:sourceIdentity, new), LABEL (clinical:sourceEHR, unchanged, a
+#   display value), INGESTION (cascade:sourceSystem, the import batch).
+#   cascade:sourceSystem's comment now says what it is NOT: it records how and
+#   when data arrived, never where it came from, and it must not be used as a
+#   reconciliation key. One batch commonly carries several organizations, and
+#   one organization commonly arrives in many batches; a reconciler keyed on it
+#   compares nothing on a single-batch Pod and splits one system across two
+#   rows on a mixed one. No property was removed or renamed and no emitted
+#   value changes meaning, so existing pods keep reading correctly.
+# - COMPATIBILITY. Absence of cascade:sourceIdentity is NOT a validation
+#   finding at any severity in this version. The shape that constrains it
+#   (cascade:SourceIdentityShape) targets sh:targetSubjectsOf
+#   cascade:sourceIdentity, so it evaluates only records that CARRY the
+#   property: every pod written before v3.5 continues to validate exactly as it
+#   did. The alternative considered was sh:minCount 1 at sh:Warning on each
+#   record shape, which would have turned every previously-valid pod amber on
+#   upgrade for a property no producer had yet had the chance to write, and
+#   would have taught readers to ignore the warning. The ratchet path is
+#   deliberate and stated here so the next step is not a judgement call: once
+#   the reference producers emit the property, add sh:minCount 1 at sh:Warning
+#   to the record shapes in health: and clinical:, and only after a release in
+#   which that warning is observably absent from conforming output, raise it to
+#   sh:Violation. Each step is its own vocabulary version.
 #
 # Version 3.4 (2026-08-03)
 # - Defined the pod export manifest vocabulary. 32 cascade: terms appearing in

--- a/test-fixtures/pathology/scenarios.json
+++ b/test-fixtures/pathology/scenarios.json
@@ -4,7 +4,7 @@
   "scenarios": [
     {
       "id": "P01",
-      "pathology": "dual-label split: one health system, two source labels",
+      "pathology": "one health system exporting two transports resolves to ONE source identity",
       "batches": [
         { "file": "p01-dual-label-fhir.json", "from": "fhir" },
         { "file": "p01-dual-label-ccda.xml", "from": "c-cda" }
@@ -12,6 +12,11 @@
       "expect": {
         "convertedRecords": [4, 6],
         "reportedResourceCount": [4, 6],
+        "_comment_distinctValuesByPredicate": "The invariant this scenario exists for, folded in from the retired KNOWN_OUTCOMES entry P01-one-system-two-source-labels. One health system exporting FHIR and a C-CDA must occupy ONE row on the pod's source axis, whichever axis is read: one canonical ORIGIN (cascade:sourceIdentity, org:meridian, derived identically from the endpoint domain and from the custodian organization name) and one display LABEL (clinical:sourceEHR). The merge count below is the other half of the same invariant: an origin-only same-source guard would make the two transports uncomparable and drop it to 0.",
+        "distinctValuesByPredicate": {
+          "https://ns.cascadeprotocol.org/core/v1#sourceIdentity": 1,
+          "https://ns.cascadeprotocol.org/clinical/v1#sourceEHR": 1
+        },
         "podRecords": 7,
         "podRecordsByType": {
           "ClinicalDocument": 2,
@@ -30,22 +35,23 @@
     },
     {
       "id": "P02",
-      "pathology": "duplicate source-id collision: one <id> across three distinct lab observations",
+      "pathology": "one <id> across three contradicting lab observations mints three subjects, not one",
       "batches": [{ "file": "p02-duplicate-source-id-ccda.xml", "from": "c-cda" }],
       "expect": {
-        "convertedRecords": [5],
-        "reportedResourceCount": [5],
-        "podRecords": 5,
+        "_comment": "Folded in from the retired KNOWN_OUTCOMES entry P02-duplicate-source-id-collision-undetected. The document states four results and the pod holds four: the three that share a root-only <id> disagree about their code, name, value, unit and reference range, so the id has stopped identifying and each claimant mints its own subject. The two SHACL maxCount violations are gone because the multi-valued subject that caused them is gone, not because anything was silenced, and the panel's four hasLabResult edges now point at four distinct members instead of collapsing to two.",
+        "convertedRecords": [7],
+        "reportedResourceCount": [7],
+        "podRecords": 7,
         "podRecordsByType": {
           "ClinicalDocument": 1,
           "LaboratoryReport": 1,
-          "LabResultRecord": 2,
+          "LabResultRecord": 4,
           "PatientProfile": 1
         },
         "merges": 0,
         "conflicts": 0,
-        "edgesInPod": 2,
-        "violations": 2,
+        "edgesInPod": 4,
+        "violations": 0,
         "importWarnings": 0
       }
     },
@@ -179,17 +185,21 @@
     },
     {
       "id": "P07-SHARED-LABEL",
-      "pathology": "the same two exports under ONE import-batch label: the same-source guard suppresses every cross-source comparison",
+      "pathology": "the same two exports under ONE import-batch label still reconcile: the guard reads the origin, not the transport",
       "batches": [
         { "file": "p07a-crosssource-labs-alpha.json", "from": "fhir", "sourceSystem": "Household export" },
         { "file": "p07b-crosssource-labs-beta.json", "from": "fhir", "sourceSystem": "Household export" }
       ],
       "expect": {
+        "_comment": "Folded in from the retired KNOWN_OUTCOMES entry P07-shared-transport-label-blocks-cross-source-dedup. Two different health systems' exports arrive under one batch label, which is the ordinary shape when a consumer health app exports several connected accounts. The same-source guard now reads cascade:sourceIdentity (org:stonebridge against org:larkfield), so the shared label no longer suppresses the comparison and this run reconciles identically to the distinct-label P07: 7 records, 5 merges. The two distinct origins below are what the guard is reading; if that ever collapses to 1, the merges collapse to 0.",
         "convertedRecords": [6, 6],
         "reportedResourceCount": [6, 6],
-        "podRecords": 12,
-        "podRecordsByType": { "LabResultRecord": 10, "PatientProfile": 2 },
-        "merges": 0,
+        "distinctValuesByPredicate": {
+          "https://ns.cascadeprotocol.org/core/v1#sourceIdentity": 2
+        },
+        "podRecords": 7,
+        "podRecordsByType": { "LabResultRecord": 6, "PatientProfile": 1 },
+        "merges": 5,
         "conflicts": 0,
         "edgesInPod": 0,
         "violations": 0,

--- a/tests/pathology-corpus.test.ts
+++ b/tests/pathology-corpus.test.ts
@@ -151,6 +151,19 @@ interface Expectations {
    * merely how many there are.
    */
   sourceBreakdown?: Record<string, number>;
+  /**
+   * Distinct object values of a predicate across the whole pod, by full
+   * predicate IRI. Optional, and asserted only where a scenario declares it.
+   *
+   * This exists because the census fields above count RECORDS, and two of the
+   * corpus's invariants are about how many distinct SOURCES those records
+   * resolve to: P01 must hold one health system to one identity across two
+   * transports, and P07-SHARED-LABEL must keep two systems distinct under one
+   * import-batch label. Both arrived here as KNOWN_OUTCOMES entries, and the
+   * ledger's retirement path is to fold the corrected expectation into the
+   * scenario — which needs a field that can hold it.
+   */
+  distinctValuesByPredicate?: Record<string, number>;
 }
 
 interface Scenario {
@@ -522,6 +535,15 @@ describe.each(ALL_SCENARIOS)('$scenario.id  $scenario.pathology', ({ scenario })
         .violations.map((v) => `  ${v.property}: ${v.message}`)
         .join('\n')}`,
     ).toBe(scenario.expect.violations);
+  });
+
+  it('resolves the expected number of distinct values per declared predicate', () => {
+    const declared = scenario.expect.distinctValuesByPredicate;
+    if (!declared) return;
+    for (const [predicate, expected] of Object.entries(declared)) {
+      const values = obs().values(predicate);
+      expect(values.length, `${predicate} across the pod: ${JSON.stringify(values)}`).toBe(expected);
+    }
   });
 
   it('emits the expected number of import warnings', () => {

--- a/tests/pathology-known-outcomes.ts
+++ b/tests/pathology-known-outcomes.ts
@@ -119,48 +119,6 @@ function merges(o: ScenarioObservation): number {
 
 export const KNOWN_OUTCOMES: KnownOutcome[] = [
   {
-    id: 'P01-one-system-two-source-labels',
-    scenario: 'P01',
-    currentWrongOutcome:
-      'One health system occupies two rows on the pod source axis. The FHIR path derives ' +
-      'clinical:sourceEHR from the registrable domain of the first absolute reference URL ' +
-      '("meridianhealth.example"); the C-CDA path derives it from the custodian organization ' +
-      'name ("Meridian Health System"). Both are defensible readings of their own document and ' +
-      'neither knows about the other, so a patient who downloaded both transports from one ' +
-      'system sees two sources.',
-    expectedOnceFixed:
-      'One system yields ONE label. Which label wins (organization name, endpoint domain, or a ' +
-      'user-visible alias resolved from both) is the open design question; the invariant the ' +
-      'harness holds is that the count of distinct labels for one system is 1, whichever is chosen.',
-    probe: (o) => ({ distinctSourceEhrLabels: o.values(NS.clinical + 'sourceEHR').length }),
-    current: { distinctSourceEhrLabels: 2 },
-    fixed: { distinctSourceEhrLabels: 1 },
-  },
-  {
-    id: 'P02-duplicate-source-id-collision-undetected',
-    scenario: 'P02',
-    currentWrongOutcome:
-      'Three lab observations that share one root-only <id> mint one subject IRI, and because ' +
-      'they are one subject inside a single converted document there is no second record for the ' +
-      'reconciler to compare: splitIdentityCollisions only ever sees ONE parsed record. So the ' +
-      'three results pile onto one subject as multi-valued testCode/testName/resultValue, the pod ' +
-      'holds 2 lab records where the document stated 4, `pod conflicts` reports nothing, and the ' +
-      'only trace is two SHACL maxCount violations that name the symptom rather than the cause.',
-    expectedOnceFixed:
-      'The four observations become four lab records with zero violations, either by minting ' +
-      'distinct IRIs when a shared id is contradicted by the entry content, or by raising the ' +
-      'collision as a conflict the way the reconciler already does for records that arrive ' +
-      'separately. The failure mode to avoid is a fix that silences the SHACL violations without ' +
-      'recovering the two lost results.',
-    probe: (o) => ({
-      labRecords: o.podRecordsByType['LabResultRecord'] ?? 0,
-      conflicts: o.conflicts.length,
-      violations: o.violations.length,
-    }),
-    current: { labRecords: 2, conflicts: 0, violations: 2 },
-    fixed: { labRecords: 4, conflicts: 0, violations: 0 },
-  },
-  {
     id: 'P04-procedure-name-written-off-shape',
     scenario: 'P04',
     currentWrongOutcome:
@@ -205,24 +163,6 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
       reportDates: ['2025-07-03'],
       observationDates: ['2025-07-03', '2025-07-03T14:22:15-04:00'],
     },
-  },
-  {
-    id: 'P07-shared-transport-label-blocks-cross-source-dedup',
-    scenario: 'P07-SHARED-LABEL',
-    currentWrongOutcome:
-      'The guard that stops two records from the same source being compared keys on ' +
-      'cascade:sourceSystem — the IMPORT-BATCH label, set by --source-system. Give two different ' +
-      "health systems' exports one batch label (the Apple Health shape, where one export carries " +
-      'several connected accounts) and the guard suppresses every cross-source comparison: none of ' +
-      'the four byte-identical duplicates merges, and the pod ends up holding two patient profiles ' +
-      'and twelve records where the same data under distinct labels yields seven.',
-    expectedOnceFixed:
-      'The guard keys on the CLINICAL source (clinical:sourceEHR, or an explicit per-record source ' +
-      'identity), not on how the records were transported, so the shared-label run reconciles ' +
-      'identically to the distinct-label run: 7 records, 5 merges.',
-    probe: (o) => ({ podRecords: o.podRecords, merges: merges(o) }),
-    current: { podRecords: 12, merges: 0 },
-    fixed: { podRecords: 7, merges: 5 },
   },
   {
     id: 'P10-negation-and-data-absent-sentinels-stored-as-allergens',

--- a/tests/pathology-reconciliation-baseline.json
+++ b/tests/pathology-reconciliation-baseline.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Baseline reconciliation scorecard for the pathology-corpus scenarios that carry a constructed ground truth. REPORT-ONLY: nothing here asserts these numbers are good, and one of the recalls is 0. The harness asserts they are KNOWN, so a change to matching has to move this file on purpose, in the same commit as the change that moved it. Scored over merge PAIRS: precision = correctPairs / predictedPairs (1 when the reconciler predicted nothing, since predicting nothing asserts nothing wrong), recall = correctPairs / truthPairs. P08 moved from recall 0 to recall 1 when the vital-sign matcher was pointed at the predicates the converters actually write and given a time-proximity rule: it now merges the clock-skew pair (systolic and diastolic, 17 minutes apart across two sources) and nothing else, so it predicts exactly the two pairs the truth names. P07-SHARED-LABEL's recall of 0 belongs to the same-source guard and is unchanged.",
+  "_comment": "Baseline reconciliation scorecard for the pathology-corpus scenarios that carry a constructed ground truth. REPORT-ONLY: nothing here asserts these numbers are good. The harness asserts they are KNOWN, so a change to matching has to move this file on purpose, in the same commit as the change that moved it. Scored over merge PAIRS: precision = correctPairs / predictedPairs (1 when the reconciler predicted nothing, since predicting nothing asserts nothing wrong), recall = correctPairs / truthPairs. P08 moved from recall 0 to recall 1 when the vital-sign matcher was pointed at the predicates the converters actually write and given a time-proximity rule: it now merges the clock-skew pair (systolic and diastolic, 17 minutes apart across two sources) and nothing else, so it predicts exactly the two pairs the truth names.",
+  "_moved_2026-08-09": "P07-SHARED-LABEL recall 0.0 -> 1.0, deliberately, in the commit that moved it. The same-source guard used to key on cascade:sourceSystem, the import-batch label, so two health systems' exports arriving under ONE label suppressed every cross-source comparison and the reconciler predicted nothing at all. It now keys on cascade:sourceIdentity, the canonical ORIGIN, and this scenario reconciles identically to the distinct-label P07 beside it: same universe, same four truth pairs, all four predicted, all four correct. Nothing about the MATCHING changed, which is why P07 and P08 are byte-identical to the entries the matcher sweep left them at. Note that the score objects themselves are compared with toEqual, so no annotation may be added inside them.",
   "scores": {
     "P07": {
       "universe": 10,
@@ -12,10 +13,10 @@
     "P07-SHARED-LABEL": {
       "universe": 10,
       "truthPairs": 4,
-      "predictedPairs": 0,
-      "correctPairs": 0,
+      "predictedPairs": 4,
+      "correctPairs": 4,
       "precision": 1,
-      "recall": 0
+      "recall": 1
     },
     "P08": {
       "universe": 8,

--- a/tests/source-identity.test.ts
+++ b/tests/source-identity.test.ts
@@ -1,0 +1,649 @@
+/**
+ * The ORIGIN axis: `cascade:sourceIdentity`, and the two things that read it.
+ *
+ * WHAT IS BEING PROTECTED
+ * -----------------------
+ * A record carries three source-shaped facts — ORIGIN (`cascade:sourceIdentity`),
+ * display LABEL (`clinical:sourceEHR`) and INGESTION (`cascade:sourceSystem`) —
+ * and before this change the codebase had two of them and used both as if they
+ * were the third. Both misuses were measured, and they fail in opposite
+ * directions:
+ *
+ *   the reconciler's same-source guard keyed on the INGESTION label, so on a pod
+ *   imported under ONE label no pair of records was ever compared (148
+ *   cross-source duplicates invisible on one real corpus);
+ *
+ *   the two converters derived the display LABEL by different rules — endpoint
+ *   domain on the FHIR path, custodian organization name on the C-CDA path — so
+ *   ONE health system rendered as TWO sources on a mixed pod.
+ *
+ * WHAT EACH TEST WOULD DO IF THE FIX WERE ABSENT
+ * ----------------------------------------------
+ * Every assertion below was observed RED before the fix landed, and each one is
+ * pinned to a specific line rather than to the feature in general. The mutation
+ * ledger in the PR records which line each group dies on. Summarised:
+ *
+ *   - the normalization pairs die if the generic-word strip is removed from
+ *     either the NAME path or the HOST path (the two paths must agree);
+ *   - the tier tests die if the fallback order changes, or if the `transport:`
+ *     prefix is dropped (which is what makes "we do not know" legible);
+ *   - the converter emission tests die if either converter stops stamping, or if
+ *     the FHIR path goes back to a per-resource label;
+ *   - the guard tests die on either half of `sameSourceStatement`: drop the
+ *     origin comparison and the shared-label pod stops reconciling, drop the
+ *     transport comparison and one system's two transports stop reconciling;
+ *   - the collision tests die if the mint stops consulting the id scope, and the
+ *     order-independence one dies if the scope is turned into a running registry
+ *     rather than a pre-scan.
+ *
+ * All data is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+
+import { orgSlug, sourceIdentity, isKnownOrigin, SOURCE_IDENTITY_PREDICATE } from '../src/lib/source-identity.js';
+import { convert } from '../src/lib/fhir-converter/index.js';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { runReconciliation } from '../src/lib/reconciler.js';
+import { ccdaRecordUri } from '../src/lib/ccda-converter/record-identity.js';
+import { deterministicUuid } from '../src/lib/fhir-converter/types.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SOURCE_SYSTEM = 'https://ns.cascadeprotocol.org/core/v1#sourceSystem';
+const SOURCE_EHR = 'https://ns.cascadeprotocol.org/clinical/v1#sourceEHR';
+
+interface Triple { s: string; p: string; o: string }
+
+function parse(ttl: string): Triple[] {
+  return new Parser({ format: 'Turtle' })
+    .parse(ttl)
+    .map((q) => ({ s: q.subject.value, p: q.predicate.value, o: q.object.value }));
+}
+
+/** Distinct object values of a predicate, sorted. */
+function values(triples: Triple[], predicate: string): string[] {
+  return [...new Set(triples.filter((t) => t.p === predicate).map((t) => t.o))].sort();
+}
+
+/** Record subjects (those carrying an rdf:type). */
+function recordSubjects(triples: Triple[]): string[] {
+  return [...new Set(triples.filter((t) => t.p === RDF_TYPE).map((t) => t.s))].sort();
+}
+
+// ---------------------------------------------------------------------------
+// The normalization
+// ---------------------------------------------------------------------------
+
+describe('orgSlug: one organization, one slug, whichever way the document names it', () => {
+  // The whole point of the algorithm: a NAME and a HOST for one organization
+  // must land on the same token, because that is the only reason a C-CDA
+  // custodian and a FHIR endpoint of one system can be recognised as one source.
+  it.each([
+    ['Meridian Health System', 'meridianhealth.example', 'meridian'],
+    ['Meridian Health System', 'fhir.meridianhealth.example', 'meridian'],
+    ['Stonebridge Hospital', 'fhir.stonebridgehospital.example', 'stonebridge'],
+    ['Larkfield Clinic', 'fhir.larkfieldclinic.example', 'larkfield'],
+    // The real-world pair the ruling was written from: an endpoint domain of
+    // "providence.org" against a custodian of "Providence Health and Services
+    // Washington and Montana". The regional qualifiers must not split the system.
+    ['Providence Health and Services Washington and Montana', 'providence.org', 'providence'],
+  ])('%s and %s both give %s', (name, host, slug) => {
+    expect(orgSlug(name)).toBe(slug);
+    expect(orgSlug(host)).toBe(slug);
+  });
+
+  it('is case, punctuation and accent insensitive', () => {
+    expect(orgSlug('MERIDIAN HEALTH SYSTEM')).toBe('meridian');
+    expect(orgSlug('Meridian Health System, Inc.')).toBe('meridian');
+    expect(orgSlug('Méridian Health System')).toBe('meridian');
+  });
+
+  it('keeps two genuinely different organizations apart', () => {
+    expect(orgSlug('fhir.stonebridgehospital.example')).not.toBe(orgSlug('fhir.larkfieldclinic.example'));
+  });
+
+  it('returns undefined rather than minting an identity out of an absence', () => {
+    // "unknown" is the ratified data-absent token the C-CDA path writes when the
+    // custodian named nobody. Slugging it would file every unattributed record on
+    // a pod under one organization called "unknown", which is the exact failure
+    // the axis exists to prevent, wearing a new name.
+    expect(orgSlug('unknown')).toBeUndefined();
+    expect(orgSlug('')).toBeUndefined();
+    expect(orgSlug('   ')).toBeUndefined();
+    expect(orgSlug(undefined)).toBeUndefined();
+  });
+
+  it('never strips a short registrable name to nothing', () => {
+    // "care" is a generic word and "kp" is only two characters; stripping to
+    // fewer than three would produce an identity that collides with everything.
+    expect(orgSlug('kp.org')).toBe('kp');
+    expect(orgSlug('healthcare.example')).toBeTruthy();
+  });
+
+  it('falls back to the whole normalized name when every token is generic', () => {
+    // "Regional Medical Center" names no one in particular, but a stable
+    // low-information identity beats filing it under "origin unknown".
+    expect(orgSlug('Regional Medical Center')).toBe('regionalmedicalcenter');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The tier cascade
+// ---------------------------------------------------------------------------
+
+describe('sourceIdentity: the fallback chain, and the prefix that keeps it honest', () => {
+  it('prefers an organization, from either a name or a host', () => {
+    expect(sourceIdentity({ organizationName: 'Meridian Health System', endpointHost: 'other.example', transportLabel: 'batch' }))
+      .toEqual({ value: 'org:meridian', tier: 'organization' });
+    expect(sourceIdentity({ endpointHost: 'fhir.meridianhealth.example', transportLabel: 'batch' }))
+      .toEqual({ value: 'org:meridian', tier: 'organization' });
+  });
+
+  it('falls back to the identifier namespace before the transport label', () => {
+    expect(sourceIdentity({ idNamespace: '2.16.840.1.113883.19.5.99992.1', transportLabel: 'Household export' }))
+      .toEqual({ value: 'ns:2.16.840.1.113883.19.5.99992.1', tier: 'namespace' });
+  });
+
+  it('reaches the transport label only last, and says so in the value', () => {
+    // The prefix is load-bearing. An unprefixed batch label in the origin axis
+    // is indistinguishable from a real organization, and core v3.5's
+    // SourceIdentityShape rejects the unprefixed spelling for that reason.
+    expect(sourceIdentity({ transportLabel: 'Household export' }))
+      .toEqual({ value: 'transport:Household export', tier: 'transport' });
+  });
+
+  it('returns undefined when there is nothing at all to say', () => {
+    expect(sourceIdentity({})).toBeUndefined();
+  });
+
+  it('treats only org: and ns: as a known origin', () => {
+    // This is what stops the guard reading two records that share a batch label
+    // and know nothing else as two records that share a source.
+    expect(isKnownOrigin('org:meridian')).toBe(true);
+    expect(isKnownOrigin('ns:2.16.840.1.113883.19.5.1')).toBe(true);
+    expect(isKnownOrigin('transport:Household export')).toBe(false);
+    expect(isKnownOrigin(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Converter emission
+// ---------------------------------------------------------------------------
+
+const MERIDIAN_FHIR = JSON.stringify({
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Condition',
+        id: 'cond-1',
+        code: { coding: [{ system: 'http://snomed.info/sct', code: '44054006', display: 'Type 2 diabetes mellitus' }] },
+        subject: { reference: 'https://fhir.meridianhealth.example/api/FHIR/R4/Patient/pt-1' },
+        // Only THIS resource names the organization. Before the bundle-level
+        // derivation, that alone produced two labels inside one export.
+        recorder: { display: 'Meridian Health System' },
+      },
+    },
+    {
+      resource: {
+        resourceType: 'Observation',
+        id: 'obs-1',
+        status: 'final',
+        category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'laboratory' }] }],
+        code: { coding: [{ system: 'http://loinc.org', code: '4548-4', display: 'Hemoglobin A1c' }], text: 'Hemoglobin A1c' },
+        subject: { reference: 'https://fhir.meridianhealth.example/api/FHIR/R4/Patient/pt-1' },
+        effectiveDateTime: '2031-02-11T09:15:00-08:00',
+        valueQuantity: { value: 7.4, unit: '%' },
+      },
+    },
+  ],
+});
+
+const MERIDIAN_CCDA = `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5.90001.1" extension="SYN-CCDA-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1"/>
+  <effectiveTime value="20310214081500-0800"/>
+  <recordTarget><patientRole>
+    <id root="2.16.840.1.113883.19.5.90001.2" extension="MRN-1"/>
+    <patient>
+      <name use="L"><given>Marisol</given><family>Quintaine</family></name>
+      <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+      <birthTime value="19710418"/>
+    </patient>
+  </patientRole></recordTarget>
+  <custodian><assignedCustodian><representedCustodianOrganization>
+    <id root="2.16.840.1.113883.19.5.90001.1"/>
+    <name>Meridian Health System</name>
+  </representedCustodianOrganization></assignedCustodian></custodian>
+  <component><structuredBody><component><section>
+    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+    <code code="30954-2" codeSystem="2.16.840.1.113883.6.1"/>
+    <title>Results</title>
+    <text>Hemoglobin A1c 7.4 %</text>
+    <entry typeCode="DRIV"><organizer classCode="BATTERY" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+      <id root="2.16.840.1.113883.19.5.90001.4" extension="SYN-ORG-A1C"/>
+      <code code="24323-8" displayName="Comprehensive metabolic panel" codeSystem="2.16.840.1.113883.6.1"/>
+      <effectiveTime value="20310211091500-0800"/>
+      <component><observation classCode="OBS" moodCode="EVN">
+        <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+        <id root="2.16.840.1.113883.19.5.90001.5" extension="SYN-OBS-A1C"/>
+        <code code="4548-4" displayName="Hemoglobin A1c" codeSystem="2.16.840.1.113883.6.1"/>
+        <effectiveTime value="20310211091500-0800"/>
+        <value xsi:type="PQ" value="7.4" unit="%"/>
+      </observation></component>
+    </organizer></entry>
+  </section></structuredBody></component>
+</ClinicalDocument>`;
+
+describe('converter emission: both transports mint the identity at one chokepoint', () => {
+  it('stamps ONE origin on every record of a FHIR bundle', async () => {
+    const result = await convert(MERIDIAN_FHIR, 'fhir', 'cascade', 'turtle', 'meridian-fhir-export');
+    const triples = parse(result.output);
+    expect(values(triples, SOURCE_IDENTITY_PREDICATE)).toEqual(['org:meridian']);
+    // Every record, not just the one that named the organization.
+    const stamped = new Set(triples.filter((t) => t.p === SOURCE_IDENTITY_PREDICATE).map((t) => t.s));
+    for (const subject of recordSubjects(triples)) expect(stamped.has(subject)).toBe(true);
+  });
+
+  it('stamps ONE origin on every record of a C-CDA document', async () => {
+    const result = await convertCcda(MERIDIAN_CCDA, { sourceSystem: 'meridian-ccda-summary' });
+    const triples = parse(result.output);
+    expect(values(triples, SOURCE_IDENTITY_PREDICATE)).toEqual(['org:meridian']);
+    const stamped = new Set(triples.filter((t) => t.p === SOURCE_IDENTITY_PREDICATE).map((t) => t.s));
+    for (const subject of recordSubjects(triples)) expect(stamped.has(subject)).toBe(true);
+  });
+
+  it('gives one health system ONE origin across both transports', async () => {
+    // The invariant. Two transports, two different derivation inputs (an endpoint
+    // host and a custodian organization name), one identity.
+    const fhir = parse((await convert(MERIDIAN_FHIR, 'fhir', 'cascade', 'turtle', 'meridian-fhir-export')).output);
+    const ccda = parse((await convertCcda(MERIDIAN_CCDA, { sourceSystem: 'meridian-ccda-summary' })).output);
+    const combined = [...values(fhir, SOURCE_IDENTITY_PREDICATE), ...values(ccda, SOURCE_IDENTITY_PREDICATE)];
+    expect(new Set(combined).size).toBe(1);
+  });
+
+  it('gives one health system ONE display label across both transports', async () => {
+    // The LABEL axis keeps its semantics — it is still what the source called the
+    // organization — but the FHIR path now prefers a stated organization NAME over
+    // the endpoint domain, which is the rule the C-CDA path already used. Without
+    // that, one system reads as "meridianhealth.example" and "Meridian Health
+    // System" on one pod.
+    const fhir = parse((await convert(MERIDIAN_FHIR, 'fhir', 'cascade', 'turtle', 'meridian-fhir-export')).output);
+    const ccda = parse((await convertCcda(MERIDIAN_CCDA, { sourceSystem: 'meridian-ccda-summary' })).output);
+    expect(values(fhir, SOURCE_EHR)).toEqual(['Meridian Health System']);
+    expect(values(ccda, SOURCE_EHR)).toEqual(['Meridian Health System']);
+  });
+
+  it('falls to the ns tier when a C-CDA custodian names nobody', async () => {
+    // A real vendor shape: the custodian element is present and carries an OID
+    // root but no <name>. There is no organization to normalize, and the OID root
+    // is a real fact about where the record's identifiers were assigned, so it is
+    // a better answer than the import-batch label — which is why the chain has
+    // three tiers and not two.
+    const nameless = MERIDIAN_CCDA.replace('<name>Meridian Health System</name>', '');
+    const triples = parse((await convertCcda(nameless, { sourceSystem: 'anonymous-batch' })).output);
+    expect(values(triples, SOURCE_IDENTITY_PREDICATE)).toEqual(['ns:2.16.840.1.113883.19.5.90001.1']);
+    // And the display label is still the ratified data-absent token, not the OID
+    // and not the batch name: the two axes answer different questions.
+    expect(values(triples, SOURCE_EHR)).toEqual(['unknown']);
+  });
+
+  it('keeps the ORIGIN and the INGESTION axes separate', async () => {
+    // Two exports of one system under two batch labels: same origin, different
+    // ingestion. Neither value may leak into the other's predicate.
+    const fhir = parse((await convert(MERIDIAN_FHIR, 'fhir', 'cascade', 'turtle', 'meridian-fhir-export')).output);
+    expect(values(fhir, SOURCE_SYSTEM)).toEqual(['meridian-fhir-export']);
+    expect(values(fhir, SOURCE_IDENTITY_PREDICATE)).toEqual(['org:meridian']);
+  });
+
+  it('falls to the transport tier, prefixed, when a bundle names and locates nobody', async () => {
+    // Every reference a urn:uuid, no Organization, no institution display: the
+    // producer must say it does not know rather than inventing an origin.
+    const anonymous = JSON.stringify({
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [{
+        resource: {
+          resourceType: 'Observation',
+          id: 'obs-anon',
+          status: 'final',
+          category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'laboratory' }] }],
+          code: { coding: [{ system: 'http://loinc.org', code: '1751-7' }], text: 'Albumin' },
+          subject: { reference: 'urn:uuid:5c1de001-0000-4000-8000-0000000000ff' },
+          effectiveDateTime: '2031-05-20T06:12:00-07:00',
+          valueQuantity: { value: 4.1, unit: 'g/dL' },
+        },
+      }],
+    });
+    const triples = parse((await convert(anonymous, 'fhir', 'cascade', 'turtle', 'Household export')).output);
+    expect(values(triples, SOURCE_IDENTITY_PREDICATE)).toEqual(['transport:Household export']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The same-source guard
+// ---------------------------------------------------------------------------
+
+const RECON_PREFIXES = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+`;
+
+/** One lab record, parameterised on the two source axes. */
+function labTtl(uri: string, opts: { batch: string; origin?: string; value?: string }): string {
+  const origin = opts.origin ? `  cascade:sourceIdentity "${opts.origin}" ;\n` : '';
+  return `${RECON_PREFIXES}
+<${uri}> a health:LabResultRecord ;
+  cascade:sourceSystem "${opts.batch}" ;
+${origin}  health:testCode <http://loinc.org/rdf#2951-2> ;
+  health:testName "Sodium" ;
+  health:performedDate "2031-05-20" ;
+  health:resultValue "${opts.value ?? '141'}" .
+`;
+}
+
+/** Merged pairs the reconciler produced, as a count of records that survived. */
+async function survivingRecords(a: string, b: string, systemA: string, systemB: string): Promise<number> {
+  const result = await runReconciliation([
+    { content: a, systemName: systemA },
+    { content: b, systemName: systemB },
+  ]);
+  return recordSubjects(parse(result.turtle)).length;
+}
+
+describe('the same-source guard reads the ORIGIN, not the transport', () => {
+  it('compares two organizations that share ONE import-batch label', async () => {
+    // The P07-SHARED-LABEL shape at unit scale, and the defect this change
+    // exists for: keyed on the batch label alone these are "same source" and
+    // never compared, so the duplicate survives.
+    const alpha = labTtl('urn:uuid:lab-alpha', { batch: 'Household export', origin: 'org:stonebridge' });
+    const beta = labTtl('urn:uuid:lab-beta', { batch: 'Household export', origin: 'org:larkfield' });
+    expect(await survivingRecords(alpha, beta, 'Household export', 'Household export')).toBe(1);
+  });
+
+  it('still refuses to compare one organization\'s own two records in one batch', async () => {
+    // The guard's real job. Two readings the same organization stated separately
+    // in one export are two facts, and a matcher let loose on them destroys one.
+    const first = labTtl('urn:uuid:lab-first', { batch: 'Household export', origin: 'org:stonebridge' });
+    const second = labTtl('urn:uuid:lab-second', { batch: 'Household export', origin: 'org:stonebridge' });
+    expect(await survivingRecords(first, second, 'Household export', 'Household export')).toBe(2);
+  });
+
+  it('compares one organization\'s two DIFFERENT ingestions', async () => {
+    // One system exporting FHIR and a C-CDA is the re-sync case reconciliation
+    // exists for. An origin-only guard would suppress this, and corpus scenario
+    // P01 would fall from 2 merges to 0.
+    const fhirSide = labTtl('urn:uuid:lab-fhir', { batch: 'meridian-fhir-export', origin: 'org:meridian' });
+    const ccdaSide = labTtl('urn:uuid:lab-ccda', { batch: 'meridian-ccda-summary', origin: 'org:meridian' });
+    expect(await survivingRecords(fhirSide, ccdaSide, 'meridian-fhir-export', 'meridian-ccda-summary')).toBe(1);
+  });
+
+  it('falls back to the batch label for records that carry no origin', async () => {
+    // A pod written before core v3.5. The guard must behave exactly as it did,
+    // which means suppressing MORE comparison, not less: duplicates left in the
+    // pod are recoverable, a wrong merge is not.
+    const first = labTtl('urn:uuid:lab-legacy-1', { batch: 'Household export' });
+    const second = labTtl('urn:uuid:lab-legacy-2', { batch: 'Household export' });
+    expect(await survivingRecords(first, second, 'Household export', 'Household export')).toBe(2);
+  });
+
+  it('treats two transport-tier origins as unknown rather than as a shared source', async () => {
+    // Both records honestly said "I do not know where this came from". That is
+    // not evidence that they came from the same place, and it is not evidence
+    // that they came from different places either, so the conservative reading
+    // wins and they are not compared.
+    const first = labTtl('urn:uuid:lab-anon-1', { batch: 'Household export', origin: 'transport:Household export' });
+    const second = labTtl('urn:uuid:lab-anon-2', { batch: 'Household export', origin: 'transport:Household export' });
+    expect(await survivingRecords(first, second, 'Household export', 'Household export')).toBe(2);
+  });
+
+  it('records that the fast path never compares two NEW records with each other, whatever the guard says', async () => {
+    // MEASURED, twice, and pinned so the day either half changes is visible.
+    //
+    // `runReconciliation` has two matching paths and picks the
+    // `--reconcile-existing` fast path when an input is marked
+    // `existingPod: true` (the flag the cross-batch sweep introduced; the old
+    // `systemName` convention was overwritten by every pod record's own triple
+    // and never selected it). On that path, the cross-batch pass assigns EVERY
+    // new record — matched or not — before the new-against-new pass runs, so
+    // that pass's guard site is unreachable and two duplicates arriving in ONE
+    // import are never compared with each other, whatever the same-source guard
+    // would have said about them. That is a property of the pass ordering, not
+    // of the origin axis, and it is pinned here rather than fixed here.
+    //
+    // The second half is the contrast that shows what is at stake: the SAME two
+    // records through the single-batch path DO merge, because the guard reads
+    // their two different known origins under the shared batch label and admits
+    // the comparison (the P07-SHARED-LABEL semantics). The fast path and the
+    // single-batch path disagreeing about a batch's internal duplicates is a
+    // real gap, and it is tracked; this test is the measurement.
+    const pod = `${RECON_PREFIXES}
+<urn:uuid:lab-already-in-pod> a health:LabResultRecord ;
+  health:testCode <http://loinc.org/rdf#2160-0> ;
+  health:testName "Creatinine" ;
+  health:performedDate "2031-05-20" ;
+  health:resultValue "1.1" .
+`;
+    const alpha = labTtl('urn:uuid:lab-alpha-x', { batch: 'Household export', origin: 'org:stonebridge' });
+    const beta = labTtl('urn:uuid:lab-beta-x', { batch: 'Household export', origin: 'org:larkfield' });
+
+    // Fast path: pod content present. The duplicate pair survives un-compared.
+    const fast = await runReconciliation([
+      { content: pod, systemName: 'existing-pod', existingPod: true },
+      { content: alpha, systemName: 'Household export' },
+      { content: beta, systemName: 'Household export' },
+    ]);
+    expect(recordSubjects(parse(fast.turtle)).length).toBe(3);
+
+    // Single-batch path: same pair, no pod content. The guard admits, they merge.
+    const single = await runReconciliation([
+      { content: alpha, systemName: 'Household export' },
+      { content: beta, systemName: 'Household export' },
+    ]);
+    expect(recordSubjects(parse(single.turtle)).length).toBe(1);
+  });
+
+  it('does not treat an origin difference on one IRI as an identity collision', async () => {
+    // Two arrivals of ONE subject IRI that differ only on the origin axis are one
+    // record retrieved twice, not two records fighting over an identity. If the
+    // origin counted as collision evidence, every re-import of a record whose
+    // origin derivation improved would split into two.
+    const uri = 'urn:uuid:lab-one-iri';
+    const first = labTtl(uri, { batch: 'batch-1', origin: 'org:stonebridge' });
+    const second = labTtl(uri, { batch: 'batch-2', origin: 'org:larkfield' });
+    const result = await runReconciliation([
+      { content: first, systemName: 'batch-1' },
+      { content: second, systemName: 'batch-2' },
+    ]);
+    expect(result.report.summary.identityCollisionsSplit).toBe(0);
+    expect(recordSubjects(parse(result.turtle)).length).toBe(1);
+  });
+
+  it('never fills a missing origin in from the record it merged away', async () => {
+    // A winner that carries no origin HAS no origin. Inheriting the loser's would
+    // attribute the surviving record to an organization it never came from, which
+    // is worse than the absence it replaces because it is not visible as a guess.
+    //
+    // The values differ inside lab tolerance ON PURPOSE: property fill-in happens
+    // only on the merge_values path, and merge_values runs only for NEAR
+    // duplicates. Two byte-identical labs resolve by trust alone and never reach
+    // the line this test pins.
+    const winner = labTtl('urn:uuid:lab-no-origin', { batch: 'batch-1' });
+    const loser = labTtl('urn:uuid:lab-with-origin', { batch: 'batch-2', origin: 'org:larkfield', value: '141.2' });
+    const result = await runReconciliation(
+      [
+        { content: winner, systemName: 'batch-1' },
+        { content: loser, systemName: 'batch-2' },
+      ],
+      { trustScores: { 'batch-1': 0.95, 'batch-2': 0.60 } },
+    );
+    const triples = parse(result.turtle);
+    expect(recordSubjects(triples).length).toBe(1);
+    expect(values(triples, SOURCE_IDENTITY_PREDICATE)).toEqual([]);
+  });
+
+  it('does not raise a conflict on the origin difference it just admitted', async () => {
+    // Two copies of one result from two organizations differ on the origin axis
+    // by construction. If that difference also counted as an identity collision,
+    // every cross-source duplicate would raise a conflict.
+    const alpha = labTtl('urn:uuid:lab-alpha-c', { batch: 'Household export', origin: 'org:stonebridge' });
+    const beta = labTtl('urn:uuid:lab-beta-c', { batch: 'Household export', origin: 'org:larkfield' });
+    const result = await runReconciliation([
+      { content: alpha, systemName: 'Household export' },
+      { content: beta, systemName: 'Household export' },
+    ]);
+    expect(result.report.summary.conflictsUnresolved).toBe(0);
+    expect(result.report.summary.identityCollisionsSplit).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The id-collision disambiguator
+// ---------------------------------------------------------------------------
+
+/** A C-CDA results section whose observations are supplied as raw XML. */
+function ccdaWithObservations(observations: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.19.5.90002.1" extension="SYN-CCDA-002"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1"/>
+  <effectiveTime value="20310406101000-0500"/>
+  <recordTarget><patientRole>
+    <id root="2.16.840.1.113883.19.5.90002.2" extension="MRN-2"/>
+    <patient>
+      <name use="L"><given>Teodoro</given><family>Halvane</family></name>
+      <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+      <birthTime value="19580922"/>
+    </patient>
+  </patientRole></recordTarget>
+  <custodian><assignedCustodian><representedCustodianOrganization>
+    <id root="2.16.840.1.113883.19.5.90002.1"/>
+    <name>Northgate Regional Laboratory</name>
+  </representedCustodianOrganization></assignedCustodian></custodian>
+  <component><structuredBody><component><section>
+    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+    <code code="30954-2" codeSystem="2.16.840.1.113883.6.1"/>
+    <title>Results</title>
+    <text>Basic metabolic panel</text>
+    <entry typeCode="DRIV"><organizer classCode="BATTERY" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+      <id root="2.16.840.1.113883.19.5.90002.4" extension="SYN-ORG-BMP"/>
+      <code code="51990-0" codeSystem="2.16.840.1.113883.6.1"/>
+      <effectiveTime value="20310406094500-0500"/>
+      ${observations.map((o) => `<component>${o}</component>`).join('\n      ')}
+    </organizer></entry>
+  </section></structuredBody></component>
+</ClinicalDocument>`;
+}
+
+/** One observation sharing the SHARED_ID root-only identifier. */
+function sharedIdObservation(code: string, name: string, value: string, unit: string): string {
+  return `<observation classCode="OBS" moodCode="EVN">
+        <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+        <id root="a1d84b70-5c31-11ef-9c1d-0800200c9a66"/>
+        <code code="${code}" displayName="${name}" codeSystem="2.16.840.1.113883.6.1"/>
+        <effectiveTime value="20310406094500-0500"/>
+        <value xsi:type="PQ" value="${value}" unit="${unit}"/>
+      </observation>`;
+}
+
+const LAB_RECORD_TYPE = 'https://ns.cascadeprotocol.org/health/v1#LabResultRecord';
+
+/** Subject IRIs of the lab records a C-CDA converted to, sorted. */
+async function labSubjects(xml: string): Promise<string[]> {
+  const triples = parse((await convertCcda(xml, { sourceSystem: 'synthetic' })).output);
+  return triples.filter((t) => t.p === RDF_TYPE && t.o === LAB_RECORD_TYPE).map((t) => t.s).sort();
+}
+
+describe('a source id contradicted by the source\'s own content stops identifying', () => {
+  const sodium = sharedIdObservation('2951-2', 'Sodium', '139', 'mmol/L');
+  const potassium = sharedIdObservation('2823-3', 'Potassium', '4.2', 'mmol/L');
+  const chloride = sharedIdObservation('2075-0', 'Chloride', '104', 'mmol/L');
+
+  it('mints one subject per contradicting claimant', async () => {
+    // Three results that disagree about their code, name, value and unit share one
+    // root-only <id>, which is the shape the public HL7 CCD sample distributes.
+    // Believing the id outright folds them onto one subject and silently loses two
+    // results; the only trace on `main` is two SHACL maxCount violations.
+    const subjects = await labSubjects(ccdaWithObservations([sodium, potassium, chloride]));
+    expect(subjects.length).toBe(3);
+    expect(new Set(subjects).size).toBe(3);
+  });
+
+  it('still folds content-identical restatements of one id onto one subject', async () => {
+    // Two entries with one id and identical content are one act stated twice.
+    // Splitting them would recreate the duplicate-on-every-import defect.
+    const subjects = await labSubjects(ccdaWithObservations([sodium, sodium]));
+    expect(subjects.length).toBe(1);
+  });
+
+  it('splits on TWO contradicting claimants, not only on three', async () => {
+    // The threshold is "more than one distinct content fingerprint under one id".
+    // A test written only against the three-way collision in the corpus fixture
+    // leaves "> 1" and "> 2" indistinguishable, and the two-way case is the more
+    // common one in real exports.
+    const subjects = await labSubjects(ccdaWithObservations([sodium, potassium]));
+    expect(subjects.length).toBe(2);
+  });
+
+  it('does not disturb an observation whose id is its own', async () => {
+    // The control. Whatever happens to the colliding entries must not happen to a
+    // properly identified one, and its IRI must not move.
+    const distinct = `<observation classCode="OBS" moodCode="EVN">
+        <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+        <id root="2.16.840.1.113883.19.5.90002.5" extension="SYN-OBS-CREAT"/>
+        <code code="2160-0" displayName="Creatinine" codeSystem="2.16.840.1.113883.6.1"/>
+        <effectiveTime value="20310406094500-0500"/>
+        <value xsi:type="PQ" value="1.1" unit="mg/dL"/>
+      </observation>`;
+    const alone = await labSubjects(ccdaWithObservations([distinct]));
+    const alongside = await labSubjects(ccdaWithObservations([sodium, potassium, chloride, distinct]));
+    expect(alone.length).toBe(1);
+    expect(alongside.length).toBe(4);
+    // The uncontradicted record's IRI is identical whether or not a collision
+    // happened elsewhere in the document.
+    expect(alongside).toContain(alone[0]);
+  });
+
+  it('is independent of the order the contradicting entries appear in', async () => {
+    // The determinism property, and the reason the scope is a PRE-SCAN rather
+    // than a registry that disambiguates the second and later claimants: under a
+    // running registry the first entry keeps the bare id, so reordering the
+    // document moves two of the three IRIs.
+    const forward = await labSubjects(ccdaWithObservations([sodium, potassium, chloride]));
+    const reversed = await labSubjects(ccdaWithObservations([chloride, potassium, sodium]));
+    expect(reversed).toEqual(forward);
+  });
+
+  it('mints the same subjects on a second conversion of the same document', async () => {
+    const xml = ccdaWithObservations([sodium, potassium, chloride]);
+    expect(await labSubjects(xml)).toEqual(await labSubjects(xml));
+  });
+
+  it('closes the scope when the document is done, so nothing minted later inherits it', async () => {
+    // The scope is module state. `beginCcdaIdScope` resets it, so a leak is
+    // invisible between two CONVERSIONS — which is exactly why this asserts on a
+    // mint OUTSIDE one. Without the `finally { endCcdaIdScope() }` the previous
+    // document's contradicted ids stay live for every later caller of the door,
+    // and this record's IRI moves.
+    //
+    // The expectation is computed from the key template rather than from a mint
+    // taken before the conversion: this file converts colliding documents in
+    // several tests, so a "before" value would ALREADY carry a leaked scope and
+    // the comparison would hold for the wrong reason.
+    const sharedId = 'a1d84b70-5c31-11ef-9c1d-0800200c9a66';
+    await labSubjects(ccdaWithObservations([sodium, potassium, chloride]));
+    const minted = ccdaRecordUri({
+      type: 'LabResult',
+      sourceId: sharedId,
+      content: {},
+      source: { code: { '@_code': '2951-2' }, value: { '@_value': '139' } },
+    });
+    expect(minted).toBe(`urn:uuid:${deterministicUuid(`LabResult:${sharedId}`)}`);
+  });
+});


### PR DESCRIPTION
## What this is

A record carries three source-shaped facts, and this codebase had two of them, using both as if they were the third:

| Axis | Predicate | Question it answers |
|---|---|---|
| ORIGIN | `cascade:sourceIdentity` (new, core v3.5) | Which ORGANIZATION the record came from, canonically, whatever transport carried it. The only axis that may key reconciliation. |
| LABEL | `clinical:sourceEHR` | What to CALL that organization on screen. Source-worded. |
| INGESTION | `cascade:sourceSystem` | How and when the data entered the pod: the import batch. Never an origin. |

Both misuses fail in measured, opposite directions:

- **Guard keyed on the ingestion label** (`P07-SHARED-LABEL`): two health systems' exports under ONE batch label — the ordinary shape when a consumer health app exports several connected accounts — suppressed every cross-source comparison. 12 records and 0 merges where 7 and 5 are right. On one real corpus the same defect hid 148 cross-source duplicates.
- **Label read as an origin** (`P01`): the FHIR path derived it from the endpoint's registrable domain, the C-CDA path from the custodian organization name, so one system rendered as two sources the moment both transports were downloaded.

## What changed

- **`src/lib/source-identity.ts` — one door.** Both converters mint the origin here: `org:{slug}` when an organization is derivable (from a stated name or an endpoint host, normalized identically), `ns:{namespace}` when only an identifier assigning authority is (FHIR server base URL / C-CDA `<id>` root OID), `transport:{label}` as an honestly-prefixed last resort that is explicitly not an origin claim. The slug normalization is biased toward collapsing two organizations rather than splitting one: a collapse leaves visible, recoverable duplicates; a split merges records an organization deliberately kept apart.
- **The same-source guard reads both axes.** Comparison is suppressed only for two things ONE known organization stated in ONE ingestion — a strict subset of the old suppression, so nothing that merged stops merging. Absent/transport-tier origins fall back to the batch label (pre-v3.5 behaviour), so pods written by older CLIs reconcile exactly as before.
- **The FHIR display label is derived per bundle,** preferring a stated organization name over the endpoint host — the rule the C-CDA path already used. One system, one label, both transports.
- **A C-CDA `<id>` contradicted by its own document stops identifying.** The public HL7 CCD sample distributes one root-only `<id>` across every Results observation, and vendors copied the shape. A document-level pre-scan finds ids claimed by content that contradicts; every claimant (including the first) mints `{type}:{id}#{fingerprint}`, so IRIs never depend on entry order, and content-identical restatements still fold onto one subject. Documents whose ids identify produce byte-identical IRIs to before.
- **Shapes synced verbatim** to spec core v3.5 / core.shapes.ttl v1.5 (`cascade:SourceIdentityShape` is open-world: absence is not a finding, so every pre-v3.5 pod validates unchanged). `VOCAB_VERSIONS` `core=3.5`.

## Corpus outcomes

- `P01`: one origin (`org:` tier) and one label across two transports; merges intact.
- `P02`: 4 lab records, 4 panel edges, 0 violations, where 2 / 2 / 2 stood.
- `P07-SHARED-LABEL`: 7 records, 5 merges — identical to the distinct-label `P07` beside it. Scorecard recall 0.0 → 1.0 in this PR, deliberately, in the same commit as the change that moved it.
- The three corresponding `KNOWN_OUTCOMES` entries are retired by folding their post-fix expectations into the scenarios (the ledger's designed retirement path). The ledger now carries five entries.

## Verification

- Full suite: **2216 passed / 0 failed / 0 skipped** (per-assertion JSON audit), after `npm run build`.
- 18 mutations were run against the implementation during development (guard sites, chokepoint tiers, mint pre-scan, scope close, metaPreds); every survivor was given a pinning test and re-run on the final rebased tree, each with a verified non-empty diff and a green build:

  | Mutation | Verdict |
  |---|---|
  | guard origin branch removed (revert to transport-only) | RED, 5 tests |
  | guard site 1 (cross-batch) reverted to `sourceSystem` | RED, 3 tests |
  | `sourceIdentity` dropped from merge-values meta-predicates | RED |
  | mint contradiction threshold `>1` → `>2` | RED |
  | C-CDA id scope never closed | RED |
  | C-CDA ns tier removed from the document origin | RED |
  | guard site 2 (fast-path new-vs-new) reverted to `sourceSystem` | SURVIVED — the site is structurally unreachable (see below) |

- The one survivor is honest, not vacuous: on the `--reconcile-existing` fast path the cross-batch pass assigns every new record before the new-vs-new pass runs, so that pass — and its guard site — is dead code, and two duplicates arriving in ONE import are never compared with each other there. The pin `records that the fast path never compares two NEW records with each other` measures both halves (fast path keeps 3 records where the single-batch path keeps 1). The gap is tracked as follow-up work.
- One mutation round exposed a real defect in the working tree (a mutation-harness restore failure had dropped `sourceIdentity` from the `merge_values` meta-predicate set); it is restored here and pinned by `never fills a missing origin in from the record it merged away`, which drives a NEAR duplicate so the merge-values path actually runs.
- New `tests/source-identity.test.ts`: 38 pins across the normalization, the fallback chain, converter emission on both transports, the guard, and the id-collision scope.

## Sequencing

Companion to spec PR #17 (core v3.5) and conformance PR #12 (fixtures). The cli vendors its own shape copies, so this merges independently, but spec #17 should land first so the vocabulary exists on `main` before a release ships emitters for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
