### PR TITLE
feat(vocab): sync core 3.6 / health 2.7 / clinical 1.15 and act on the four rulings

### DIFF
--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -95,9 +95,31 @@
 #   genomics.shapes.ttl diffs the sync script also produces are the same
 #   pre-existing drift the 2026-08-08 entry names, unrelated to this change, and
 #   left for their own sync.
-core=3.5
-health=2.6
-clinical=1.14
+# 2026-08-14 — core 3.5→3.6, health 2.6→2.7, clinical 1.14→1.15
+#   Four vocabulary rulings. Shapes re-synced with scripts/sync-shapes-from-spec.sh.
+#   - clinical:VitalSignShape's interpretation is bound to the same 74-value set
+#     the lab shapes use, at sh:Warning (Violation in a later version). Through
+#     v1.14 the identical predicate was checked on labs and unchecked on vitals.
+#   - Both interpretation value sets gain the 14 data-absent-reason codes they
+#     lacked (60 -> 74). ACCEPTED_INTERPRETATION_CODES in
+#     src/lib/fhir-converter/interpretation.ts is the mirror and is asserted
+#     against the shapes by tests/fhir-interpretation-passthrough.ts.
+#   - core v3.6 adds cascade:dataAbsentReason. The C-CDA lab handler now maps
+#     <value nullFlavor="..."/> through it, so UNK / NAV / NASK / ASKU stop
+#     collapsing into one blank. Mapping table: src/lib/ccda-converter/null-flavor.ts.
+#   - clinical v1.15 rules clinical:procedureName canonical; the C-CDA procedures
+#     handler writes it instead of the undefined health:procedureName. The shape
+#     accepts either spelling through an sh:or for now, so pods holding the old
+#     triples do not have to be rewritten.
+#   - core v3.6 states the canonical form of a multi-valued identity input;
+#     canonicalSetKey in src/lib/fhir-converter/types.ts implements it.
+#   Note: src/shapes/evidence.ttl and src/shapes/genomics.shapes.ttl still differ
+#   from spec. That drift predates this change and belongs to its own sync; the
+#   sync script was run and those two files were deliberately reverted.
+#
+core=3.6
+health=2.7
+clinical=1.15
 coverage=1.4
 checkup=3.3
 pots=1.4

--- a/src/lib/ccda-converter/null-flavor.ts
+++ b/src/lib/ccda-converter/null-flavor.ts
@@ -1,0 +1,100 @@
+/**
+ * HL7 v3 NullFlavor to FHIR data-absent-reason.
+ *
+ * WHY A MAPPING AND NOT A PASSTHROUGH
+ * -----------------------------------
+ * A C-CDA document states WHY an element is missing, using
+ * http://terminology.hl7.org/CodeSystem/v3-NullFlavor (OID
+ * 2.16.840.1.113883.5.1008). Cascade records that reason on
+ * `cascade:dataAbsentReason`, which core v3.6 binds to
+ * http://terminology.hl7.org/CodeSystem/data-absent-reason (value set
+ * http://hl7.org/fhir/ValueSet/data-absent-reason) — the flat, all-selectable
+ * set FHIR R4 binds `Observation.dataAbsentReason` to.
+ *
+ * The raw nullFlavor code is deliberately NOT written through. Accepting both
+ * spellings would give every absence two encodings and turn "are these the same
+ * absence?" into a string-comparison question, and the shape in `core.shapes.ttl`
+ * rejects a raw NullFlavor code for exactly that reason. The mapping is stated
+ * normatively on `cascade:dataAbsentReason` in `spec/ontologies/core/v1/core.ttl`;
+ * this table is that statement, executable. Change one and change the other.
+ *
+ * WHAT IS DELIBERATELY NOT MAPPED
+ * -------------------------------
+ * `DER`, `UNC`, `QS` and `TRC` are not absences. They say a value exists and is
+ * derivable, unencoded, non-zero-but-unquantified, or trace — claims about the
+ * value, not about its absence — and flattening them into an absence reason
+ * would assert something the source did not. They return `undefined`, which
+ * leaves the record exactly as it is today rather than making it wrong.
+ */
+
+/**
+ * The 15 codes of the data-absent-reason code system, in the order the code
+ * system lists them. Exported so a test can assert this file and the shape's
+ * `sh:in` still agree; a mapping that produces a code the shape rejects would
+ * write an invalid pod.
+ */
+export const DATA_ABSENT_REASON_CODES = [
+  'unknown',
+  'asked-unknown',
+  'temp-unknown',
+  'not-asked',
+  'asked-declined',
+  'masked',
+  'not-applicable',
+  'unsupported',
+  'as-text',
+  'error',
+  'not-a-number',
+  'negative-infinity',
+  'positive-infinity',
+  'not-performed',
+  'not-permitted',
+] as const;
+
+export type DataAbsentReason = (typeof DATA_ABSENT_REASON_CODES)[number];
+
+const NULL_FLAVOR_TO_DATA_ABSENT_REASON: Record<string, DataAbsentReason> = {
+  // A proper value applies but is not known.
+  UNK: 'unknown',
+  // No information at all, and no reason offered. The weakest claim there is,
+  // so it maps to the weakest code rather than to a specific reason.
+  NI: 'unknown',
+  // Information was sought and not found: somebody asked.
+  ASKU: 'asked-unknown',
+  // Not sought at all. Distinct from ASKU, and this distinction is the single
+  // most common thing lost by dropping nullFlavor.
+  NASK: 'not-asked',
+  // Not available now, expected later.
+  NAV: 'temp-unknown',
+  // Not available, with no expectation of later availability. There is no
+  // data-absent-reason code for "never coming", so it lands on the honest
+  // weaker claim rather than borrowing temp-unknown, which would assert an
+  // expectation the source explicitly denied.
+  NAVU: 'unknown',
+  // Withheld for security or privacy.
+  MSK: 'masked',
+  // Known to have no proper value.
+  NA: 'not-applicable',
+  // The real value is outside the permitted value domain.
+  OTH: 'unsupported',
+  NINF: 'negative-infinity',
+  PINF: 'positive-infinity',
+};
+
+/**
+ * Map one nullFlavor attribute to a data-absent-reason code.
+ *
+ * Returns `undefined` when there is no nullFlavor, when it is not a string, or
+ * when it is one of the codes above that is not an absence. Any OTHER
+ * unrecognised code maps to `unknown`, which asserts only that a value was
+ * expected and is missing — true of every nullFlavor by definition, so it can
+ * never be wrong, whereas guessing a specific reason can.
+ */
+export function mapNullFlavorToDataAbsentReason(raw: unknown): DataAbsentReason | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const code = raw.trim().toUpperCase();
+  if (code.length === 0) return undefined;
+  // Claims about a value that exists, not about its absence. See the header.
+  if (code === 'DER' || code === 'UNC' || code === 'QS' || code === 'TRC') return undefined;
+  return NULL_FLAVOR_TO_DATA_ABSENT_REASON[code] ?? 'unknown';
+}

--- a/src/lib/ccda-converter/sections/labs.ts
+++ b/src/lib/ccda-converter/sections/labs.ts
@@ -47,6 +47,7 @@ import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { contentFingerprint, EMPTY_SEED } from '../../identity.js';
 import { resolveCodeUri } from '../code-systems.js';
 import { ccdaDateQuad } from '../dates.js';
+import { mapNullFlavorToDataAbsentReason } from '../null-flavor.js';
 import { buildNarrativeIdMap, narrativeTextFor, resolveNarrativeName } from '../narrative-reference.js';
 import { buildEncounterRecord } from './encounters.js';
 import { DataFactory } from 'n3';
@@ -162,6 +163,24 @@ function extractObservationQuads(
   const value = valueEl?.['@_value'] ?? valueEl?.value ?? valueEl?.['#text'] ?? '';
   const unit = valueEl?.['@_unit'] ?? valueEl?.unit ?? '';
 
+  // A <value nullFlavor="..."/> carries no number and IS a statement: HL7 v3
+  // separates UNK ("a value applies, nobody knows it"), NAV ("we will know
+  // later"), NASK ("nobody asked") and ASKU ("we asked, the patient did not
+  // know") deliberately, and the last one means somebody had the conversation.
+  // Reading only @_value dropped all four to the same empty string, so three
+  // different clinical facts became one indistinguishable blank and re-asking
+  // was the only recovery.
+  //
+  // core v3.6 defines cascade:dataAbsentReason and states the mapping this call
+  // implements. Note the value set is FHIR data-absent-reason, not v3-NullFlavor:
+  // the raw nullFlavor code is deliberately NOT written through, because an
+  // absence with two encodings turns "is this the same absence?" into a
+  // string-comparison question. No value is invented for the record; only the
+  // reason is recovered.
+  const dataAbsentReason = mapNullFlavorToDataAbsentReason(
+    valueEl?.['@_nullFlavor'] ?? valueEl?.nullFlavor,
+  );
+
   // Extract reference range
   const refRange = obs?.referenceRange?.observationRange;
   const refRangeText = refRange?.text?.['#text'] ?? refRange?.text ?? '';
@@ -221,6 +240,12 @@ function extractObservationQuads(
   if (performedQuad) quads.push(performedQuad);
   if (value) quads.push(makeQuad(subj, namedNode(NS.health + 'resultValue'), literal(value)));
   if (unit) quads.push(makeQuad(subj, namedNode(NS.health + 'resultUnit'), literal(unit)));
+  // Only when there is no value: cascade:dataAbsentReason explains an ABSENT
+  // value (FHIR R4 Observation.dataAbsentReason), so a record carrying both
+  // would be asserting that the value it just stated is missing.
+  if (!value && dataAbsentReason) {
+    quads.push(makeQuad(subj, namedNode(NS.cascade + 'dataAbsentReason'), literal(dataAbsentReason)));
+  }
   if (refRangeText) quads.push(makeQuad(subj, namedNode(NS.health + 'referenceRangeText'), literal(refRangeText)));
   if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
 

--- a/src/lib/ccda-converter/sections/procedures.ts
+++ b/src/lib/ccda-converter/sections/procedures.ts
@@ -76,7 +76,23 @@ export function extractProcedureQuads(
     const subj = namedNode(uri);
     quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Procedure')));
     quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
-    if (procedureName) quads.push(makeQuad(subj, namedNode(NS.health + 'procedureName'), literal(procedureName)));
+    // clinical:procedureName, NOT health:procedureName. The record above is typed
+    // clinical:Procedure, clinical:ProcedureShape targets that class and names
+    // this property, and clinical:procedureName is the only spelling any Cascade
+    // vocabulary defines: health: has no procedure class and no procedure-name
+    // property at all. Writing the health: spelling made every converted
+    // procedure fail the shape's name requirement WHILE CARRYING A NAME, and put
+    // that name on a predicate no shape targets, so the name itself was
+    // validated by nothing.
+    //
+    // Ratified in clinical v1.15, which also opened the migration window: the
+    // shape accepts a name in either spelling through an sh:or so pods already
+    // holding health:procedureName triples do not have to be rewritten, and
+    // clinical:ProcedureNameSpellingShape warns wherever the old spelling
+    // appears. Producers write the canonical spelling only — dual-writing would
+    // add a duplicate triple to every new record for no validation benefit,
+    // since the sh:or already covers the old pods.
+    if (procedureName) quads.push(makeQuad(subj, namedNode(NS.clinical + 'procedureName'), literal(procedureName)));
     // Typed from the raw effectiveTime; see `dates.ts`.
     const performedQuad = ccdaDateQuad(uri, NS.health + 'performedDate', dateVal, warnings);
     if (performedQuad) quads.push(performedQuad);

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -41,6 +41,7 @@ import {
   codeableConceptKey,
   codeableConceptSetKey,
   structuredKey,
+  canonicalSetKey,
 } from './types.js';
 import {
   referencePlaceholder,
@@ -575,6 +576,11 @@ function labMeasuredValueKey(resource: any): string | undefined {
  * and two servers may enumerate the same categories in different order. Sorting
  * therefore removes a source of spurious SPLITS; it can never cause a merge,
  * since a differing set still sorts to a differing string.
+ *
+ * Deduplicated as well, since core v3.6: a repeated category is the same claim
+ * twice and must not split the record from one that states it once. The
+ * canonical form is shared with the other set-valued key builders rather than
+ * respelled here. Separator stays ',' — the one this site already shipped.
  */
 function labCategoryKey(resource: any): string | undefined {
   if (!Array.isArray(resource?.category)) return undefined;
@@ -587,7 +593,7 @@ function labCategoryKey(resource: any): string | undefined {
     }
     if (typeof cat?.text === 'string' && cat.text.trim().length > 0) parts.push(cat.text.trim());
   }
-  return parts.length > 0 ? parts.sort().join(',') : undefined;
+  return canonicalSetKey(parts, ',');
 }
 
 /**

--- a/src/lib/fhir-converter/interpretation.ts
+++ b/src/lib/fhir-converter/interpretation.ts
@@ -6,8 +6,9 @@
  * ObservationInterpretation code system
  * (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), and as of
  * health v2.6 `health:interpretation` is bound to the same 49 selectable codes,
- * plus the data-absent-reason code `unknown` and the ten English words the
- * previous five-member enum used.
+ * plus the data-absent-reason codes and the ten English words the previous
+ * five-member enum used. health v2.7 widened the data-absent-reason half from
+ * `unknown` alone to all fifteen codes.
  *
  * So the importer's job is now to CARRY the code, not to translate it. It used to
  * translate: H and L both became "abnormal", HH and LL both became "critical",
@@ -17,7 +18,10 @@
  * indistinguishable from "the source reported no interpretation", and no
  * downstream reader could tell which had happened.
  *
- * `unknown` now means one thing: the source Observation carried no interpretation.
+ * `unknown` now means one thing: the source Observation carried no interpretation
+ * and gave no reason. When the source DID give a reason, the specific
+ * data-absent-reason code carries it instead — see mapNullFlavorToDataAbsentReason
+ * in the C-CDA converter for the nullFlavor half of the same idea.
  *
  * THE LIST BELOW IS A COPY, AND A COPY DRIFTS
  * -------------------------------------------
@@ -30,8 +34,14 @@
 
 /**
  * Every value `health:interpretation` accepts: the 49 selectable HL7 v3
- * ObservationInterpretation codes, the data-absent-reason code `unknown`, and the
- * ten retained health v2.5 words.
+ * ObservationInterpretation codes, ALL FIFTEEN data-absent-reason codes, and the
+ * ten retained health v2.5 words. 74 values.
+ *
+ * health v2.7 widened the data-absent-reason half from the single `unknown` to
+ * the whole code system, so a source that says WHY an interpretation is missing
+ * keeps saying it. Under v2.6 a C-CDA `<interpretationCode nullFlavor="NASK"/>`
+ * ("nobody asked") and one carrying `ASKU` ("we asked, they did not know") both
+ * had to be flattened to `unknown`, and two different clinical facts became one.
  */
 export const ACCEPTED_INTERPRETATION_CODES: ReadonlySet<string> = new Set([
   'EX', 'HM', 'OBX', 'CAR', 'Carrier', 'B', 'D', 'U', 'W',
@@ -40,7 +50,10 @@ export const ACCEPTED_INTERPRETATION_CODES: ReadonlySet<string> = new Set([
   'AA', 'H', 'L', 'HH', 'LL', 'HX', 'LX', 'H>', 'HU', 'E', 'L<', 'LU',
   'ND', 'IND', 'NEG', 'POS', 'EXP', 'UNE', 'DET',
   'SYN-R', 'NR', 'RR', 'WR', 'SDD', 'SYN-S',
-  'unknown',
+  'unknown', 'asked-unknown', 'temp-unknown', 'not-asked',
+  'asked-declined', 'masked', 'not-applicable', 'unsupported',
+  'as-text', 'error', 'not-a-number', 'negative-infinity',
+  'positive-infinity', 'not-performed', 'not-permitted',
   'normal', 'high', 'low', 'abnormal', 'critical',
   'Normal', 'High', 'Low', 'Abnormal', 'Critical',
 ]);

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -590,7 +590,47 @@ export function codeableConceptKey(cc: any): string | undefined {
     }
   }
   if (typeof cc.text === 'string' && cc.text.trim().length > 0) parts.push(cc.text.trim());
-  return parts.length > 0 ? parts.sort().join(',') : undefined;
+  return canonicalSetKey(parts, ',');
+}
+
+/**
+ * The canonical form of a SET-valued identity input, stated normatively in core
+ * v3.6 on `cascade:cascadeUri`: discard empty members, deduplicate, sort by code
+ * point, join with a fixed separator.
+ *
+ * WHAT THE DEDUPE CHANGES, PRECISELY. Sorting was already here. Deduplication is
+ * the new half, and it moves an identity for exactly one kind of record: one
+ * whose source listed the SAME coding more than once, which real bundles produce
+ * when a resource is assembled from several sources. Those are the records the
+ * rule exists to stop splitting. A record with one member, or with distinct
+ * members, hashes byte-for-byte as it did before — a one-element array joins to
+ * the bare element with any separator — which is what keeps every identity
+ * already written exactly where it is. `tests/uri-generation.test.ts` pins that
+ * as a golden value rather than leaving it as a claim.
+ *
+ * THE SEPARATOR IS A PARAMETER, AND THAT IS DELIBERATE. core v3.6 recommends
+ * U+002C and requires it of NEW implementations, but explicitly lets an
+ * implementation that already ships a different fixed separator keep it, because
+ * changing a separator re-mints every identifier that site ever produced — the
+ * precise harm the rule exists to prevent. This repository ships ',' at two
+ * sites and ';' at one, so each caller passes the separator it already shipped
+ * and none of them moves. The cross-implementation contract is the three
+ * invariants (order independence, scalar agreement, duplicate independence), not
+ * the byte string.
+ *
+ * DO NOT REACH FOR THIS FOR ORDERED INPUTS. It is for elements that are SETS:
+ * `CodeableConcept.coding`, a repeating CodeableConcept, a category list. FHIR
+ * `name[0]` is the primary name and a component or note list is a sequence;
+ * sorting those merges records the source deliberately kept apart. `stableStringify`
+ * preserves array order for that reason and is not built on this.
+ */
+export function canonicalSetKey(parts: string[], separator: string): string | undefined {
+  const seen = new Set<string>();
+  for (const p of parts) {
+    const t = p.trim();
+    if (t.length > 0) seen.add(t);
+  }
+  return seen.size > 0 ? [...seen].sort().join(separator) : undefined;
 }
 
 /**
@@ -609,7 +649,11 @@ export function codeableConceptSetKey(value: unknown): string | undefined {
     const key = codeableConceptKey(item);
     if (key) parts.push(key);
   }
-  return parts.length > 0 ? parts.sort().join(';') : undefined;
+  // ';' and not ',' — this site has always joined with ';' and changing it would
+  // re-mint every identity it has ever produced. core v3.6 permits exactly this:
+  // an existing site keeps its separator, and conformance is the three
+  // invariants rather than the byte string. See canonicalSetKey.
+  return canonicalSetKey(parts, ';');
 }
 
 /**

--- a/src/shapes/clinical.shapes.ttl
+++ b/src/shapes/clinical.shapes.ttl
@@ -1,6 +1,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
@@ -13,6 +14,35 @@
 # different data sources (EHR, device, patient-reported).
 #
 # Changelog:
+# v1.15 (2026-08-14): Check what was unchecked, keep what was being dropped, and
+#     stop failing records that carry the thing they are failing for missing.
+#     Additive and strictly widening: no graph that validated under v1.14 stops
+#     validating, and the only new finding anywhere is at sh:Warning.
+#
+#     1. clinical:VitalSignShape's clinical:interpretation is bound to the same
+#        value set the lab shapes use, at sh:Warning. v1.14 put the sh:in on the
+#        LAB shapes only, so the identical predicate was checked on a lab result
+#        and unchecked on a vital sign. sh:Warning first and sh:Violation in a
+#        later version is the ratchet core v3.5 wrote down for a value that
+#        existing data carries. See the long note above the property.
+#     2. Both interpretation value sets gain the fourteen data-absent-reason
+#        codes they did not carry. v1.14 accepted "unknown" alone, so every
+#        reason for an absent interpretation was the same reason; C-CDA
+#        nullFlavor NASK, ASKU and NAV are three different clinical facts.
+#        Still byte-identical to health:interpretation.
+#     3. NEW property shapes for clinical:interpretationSourceCode on the lab
+#        and vital shapes: a single string, no value set and no pattern, holding
+#        a source code that is in neither bound value set, verbatim.
+#     4. clinical:ProcedureShape's name requirement becomes an sh:or over
+#        clinical:procedureName and health:procedureName, plus the new
+#        warning-severity clinical:ProcedureNameSpellingShape. A C-CDA import
+#        path writes the name to the health: spelling on records typed
+#        clinical:Procedure, so every converted procedure failed the name
+#        requirement while carrying a name, on a predicate no shape targeted.
+#        This is a MIGRATION WINDOW and both halves are removed together in a
+#        later version; the rationale is on clinical:procedureName in
+#        clinical.ttl.
+#
 # v1.14 (2026-08-08): Align to ratified standards; add the missing Encounter
 #     shape. Shapes-only, and strictly widening apart from the new shape: every
 #     graph that validated before still validates.
@@ -741,11 +771,12 @@ clinical:LabResultShape a sh:NodeShape ;
     # concepts are excluded because they are not values. Deprecated codes are
     # accepted: historical results carry them.
     #
-    # Plus "unknown" from
-    # http://terminology.hl7.org/CodeSystem/data-absent-reason, written by
-    # importers when the source Observation carried no interpretation, and the
-    # ten words of the previous enum, retained so data written against earlier
-    # clinical versions keeps validating.
+    # Plus ALL FIFTEEN codes of
+    # http://terminology.hl7.org/CodeSystem/data-absent-reason (v1.15; v1.14
+    # accepted only "unknown"), for a source Observation whose interpretation
+    # element was absent or null-flavoured, and the ten words of the previous
+    # enum, retained so data written against earlier clinical versions keeps
+    # validating.
     #
     # Kept byte-identical to the health:interpretation list in
     # health.shapes.ttl. These are two spellings of one record (clinical:LabResult
@@ -761,11 +792,23 @@ clinical:LabResultShape a sh:NodeShape ;
                "AA" "H" "L" "HH" "LL" "HX" "LX" "H>" "HU" "E" "L<" "LU"
                "ND" "IND" "NEG" "POS" "EXP" "UNE" "DET"
                "SYN-R" "NR" "RR" "WR" "SDD" "SYN-S"
-               "unknown"
+               "unknown" "asked-unknown" "temp-unknown" "not-asked"
+               "asked-declined" "masked" "not-applicable" "unsupported"
+               "as-text" "error" "not-a-number" "negative-infinity"
+               "positive-infinity" "not-performed" "not-permitted"
                "normal" "high" "low" "abnormal" "critical"
                "Normal" "High" "Low" "Abnormal" "Critical") ;
         sh:name "Interpretation"@en ;
-        sh:message "Interpretation must be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), the data-absent-reason code 'unknown', or one of the retained legacy words"@en
+        sh:message "Interpretation must be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), a code from http://terminology.hl7.org/CodeSystem/data-absent-reason, or one of the retained legacy words. A source code in none of those is carried verbatim on clinical:interpretationSourceCode."@en
+    ] ;
+
+    # v1.15: the verbatim escape hatch. Single string, no value set, no pattern.
+    sh:property [
+        sh:path clinical:interpretationSourceCode ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Interpretation Source Code"@en ;
+        sh:message "Interpretation source code must be a single string: the source's verbatim code, unmodified"@en
     ] ;
 
     # Optional: loincCode (can be string or URI reference)
@@ -976,15 +1019,53 @@ clinical:ProcedureShape a sh:NodeShape ;
     rdfs:label "Procedure Shape"@en ;
     rdfs:comment "Validation constraints for procedure records"@en ;
 
-    # Required: procedureName
+    # Required: a name, in either spelling (v1.15 RULING).
+    #
+    # Through v1.14 this was a bare sh:minCount 1 on clinical:procedureName. A
+    # C-CDA import path writes the name to health:procedureName instead, on
+    # records it types clinical:Procedure, so every converted procedure failed
+    # this constraint WHILE CARRYING A NAME, and carried it on a predicate no
+    # shape targets, so the name itself was validated by nothing. Measured 2 of
+    # 2, 7 of 7 and 1 of 1 across three public sample documents.
+    #
+    # This is a MIGRATION WINDOW, not a ratified dual spelling. The health:
+    # vocabulary defines neither health:procedureName nor a procedure class, and
+    # the record is typed clinical:Procedure, so clinical:procedureName is the
+    # only defined spelling and the only one a producer may write. The full
+    # rationale, and what a consumer must re-query, is on clinical:procedureName
+    # in clinical.ttl.
+    #
+    # The requirement moves to a node-level sh:or so that a Pod already holding
+    # the health: triples stops failing without any data being rewritten. The
+    # form follows health:DailyVitalReadingShape, which requires a timestamp in
+    # either of two spellings the same way. Per-spelling datatype, length and
+    # cardinality constraints stay below, so neither spelling is unchecked.
+    #
+    # BOTH the sh:or alternative and ProcedureNameSpellingShape below are removed
+    # in a later clinical version, once the warning is observably absent from
+    # conforming output, restoring a bare sh:minCount 1 on clinical:procedureName.
+    sh:or (
+        [ sh:property [ sh:path clinical:procedureName ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path health:procedureName ; sh:minCount 1 ] ]
+    ) ;
+    sh:message "Procedure must have a name, as clinical:procedureName (canonical) or health:procedureName (deprecated import spelling, accepted during the clinical v1.15 migration window)"@en ;
+
     sh:property [
         sh:path clinical:procedureName ;
         sh:datatype xsd:string ;
-        sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
         sh:name "Procedure Name"@en ;
-        sh:message "Procedure must have a name"@en
+        sh:message "Procedure name must be a single non-empty string"@en
+    ] ;
+
+    sh:property [
+        sh:path health:procedureName ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Procedure Name (deprecated spelling)"@en ;
+        sh:message "Procedure name must be a single non-empty string"@en
     ] ;
 
     # Optional: procedureDate
@@ -1068,6 +1149,31 @@ clinical:ProcedureShape a sh:NodeShape ;
         sh:name "Schema Version"@en
     ] .
 
+# The migration signal for the procedure-name spelling (clinical v1.15).
+#
+# Kept in its own shape so that its severity is unambiguous: this is sh:Warning,
+# while ProcedureShape's own constraints stay at the default sh:Violation. It
+# targets the SUBJECTS OF the deprecated predicate rather than the class, so it
+# fires exactly once per record that carries the health: spelling and never on a
+# record that does not, whatever that record is typed.
+#
+# It exists so that the sh:or above cannot quietly become permanent. The window
+# closes when this warning is observably absent from conforming output; at that
+# point this shape and the health: branch of the sh:or are both removed and
+# clinical:procedureName goes back to a bare sh:minCount 1.
+clinical:ProcedureNameSpellingShape a sh:NodeShape ;
+    sh:targetSubjectsOf health:procedureName ;
+    rdfs:label "Procedure Name Spelling Shape"@en ;
+    rdfs:comment "Warns that a record carries the deprecated health:procedureName spelling. Accepted during the clinical v1.15 migration window; removed with the window."@en ;
+
+    sh:property [
+        sh:path health:procedureName ;
+        sh:maxCount 0 ;
+        sh:name "Procedure Name (deprecated spelling)"@en ;
+        sh:message "Procedure name is written on health:procedureName, which no Cascade vocabulary defines. Write clinical:procedureName instead: it is the property whose domain is clinical:Procedure and the one clinical:ProcedureShape names. Accepted during the clinical v1.15 migration window; this becomes a VIOLATION when the window closes."@en ;
+        sh:severity sh:Warning
+    ] .
+
 # ============================================================================
 # Shape: Vital Sign
 # ============================================================================
@@ -1117,11 +1223,71 @@ clinical:VitalSignShape a sh:NodeShape ;
     ] ;
 
     # Optional: interpretation
+    #
+    # v1.15 RULING: the lab value set now applies here too, at sh:Warning.
+    #
+    # Through v1.14 this property shape carried sh:datatype and sh:maxCount and
+    # no sh:in, while the two LAB shapes (clinical:LabResultShape and
+    # health:LabResultRecordShape) bound the identical predicate to the 49
+    # selectable HL7 v3 ObservationInterpretation codes. So the same
+    # interpretation string was checked on a lab result and unchecked on a vital
+    # sign, and the vital path was the one an importer could write anything to.
+    # clinical.ttl v1.13 recorded that gap as intentional, because emitted vital
+    # data uses "elevated", which is in neither ratified set, and a Violation
+    # here would have rejected records that already exist.
+    #
+    # That reasoning justified not making it a VIOLATION. It never justified
+    # leaving the property unchecked. So the binding is applied at sh:Warning,
+    # which is exactly the ratchet core v3.5 wrote down for this situation: a
+    # value existing data carries is REPORTED, not rejected, and the severity is
+    # raised to sh:Violation in a later clinical version only after a release in
+    # which the warning is observably absent from conforming output. Each step
+    # is its own vocabulary version, so this is not a judgement call later.
+    #
+    # The migration for the affected records is not "pick a different word": it
+    # is clinical:interpretation "H" plus clinical:interpretationSourceCode
+    # "elevated", which states the ratified reading AND keeps what the source
+    # said. That is the whole reason the source-code property is in the same
+    # release.
+    #
+    # The list is byte-identical to the one on clinical:LabResultShape above and
+    # to health:interpretation in health.shapes.ttl. Three copies of one value
+    # set is a drift hazard and is accepted deliberately: SHACL has no value-set
+    # include, and the alternative (a shared shape reached by sh:node) would
+    # bring the lab shape's Violation severity with it, which is the one thing
+    # this constraint must not do on vitals yet.
     sh:property [
         sh:path clinical:interpretation ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
-        sh:name "Interpretation"@en
+        sh:in ("EX" "HM" "OBX" "CAR" "Carrier" "B" "D" "U" "W"
+               "<" ">" "AC" "IE" "QCF" "TOX"
+               "A" "N" "I" "MS" "NCL" "NS" "R" "S" "VS"
+               "AA" "H" "L" "HH" "LL" "HX" "LX" "H>" "HU" "E" "L<" "LU"
+               "ND" "IND" "NEG" "POS" "EXP" "UNE" "DET"
+               "SYN-R" "NR" "RR" "WR" "SDD" "SYN-S"
+               "unknown" "asked-unknown" "temp-unknown" "not-asked"
+               "asked-declined" "masked" "not-applicable" "unsupported"
+               "as-text" "error" "not-a-number" "negative-infinity"
+               "positive-infinity" "not-performed" "not-permitted"
+               "normal" "high" "low" "abnormal" "critical"
+               "Normal" "High" "Low" "Abnormal" "Critical") ;
+        sh:name "Interpretation"@en ;
+        sh:message "Interpretation should be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), a code from http://terminology.hl7.org/CodeSystem/data-absent-reason, or one of the retained legacy words. Carry a code the value sets do not contain verbatim on clinical:interpretationSourceCode and put the nearest ratified reading here. WARNING in clinical v1.15; this becomes a VIOLATION in a later version."@en ;
+        sh:severity sh:Warning
+    ] ;
+
+    # v1.15: the verbatim escape hatch, same as on the lab shape. sh:Violation
+    # (the shape's default) rather than sh:Warning, because unlike the value set
+    # above there is no existing data to be lenient toward: the property is new
+    # in this version, so the only records carrying it are records written
+    # against this version.
+    sh:property [
+        sh:path clinical:interpretationSourceCode ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Interpretation Source Code"@en ;
+        sh:message "Interpretation source code must be a single string: the source's verbatim code, unmodified"@en
     ] ;
 
     # Optional: deviceName

--- a/src/shapes/clinical.ttl
+++ b/src/shapes/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-08-08"^^xsd:date ;
-    owl:versionInfo "1.14" ;
+    dct:modified "2026-08-14"^^xsd:date ;
+    owl:versionInfo "1.15" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -727,13 +727,27 @@ clinical:referenceRange a owl:DatatypeProperty ;
 
 clinical:interpretation a owl:DatatypeProperty ;
     rdfs:label "Interpretation"@en ;
-    rdfs:comment """Categorical reading of an observation against its reference range.
+    rdfs:comment """Categorical reading of an observation against its reference range, as a code from the HL7 v3 ObservationInterpretation code system, the code system FHIR R4 binds Observation.interpretation to. Any of the 15 data-absent-reason codes is also accepted, for a source whose interpretation element was absent or null-flavoured. The ten English words of the pre-v1.14 enum are retained so older data keeps validating and are not recommended for new writes.
 
-clinical:LabResultShape constrains this property with sh:in to normal | high | low | abnormal | critical (and capitalized forms). clinical:VitalSignShape deliberately does NOT, and as of v1.13 the inconsistency is intentional rather than an oversight: emitted vital-sign data uses "elevated", which is outside the lab set, so applying the lab constraint to vital signs would be a BREAKING change for existing pods rather than a clarification.
+ONE VALUE SET ACROSS BOTH OBSERVATION SHAPES, as of v1.15. Through v1.14, clinical:LabResultShape bound this property with sh:in and clinical:VitalSignShape did not, so the same predicate on the same kind of value was checked on labs and unchecked on vitals. That gap was recorded as intentional because emitted vital data used "elevated", which is in neither ratified set, and constraining vitals would have failed those records. v1.15 closes it the way core v3.5 wrote down for exactly this situation: the value set is applied to clinical:VitalSignShape at sh:Warning, not sh:Violation, so the records that carry a non-ratified word are reported rather than rejected, and it is raised to sh:Violation in a later clinical version only after a release in which the warning is observably absent from conforming output. "elevated" migrates to the ratified code plus a verbatim clinical:interpretationSourceCode.
 
-Note also that neither set is the FHIR set. FHIR R4 Observation.interpretation binds to v3-ObservationInterpretation, whose codes are symbolic (N, H, L, A, HH, LL, AA), not English words. Both Cascade sets are local vocabulary. Reconciling the two spellings and then aligning them onto the FHIR codes is the ordered fix; doing either half on its own breaks readers."""@en ;
+A source code in NEITHER value set is carried verbatim on clinical:interpretationSourceCode rather than being forced into this property or dropped."""@en ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation> ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/data-absent-reason> ;
     rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
     rdfs:range xsd:string .
+
+clinical:interpretationSourceCode a owl:DatatypeProperty ;
+    rdfs:label "Interpretation Source Code"@en ;
+    rdfs:comment """The interpretation code the SOURCE wrote, copied verbatim, for the case where that code is a member of neither value set clinical:interpretation is bound to (HL7 v3 ObservationInterpretation, and data-absent-reason). Kept semantically identical to health:interpretationSourceCode, for the reason recorded on the interpretation shapes: these are two spellings of one record, and letting them drift is how one spelling silently becomes the lenient one.
+
+WRITE IT ONLY THEN. A code that IS in one of the bound value sets belongs on clinical:interpretation and must not be duplicated here.
+
+It is deliberately unconstrained: no value set, no pattern, no case folding. A producer that recognises the source code's intent should ALSO write its nearest ratified equivalent on clinical:interpretation, so a consumer reading only the bound property still gets a usable reading."""@en ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso clinical:interpretation ;
+    rdfs:seeAlso health:interpretationSourceCode ;
+    owl:versionInfo "Added in clinical v1.15" .
 
 clinical:specimenType a owl:DatatypeProperty ;
     rdfs:label "Specimen Type"@en ;
@@ -841,9 +855,16 @@ clinical:expirationDate a owl:DatatypeProperty ;
 
 clinical:procedureName a owl:DatatypeProperty ;
     rdfs:label "Procedure Name"@en ;
-    rdfs:comment "Name of the procedure performed"@en ;
+    rdfs:comment """Name of the procedure performed. This is the CANONICAL and only defined spelling: it is the property whose rdfs:domain is clinical:Procedure, the one clinical:ProcedureShape names, and the one the JSON-LD context maps.
+
+THE health: SPELLING IS NOT A SECOND SPELLING (v1.15). A C-CDA import path has been writing the procedure name to a `health:procedureName` predicate that the health vocabulary does not define, on records it types clinical:Procedure. The result was a record that CARRIES a name, fails clinical:ProcedureShape's name requirement as though it had none, and carries that name on a predicate no shape targets, so the name itself is validated by nothing.
+
+This is resolved in favour of clinical:procedureName rather than by blessing the health: spelling, for three reasons. There is no health-namespace procedure vocabulary at all: no health:ProcedureRecord, no health:procedureName, so ratifying the emission would mint an undefined-term family of exactly the kind health v2.5 spent a release eliminating. The record is typed clinical:Procedure, so a health: name predicate on it is a namespace mismatch inside a single record rather than a coherent alternative serialization. And the repository's one dual-spelling precedent, health:DailyVitalReadingShape's sh:or over cascade:date and health:date, exists because BOTH serializations are live and defined; here only one spelling is defined, so that precedent does not reach this case.
+
+MIGRATION, and what a reader must re-query. clinical:ProcedureShape satisfies its name requirement through sh:or over both spellings from v1.15, so a Pod already holding health:procedureName triples stops failing immediately and no data has to be rewritten to become valid. A separate warning-severity shape fires wherever the health: spelling is present. Producers write clinical:procedureName only. Both the sh:or alternative and the warning shape are removed in a later clinical version, once the warning is observably absent from conforming output; each step is its own vocabulary version. A consumer querying health:procedureName must add clinical:procedureName to its query now and can drop the health: term at that later version."""@en ;
     rdfs:domain clinical:Procedure ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    owl:versionInfo "Canonical spelling restated, and the health: emission given a migration window, in clinical v1.15" .
 
 clinical:procedureDate a owl:DatatypeProperty ;
     rdfs:label "Procedure Date"@en ;
@@ -1330,6 +1351,40 @@ clinical:isActive a owl:DatatypeProperty ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.15 (2026-08-14)
+# - ONE new property, clinical:interpretationSourceCode: the source's verbatim
+#   interpretation code, written only when that code is a member of neither
+#   value set clinical:interpretation is bound to. Kept semantically identical
+#   to health:interpretationSourceCode (health v2.7). The alternative
+#   considered and rejected was accepting the loss with a warning: a closed
+#   value set plus a lossy importer means a laboratory's local flag is either
+#   dropped or written into a field that then fails, and either way the Pod can
+#   no longer answer what the source actually said.
+# - clinical:VitalSignShape's interpretation is bound to the same value set the
+#   lab shapes use, at sh:Warning. Through v1.14 the lab shapes carried the
+#   sh:in and the vital shape carried none, so the identical predicate was
+#   checked on one record type and unchecked on the other. sh:Warning first,
+#   sh:Violation in a later version once the warning is observably absent from
+#   conforming output, is the ratchet core v3.5 wrote down for precisely this
+#   case: a value that existing data carries is reported, not rejected.
+# - clinical:interpretation's value set (both shapes) gains the fourteen
+#   data-absent-reason codes it did not already carry. v1.14 accepted "unknown"
+#   alone, which made every reason for an absent interpretation identical; a
+#   C-CDA nullFlavor of NASK, ASKU and NAV are three different clinical facts.
+#   Byte-identical to the health:interpretation list, as before.
+# - clinical:ProcedureShape's name requirement moves from a bare sh:minCount on
+#   clinical:procedureName to an sh:or over clinical:procedureName and the
+#   undefined health:procedureName that a C-CDA import path emits, plus a
+#   warning-severity shape that fires on the health: spelling. This is a
+#   MIGRATION WINDOW, not a ratified dual spelling; the rationale, the ratchet
+#   out of it, and what a consumer must re-query are stated on
+#   clinical:procedureName above. Every previously-valid graph stays valid and
+#   a class of graph that was failing for carrying a name now passes.
+# - COMPATIBILITY. Additive and strictly widening. Every graph that validated
+#   under v1.14 validates under v1.15 at the same severity, with one deliberate
+#   exception at sh:Warning only: a vital sign carrying an interpretation
+#   outside the ratified set is now reported. No Violation is added anywhere.
 #
 # Version 1.14 (2026-08-08)
 # - SHACL only; no class or property added, removed, renamed or deprecated.

--- a/src/shapes/core.shapes.ttl
+++ b/src/shapes/core.shapes.ttl
@@ -7,12 +7,13 @@
 # ============================================================================
 # Cascade Protocol -- Core Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.5 (2026-08-09)
+# Version: 1.6 (2026-08-14)
 # Validates: cascade:PatientProfile, cascade:Address, cascade:EmergencyContact,
 #            cascade:PharmacyInfo, cascade:AdvanceDirectives, cascade:ProxyAgent,
 #            cascade:ExportManifest, cascade:RecordSummary,
-#            cascade:InteractionScenario, and the value of cascade:sourceIdentity
-#            wherever it appears
+#            cascade:InteractionScenario, and the values of
+#            cascade:sourceIdentity and cascade:dataAbsentReason wherever
+#            they appear
 #
 # Severity levels:
 #   sh:Violation -- Must fix (blocks operations)
@@ -657,8 +658,58 @@ cascade:SourceIdentityShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Data Absent Reason (core v3.6)
+# ============================================================================
+# Open-world, exactly like SourceIdentityShape above: sh:targetSubjectsOf, so it
+# constrains the VALUE wherever cascade:dataAbsentReason appears and never
+# requires the property's presence. Every pod written before core v3.6 validates
+# unchanged, because none of them carries the predicate.
+#
+# The sh:in list is the 15 codes of
+# http://terminology.hl7.org/CodeSystem/data-absent-reason, verbatim, as
+# gathered by the value set http://hl7.org/fhir/ValueSet/data-absent-reason. No
+# code is added and none is dropped. In particular the raw HL7 v3 NullFlavor
+# codes (UNK, NAV, NASK, ASKU, ...) are deliberately NOT accepted here: an
+# importer maps them on the way in, per the mapping table stated on the property
+# in core.ttl, and accepting both spellings would give every absence two
+# encodings and make "is this the same absence?" a string-comparison question.
+#
+# sh:Violation rather than sh:Warning, and that is not a ratchet skipped. The
+# ratchet in core v3.5 was about REQUIRING a property no producer had written
+# yet. Here nothing is required; the constraint only says that a producer which
+# chooses to write this brand-new property must write a code from the value set
+# it was defined against. There is no existing data to be lenient toward.
+
+cascade:DataAbsentReasonShape a sh:NodeShape ;
+    sh:targetSubjectsOf cascade:dataAbsentReason ;
+    rdfs:label "Data Absent Reason Shape"@en ;
+    rdfs:comment "Constrains the value of cascade:dataAbsentReason on any record that carries it. Open-world: absence is not a finding."@en ;
+
+    sh:property [
+        sh:path cascade:dataAbsentReason ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in ("unknown" "asked-unknown" "temp-unknown" "not-asked"
+               "asked-declined" "masked" "not-applicable" "unsupported"
+               "as-text" "error" "not-a-number" "negative-infinity"
+               "positive-infinity" "not-performed" "not-permitted") ;
+        sh:name "Data Absent Reason"@en ;
+        sh:message "cascade:dataAbsentReason must be a single code from http://terminology.hl7.org/CodeSystem/data-absent-reason. A raw HL7 v3 NullFlavor code (UNK, NAV, NASK, ASKU, ...) is not accepted: map it on import using the table on the property in core.ttl."@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.6 (2026-08-14)
+# - Added DataAbsentReasonShape for core v3.6's cascade:dataAbsentReason.
+#   sh:targetSubjectsOf, so it constrains the value wherever the property
+#   appears and never requires its presence; pods written before v3.6 validate
+#   unchanged. VIOLATION for a non-string, a repeated value, or a code outside
+#   the 15-member data-absent-reason value set, which includes a raw HL7 v3
+#   NullFlavor code written through unmapped.
 #
 # Version 1.5 (2026-08-09)
 # - Added SourceIdentityShape for core v3.5's cascade:sourceIdentity.

--- a/src/shapes/core.ttl
+++ b/src/shapes/core.ttl
@@ -19,8 +19,8 @@
     dct:description "Core vocabulary for schema versioning, data provenance, identity management, and patient demographics across all Cascade Protocol applications"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-10-31"^^xsd:date ;
-    dct:modified "2026-08-09"^^xsd:date ;
-    owl:versionInfo "3.5" ;
+    dct:modified "2026-08-14"^^xsd:date ;
+    owl:versionInfo "3.6" ;
     rdfs:comment "This vocabulary defines cross-cutting concepts used by all Cascade Protocol health data applications: schema versioning, data provenance, patient demographics (PatientProfile), and supporting identity classes (Address, PharmacyInfo, AdvanceDirectives). Domain-specific vocabularies (e.g., pots:, ecg:, glucose:) import this core vocabulary."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/core/v1.0/> .
 
@@ -201,8 +201,30 @@ cascade:addedInSchemaVersion a owl:AnnotationProperty ;
 
 cascade:cascadeUri a owl:DatatypeProperty ;
     rdfs:label "Cascade URI"@en ;
-    rdfs:comment "Stable identifier URI for a Cascade data element. Used across vocabularies to mint persistent identifiers for supplements, medications, and other resources."@en ;
-    rdfs:range xsd:anyURI .
+    rdfs:comment """Stable identifier URI for a Cascade data element. Used across vocabularies to mint persistent identifiers for supplements, medications, and other resources.
+
+CANONICAL FORM OF A MULTI-VALUED IDENTITY INPUT (v3.6, NORMATIVE).
+
+An implementation that derives a record's identifier from the record's own content hashes a set of named content fields. Since health v2.6 and clinical v1.14 made the code fields (icd10Code, snomedCode, testCode, labCategory) 0..* to match FHIR R4 CodeableConcept.coding, one of those fields can hold several values, and a hash taken over an unordered field is only stable if the field is first put into a canonical form. Without one, two exports of the SAME record that list the same codings in a different order mint two different identifiers and the record silently splits in two.
+
+The canonical form of a multi-valued identity input is:
+  1. Discard members that are null or empty after trimming; trim each surviving member.
+  2. Deduplicate the survivors.
+  3. Sort ascending by Unicode code point. (Code point, not locale collation: a locale-dependent order would make identity depend on the machine.)
+  4. Join with a single separator character that the implementation fixes and documents. U+002C COMMA is the RECOMMENDED separator and new implementations MUST use it.
+  5. A one-element sequence MUST canonicalize to exactly the bare scalar form.
+  6. A sequence with no surviving member is treated as an absent field, exactly as a null scalar is.
+
+THE THREE INVARIANTS, which are normative independently of the separator and are what the conformance vectors check:
+  ORDER INDEPENDENCE     Shuffling the members of a multi-valued identity input MUST NOT change the identifier.
+  SCALAR AGREEMENT       A field holding exactly one value MUST mint the same identifier whether it is spelled as a scalar or as a one-element sequence. This is what keeps every identifier written before the fields became 0..* exactly where it is.
+  DUPLICATE INDEPENDENCE Repeating a member MUST NOT change the identifier.
+
+SCOPE, AND THE ONE PLACE THIS RULE MUST NOT BE APPLIED. It governs identity inputs whose source element is a SET: FHIR CodeableConcept.coding and the repeating code fields named above. It MUST NOT be applied to an input whose source order carries meaning, because sorting there merges records that the source deliberately distinguished. FHIR name[0] is the primary name, and a component or note list is a sequence, not a set. An implementation that already hashes such a list in document order MUST keep doing so; widening this rule to cover it is a data change, not a canonicalization.
+
+MIGRATION. An implementation that already ships a fixed separator other than U+002C at an existing identity site KEEPS that separator. Changing it re-mints every identifier the site has ever produced, which is precisely the harm this rule exists to prevent; the cross-implementation contract is the three invariants above, not the byte string. Adding the dedupe and the sort where they are missing moves an identifier only for a record that carried duplicate or unsorted members, which is the defect being corrected."""@en ;
+    rdfs:range xsd:anyURI ;
+    owl:versionInfo "Canonical form of multi-valued identity inputs stated in core v3.6" .
 
 # ============================================================================
 # Shared Preference Properties (v1.3)
@@ -711,6 +733,64 @@ cascade:forSystem a owl:DatatypeProperty ;
     rdfs:range xsd:string .
 
 # ============================================================================
+# Data Absence (v3.6)
+# ============================================================================
+# WHY THIS EXISTS. A source document distinguishes several reasons a value is
+# missing, and every one of them currently arrives in a Pod as the same thing:
+# nothing. A C-CDA <value nullFlavor="NAV"/> ("we will know this later"), a
+# <value nullFlavor="NASK"/> ("nobody asked") and a <value nullFlavor="ASKU"/>
+# ("we asked, the patient did not know") are three different clinical facts, and
+# an importer that drops all three writes one indistinguishable blank. A reader
+# then cannot tell a test that was never ordered from one whose result is still
+# pending, and re-asking is the only recovery.
+#
+# The distinction is already ratified twice over, so none of it is invented
+# here: HL7 v3 NullFlavor (http://terminology.hl7.org/CodeSystem/v3-NullFlavor,
+# OID 2.16.840.1.113883.5.1008) is what C-CDA writes, and FHIR
+# data-absent-reason
+# (http://terminology.hl7.org/CodeSystem/data-absent-reason, value set
+# http://hl7.org/fhir/ValueSet/data-absent-reason) is the harmonized flat set
+# FHIR R4 binds Observation.dataAbsentReason to.
+#
+# Cascade binds to data-absent-reason, for three reasons stated here so the
+# choice is not re-litigated: (1) it is already the code system this vocabulary
+# cites — health:interpretation and clinical:interpretation have accepted its
+# "unknown" code since health v2.6 / clinical v1.14, so binding elsewhere would
+# put two absence vocabularies in one record; (2) its 15 codes are all
+# selectable, whereas v3-NullFlavor marks NI, UNK, OTH and INV abstract, and
+# this repository's own Validation Profile treats abstract concepts as hierarchy
+# nodes rather than values; (3) FHIR is the transport Cascade converts from on
+# both paths. The C-CDA importer maps nullFlavor to data-absent-reason on the
+# way in; the mapping is stated on the property below.
+
+cascade:dataAbsentReason a owl:DatatypeProperty ;
+    rdfs:label "Data Absent Reason"@en ;
+    rdfs:comment """Why this record's primary value is absent. Semantics are exactly FHIR R4 Observation.dataAbsentReason (https://hl7.org/fhir/R4/observation-definitions.html#Observation.dataAbsentReason): it explains the absence of the record's VALUE, and it is meaningful only when that value is in fact absent. A record that carries a value MUST NOT also carry this property.
+
+VALUE SET. One of the 15 codes of http://terminology.hl7.org/CodeSystem/data-absent-reason, as gathered by the value set http://hl7.org/fhir/ValueSet/data-absent-reason: unknown, asked-unknown, temp-unknown, not-asked, asked-declined, masked, not-applicable, unsupported, as-text, error, not-a-number, negative-infinity, positive-infinity, not-performed, not-permitted.
+
+MAPPING FROM HL7 v3 NullFlavor, which is what a C-CDA document writes (http://terminology.hl7.org/CodeSystem/v3-NullFlavor, OID 2.16.840.1.113883.5.1008). An importer reading a nullFlavor attribute MUST map it as follows and MUST NOT write the raw nullFlavor code into this property:
+  UNK  -> unknown          a proper value applies but is not known
+  ASKU -> asked-unknown    the source was asked and did not know
+  NASK -> not-asked        the information was never sought
+  NAV  -> temp-unknown     not available now, expected later
+  NAVU -> unknown          not available, with no expectation of later
+  MSK  -> masked           withheld for security or privacy
+  NA   -> not-applicable   known to have no proper value
+  OTH  -> unsupported      the real value is outside the permitted value domain
+  NI   -> unknown          no information, and no reason given
+  NINF -> negative-infinity
+  PINF -> positive-infinity
+Any other nullFlavor maps to "unknown", which is the code that asserts only that a value was expected and is missing.
+
+WHAT THIS IS NOT. It is not an interpretation, and it is not a substitute for one: an absent interpretation on a record whose value IS present is recorded on the interpretation property itself, whose value set accepts the same data-absent-reason codes. It is not a validation finding: absence of this property means only that the producer said nothing about why a value is missing."""@en ;
+    rdfs:domain owl:Thing ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/data-absent-reason> ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/v3-NullFlavor> ;
+    owl:versionInfo "Added in core v3.6" .
+
+# ============================================================================
 # Alignment with W3C PROV-O
 # ============================================================================
 
@@ -732,6 +812,37 @@ cascade:forSystem a owl:DatatypeProperty ;
 
 # ============================================================================
 # Changelog
+#
+# Version 3.6 (2026-08-14)
+# - Added cascade:dataAbsentReason (owl:DatatypeProperty, domain owl:Thing,
+#   range xsd:string): why a record's primary VALUE is absent, bound to the 15
+#   codes of http://terminology.hl7.org/CodeSystem/data-absent-reason. Semantics
+#   are exactly FHIR R4 Observation.dataAbsentReason. The nullFlavor-to-
+#   data-absent-reason mapping a C-CDA importer must implement is stated on the
+#   property, so the four distinctions a real document draws (UNK, NAV, NASK,
+#   ASKU) stop collapsing into one indistinguishable blank on import. Nothing is
+#   invented: both code systems are ratified and cited by canonical URL.
+#   Binding to data-absent-reason rather than to v3-NullFlavor is deliberate and
+#   its three reasons are recorded above the property.
+# - Stated the CANONICAL FORM of a multi-valued identity input on
+#   cascade:cascadeUri. Vocabulary-wise this file is unchanged by it: no term is
+#   added, and the statement constrains implementations rather than data. It is
+#   here because health v2.6 and clinical v1.14 made four code fields 0..* and
+#   an identifier hashed over an unordered field is not stable until the field
+#   has a canonical form. The rule is dedupe, sort by code point, join with a
+#   fixed separator, and a one-element sequence canonicalizes to the bare
+#   scalar, so no identifier written before those fields became repeatable
+#   moves. The three invariants (order independence, scalar agreement,
+#   duplicate independence) are normative independently of the separator, which
+#   is what lets an implementation that already ships a different separator
+#   comply without re-minting. The scope limit is as load-bearing as the rule:
+#   it applies to inputs that are SETS and must never be applied to an input
+#   whose source order carries meaning, because sorting there merges records the
+#   source deliberately distinguished.
+# - COMPATIBILITY. Both changes are additive. cascade:DataAbsentReasonShape
+#   targets sh:targetSubjectsOf, so it evaluates only records that CARRY the new
+#   property and every pod written before v3.6 validates exactly as it did. No
+#   class or property was removed, renamed or deprecated.
 #
 # Version 3.5 (2026-08-09)
 # - Added cascade:sourceIdentity (owl:DatatypeProperty, range xsd:string): the

--- a/src/shapes/health.shapes.ttl
+++ b/src/shapes/health.shapes.ttl
@@ -9,7 +9,7 @@
 # ============================================================================
 # Cascade Protocol — Health & Wellness Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.3 (2026-08-08)
+# Version: 1.4 (2026-08-14)
 # Validates: health:SelfReport, health:VO2MaxStatistics, health:HRVStatistics,
 #            health:BPStatistics, health:MetricTrend, health:ActivitySnapshot,
 #            health:SleepSnapshot, health:HealthProfile,
@@ -729,6 +729,22 @@ health:SocialHistoryRecordShape a sh:NodeShape ;
 # Changelog
 # ============================================================================
 #
+# Version 1.4 (2026-08-14) — health v2.7
+# - health:interpretation: the sh:in list gains the fourteen data-absent-reason
+#   codes it did not already carry, so the list is now the 49 selectable HL7 v3
+#   ObservationInterpretation codes, ALL FIFTEEN codes of
+#   http://terminology.hl7.org/CodeSystem/data-absent-reason, and the ten
+#   retained v2.5 words: 74 values. v2.6 accepted "unknown" alone, which made
+#   every reason for an absent interpretation identical.
+# - NEW: a property shape for health:interpretationSourceCode. Single string,
+#   no value set and no pattern, by design.
+# - No interpretation constraint was added to DailyVitalReadingShape. See the
+#   v2.7 changelog note in health.ttl: health:interpretation's domain is
+#   health:LabResultRecord and health:DailyVitalReading carries no
+#   interpretation predicate, so the constraint would be vacuous. The vital
+#   binding is clinical:VitalSignShape in clinical v1.15.
+# - Strictly widening: every graph valid under v1.3 is valid under v1.4.
+#
 # Version 1.3 (2026-08-08) — health v2.6
 # - health:interpretation: the sh:in list is now the 49 selectable codes of the
 #   HL7 v3 ObservationInterpretation code system,
@@ -885,13 +901,27 @@ health:LabResultRecordShape a sh:NodeShape ;
     #
     # Then two additions that are not from that code system and are named here
     # rather than left to be inferred:
-    #   - "unknown", from http://terminology.hl7.org/CodeSystem/data-absent-reason
-    #     ("The value is expected to exist but is not known"). Importers write it
-    #     when the source Observation carried no interpretation at all, which is
-    #     the single most common value in a real export.
+    #   - ALL FIFTEEN codes of
+    #     http://terminology.hl7.org/CodeSystem/data-absent-reason (value set
+    #     http://hl7.org/fhir/ValueSet/data-absent-reason). v2.6 admitted only
+    #     "unknown" here, for the very common source Observation that carried no
+    #     interpretation at all. health v2.7 admits the rest, because a source
+    #     that says WHY the element is absent is saying something, and one
+    #     accepted code made every reason identical: a C-CDA
+    #     <interpretationCode nullFlavor="NASK"/> (nobody asked) became
+    #     indistinguishable from nullFlavor="ASKU" (asked, did not know) and
+    #     from nullFlavor="NAV" (expected later). Putting a data-absent-reason
+    #     coding INTO the CodeableConcept that is missing is FHIR's own idiom,
+    #     not a Cascade convention, so this is deference and not invention. The
+    #     nullFlavor-to-data-absent-reason mapping an importer must implement is
+    #     stated once, on cascade:dataAbsentReason in core v3.6.
     #   - the ten lower- and title-case English words of the previous enum,
     #     retained so that data already written against health v2.5 keeps
     #     validating. They are NOT recommended for new writes.
+    #
+    # A source code in NEITHER value set is not forced in here and is not
+    # dropped: it goes verbatim on health:interpretationSourceCode (v2.7), and
+    # the producer writes its nearest ratified equivalent here.
     sh:property [
         sh:path health:interpretation ;
         sh:datatype xsd:string ;
@@ -902,11 +932,27 @@ health:LabResultRecordShape a sh:NodeShape ;
                "AA" "H" "L" "HH" "LL" "HX" "LX" "H>" "HU" "E" "L<" "LU"
                "ND" "IND" "NEG" "POS" "EXP" "UNE" "DET"
                "SYN-R" "NR" "RR" "WR" "SDD" "SYN-S"
-               "unknown"
+               "unknown" "asked-unknown" "temp-unknown" "not-asked"
+               "asked-declined" "masked" "not-applicable" "unsupported"
+               "as-text" "error" "not-a-number" "negative-infinity"
+               "positive-infinity" "not-performed" "not-permitted"
                "normal" "high" "low" "abnormal" "critical"
                "Normal" "High" "Low" "Abnormal" "Critical") ;
         sh:name "Interpretation"@en ;
-        sh:message "Interpretation must be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), the data-absent-reason code 'unknown', or one of the retained health v2.5 words"@en ;
+        sh:message "Interpretation must be a code from the HL7 v3 ObservationInterpretation code system (http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation), a code from http://terminology.hl7.org/CodeSystem/data-absent-reason, or one of the retained health v2.5 words. A source code in none of those is carried verbatim on health:interpretationSourceCode."@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # health:interpretationSourceCode (v2.7) is deliberately unconstrained apart
+    # from being a single string. It carries a source code that is a member of
+    # no bound value set, verbatim; a value set or a pattern here would recreate
+    # exactly the loss the property exists to prevent.
+    sh:property [
+        sh:path health:interpretationSourceCode ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Interpretation Source Code"@en ;
+        sh:message "Interpretation source code must be a single string: the source's verbatim code, unmodified"@en ;
         sh:severity sh:Violation
     ] ;
 

--- a/src/shapes/health.ttl
+++ b/src/shapes/health.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for consumer-generated wellness observations from wearable devices and HealthKit. Maps Cascade wellness properties to established SNOMED CT and LOINC codes following the three-layer ontology architecture."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-01-29"^^xsd:date ;
-    dct:modified "2026-08-08"^^xsd:date ;
-    owl:versionInfo "2.6" ;
+    dct:modified "2026-08-14"^^xsd:date ;
+    owl:versionInfo "2.7" ;
     rdfs:comment """Three-layer ontology for wellness data:
         Layer 1 (Established standards): SNOMED CT concept IDs + LOINC observation codes
         Layer 2 (Cascade health vocabulary): health: namespace properties linking to Layer 1
@@ -30,6 +30,42 @@
     rdfs:seeAlso <https://cascadeprotocol.org/docs/health/v1/> .
 
 # Changelog:
+# v2.7 (2026-08-14): Let a source's absence and a source's unrecognised code
+#     both survive import. Additive: one new property, one widened value set,
+#     and nothing that validated under v2.6 stops validating.
+#
+#     1. health:interpretation's value set is widened from the single
+#        data-absent-reason code "unknown" to all 15 codes of
+#        http://terminology.hl7.org/CodeSystem/data-absent-reason (value set
+#        http://hl7.org/fhir/ValueSet/data-absent-reason). v2.6 already
+#        accepted one code from that system for the case of a source that
+#        carried no interpretation; accepting only one of the fifteen made
+#        every reason for the absence identical. FHIR's own pattern for a
+#        CodeableConcept element that is absent for a stated reason is a
+#        data-absent-reason coding in that element, so this is the ratified
+#        spelling rather than a Cascade convention. It is what lets a C-CDA
+#        <interpretationCode nullFlavor="NASK"/> ("nobody asked") arrive
+#        distinguishable from nullFlavor="ASKU" ("asked, did not know") and
+#        nullFlavor="NAV" ("known later"); the nullFlavor mapping table is
+#        stated once, on cascade:dataAbsentReason in core v3.6.
+#     2. NEW health:interpretationSourceCode: the source's verbatim
+#        interpretation code, written ONLY when that code is a member of
+#        neither bound value set. The alternative considered and rejected was
+#        accepting the loss with a warning. A closed value set plus a lossy
+#        importer means a laboratory's local flag is either dropped on the
+#        floor or written into a field that then fails validation, and in both
+#        cases the Pod can no longer answer what the source actually said.
+#        Unconstrained by design: it is a verbatim carbon copy, not a code.
+#     3. NOT changed, and stated here so its absence is not read as an
+#        oversight: no interpretation constraint was added to
+#        health:DailyVitalReadingShape. health:interpretation's rdfs:domain is
+#        health:LabResultRecord and health's only vital class,
+#        health:DailyVitalReading, carries no interpretation predicate at all,
+#        so a shape there would constrain a triple no conforming record can
+#        write. The vital-sign interpretation binding this release adds lives
+#        in clinical v1.15 on clinical:VitalSignShape, which is the vital
+#        shape that actually exists.
+#
 # v2.6 (2026-08-08): Align the lab-result constraints to the ratified standards
 #     they claim to follow. Shapes-only; no class or property is added, removed
 #     or renamed, and nothing that validated under v2.5 stops validating.
@@ -1182,12 +1218,27 @@ health:resultUnit a owl:DatatypeProperty ;
 
 health:interpretation a owl:DatatypeProperty ;
     rdfs:label "Interpretation"@en ;
-    rdfs:comment "Categorical reading of the result, as a code from the HL7 v3 ObservationInterpretation code system: normality (N, A, H, L, HH, LL, ...), susceptibility (S, I, R, SDD, ...), detection (POS, NEG, DET, ND, IND), reactivity (RR, WR, NR), change (B, D, U, W) and the exception codes. The data-absent-reason code 'unknown' is also accepted, for a source observation that carried no interpretation. At most one value per record."@en ;
+    rdfs:comment "Categorical reading of the result, as a code from the HL7 v3 ObservationInterpretation code system: normality (N, A, H, L, HH, LL, ...), susceptibility (S, I, R, SDD, ...), detection (POS, NEG, DET, ND, IND), reactivity (RR, WR, NR), change (B, D, U, W) and the exception codes. Any of the 15 data-absent-reason codes is also accepted, for a source observation whose interpretation element was absent or null-flavoured; that is FHIR's own spelling for a CodeableConcept that is missing for a stated reason, and it is what keeps 'nobody asked' distinguishable from 'asked, did not know'. A source code that is a member of neither value set is carried verbatim on health:interpretationSourceCode instead of being forced into this one. At most one value per record."@en ;
     rdfs:domain health:LabResultRecord ;
     rdfs:range xsd:string ;
     rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation> ;
+    rdfs:seeAlso <http://terminology.hl7.org/CodeSystem/data-absent-reason> ;
     rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
-    owl:versionInfo "Added in health v2.5; bound to HL7 v3 ObservationInterpretation in health v2.6" .
+    owl:versionInfo "Added in health v2.5; bound to HL7 v3 ObservationInterpretation in health v2.6; data-absent-reason codes admitted in health v2.7" .
+
+health:interpretationSourceCode a owl:DatatypeProperty ;
+    rdfs:label "Interpretation Source Code"@en ;
+    rdfs:comment """The interpretation code the SOURCE wrote, copied verbatim, for the case where that code is a member of neither value set health:interpretation is bound to (HL7 v3 ObservationInterpretation, and data-absent-reason). A laboratory's local abnormality flag is the ordinary case.
+
+WRITE IT ONLY THEN. A code that IS in one of the bound value sets belongs on health:interpretation and must not be duplicated here; this property is the escape hatch for the residue, not a parallel spelling.
+
+It is deliberately unconstrained: no value set, no pattern, no case folding. The whole point is that the value is whatever the source said, so a reader can recover the original assertion and a later mapping can be built from real observed codes rather than guesses. Constraining it would recreate the loss it exists to prevent.
+
+A producer that recognises the source code's INTENT should also write its best ratified equivalent on health:interpretation, so that a consumer reading only the bound property still gets a usable reading. The pair 'interpretation A, interpretationSourceCode elevated' says: the source said "elevated", and the nearest ratified code is A (Abnormal)."""@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso health:interpretation ;
+    owl:versionInfo "Added in health v2.7" .
 
 health:performedDate a owl:DatatypeProperty ;
     rdfs:label "Performed Date"@en ;

--- a/test-fixtures/pathology/scenarios.json
+++ b/test-fixtures/pathology/scenarios.json
@@ -6,12 +6,24 @@
       "id": "P01",
       "pathology": "one health system exporting two transports resolves to ONE source identity",
       "batches": [
-        { "file": "p01-dual-label-fhir.json", "from": "fhir" },
-        { "file": "p01-dual-label-ccda.xml", "from": "c-cda" }
+        {
+          "file": "p01-dual-label-fhir.json",
+          "from": "fhir"
+        },
+        {
+          "file": "p01-dual-label-ccda.xml",
+          "from": "c-cda"
+        }
       ],
       "expect": {
-        "convertedRecords": [4, 6],
-        "reportedResourceCount": [4, 6],
+        "convertedRecords": [
+          4,
+          6
+        ],
+        "reportedResourceCount": [
+          4,
+          6
+        ],
         "_comment_distinctValuesByPredicate": "The invariant this scenario exists for, folded in from the retired KNOWN_OUTCOMES entry P01-one-system-two-source-labels. One health system exporting FHIR and a C-CDA must occupy ONE row on the pod's source axis, whichever axis is read: one canonical ORIGIN (cascade:sourceIdentity, org:meridian, derived identically from the endpoint domain and from the custodian organization name) and one display LABEL (clinical:sourceEHR). The merge count below is the other half of the same invariant: an origin-only same-source guard would make the two transports uncomparable and drop it to 0.",
         "distinctValuesByPredicate": {
           "https://ns.cascadeprotocol.org/core/v1#sourceIdentity": 1,
@@ -36,11 +48,20 @@
     {
       "id": "P02",
       "pathology": "one <id> across three contradicting lab observations mints three subjects, not one",
-      "batches": [{ "file": "p02-duplicate-source-id-ccda.xml", "from": "c-cda" }],
+      "batches": [
+        {
+          "file": "p02-duplicate-source-id-ccda.xml",
+          "from": "c-cda"
+        }
+      ],
       "expect": {
         "_comment": "Folded in from the retired KNOWN_OUTCOMES entry P02-duplicate-source-id-collision-undetected. The document states four results and the pod holds four: the three that share a root-only <id> disagree about their code, name, value, unit and reference range, so the id has stopped identifying and each claimant mints its own subject. The two SHACL maxCount violations are gone because the multi-valued subject that caused them is gone, not because anything was silenced, and the panel's four hasLabResult edges now point at four distinct members instead of collapsing to two.",
-        "convertedRecords": [7],
-        "reportedResourceCount": [7],
+        "convertedRecords": [
+          7
+        ],
+        "reportedResourceCount": [
+          7
+        ],
         "podRecords": 7,
         "podRecordsByType": {
           "ClinicalDocument": 1,
@@ -58,10 +79,19 @@
     {
       "id": "P03",
       "pathology": "narrative-only test names, one reference dangling",
-      "batches": [{ "file": "p03-narrative-names-ccda.xml", "from": "c-cda" }],
+      "batches": [
+        {
+          "file": "p03-narrative-names-ccda.xml",
+          "from": "c-cda"
+        }
+      ],
       "expect": {
-        "convertedRecords": [8],
-        "reportedResourceCount": [8],
+        "convertedRecords": [
+          8
+        ],
+        "reportedResourceCount": [
+          8
+        ],
         "podRecords": 8,
         "podRecordsByType": {
           "ClinicalDocument": 1,
@@ -79,7 +109,11 @@
           {
             "on": "health:LabResultRecord",
             "predicate": "health:testName",
-            "values": ["Free thyroxine", "Thyroid stimulating hormone", "Triiodothyronine"]
+            "values": [
+              "Free thyroxine",
+              "Thyroid stimulating hormone",
+              "Triiodothyronine"
+            ]
           }
         ]
       }
@@ -87,10 +121,19 @@
     {
       "id": "P04",
       "pathology": "date-precision variety: day, timed with offset, and a month that must not be emitted",
-      "batches": [{ "file": "p04-date-precision-ccda.xml", "from": "c-cda" }],
+      "batches": [
+        {
+          "file": "p04-date-precision-ccda.xml",
+          "from": "c-cda"
+        }
+      ],
       "expect": {
-        "convertedRecords": [8],
-        "reportedResourceCount": [8],
+        "convertedRecords": [
+          8
+        ],
+        "reportedResourceCount": [
+          8
+        ],
         "podRecords": 8,
         "podRecordsByType": {
           "ClinicalDocument": 2,
@@ -102,19 +145,47 @@
         "merges": 0,
         "conflicts": 0,
         "edgesInPod": 3,
-        "violations": 1,
-        "importWarnings": 0
+        "violations": 0,
+        "importWarnings": 0,
+        "_valuesNote": "violations is 0 from clinical v1.15. It was 1, and the one was the procedure name: this document's single procedure carried its name on health:procedureName, which no Cascade vocabulary defines, while clinical:ProcedureShape required clinical:procedureName -- so the record FAILED for missing a name it was carrying, and the name it carried was validated by nothing. The converter now writes the canonical spelling. The values assertion below is the fold-in of the retired ledger entry P04-procedure-name-written-off-shape and pins BOTH halves: the name is on clinical:procedureName, and health:procedureName is empty. Asserting only the first would pass if the converter dual-wrote.",
+        "values": [
+          {
+            "on": "clinical:Procedure",
+            "predicate": "clinical:procedureName",
+            "values": [
+              "Colonoscopy"
+            ]
+          },
+          {
+            "on": "clinical:Procedure",
+            "predicate": "health:procedureName",
+            "values": []
+          }
+        ]
       }
     },
     {
       "id": "P05",
       "pathology": "HL7 interpretation codes across the set, and multi-category observations",
-      "batches": [{ "file": "p05-interpretation-categories-fhir.json", "from": "fhir" }],
+      "batches": [
+        {
+          "file": "p05-interpretation-categories-fhir.json",
+          "from": "fhir"
+        }
+      ],
       "expect": {
-        "convertedRecords": [8],
-        "reportedResourceCount": [8],
+        "convertedRecords": [
+          8
+        ],
+        "reportedResourceCount": [
+          8
+        ],
         "podRecords": 8,
-        "podRecordsByType": { "LabResultRecord": 6, "PatientProfile": 1, "VitalSign": 1 },
+        "podRecordsByType": {
+          "LabResultRecord": 6,
+          "PatientProfile": 1,
+          "VitalSign": 1
+        },
         "merges": 0,
         "conflicts": 0,
         "edgesInPod": 0,
@@ -125,30 +196,55 @@
           {
             "on": "health:LabResultRecord",
             "predicate": "health:interpretation",
-            "values": ["H", "H", "POS", "S", "unknown"]
+            "values": [
+              "H",
+              "H",
+              "POS",
+              "S",
+              "unknown"
+            ]
           },
           {
             "on": "health:LabResultRecord",
             "predicate": "health:labCategory",
             "values": [
-              "laboratory", "laboratory", "laboratory",
-              "laboratory", "laboratory", "laboratory",
+              "laboratory",
+              "laboratory",
+              "laboratory",
+              "laboratory",
+              "laboratory",
+              "laboratory",
               "procedure"
             ]
           }
         ],
-        "sourceBreakdown": { "unknown": 8 }
+        "sourceBreakdown": {
+          "unknown": 8
+        }
       }
     },
     {
       "id": "P06",
       "pathology": "indication absence: reasonReference, resolvable reasonCode, unresolvable reasonCode, and neither",
-      "batches": [{ "file": "p06-indication-absence-fhir.json", "from": "fhir" }],
+      "batches": [
+        {
+          "file": "p06-indication-absence-fhir.json",
+          "from": "fhir"
+        }
+      ],
       "expect": {
-        "convertedRecords": [8],
-        "reportedResourceCount": [8],
+        "convertedRecords": [
+          8
+        ],
+        "reportedResourceCount": [
+          8
+        ],
         "podRecords": 8,
-        "podRecordsByType": { "ConditionRecord": 2, "Medication": 5, "PatientProfile": 1 },
+        "podRecordsByType": {
+          "ConditionRecord": 2,
+          "Medication": 5,
+          "PatientProfile": 1
+        },
         "merges": 0,
         "conflicts": 0,
         "edgesInPod": 1,
@@ -160,14 +256,29 @@
       "id": "P07",
       "pathology": "cross-source exact lab duplicates across two import batches",
       "batches": [
-        { "file": "p07a-crosssource-labs-alpha.json", "from": "fhir" },
-        { "file": "p07b-crosssource-labs-beta.json", "from": "fhir" }
+        {
+          "file": "p07a-crosssource-labs-alpha.json",
+          "from": "fhir"
+        },
+        {
+          "file": "p07b-crosssource-labs-beta.json",
+          "from": "fhir"
+        }
       ],
       "expect": {
-        "convertedRecords": [6, 6],
-        "reportedResourceCount": [6, 6],
+        "convertedRecords": [
+          6,
+          6
+        ],
+        "reportedResourceCount": [
+          6,
+          6
+        ],
         "podRecords": 7,
-        "podRecordsByType": { "LabResultRecord": 6, "PatientProfile": 1 },
+        "podRecordsByType": {
+          "LabResultRecord": 6,
+          "PatientProfile": 1
+        },
         "merges": 5,
         "conflicts": 0,
         "edgesInPod": 0,
@@ -175,30 +286,63 @@
         "importWarnings": 0
       },
       "groundTruth": [
-        ["p07a-sodium", "lf-na"],
-        ["p07a-potassium", "lf-k"],
-        ["p07a-bun", "lf-bun"],
-        ["p07a-calcium", "lf-ca"],
-        ["p07a-only-magnesium"],
-        ["lf-only-phosphorus"]
+        [
+          "p07a-sodium",
+          "lf-na"
+        ],
+        [
+          "p07a-potassium",
+          "lf-k"
+        ],
+        [
+          "p07a-bun",
+          "lf-bun"
+        ],
+        [
+          "p07a-calcium",
+          "lf-ca"
+        ],
+        [
+          "p07a-only-magnesium"
+        ],
+        [
+          "lf-only-phosphorus"
+        ]
       ]
     },
     {
       "id": "P07-SHARED-LABEL",
       "pathology": "the same two exports under ONE import-batch label still reconcile: the guard reads the origin, not the transport",
       "batches": [
-        { "file": "p07a-crosssource-labs-alpha.json", "from": "fhir", "sourceSystem": "Household export" },
-        { "file": "p07b-crosssource-labs-beta.json", "from": "fhir", "sourceSystem": "Household export" }
+        {
+          "file": "p07a-crosssource-labs-alpha.json",
+          "from": "fhir",
+          "sourceSystem": "Household export"
+        },
+        {
+          "file": "p07b-crosssource-labs-beta.json",
+          "from": "fhir",
+          "sourceSystem": "Household export"
+        }
       ],
       "expect": {
         "_comment": "Folded in from the retired KNOWN_OUTCOMES entry P07-shared-transport-label-blocks-cross-source-dedup. Two different health systems' exports arrive under one batch label, which is the ordinary shape when a consumer health app exports several connected accounts. The same-source guard now reads cascade:sourceIdentity (org:stonebridge against org:larkfield), so the shared label no longer suppresses the comparison and this run reconciles identically to the distinct-label P07: 7 records, 5 merges. The two distinct origins below are what the guard is reading; if that ever collapses to 1, the merges collapse to 0.",
-        "convertedRecords": [6, 6],
-        "reportedResourceCount": [6, 6],
+        "convertedRecords": [
+          6,
+          6
+        ],
+        "reportedResourceCount": [
+          6,
+          6
+        ],
         "distinctValuesByPredicate": {
           "https://ns.cascadeprotocol.org/core/v1#sourceIdentity": 2
         },
         "podRecords": 7,
-        "podRecordsByType": { "LabResultRecord": 6, "PatientProfile": 1 },
+        "podRecordsByType": {
+          "LabResultRecord": 6,
+          "PatientProfile": 1
+        },
         "merges": 5,
         "conflicts": 0,
         "edgesInPod": 0,
@@ -206,26 +350,57 @@
         "importWarnings": 0
       },
       "groundTruth": [
-        ["p07a-sodium", "lf-na"],
-        ["p07a-potassium", "lf-k"],
-        ["p07a-bun", "lf-bun"],
-        ["p07a-calcium", "lf-ca"],
-        ["p07a-only-magnesium"],
-        ["lf-only-phosphorus"]
+        [
+          "p07a-sodium",
+          "lf-na"
+        ],
+        [
+          "p07a-potassium",
+          "lf-k"
+        ],
+        [
+          "p07a-bun",
+          "lf-bun"
+        ],
+        [
+          "p07a-calcium",
+          "lf-ca"
+        ],
+        [
+          "p07a-only-magnesium"
+        ],
+        [
+          "lf-only-phosphorus"
+        ]
       ]
     },
     {
       "id": "P08",
       "pathology": "three same-source readings hours apart that must never merge, plus a clock-skew duplicate from a second source that should",
       "batches": [
-        { "file": "p08a-repeat-vitals-alpha.json", "from": "fhir" },
-        { "file": "p08b-repeat-vitals-beta.json", "from": "fhir" }
+        {
+          "file": "p08a-repeat-vitals-alpha.json",
+          "from": "fhir"
+        },
+        {
+          "file": "p08b-repeat-vitals-beta.json",
+          "from": "fhir"
+        }
       ],
       "expect": {
-        "convertedRecords": [7, 3],
-        "reportedResourceCount": [7, 3],
+        "convertedRecords": [
+          7,
+          3
+        ],
+        "reportedResourceCount": [
+          7,
+          3
+        ],
         "podRecords": 7,
-        "podRecordsByType": { "PatientProfile": 1, "VitalSign": 6 },
+        "podRecordsByType": {
+          "PatientProfile": 1,
+          "VitalSign": 6
+        },
         "merges": 3,
         "conflicts": 0,
         "edgesInPod": 0,
@@ -233,26 +408,55 @@
         "importWarnings": 0
       },
       "groundTruth": [
-        ["hv-sys-morning"],
-        ["hv-dia-morning"],
-        ["hv-sys-midday"],
-        ["hv-dia-midday"],
-        ["hv-sys-evening", "rc-sys-skew"],
-        ["hv-dia-evening", "rc-dia-skew"]
+        [
+          "hv-sys-morning"
+        ],
+        [
+          "hv-dia-morning"
+        ],
+        [
+          "hv-sys-midday"
+        ],
+        [
+          "hv-dia-midday"
+        ],
+        [
+          "hv-sys-evening",
+          "rc-sys-skew"
+        ],
+        [
+          "hv-dia-evening",
+          "rc-dia-skew"
+        ]
       ]
     },
     {
       "id": "P09",
       "pathology": "medication chains: dose supersession, stale-active, and one dose disagreement asked through two FHIR shapes",
       "batches": [
-        { "file": "p09a-med-chains-alpha.json", "from": "fhir" },
-        { "file": "p09b-med-chains-beta.json", "from": "fhir" }
+        {
+          "file": "p09a-med-chains-alpha.json",
+          "from": "fhir"
+        },
+        {
+          "file": "p09b-med-chains-beta.json",
+          "from": "fhir"
+        }
       ],
       "expect": {
-        "convertedRecords": [5, 6],
-        "reportedResourceCount": [5, 6],
+        "convertedRecords": [
+          5,
+          6
+        ],
+        "reportedResourceCount": [
+          5,
+          6
+        ],
         "podRecords": 6,
-        "podRecordsByType": { "Medication": 5, "PatientProfile": 1 },
+        "podRecordsByType": {
+          "Medication": 5,
+          "PatientProfile": 1
+        },
         "merges": 1,
         "conflicts": 4,
         "edgesInPod": 0,
@@ -277,12 +481,24 @@
     {
       "id": "P10",
       "pathology": "allergy sentinels: a real allergen, a No Known Allergies negation, and an Unknown Allergen data-absent marker",
-      "batches": [{ "file": "p10-allergy-sentinels-fhir.json", "from": "fhir" }],
+      "batches": [
+        {
+          "file": "p10-allergy-sentinels-fhir.json",
+          "from": "fhir"
+        }
+      ],
       "expect": {
-        "convertedRecords": [5],
-        "reportedResourceCount": [5],
+        "convertedRecords": [
+          5
+        ],
+        "reportedResourceCount": [
+          5
+        ],
         "podRecords": 5,
-        "podRecordsByType": { "AllergyRecord": 4, "PatientProfile": 1 },
+        "podRecordsByType": {
+          "AllergyRecord": 4,
+          "PatientProfile": 1
+        },
         "merges": 0,
         "conflicts": 0,
         "edgesInPod": 0,
@@ -293,12 +509,25 @@
     {
       "id": "P11",
       "pathology": "one lipid draw reported three times under three display names, over shared results",
-      "batches": [{ "file": "p11-panel-name-variants-fhir.json", "from": "fhir" }],
+      "batches": [
+        {
+          "file": "p11-panel-name-variants-fhir.json",
+          "from": "fhir"
+        }
+      ],
       "expect": {
-        "convertedRecords": [8],
-        "reportedResourceCount": [8],
+        "convertedRecords": [
+          8
+        ],
+        "reportedResourceCount": [
+          8
+        ],
         "podRecords": 8,
-        "podRecordsByType": { "LaboratoryReport": 3, "LabResultRecord": 4, "PatientProfile": 1 },
+        "podRecordsByType": {
+          "LaboratoryReport": 3,
+          "LabResultRecord": 4,
+          "PatientProfile": 1
+        },
         "merges": 0,
         "conflicts": 0,
         "edgesInPod": 12,
@@ -310,12 +539,24 @@
       "id": "P12",
       "pathology": "vendor-shipped defects: an unsubstituted template placeholder as the document id, a malformed 9-digit date, an empty nullFlavor section, and nullFlavor variety on values",
       "batches": [
-        { "file": "p12-vendor-defects-a-ccda.xml", "from": "c-cda" },
-        { "file": "p12-vendor-defects-b-ccda.xml", "from": "c-cda" }
+        {
+          "file": "p12-vendor-defects-a-ccda.xml",
+          "from": "c-cda"
+        },
+        {
+          "file": "p12-vendor-defects-b-ccda.xml",
+          "from": "c-cda"
+        }
       ],
       "expect": {
-        "convertedRecords": [8, 5],
-        "reportedResourceCount": [8, 5],
+        "convertedRecords": [
+          8,
+          5
+        ],
+        "reportedResourceCount": [
+          8,
+          5
+        ],
         "podRecords": 12,
         "podRecordsByType": {
           "ClinicalDocument": 3,
@@ -328,12 +569,25 @@
         "edgesInPod": 6,
         "violations": 0,
         "importWarnings": 1,
-        "_valuesNote": "The one warning is the malformed 9-digit effectiveTime: the day is still emitted, so no record loses its date, but the import says the value was salvaged rather than stated. requiresLLMExtraction is false on all three narrative documents, including the Allergies section carrying nullFlavor=\"NI\": a section that has already said in the ratified way that it holds no information is not offered to a model with the question of what allergies it contains.",
+        "_valuesNote": "The one warning is the malformed 9-digit effectiveTime: the day is still emitted, so no record loses its date, but the import says the value was salvaged rather than stated. requiresLLMExtraction is false on all three narrative documents, including the Allergies section carrying nullFlavor=\"NI\": a section that has already said in the ratified way that it holds no information is not offered to a model with the question of what allergies it contains. From core v3.6 the three nullFlavor'd values are no longer one indistinguishable blank: UNK, NAV and ASKU map to the data-absent-reason codes unknown, temp-unknown and asked-unknown, so 'we never measured it', 'the result is coming' and 'we asked and were not told' stay three different answers. This is the fold-in of the retired ledger entry P12-nullflavor-variety-collapses-to-one-absence. The records still carry no health:resultValue: inventing one was never the fix, and podRecordsByType is unchanged.",
         "values": [
           {
             "on": "clinical:ClinicalDocument",
             "predicate": "cascade:requiresLLMExtraction",
-            "values": ["false", "false", "false"]
+            "values": [
+              "false",
+              "false",
+              "false"
+            ]
+          },
+          {
+            "on": "health:LabResultRecord",
+            "predicate": "cascade:dataAbsentReason",
+            "values": [
+              "asked-unknown",
+              "temp-unknown",
+              "unknown"
+            ]
           }
         ]
       }

--- a/tests/ccda-narrative-names.test.ts
+++ b/tests/ccda-narrative-names.test.ts
@@ -36,7 +36,6 @@ import {
 import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
 import {
   assertOnlyKnownViolations,
-  expectKnownViolationsStillPresent,
 } from './known-shacl-gaps.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -45,6 +44,7 @@ const __dirname = path.dirname(__filename);
 const FIXTURES = path.resolve(__dirname, '../test-fixtures');
 
 const HEALTH = 'https://ns.cascadeprotocol.org/health/v1#';
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
 const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
 
 async function convertFixture(name: string): Promise<Quad[]> {
@@ -208,7 +208,14 @@ describe('C-CDA condition and procedure names from the section narrative', () =>
 
   it('procedures: procedureName resolves from the code originalText reference', async () => {
     const quads = await convertFixture('ccda-narrative-names.xml');
-    expect(recordBySourceId(quads, 'NN-PROC-001')[HEALTH + 'procedureName']).toEqual(['Colonoscopy']);
+    const rec = recordBySourceId(quads, 'NN-PROC-001');
+    // On clinical:procedureName since clinical v1.15, and BOTH halves are pinned.
+    // Asserting only the first would still pass if the converter dual-wrote, and a
+    // dual write is the outcome the ruling explicitly did not take: the shape's
+    // sh:or already covers pods holding the old spelling, so writing both would add
+    // a duplicate triple to every new record for no validation benefit.
+    expect(rec[CLINICAL + 'procedureName']).toEqual(['Colonoscopy']);
+    expect(rec[HEALTH + 'procedureName']).toBeUndefined();
   });
 });
 
@@ -246,14 +253,13 @@ describe('C-CDA narrative names — SHACL', () => {
     const validation = validateTurtle(result.output, store, shapeFiles, 'ccda-narrative-names.xml');
     const violations = validation.results.filter((r) => r.severity === 'violation');
 
-    // `procedureName` is a DIFFERENT, pre-existing defect: `clinical:ProcedureShape`
-    // requires `clinical:procedureName`, and `procedures.ts` writes the name to
-    // `health:procedureName`. Resolving the name from the narrative — which the
-    // test above proves happened — cannot satisfy a constraint on a predicate the
-    // handler does not write. It is documented in `known-shacl-gaps.ts` and
-    // asserted through that file's matchers, which fail both on a NEW violation
-    // and on this one silently disappearing.
+    // The `procedureName` gap this file used to document is CLOSED as of clinical
+    // v1.15: `procedures.ts` writes `clinical:procedureName`, the spelling
+    // `clinical:ProcedureShape` names, so the record no longer fails for missing a
+    // name it was carrying. `known-shacl-gaps.ts` now holds no entries, and its
+    // matcher is kept here rather than deleted so the assertion stays "no
+    // violations except the known ones" and the next gap has somewhere to land.
     assertOnlyKnownViolations(violations);
-    expectKnownViolationsStillPresent(violations, ['procedureName']);
+    expect(violations, 'the C-CDA converter leaves no SHACL violation on this fixture').toEqual([]);
   });
 });

--- a/tests/ccda-null-flavor.test.ts
+++ b/tests/ccda-null-flavor.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The HL7 v3 NullFlavor to FHIR data-absent-reason mapping.
+ *
+ * WHY THIS FILE EXISTS RATHER THAN LEANING ON THE PATHOLOGY CORPUS. The P12
+ * scenario exercises this mapping end to end, but its fixture carries only three
+ * nullFlavors: UNK, NAV and ASKU. Mutating `NASK -> 'not-asked'` to
+ * `NASK -> 'unknown'` left the ENTIRE suite green, which means the single
+ * distinction most often lost on import ("nobody asked" versus "we asked and
+ * were not told") was unpinned by anything. A corpus fixture proves the wiring;
+ * only a table test proves the table.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  mapNullFlavorToDataAbsentReason,
+  DATA_ABSENT_REASON_CODES,
+} from '../src/lib/ccda-converter/null-flavor.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SHAPES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'shapes');
+
+describe('nullFlavor to data-absent-reason', () => {
+  // Each of these is a DIFFERENT clinical fact. Collapsing any pair is the
+  // defect the mapping exists to end, so each is asserted individually rather
+  // than through a loop over the table, which would just restate the table.
+  it('keeps "nobody asked" and "we asked, they did not know" apart', () => {
+    expect(mapNullFlavorToDataAbsentReason('NASK')).toBe('not-asked');
+    expect(mapNullFlavorToDataAbsentReason('ASKU')).toBe('asked-unknown');
+    expect(mapNullFlavorToDataAbsentReason('NASK')).not.toBe(
+      mapNullFlavorToDataAbsentReason('ASKU'),
+    );
+  });
+
+  it('keeps "coming later" apart from "not known"', () => {
+    expect(mapNullFlavorToDataAbsentReason('NAV')).toBe('temp-unknown');
+    expect(mapNullFlavorToDataAbsentReason('UNK')).toBe('unknown');
+    expect(mapNullFlavorToDataAbsentReason('NAV')).not.toBe(
+      mapNullFlavorToDataAbsentReason('UNK'),
+    );
+  });
+
+  it('maps the remaining absence flavours', () => {
+    expect(mapNullFlavorToDataAbsentReason('NI')).toBe('unknown');
+    expect(mapNullFlavorToDataAbsentReason('MSK')).toBe('masked');
+    expect(mapNullFlavorToDataAbsentReason('NA')).toBe('not-applicable');
+    expect(mapNullFlavorToDataAbsentReason('OTH')).toBe('unsupported');
+    expect(mapNullFlavorToDataAbsentReason('NINF')).toBe('negative-infinity');
+    expect(mapNullFlavorToDataAbsentReason('PINF')).toBe('positive-infinity');
+  });
+
+  it('does NOT claim an absence for flavours that assert a value exists', () => {
+    // DER (derivable), UNC (un-encoded), QS (non-zero but unquantified) and TRC
+    // (trace) are claims ABOUT a value, not statements that one is missing.
+    // Flattening them into an absence reason would assert something the source
+    // did not say, so they return undefined and the record is left as it is.
+    for (const code of ['DER', 'UNC', 'QS', 'TRC']) {
+      expect(mapNullFlavorToDataAbsentReason(code), code).toBeUndefined();
+    }
+  });
+
+  it('NAVU does not borrow temp-unknown', () => {
+    // "Not available, no expectation of future availability" is the opposite of
+    // temp-unknown's "expected later". There is no data-absent-reason code for
+    // "never coming", so it must land on the weaker honest claim rather than on
+    // one that asserts an expectation the source explicitly denied.
+    expect(mapNullFlavorToDataAbsentReason('NAVU')).toBe('unknown');
+    expect(mapNullFlavorToDataAbsentReason('NAVU')).not.toBe('temp-unknown');
+  });
+
+  it('an unrecognised flavour degrades to unknown, never to a guess', () => {
+    // "unknown" asserts only that a value was expected and is missing, which is
+    // true of every nullFlavor by definition, so it can never be wrong. A
+    // specific reason can.
+    expect(mapNullFlavorToDataAbsentReason('ZZZ')).toBe('unknown');
+  });
+
+  it('absence of a nullFlavor is not an absence reason', () => {
+    for (const v of [undefined, null, '', '   ', 42, {}]) {
+      expect(mapNullFlavorToDataAbsentReason(v)).toBeUndefined();
+    }
+  });
+
+  it('is case- and whitespace-tolerant on the attribute value', () => {
+    expect(mapNullFlavorToDataAbsentReason(' nask ')).toBe('not-asked');
+    expect(mapNullFlavorToDataAbsentReason('AsKu')).toBe('asked-unknown');
+  });
+
+  it('every code it can emit is accepted by the bundled shape', () => {
+    // The mapping and cascade:DataAbsentReasonShape's sh:in are two copies of one
+    // value set. If they drift, the converter writes a pod its own validator
+    // rejects. Read from the SHAPES rather than from a second hand-written list,
+    // so this fails on a spec change rather than agreeing with a stale copy.
+    const shape = fs.readFileSync(path.join(SHAPES, 'core.shapes.ttl'), 'utf-8');
+    const block = shape.slice(shape.indexOf('cascade:DataAbsentReasonShape'));
+    const inList = block.slice(block.indexOf('sh:in ('), block.indexOf(') ;', block.indexOf('sh:in (')));
+    const accepted = [...inList.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+
+    expect(accepted, 'the shape must actually declare a value set').not.toHaveLength(0);
+    expect([...accepted].sort()).toEqual([...DATA_ABSENT_REASON_CODES].sort());
+
+    for (const flavour of ['UNK', 'ASKU', 'NASK', 'NAV', 'NAVU', 'MSK', 'NA', 'OTH', 'NINF', 'PINF', 'ZZZ']) {
+      const mapped = mapNullFlavorToDataAbsentReason(flavour);
+      expect(accepted, `${flavour} -> ${mapped}`).toContain(mapped);
+    }
+  });
+
+  it('never emits a raw NullFlavor code', () => {
+    // The shape rejects raw NullFlavor codes deliberately: an absence with two
+    // encodings turns "is this the same absence?" into a string comparison.
+    for (const flavour of ['UNK', 'ASKU', 'NASK', 'NAV', 'NAVU', 'MSK', 'NA', 'OTH']) {
+      expect(mapNullFlavorToDataAbsentReason(flavour)).not.toBe(flavour);
+    }
+  });
+});

--- a/tests/known-shacl-gaps.ts
+++ b/tests/known-shacl-gaps.ts
@@ -60,21 +60,39 @@ export interface SeverityIssue {
 /**
  * Local names of the properties the C-CDA converter is currently known to
  * violate.
+ *
+ * EMPTY as of clinical v1.15, and that is the point of the file rather than the
+ * end of it. The one entry was `procedureName`: `procedures.ts` wrote the name to
+ * `health:procedureName` while `clinical:ProcedureShape` required
+ * `clinical:procedureName`, so every converted procedure failed for missing a
+ * name it was carrying, on a predicate no shape targeted. The converter now
+ * writes the canonical spelling and the violation is gone, so the entry is gone
+ * with it: `expectKnownViolationsStillPresent` is designed to fail once a listed
+ * gap stops being produced, which is exactly what forced this file open.
+ *
+ * With the set empty, `assertOnlyKnownViolations` degenerates to "there are no
+ * violations", which is the correct assertion while there is no known gap. The
+ * machinery stays so the next gap is recorded here rather than absorbed into a
+ * test's expectations.
  */
-export const KNOWN_VIOLATION_PROPERTIES = new Set(['procedureName']);
+export const KNOWN_VIOLATION_PROPERTIES = new Set<string>();
 
 /**
- * The substring that identifies the finding specifically.
+ * Message substrings that identify each known gap specifically.
  *
- * Deliberately a phrase from the SHAPES, not one invented here: if `spec`
- * reworded or dropped the message, the match stops and this file is forced open
- * rather than silently widening to cover some other `procedureName` failure.
+ * Deliberately phrases from the SHAPES, not ones invented here: if `spec`
+ * reworded or dropped a message, the match stops and this file is forced open
+ * rather than silently widening to cover some other failure on the same
+ * property. Empty while KNOWN_VIOLATION_PROPERTIES is empty.
  */
-const PROCEDURE_NAME_MESSAGE = 'Procedure must have a name';
+const KNOWN_VIOLATION_MESSAGES: Record<string, string> = {};
 
 function isKnownViolation(v: SeverityIssue): boolean {
+  const marker = KNOWN_VIOLATION_MESSAGES[v.property];
   return (
-    KNOWN_VIOLATION_PROPERTIES.has(v.property) && v.message.includes(PROCEDURE_NAME_MESSAGE)
+    marker !== undefined &&
+    KNOWN_VIOLATION_PROPERTIES.has(v.property) &&
+    v.message.includes(marker)
   );
 }
 

--- a/tests/pathology-known-outcomes.ts
+++ b/tests/pathology-known-outcomes.ts
@@ -119,26 +119,6 @@ function merges(o: ScenarioObservation): number {
 
 export const KNOWN_OUTCOMES: KnownOutcome[] = [
   {
-    id: 'P04-procedure-name-written-off-shape',
-    scenario: 'P04',
-    currentWrongOutcome:
-      'The C-CDA procedures handler writes the procedure name to health:procedureName, which no ' +
-      'shape targeting clinical:Procedure declares, while clinical:ProcedureShape requires ' +
-      'clinical:procedureName. So the record CARRIES a name, validates as though it had none, and ' +
-      'the name it carries is validated by nothing.',
-    expectedOnceFixed:
-      'The name lands on clinical:procedureName and the violation goes away. Moving it is a data ' +
-      'change for every consumer already querying health:procedureName, which is why it wants its ' +
-      'own change with its own note about what to re-query.',
-    probe: (o) => ({
-      violations: o.violations.filter((v) => v.property === 'procedureName').length,
-      onHealth: o.valuesOn(NS.clinical + 'Procedure', NS.health + 'procedureName'),
-      onClinical: o.valuesOn(NS.clinical + 'Procedure', NS.clinical + 'procedureName'),
-    }),
-    current: { violations: 1, onHealth: ['Colonoscopy'], onClinical: [] },
-    fixed: { violations: 0, onHealth: [], onClinical: ['Colonoscopy'] },
-  },
-  {
     id: 'P04-lab-report-date-promoted-to-midnight',
     scenario: 'P04',
     currentWrongOutcome:
@@ -201,33 +181,6 @@ export const KNOWN_OUTCOMES: KnownOutcome[] = [
     }),
     current: { reports: 3, edges: 12 },
     fixed: { reports: 1, edges: 4 },
-  },
-  {
-    id: 'P12-nullflavor-variety-collapses-to-one-absence',
-    scenario: 'P12',
-    currentWrongOutcome:
-      'UNK ("unknown"), NAV ("temporarily unavailable") and ASKU ("asked but unknown") are three ' +
-      'different statements about WHY a value is missing, and HL7 v3 separates them deliberately: ' +
-      'the third one means somebody asked the patient. All three produce a lab record with no ' +
-      'health:resultValue and nothing else, so the three become one indistinguishable blank and the ' +
-      'reason the source took the trouble to state is discarded.',
-    expectedOnceFixed:
-      'The nullFlavor is carried, so "we never measured it", "the result is coming" and "we asked ' +
-      'and were not told" stay three different answers. The records still carry no resultValue — ' +
-      'inventing one is not the fix. BLOCKED ON VOCABULARY, deliberately: the predicate this entry ' +
-      'names, health:dataAbsentReason, does not exist. No property in health, clinical or core ' +
-      'carries a reason-for-absence today, and vocabulary is authored in `spec/` and synced into ' +
-      'src/shapes/ — emitting a term the ontology does not define would put an unvalidatable ' +
-      'predicate in every pod and is not a smaller change than adding it properly. So the CONVERTER ' +
-      'fix waits on a spec addition binding health:dataAbsentReason to the HL7 v3 NullFlavor / FHIR ' +
-      'data-absent-reason value set, and this entry stays open to say so rather than being answered ' +
-      'with an invented term.',
-    probe: (o) => ({
-      labsWithoutValue: o.countMissing(NS.health + 'LabResultRecord', NS.health + 'resultValue'),
-      dataAbsentReasons: o.values(NS.health + 'dataAbsentReason').length,
-    }),
-    current: { labsWithoutValue: 3, dataAbsentReasons: 0 },
-    fixed: { labsWithoutValue: 3, dataAbsentReasons: 3 },
   },
 ];
 

--- a/tests/uri-generation.test.ts
+++ b/tests/uri-generation.test.ts
@@ -15,7 +15,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { contentHashedUri, mintSubjectUri, medicationUri } from '../src/lib/fhir-converter/types.js';
+import {
+  contentHashedUri,
+  mintSubjectUri,
+  medicationUri,
+  codeableConceptKey,
+  codeableConceptSetKey,
+  canonicalSetKey,
+} from '../src/lib/fhir-converter/types.js';
 
 describe('deterministicUuid cross-SDK contract', () => {
   it('SHA-1("hello") produces the canonical UUID', () => {
@@ -83,5 +90,132 @@ describe('deterministicUuid cross-SDK contract', () => {
     const base = { rxNormCode: '29046', startDate: '2020-04-01', patient: 'urn:uuid:p1' };
     expect(medicationUri({ ...base, medicationName: 'Lisinopril 10 mg' }))
       .toBe(medicationUri({ ...base, medicationName: 'Lisinopril 20 mg' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical form of a SET-valued identity input (core v3.6)
+//
+// The rule is stated normatively on cascade:cascadeUri in spec: discard empty
+// members, deduplicate, sort by code point, join with a fixed separator, and a
+// one-element sequence canonicalizes to the bare scalar.
+//
+// THE GOLDEN PINS BELOW ARE THE POINT OF THIS BLOCK. The three invariants are
+// worth testing, but the claim that actually had to be proved before shipping is
+// the NEGATIVE one: that adding dedupe to these key builders moved no identity
+// that had already been written. So the single-code and scalar cases are pinned
+// to literal URIs, not to each other. A test that only compares two computed
+// values passes just as happily when both have moved.
+// ---------------------------------------------------------------------------
+
+describe('canonical form of a set-valued identity input (core v3.6)', () => {
+  // The URI a single-coding CodeableConcept minted BEFORE dedupe was added.
+  //
+  // HOW THIS VALUE WAS OBTAINED, because a golden pin copied out of the run it is
+  // meant to constrain proves nothing. Three independent derivations agree:
+  //   1. An independent SHA-1 implementation applied to the identity string
+  //      "Observation::code=http://loinc.org|2339-0" by hand.
+  //   2. This module's code at origin/main, i.e. BEFORE canonicalSetKey existed.
+  //   3. This module's code now.
+  // The only output that differs between (2) and (3) anywhere is the duplicate
+  // case: codeableConceptSetKey(['medication','food','food']) was
+  // "food;food;medication" and is now "food;medication". That single collapse is
+  // the whole behavioural change, and it is the defect being corrected.
+  const SINGLE_CODING_URI = 'urn:uuid:69d60ee0-84eb-5ecf-be93-c243962b1ae5';
+
+  it('GOLDEN PIN: one coding hashes exactly as it did before dedupe existed', () => {
+    // identity string: Observation::code=http://loinc.org|2339-0
+    const uri = contentHashedUri('Observation', {
+      code: codeableConceptKey({ coding: [{ system: 'http://loinc.org', code: '2339-0' }] }),
+    });
+    expect(uri).toBe(SINGLE_CODING_URI);
+  });
+
+  it('GOLDEN PIN: a scalar field spelled directly hashes to the same URI', () => {
+    // SCALAR AGREEMENT. The key builder is not involved at all here: this is the
+    // bare string a pre-0..* caller would have passed. It must land on the same
+    // value the coding array does, or the two spellings of one record split.
+    const uri = contentHashedUri('Observation', { code: 'http://loinc.org|2339-0' });
+    expect(uri).toBe(SINGLE_CODING_URI);
+  });
+
+  it('GOLDEN PIN: repeating that one coding does not move it', () => {
+    // DUPLICATE INDEPENDENCE, pinned to the literal rather than to a comparison,
+    // so it also proves the dedupe collapses TO the pre-existing value and not
+    // to some new one.
+    const uri = contentHashedUri('Observation', {
+      code: codeableConceptKey({
+        coding: [
+          { system: 'http://loinc.org', code: '2339-0' },
+          { system: 'http://loinc.org', code: '2339-0' },
+        ],
+      }),
+    });
+    expect(uri).toBe(SINGLE_CODING_URI);
+  });
+
+  it('ORDER INDEPENDENCE: two exports listing the same codings differently agree', () => {
+    const a = codeableConceptKey({
+      coding: [
+        { system: 'http://snomed.info/sct', code: '73211009' },
+        { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'E11.9' },
+      ],
+    });
+    const b = codeableConceptKey({
+      coding: [
+        { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'E11.9' },
+        { system: 'http://snomed.info/sct', code: '73211009' },
+      ],
+    });
+    expect(a).toBe(b);
+    expect(contentHashedUri('Condition', { code: a })).toBe(contentHashedUri('Condition', { code: b }));
+  });
+
+  it('a differing SET still differs: canonicalization removes splits, never merges', () => {
+    // The guard on the whole change. Sorting and deduping may only collapse
+    // spellings of ONE set; if it ever collapsed two different sets, every
+    // assertion above would still pass while the converter silently merged
+    // distinct records.
+    const two = codeableConceptKey({
+      coding: [
+        { system: 'http://snomed.info/sct', code: '73211009' },
+        { system: 'http://snomed.info/sct', code: '44054006' },
+      ],
+    });
+    const one = codeableConceptKey({ coding: [{ system: 'http://snomed.info/sct', code: '73211009' }] });
+    expect(two).not.toBe(one);
+    expect(contentHashedUri('Condition', { code: two })).not.toBe(contentHashedUri('Condition', { code: one }));
+  });
+
+  it('sorts by code point, not by locale', () => {
+    // A locale-aware comparator orders these a01, B02, Z01 and would make a
+    // record's identity depend on the machine that imported it.
+    expect(canonicalSetKey(['Z01', 'a01', 'B02'], ',')).toBe('B02,Z01,a01');
+  });
+
+  it('empty and whitespace-only members are discarded, not hashed', () => {
+    expect(canonicalSetKey(['2339-0', '', '   '], ',')).toBe('2339-0');
+    expect(canonicalSetKey(['', '  '], ',')).toBeUndefined();
+    // An all-empty set is ABSENT, and contentHashedUri drops absent fields, so
+    // it must hash identically to the field never being supplied.
+    expect(contentHashedUri('Observation', { date: '2024-01-10', code: canonicalSetKey([''], ',') }))
+      .toBe(contentHashedUri('Observation', { date: '2024-01-10' }));
+  });
+
+  it('keeps the separator each existing site already shipped', () => {
+    // core v3.6 recommends U+002C and REQUIRES it of new implementations, but
+    // lets an existing site keep what it ships, because changing a separator
+    // re-mints every identity that site ever produced. codeableConceptSetKey has
+    // always joined with ';'. This test is what stops a well-meaning
+    // "consistency" edit from silently re-minting every multi-concept record.
+    expect(codeableConceptSetKey(['food', 'medication'])).toBe('food;medication');
+    expect(canonicalSetKey(['food', 'medication'], ',')).toBe('food,medication');
+  });
+
+  it('codeableConceptSetKey deduplicates and orders its members', () => {
+    expect(codeableConceptSetKey(['medication', 'food', 'food'])).toBe('food;medication');
+    expect(codeableConceptSetKey(['food', 'medication'])).toBe(
+      codeableConceptSetKey(['medication', 'food']),
+    );
   });
 });


### PR DESCRIPTION
## Scope

Syncs the embedded shapes to core 3.6 / health 2.7 / clinical 1.15 and acts on the four rulings in the-cascade-protocol/spec#18. Merges **after** that PR.

Deliberately untouched: the reconciler, `src/lib/output.ts`, the JSON output boundary, and `quadsToTurtle` / `quadsToJsonLd` (`types.ts` lines 680+). This branch's edits to `types.ts` are confined to the identity chokepoint above that line.

## Counts

| | before | after |
|---|---|---|
| test files | 138 | **139** |
| tests | 2216 | **2235** |
| failed | 0 | **0** |
| skipped | 0 | **0** |

`npx tsc --noEmit` clean before and after. `npm run build` was run before every suite run, since ~20 tests spawn `dist/`.

The first baseline run of this branch reported 6 failures; that was a background run racing the shape sync, not a real result. The clean baseline was re-measured from a stashed tree: 138 files / 2216 tests, 0 failed.

## Ruling D - the procedure name

`src/lib/ccda-converter/sections/procedures.ts` wrote the name to `health:procedureName`, a predicate no Cascade vocabulary defines, on records it types `clinical:Procedure`. Every converted procedure therefore failed `clinical:ProcedureShape`'s name requirement *while carrying a name*, and carried it on a predicate no shape targets, so the name itself was validated by nothing. It now writes `clinical:procedureName`.

**Single write, not dual.** The shape's new `sh:or` already covers pods holding the old spelling, so dual-writing would add a duplicate triple to every new record for no validation benefit. The test pins **both** halves - name present on `clinical:procedureName` **and** `health:procedureName` absent - because asserting only the first would pass a dual write.

## Ruling C - nullFlavor stops collapsing

`sections/labs.ts` read `<value>` for `@_value` only, so `UNK`, `NAV` and `ASKU` all produced a record with no `resultValue` and nothing else. New `src/lib/ccda-converter/null-flavor.ts` maps HL7 v3 NullFlavor to FHIR data-absent-reason - the mapping core v3.6 states normatively on the property - and the handler emits `cascade:dataAbsentReason`, **only when there is no value**, since the property explains an *absent* one.

`DER`, `UNC`, `QS` and `TRC` are deliberately not mapped: they are claims that a value exists (derivable, un-encoded, non-zero-unquantified, trace), and flattening them into an absence reason would assert something the source did not.

`cascade:dataAbsentReason` lives in `core`, not `health`. The retired ledger entry named `health:dataAbsentReason`; absence-of-a-value is cross-cutting rather than lab-specific, so it follows `cascade:sourceIdentity`'s precedent - `rdfs:domain owl:Thing`, open-world `sh:targetSubjectsOf` shape. Flagging the rename since the ledger predicted the other spelling.

## Ruling B - canonical form of a set-valued identity input

`canonicalSetKey` adds **deduplication** to the three set-valued key builders (`codeableConceptKey`, `codeableConceptSetKey`, `labCategoryKey`), which already sorted. Each caller keeps the separator it already ships (`,` twice, `;` once), which core v3.6 explicitly permits: changing a separator re-mints every identity that site ever produced.

`stableStringify` and `structuredKey` are **not** built on this and must not be. They back ordered inputs - `name[0]` is the primary name, a component or note list is a sequence - where sorting would merge records the source deliberately kept apart.

**Proof that no existing identity moved**, which is the claim that actually had to hold:

| derivation | single coding | scalar spelling |
|---|---|---|
| independent SHA-1 implementation | `69d60ee0-…` | `69d60ee0-…` |
| this module at `origin/main` | `69d60ee0-…` | `69d60ee0-…` |
| this module now | `69d60ee0-…` | `69d60ee0-…` |

The **only** output that differs anywhere between `origin/main` and this commit is `codeableConceptSetKey(['medication','food','food'])`: `"food;food;medication"` becomes `"food;medication"`. That single collapse is the defect being fixed. The golden tests pin literal URIs rather than comparing two computed values, because a comparison passes just as happily when both sides have moved.

## Pathology ledger - two entries retired

Retired by **folding the fixed expectations into `scenarios.json`**, never by deleting an assertion. Ledger 5 entries to 3.

- **`P04-procedure-name-written-off-shape`** → P04 `violations` 1 to 0, plus a `values` assertion pinning both halves of the name.
- **`P12-nullflavor-variety-collapses-to-one-absence`** → P12 gains a `values` assertion for `cascade:dataAbsentReason` = `["asked-unknown","temp-unknown","unknown"]`. `podRecordsByType` is unchanged: the records still carry no `resultValue`, because inventing one was never the fix.

Still open (untouched): `P04-lab-report-date-promoted-to-midnight`, `P10-negation-and-data-absent-sentinels-stored-as-allergens`, `P11-panel-name-variants-are-never-reconciled`.

`tests/known-shacl-gaps.ts` `KNOWN_VIOLATION_PROPERTIES` is now **empty** - its one entry was the procedure name. The machinery is kept rather than deleted so the next gap is recorded there instead of being absorbed into a test's expectations.

## Mutation settle

Six hand-flips, each with a confirmed non-empty diff, a rebuild, and a full suite run, reverted after:

| # | mutation | result |
|---|---|---|
| C1 | `procedures.ts` back to `health:procedureName` | **KILLED** (2 tests) |
| C2 | delete the `dataAbsentReason` emission | **KILLED** (P12) |
| C3 | remove dedupe from `canonicalSetKey` | **KILLED** (2 tests) |
| C4 | collapse `NASK` into `'unknown'` | **SURVIVED**, then KILLED |
| C5 | flip the `';'` separator to `','` | **KILLED** (2 tests) |
| C6 | drop the 14 data-absent-reason codes | **KILLED** (interpretation) |

**C4 survived the first attempt with the entire suite green.** The P12 fixture carries `UNK`, `NAV` and `ASKU` but not `NASK`, so "nobody asked" versus "we asked and were not told" - the single distinction most often lost on import, and a large part of the point of this change - was pinned by nothing. `tests/ccda-null-flavor.test.ts` was written in response: it covers the table directly, including the four flavours that must **not** map, the `NAVU` case that must not borrow `temp-unknown`, and the agreement between the mapping and the bundled shape's `sh:in`. C4 was then re-run and killed. Reporting the survivor because a corpus fixture proves the wiring and only a table test proves the table.

## Note for the parallel branch

`src/lib/fhir-converter/types.ts` is shared: this branch touches the identity chokepoint (lines under 680), and `quadsToTurtle` / `quadsToJsonLd` live at 680+. No overlap, but the file will appear in both diffs.

