### PR TITLE
Reconcile a pod's own duplicates, ratify tier-0 silent merge, fix the fast-path pass ordering, and guarantee RFC 8259 JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+**`cascade pod reconcile <pod-dir>`: a pod can now be reconciled against itself.**
+`pod import --reconcile-existing` compares ARRIVING records against stored ones and deliberately
+never compares two stored records with each other, which is the right restriction for an import:
+rewriting records the user did not just hand over must not be an invisible side effect of importing
+an unrelated file. The consequence was that duplicates already IN a pod were permanent. Nothing in
+the tool ever compared them, so no sequence of imports could ever clear them.
+
+This verb is the same reconciler, the same matching and the same conflict machinery, pointed at pod
+content and named honestly as the mutation it is:
+
+- **Dry run is the DEFAULT.** With no flags it reads the pod, runs the full reconciliation, prints
+  what WOULD merge and what WOULD be raised for review, writes nothing, and exits 0. `--apply` is a
+  separate typed decision made after reading that report. `--json` gives the same report machine
+  readable, `--report <file>` writes it to disk.
+- **A record file it cannot read refuses the whole run**, dry run included, at exit 2. Every count
+  this verb prints is a claim about the pod's WHOLE record set, and a file that was never opened
+  could hold a third copy, so a confident report over a partial read is a wrong answer rather than a
+  small one. An unparseable file that is NOT a registered record bucket is warned about and stepped
+  over: a pod legitimately keeps notes and analyses alongside its records.
+- Unresolved conflicts go into the same `settings/pending-conflicts.ttl` queue that `pod conflicts`
+  and `pod resolve` already read. It is covered by the pod read-conformance matrix as a read verb.
+
+**Tier 0: cross-source exact lab duplication merges without raising a conflict, and is journaled.**
+Two organizations reporting one draw is the commonest thing a multi-source pod holds, and queueing a
+question for each one does not produce caution, it produces a queue nobody finishes with the
+genuinely disagreeing pairs buried in it. The class is drawn narrowly and every clause is load
+bearing: same LOINC, the same exact INSTANT (never day level, because a same-day repeat draw is a
+real second measurement), byte-identical content on every non-provenance predicate, and two DIFFERENT
+origins that both name a real organization (`org:` / `ns:`). A `transport:` or absent origin is
+unknown rather than different and is excluded, so a pod written before origins existed reconciles
+exactly as it did before. Measured over 144 candidate groups at a 22% duplicate base rate: zero false
+positives.
+
+Silent means not interrupting, not unrecorded. Every tier-0 merge is counted in the run report as
+`tier0MergesApplied`, itemized in `report.tier0Merges` with the surviving IRI and every IRI it
+absorbed, and appended to `settings/tier0-merge-journal.json` with the FULL content of each discarded
+record, so any merge can be found and undone without the originals. Tier-0 groups are exempt from the
+opt-in cross-provenance guard, which otherwise flagged every benign cross-source duplicate, since two
+organizations reporting one draw differ on provenance class as a matter of course.
+
+### Fixed
+
+**A batch's own internal duplicates imported un-reconciled whenever the pod held any content.**
+On the `--reconcile-existing` fast path, which is the default, the cross-batch pass called
+`assigned.add()` on EVERY new record, matched or not, before the new-against-new pass ran. That pass
+had no unassigned record left to seed from, so it and its same-source guard site were structurally
+dead code, and two duplicates arriving in one import were never compared with each other. The
+single-batch path merged the same pair: 3 records against 1 on identical inputs.
+
+The two passes are now ONE pass whose candidate list is the union of both pools, which makes the fast
+path run the same algorithm the single-batch path runs, restricted so that only new records seed a
+group. Deferring assignment, or running the within-batch pass first, were both considered and
+rejected: each fixes one pair and leaves a different pair un-merged (three copies of one result, one
+in the pod and two in the batch, reach 2 records under either and 1 only under a single pass). The
+restriction that two records already in the pod are never compared with each other is KEPT
+deliberately, and is what `pod reconcile` now exists to do on purpose.
+
+**`--json` output is guaranteed RFC 8259 valid; `pod query --all --edges --json` could emit a
+document jq refused to parse.** Measured on a real pod: 3.7 MB to stdout, exit 0, empty stderr, and
+jq rejected all of it. Turtle admits `\uXXXX` escapes, so a pod literal can hold an UNPAIRED
+surrogate; nothing on the read path rejects it, and `JSON.stringify` (well-formed since ES2019)
+faithfully re-emits it as `\ud800`, which `JSON.parse` accepts, Python's `json` accepts, and jq
+rejects. Two of three parsers accepting is how a corrupt payload looks healthy.
+
+Every JSON-emitting surface now goes through one encoder (`src/lib/json-output.ts`), which replaces
+unpaired surrogates with U+FFFD in string values AND in object keys. Well-formed surrogate pairs,
+C0 escapes and every already-valid document are byte-unchanged. Routed: `pod query`, `pod conflicts`,
+`validate`, `advisory`, the `--report` files written by `pod import` and `reconcile`, the `pod
+extract` sidecars, and the shared error/warning envelopes.
+
+---
+
 ## [0.16.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ cascade pod init ./my-pod
 cascade capabilities
 ```
 
+## Reconciling a pod's own duplicates
+
+`pod import` compares arriving records against stored ones, and never two stored records with each
+other. So duplicates a pod already holds stay there. `pod reconcile` is the verb that finds them.
+
+It reports first, and writes nothing until you say so:
+
+```bash
+# What WOULD merge. Reads the pod, changes nothing.
+cascade pod reconcile ./my-pod
+cascade --json pod reconcile ./my-pod
+cascade pod reconcile ./my-pod --report duplicates.json
+
+# Merge, having read the report above.
+cascade pod reconcile ./my-pod --apply
+```
+
+Two organizations reporting the same lab result, at the same instant, with identical values, are
+merged without raising a conflict. Every such merge is appended to `settings/tier0-merge-journal.json`
+with the full content of the record it discarded, so it can be reviewed or undone afterwards.
+Anything less certain than that is reported for review and reaches `cascade pod conflicts`.
+
+If a record file cannot be read, the command refuses to run at all (exit 2) rather than report counts
+about a pod it only partly opened.
+
 ## Pod graph queries
 
 A pod is a typed RDF graph. Beyond the flat per-type buckets of `pod query --all`,

--- a/src/commands/advisory.ts
+++ b/src/commands/advisory.ts
@@ -52,6 +52,7 @@ import {
   type AdvisoryCacheStatus,
 } from '../lib/advisory/feed-client.js';
 import { parseTurtle } from '../lib/turtle-parser.js';
+import { toJsonText } from '../lib/json-output.js';
 
 const { namedNode } = DataFactory;
 
@@ -188,7 +189,7 @@ async function runValidate(program: Command, patchPath: string): Promise<void> {
   const parseResult = parseCap(src);
   if (!parseResult.ast) {
     if (opts.json) {
-      console.log(JSON.stringify({ valid: false, parseErrors: parseResult.errors }, null, 2));
+      console.log(toJsonText({ valid: false, parseErrors: parseResult.errors }));
     } else {
       console.error(`Parse failed for ${patchPath}:`);
       for (const e of parseResult.errors) {
@@ -201,14 +202,12 @@ async function runValidate(program: Command, patchPath: string): Promise<void> {
   const validation = validateCap(parseResult.ast);
   if (opts.json) {
     console.log(
-      JSON.stringify(
+      toJsonText(
         {
           valid: validation.valid,
           violations: validation.violations,
           envelope: parseResult.ast.envelope,
         },
-        null,
-        2,
       ),
     );
   } else {
@@ -290,7 +289,7 @@ async function runApply(
   const bindings = evaluateSelector(parseResult.ast, podStore);
   if (bindings.length === 0) {
     if (opts.json) {
-      console.log(JSON.stringify({ applied: 0, reason: 'inapplicable' }, null, 2));
+      console.log(toJsonText({ applied: 0, reason: 'inapplicable' }));
     } else {
       console.log(`Advisory not applicable to this pod (zero selector matches).`);
     }
@@ -315,15 +314,13 @@ async function runApply(
 
   if (opts.json) {
     console.log(
-      JSON.stringify(
+      toJsonText(
         {
           applied: applyResult.matchesApplied,
           activityIris: applyResult.activityIris,
           matchedRecordIris: applyResult.matchedRecordIris,
           insertedTriples: applyResult.insertedQuads.length,
         },
-        null,
-        2,
       ),
     );
   } else {
@@ -347,7 +344,7 @@ async function runList(program: Command, options: ListOptions): Promise<void> {
         : undefined;
   const records = listCacheRecords(options.pod, filter as AdvisoryCacheStatus | undefined);
   if (opts.json) {
-    console.log(JSON.stringify(records, null, 2));
+    console.log(toJsonText(records));
     return;
   }
   if (records.length === 0) {
@@ -423,10 +420,8 @@ async function runRevert(program: Command, options: RevertOptions): Promise<void
 
   if (opts.json) {
     console.log(
-      JSON.stringify(
+      toJsonText(
         { reverted: options.advisory, activitiesRemoved: activitySubjects.size, triplesRemoved: removedCount },
-        null,
-        2,
       ),
     );
   } else {
@@ -446,7 +441,7 @@ async function runFeedPull(
   const opts = globalOpts(program);
   const result = await pullFeed(url, options.pod);
   if (opts.json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(toJsonText(result));
   } else if (!result.ok) {
     console.error(`Feed pull failed: ${result.reason}`);
   } else {
@@ -501,7 +496,7 @@ async function runDryRun(
   const bindings = evaluateSelector(parseResult.ast, cloneStore);
   if (bindings.length === 0) {
     if (opts.json) {
-      console.log(JSON.stringify({ matches: 0, wouldInsert: 0 }, null, 2));
+      console.log(toJsonText({ matches: 0, wouldInsert: 0 }));
     } else {
       console.log(`Advisory inapplicable to this pod (zero matches). No triples would be inserted.`);
     }
@@ -517,7 +512,7 @@ async function runDryRun(
 
   if (opts.json) {
     console.log(
-      JSON.stringify(
+      toJsonText(
         {
           matches: bindings.length,
           wouldInsert: result.insertedQuads.length,
@@ -525,8 +520,6 @@ async function runDryRun(
           matchedRecordIris: result.matchedRecordIris,
           turtle: quadsToTurtle(result.insertedQuads),
         },
-        null,
-        2,
       ),
     );
   } else {

--- a/src/commands/pod/conflicts.ts
+++ b/src/commands/pod/conflicts.ts
@@ -20,6 +20,7 @@ import { Command } from 'commander';
 import { loadPendingConflicts, ConflictStoreError } from '../../lib/user-resolutions.js';
 import { resolvePodDir, resolvePodDekIfEncrypted } from './helpers.js';
 import { printError, type OutputOptions } from '../../lib/output.js';
+import { toJsonText } from '../../lib/json-output.js';
 
 export function registerConflictsCommand(podProgram: Command, program: Command): void {
   podProgram
@@ -46,7 +47,7 @@ export function registerConflictsCommand(podProgram: Command, program: Command):
       }
 
       if (options.format === 'json') {
-        console.log(JSON.stringify(conflicts, null, 2));
+        console.log(toJsonText(conflicts));
       } else {
         if (conflicts.length === 0) {
           console.log(`No unresolved conflicts in pod at ${podDir}`);

--- a/src/commands/pod/extract.ts
+++ b/src/commands/pod/extract.ts
@@ -30,6 +30,7 @@ import crypto from 'crypto';
 import { getProperties, CASCADE_NAMESPACES } from '../../lib/turtle-parser.js';
 import { resolvePodDir, fileExists } from './helpers.js';
 import { openPod, PodUnreadableError, type PodReader } from '../../lib/pod-read.js';
+import { toJsonText } from '../../lib/json-output.js';
 
 // ── LOINC section code → CDA section string (used by /extract API) ───────────
 
@@ -651,7 +652,7 @@ export function registerExtractSubcommand(pod: Command): void {
         if (toAdd.length > 0) {
           await fs.writeFile(
             queuePath,
-            JSON.stringify([...existing, ...toAdd], null, 2),
+            toJsonText([...existing, ...toAdd]),
             'utf-8',
           );
         }
@@ -676,7 +677,7 @@ export function registerExtractSubcommand(pod: Command): void {
         const existingSet = new Set(existing);
         const newIds = succeededBlockIds.filter((id) => !existingSet.has(id));
         if (newIds.length > 0) {
-          await fs.writeFile(donePath, JSON.stringify([...existing, ...newIds], null, 2), 'utf-8');
+          await fs.writeFile(donePath, toJsonText([...existing, ...newIds]), 'utf-8');
         }
       }
 
@@ -693,7 +694,7 @@ export function registerExtractSubcommand(pod: Command): void {
         const existingKeys = new Set(existing.map((e) => `${e.blockUri}:${e.section}`));
         const newErrors = extractionErrors.filter((e) => !existingKeys.has(`${e.blockUri}:${e.section}`));
         if (newErrors.length > 0) {
-          await fs.writeFile(errorsPath, JSON.stringify([...existing, ...newErrors], null, 2), 'utf-8');
+          await fs.writeFile(errorsPath, toJsonText([...existing, ...newErrors]), 'utf-8');
         }
       }
 

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -61,6 +61,8 @@ import {
 import { obtainPassphrase } from '../../lib/passphrase.js';
 import { classifyImportInput, isPathInsidePod } from '../../lib/import-input.js';
 import { mergeIntoBucket, derelativizeQuads, relBaseFor } from '../../lib/bucket-write.js';
+import { toJsonText } from '../../lib/json-output.js';
+import { appendTier0Journal, TIER0_JOURNAL_RELATIVE_PATH } from '../../lib/tier0-journal.js';
 
 // ---------------------------------------------------------------------------
 // Import report type
@@ -796,6 +798,23 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           if (pendingConflicts.length > 0) {
             printVerbose(`  ${pendingConflicts.length} unresolved conflict(s) written to settings/pending-conflicts.ttl`, globalOpts);
           }
+
+          // Tier-0 merges applied WITHOUT asking. Journaled with the discarded
+          // records' full content, which is the condition on which the ruling
+          // allows them to be silent at all. Not printVerbose for the same
+          // reason the identity-collision warning is not: a user who is never
+          // told cannot review a decision that was made for them.
+          const tier0 = reconcileResult.report.tier0Merges;
+          if (tier0.length > 0) {
+            appendTier0Journal(podDir, tier0, 'pod import', dek);
+            printWarning(
+              `${tier0.length} cross-source exact lab duplicate(s) merged automatically. ` +
+                `Identical result, same instant, different known sources, merged without raising a ` +
+                `conflict. Every one is recorded with the discarded records in ` +
+                `${TIER0_JOURNAL_RELATIVE_PATH}, and can be undone from it.`,
+              globalOpts,
+            );
+          }
         }
       } else {
         mergedTurtle = allInputs.map(i => i.content).join('\n\n');
@@ -1179,7 +1198,7 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // The report file is a user-named output path, not pod content, so writing
       // it does not break the dry-run promise of leaving the pod untouched.
       if (options.report) {
-        await fs.writeFile(options.report, JSON.stringify(importReport, null, 2), 'utf-8');
+        await fs.writeFile(options.report, toJsonText(importReport), 'utf-8');
         printVerbose(
           `${dryRun ? '[dry-run] ' : ''}Import report written to: ${options.report}`,
           globalOpts,

--- a/src/commands/pod/index.ts
+++ b/src/commands/pod/index.ts
@@ -9,6 +9,7 @@
  *   export <pod-dir>    Export pod data
  *   info <pod-dir>      Show pod metadata and statistics
  *   doctor <pod-dir>    Diagnose a damaged pod, and repair it with --write
+ *   reconcile <pod-dir> Report (and with --apply, merge) duplicates the pod already holds
  *
  * This module delegates to focused subcommand modules:
  *   - init.ts    Pod initialization with templates
@@ -34,6 +35,7 @@ import { registerAddRecordSubcommand } from './add-record.js';
 import { registerRetractSubcommand } from './retract.js';
 import { registerEraseSubcommand } from './erase.js';
 import { registerDoctorSubcommand } from './doctor.js';
+import { registerReconcileSubcommand } from './reconcile.js';
 
 export function registerPodCommand(program: Command): void {
   const pod = program.command('pod').description('Manage Cascade Pod structures');
@@ -54,4 +56,5 @@ export function registerPodCommand(program: Command): void {
   registerRetractSubcommand(pod, program);
   registerEraseSubcommand(pod, program);
   registerDoctorSubcommand(pod, program);
+  registerReconcileSubcommand(pod, program);
 }

--- a/src/commands/pod/reconcile.ts
+++ b/src/commands/pod/reconcile.ts
@@ -1,0 +1,614 @@
+/**
+ * cascade pod reconcile <pod-dir>
+ *
+ * Reconcile a pod against ITSELF: find and merge the duplicates it already
+ * holds.
+ *
+ * WHY THIS VERB HAS TO EXIST
+ * --------------------------
+ * `pod import --reconcile-existing` reconciles ARRIVING records against stored
+ * ones. It deliberately never compares two stored records with each other, and
+ * that restriction is right for an import: reconciling a pod's existing content
+ * is a mutation of records the user did not just hand over, and it must not
+ * happen as an invisible side effect of importing an unrelated file.
+ *
+ * The consequence, though, is that duplicates ALREADY in a pod are permanent.
+ * Nothing in the tool ever compares them, so every pod written before
+ * cross-source matching existed carries its duplicates forever, and no sequence
+ * of imports can clear them. That is this verb: the same reconciler, the same
+ * matching, the same conflict machinery, pointed at pod content — and named
+ * honestly as the mutation it is.
+ *
+ * DRY RUN IS THE DEFAULT, AND THAT IS THE DESIGN
+ * ----------------------------------------------
+ * The command reports first. With no flags it reads the pod, runs the whole
+ * reconciliation, prints exactly what WOULD merge and what WOULD be raised as a
+ * conflict, writes nothing, and exits 0. `--apply` is a separate, typed decision
+ * made after reading that report.
+ *
+ * A verb that rewrites a person's health records the first time they run it,
+ * because they were curious what it did, is not a tool anyone should trust with
+ * a pod. And the report is useful on its own: "how much cross-source duplication
+ * do I actually have" is a question worth answering without changing anything.
+ *
+ * Exit codes:
+ *   0 — the run completed (a dry run, or an --apply that wrote successfully)
+ *   1 — the reconciliation ran but at least one bucket could not be WRITTEN
+ *   2 — the pod could not be opened, or a record file in it could not be READ.
+ *       The second one is exit 2 in the DRY RUN too: this command's whole output
+ *       is a claim about the pod's whole record set, and it must not make that
+ *       claim about files it never opened.
+ */
+
+import type { Command } from 'commander';
+import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { printResult, printError, printVerbose, type OutputOptions } from '../../lib/output.js';
+import { toJsonText } from '../../lib/json-output.js';
+import { runReconciliation, type ReconcilerInput, type Tier0Merge } from '../../lib/reconciler.js';
+import { DATA_TYPES, resolvePodDir } from './helpers.js';
+import { openPod, PodReadLedger, tidyReason, type PodReader } from '../../lib/pod-read.js';
+import { mergeIntoBucket, derelativizeQuads, relBaseFor } from '../../lib/bucket-write.js';
+import {
+  writePendingConflicts,
+  generateConflictId,
+  type PendingConflict,
+} from '../../lib/user-resolutions.js';
+import { randomUUID } from 'node:crypto';
+import { appendTier0Journal, TIER0_JOURNAL_RELATIVE_PATH } from '../../lib/tier0-journal.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/** Pod directories holding reconcilable records. Matches `pod import`. */
+const DATA_DIRS = ['clinical', 'wellness'] as const;
+
+// ---------------------------------------------------------------------------
+// The report
+// ---------------------------------------------------------------------------
+
+/** One group the reconciler would collapse or raise, as the report names it. */
+export interface ReconcileGroupReport {
+  /** `exact_duplicate`, `near_duplicate`, `value_conflict`, ... */
+  type: string;
+  recordType: string;
+  /** The record that would survive. */
+  canonicalUri: string;
+  /** What made them one record, e.g. `loinc:2951-2+2031-05-20`. */
+  matchedOn: string;
+  /** How the reconciler would settle it. */
+  strategy: string;
+  /** False when it would be raised for a person to answer instead of merged. */
+  resolved: boolean;
+  /** True for the narrow, silently-mergeable cross-source exact lab class. */
+  tier0: boolean;
+  sources: string[];
+}
+
+export interface ReconcileReport {
+  podDir: string;
+  ranAt: string;
+  /** False for a dry run. The single most important field in this object. */
+  applied: boolean;
+  /** Pod-relative bucket paths that were read. */
+  filesRead: string[];
+  /**
+   * Record buckets that could not be read.
+   *
+   * ALWAYS EMPTY in any report a caller actually receives, and that is the
+   * point: an unreadable record bucket ends the run at exit 2 before a report
+   * exists. The field is kept so the shape of the report states the invariant
+   * rather than leaving a reader to infer it, and so a future partial-read mode
+   * would have somewhere honest to put the names. It never means "some of your
+   * records were quietly skipped", because that outcome is not reachable.
+   */
+  filesUnreadable: string[];
+  recordsBefore: number;
+  recordsAfter: number;
+  summary: {
+    exactDuplicatesRemoved: number;
+    nearDuplicatesMerged: number;
+    conflictsResolved: number;
+    conflictsUnresolved: number;
+    identityCollisionsSplit: number;
+    tier0MergesApplied: number;
+  };
+  /** Every group that is not a plain pass-through, itemized. */
+  groups: ReconcileGroupReport[];
+  /** The tier-0 subset, with the discarded records retained for undo. */
+  tier0Merges: Tier0Merge[];
+  filesWritten: string[];
+}
+
+// ---------------------------------------------------------------------------
+
+/** Parse Turtle into quads grouped by subject, under a per-text sentinel base. */
+async function parseBySubject(turtle: string): Promise<Map<string, Quad[]>> {
+  const base = relBaseFor(turtle);
+  const parser = new Parser({ format: 'Turtle', baseIRI: base });
+  const collected: Quad[] = [];
+  return new Promise((resolve, reject) => {
+    parser.parse(turtle, (error, quad) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (!quad) {
+        const bySubject = new Map<string, Quad[]>();
+        for (const q of derelativizeQuads(collected, base)) {
+          const bucket = bySubject.get(q.subject.value);
+          if (bucket) bucket.push(q);
+          else bySubject.set(q.subject.value, [q]);
+        }
+        resolve(bySubject);
+        return;
+      }
+      collected.push(quad);
+    });
+  });
+}
+
+/** Route a subject's rdf:type to the DATA_TYPES bucket that holds it. */
+function routeTypeKey(quads: Quad[]): string {
+  const typeIri = quads.find((q) => q.predicate.value === RDF_TYPE)?.object.value ?? '';
+  for (const [key, info] of Object.entries(DATA_TYPES)) {
+    if (info.isFhirPassthroughBucket) continue;
+    if (info.rdfTypes.includes(typeIri)) return key;
+  }
+  return 'fhir-passthrough';
+}
+
+/** Pod-relative path of every REGISTERED record bucket, keyed by DATA_TYPES key. */
+function registeredBuckets(): Array<{ key: string; rel: string }> {
+  return Object.entries(DATA_TYPES)
+    .map(([key, info]) => ({ key, rel: `${info.directory}/${info.filename}` }))
+    .filter(({ rel }) => DATA_DIRS.some((d) => rel.startsWith(`${d}/`)))
+    .sort((a, b) => a.rel.localeCompare(b.rel));
+}
+
+/**
+ * Read every REGISTERED record bucket as a reconciler input.
+ *
+ * ONLY registered buckets, and that is a safety property rather than a
+ * shortcut. This verb's output is a COMPLETE replacement of the records it
+ * covers: what comes back from the reconciler is routed by `rdf:type` and
+ * written over the bucket that type belongs to. A pod legitimately keeps notes,
+ * analyses and literature as `.ttl` under `clinical/`, and reading one of those
+ * would sweep its subjects into the merged result, where routing has no bucket
+ * for them and files them under passthrough — quietly RELOCATING a note as a
+ * side effect of reconciling records. `pod import` sweeps the directory because
+ * it only ever adds; a verb that replaces cannot.
+ *
+ * Each bucket is its OWN input, labelled with its pod-relative path. The label
+ * is only a default for records that state no `cascade:sourceSystem`, and pod
+ * records all state one, so it never overrides what the pod says: it exists so
+ * the report can name which file a record came out of.
+ *
+ * `existingPod` is deliberately NOT set. That flag selects the import fast path,
+ * whose whole point is that stored records are candidates but never seeds, and a
+ * pod-only reconcile would then compare nothing with anything. This verb wants
+ * the ordinary path, where every record is a seed, which is exactly the
+ * comparison an import declines to make and the reason this verb exists.
+ */
+async function readPodBuckets(
+  reader: PodReader,
+): Promise<{
+  inputs: ReconcilerInput[];
+  filesRead: string[];
+  unreadable: string[];
+  ledger: PodReadLedger;
+}> {
+  const inputs: ReconcilerInput[] = [];
+  const filesRead: string[] = [];
+  const unreadable: string[] = [];
+  const ledger = new PodReadLedger();
+
+  for (const { rel } of registeredBuckets()) {
+    const abs = path.join(reader.podDir, ...rel.split('/'));
+    if (!fsSync.existsSync(abs)) continue;
+    ledger.attempt();
+
+    // Through the SHARED read door, not a local try/catch. It is the only thing
+    // that can tell a wrong key from a plaintext file inside a sealed pod: those
+    // fail GCM identically, and the raw error for both blames the passphrase,
+    // which for the second one is a lie that sends a user to re-check the one
+    // thing that is not wrong.
+    const text = reader.readText(abs);
+    if (!text.ok) {
+      ledger.record(text.failure);
+      unreadable.push(rel);
+      continue;
+    }
+    if (text.value.trim().length === 0) continue;
+
+    try {
+      await parseBySubject(text.value);
+    } catch (e: unknown) {
+      ledger.record({
+        file: rel,
+        kind: 'parse',
+        reason: tidyReason(e instanceof Error ? e.message : String(e)),
+      });
+      unreadable.push(rel);
+      continue;
+    }
+
+    inputs.push({ content: text.value, systemName: rel });
+    filesRead.push(rel);
+  }
+  return { inputs, filesRead, unreadable, ledger };
+}
+
+/**
+ * Record subjects (those carrying an `rdf:type`) in one Turtle document.
+ *
+ * The BEFORE and AFTER counts this verb reports are both taken this way, over
+ * the actual text, and that symmetry is the point.
+ *
+ * The reconciler's own `finalRecordCount` is the number of GROUPS, which counts
+ * only reconcilable records: a pod's documents, reports and profile pass through
+ * as subjects the matcher never groups, so they are absent from it. Reporting
+ * that against a subject count of the input made a pod where nothing merged read
+ * "4 records in, 3 records out" — a fabricated deletion, on the one surface
+ * whose entire job is to tell a user what a merge would cost them.
+ */
+function countRecordSubjects(turtle: string): number {
+  const subjects = new Set<string>();
+  for (const q of new Parser({ format: 'Turtle', baseIRI: relBaseFor(turtle) }).parse(turtle)) {
+    if (q.predicate.value === RDF_TYPE) subjects.add(q.subject.value);
+  }
+  return subjects.size;
+}
+
+/** The same count across every input document. */
+function countRecordsIn(inputs: ReconcilerInput[]): number {
+  const subjects = new Set<string>();
+  for (const input of inputs) {
+    for (const q of new Parser({ format: 'Turtle', baseIRI: relBaseFor(input.content) }).parse(
+      input.content,
+    )) {
+      if (q.predicate.value === RDF_TYPE) subjects.add(q.subject.value);
+    }
+  }
+  return subjects.size;
+}
+
+// ---------------------------------------------------------------------------
+
+function renderTextReport(report: ReconcileReport): string {
+  const lines: string[] = [];
+  const s = report.summary;
+  const merges = s.exactDuplicatesRemoved + s.nearDuplicatesMerged;
+
+  lines.push('');
+  lines.push(report.applied ? `Reconciled pod at ${report.podDir}` : `Dry run over pod at ${report.podDir}`);
+  lines.push(`  Read ${report.filesRead.length} record file(s), ${report.recordsBefore} record(s).`);
+  lines.push('');
+
+  if (merges === 0 && s.conflictsUnresolved === 0 && s.conflictsResolved === 0) {
+    lines.push('  No duplicates and no conflicts found. Nothing to reconcile.');
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  lines.push(report.applied ? '  Applied:' : '  Would apply:');
+  lines.push(`    ${s.exactDuplicatesRemoved} exact duplicate group(s) merged`);
+  lines.push(`    ${s.nearDuplicatesMerged} near-duplicate group(s) merged`);
+  lines.push(`    ${s.conflictsResolved} conflict(s) resolved by trust`);
+  lines.push(
+    `    ${report.recordsBefore} record(s) in, ${report.recordsAfter} record(s) out ` +
+      `(${report.recordsBefore - report.recordsAfter} fewer)`,
+  );
+  lines.push('');
+
+  if (s.tier0MergesApplied > 0) {
+    lines.push(
+      `  Of those, ${s.tier0MergesApplied} are cross-source exact lab duplicates (tier 0): identical`,
+    );
+    lines.push('  result, same instant, different known sources. These merge without asking, and each');
+    lines.push(`  one is recorded with its discarded record in ${TIER0_JOURNAL_RELATIVE_PATH}.`);
+    for (const m of report.tier0Merges) {
+      lines.push(`    ${m.matchedOn}  ${m.origins.join(' + ')}`);
+      lines.push(`      keep    ${m.canonicalUri}`);
+      for (const d of m.discarded) lines.push(`      merge   ${d.uri}`);
+    }
+    lines.push('');
+  }
+
+  const unresolved = report.groups.filter((g) => !g.resolved);
+  if (unresolved.length > 0) {
+    lines.push(`  ${unresolved.length} group(s) NOT merged, raised for review:`);
+    for (const g of unresolved) {
+      lines.push(`    ${g.recordType}  ${g.matchedOn || '(no match key)'}  [${g.type}]`);
+    }
+    lines.push(
+      report.applied
+        ? '    Run `cascade pod conflicts <pod-dir>` to see them.'
+        : '    With --apply these are written to settings/pending-conflicts.ttl.',
+    );
+    lines.push('');
+  }
+
+  if (report.filesUnreadable.length > 0) {
+    lines.push(`  ${report.filesUnreadable.length} file(s) could NOT be read and were excluded:`);
+    for (const f of report.filesUnreadable) lines.push(`    ${f}`);
+    lines.push('');
+  }
+
+  if (!report.applied) {
+    lines.push('  DRY RUN. Nothing was written.');
+    lines.push(`  Re-run with --apply to merge: cascade pod reconcile ${report.podDir} --apply`);
+    lines.push('');
+  } else {
+    lines.push(`  Wrote ${report.filesWritten.length} file(s).`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+
+export function registerReconcileSubcommand(podProgram: Command, program: Command): void {
+  podProgram
+    .command('reconcile')
+    .description(
+      'Find (and with --apply, merge) duplicates a pod ALREADY holds. Dry run by default.',
+    )
+    .argument('<pod-dir>', 'Path to the Cascade Pod directory')
+    .option(
+      '--apply',
+      'Actually merge and write. Without this the command only reports what it would do.',
+      false,
+    )
+    .option('--trust <scores>', 'Trust scores, e.g. hospital=0.95,clinic=0.85')
+    .option('--report <file>', 'Write the full report as JSON to this file')
+    .action(
+      async (
+        podDirArg: string,
+        options: { apply?: boolean; trust?: string; report?: string },
+      ) => {
+        const globalOpts = program.opts() as OutputOptions;
+        const podDir = resolvePodDir(podDirArg);
+        const apply = options.apply === true;
+
+        // "This pod has no duplicates" and "there is no pod here" are opposite
+        // answers, and a directory that does not exist reads as an empty sweep
+        // unless it is checked for. `openPod` cannot make this distinction: an
+        // unencrypted pod needs no key, so a missing directory opens fine.
+        if (!fsSync.existsSync(podDir) || !fsSync.statSync(podDir).isDirectory()) {
+          printError(`Not a pod directory: ${podDir}`, globalOpts);
+          process.exitCode = 2;
+          return;
+        }
+
+        let reader: PodReader;
+        try {
+          reader = await openPod(podDir);
+        } catch (err: unknown) {
+          printError(
+            `Could not open the pod at ${podDir}: ${err instanceof Error ? err.message : String(err)}`,
+            globalOpts,
+          );
+          process.exitCode = 2;
+          return;
+        }
+        const dek = reader.dek;
+
+        const trustScores: Record<string, number> = {};
+        for (const pair of (options.trust ?? '').split(',')) {
+          const [k, v] = pair.split('=');
+          if (k && v && !Number.isNaN(Number(v))) trustScores[k.trim()] = Number(v);
+        }
+
+        const { inputs, filesRead, unreadable, ledger } = await readPodBuckets(reader);
+
+        // A record file this run could not read is FATAL, in the dry run as much
+        // as under --apply, and that is the whole judgement of this command.
+        //
+        // Every number this verb prints is a statement about the pod's WHOLE
+        // record set: "these two are duplicates" is only true if nothing else in
+        // the pod is a third copy, and "nothing would merge" is only true if
+        // every record was compared. A file that was never opened could hold
+        // either. So a report produced over a partial read is not a smaller
+        // answer, it is a wrong one — the same reasoning `pod doctor` applies,
+        // for the same reason: a verb whose entire output is a claim about the
+        // pod must not make that claim about files it never read.
+        //
+        // The ledger's softer branch cannot fire here: it downgrades a parse
+        // failure only for a file that is NOT a registered record file, and
+        // `readPodBuckets` reads nothing else. So every read failure this verb
+        // can have is fatal, and there is no partial-answer case to print.
+        if (ledger.hasFatal) {
+          for (const f of ledger.fatal) {
+            printError(`Could not read ${f.file}: ${f.reason}`, globalOpts);
+          }
+          printError(
+            `Refusing to reconcile ${podDir}: ${ledger.fatal.length} of ${ledger.attempted} record ` +
+              `file(s) could not be read. Every count this command reports is a claim about the ` +
+              `whole pod, and those files were never opened. The pod is unchanged.`,
+            globalOpts,
+          );
+          process.exitCode = 2;
+          return;
+        }
+
+        if (inputs.length === 0) {
+          printResult(
+            globalOpts.json
+              ? {
+                  podDir,
+                  ranAt: new Date().toISOString(),
+                  applied: false,
+                  filesRead,
+                  filesUnreadable: unreadable,
+                  recordsBefore: 0,
+                  recordsAfter: 0,
+                  summary: {
+                    exactDuplicatesRemoved: 0,
+                    nearDuplicatesMerged: 0,
+                    conflictsResolved: 0,
+                    conflictsUnresolved: 0,
+                    identityCollisionsSplit: 0,
+                    tier0MergesApplied: 0,
+                  },
+                  groups: [],
+                  tier0Merges: [],
+                  filesWritten: [],
+                }
+              : `\nNo reconcilable records found in ${podDir}.\n`,
+            globalOpts,
+          );
+          return;
+        }
+
+        const recordsBefore = countRecordsIn(inputs);
+        printVerbose(`Reconciling ${recordsBefore} record(s) from ${inputs.length} file(s)...`, globalOpts);
+
+        const result = await runReconciliation(inputs, { trustScores, labTolerance: 0.05 });
+
+        const groups: ReconcileGroupReport[] = (
+          result.report.transformations as Array<{
+            type: string;
+            recordType: string;
+            canonicalUri: string;
+            matchedOn: string;
+            strategy: string;
+            resolved: boolean;
+            tier0?: boolean;
+            sources?: string[];
+          }>
+        ).map((t) => ({
+          type: t.type,
+          recordType: t.recordType,
+          canonicalUri: t.canonicalUri,
+          matchedOn: t.matchedOn,
+          strategy: t.strategy,
+          resolved: t.resolved,
+          tier0: t.tier0 === true,
+          sources: t.sources ?? [],
+        }));
+
+        const report: ReconcileReport = {
+          podDir,
+          ranAt: new Date().toISOString(),
+          applied: false,
+          filesRead,
+          filesUnreadable: unreadable,
+          recordsBefore,
+          recordsAfter: countRecordSubjects(result.turtle),
+          summary: {
+            exactDuplicatesRemoved: result.report.summary.exactDuplicatesRemoved,
+            nearDuplicatesMerged: result.report.summary.nearDuplicatesMerged,
+            conflictsResolved: result.report.summary.conflictsResolved,
+            conflictsUnresolved: result.report.summary.conflictsUnresolved,
+            identityCollisionsSplit: result.report.summary.identityCollisionsSplit,
+            tier0MergesApplied: result.report.summary.tier0MergesApplied,
+          },
+          groups,
+          tier0Merges: result.report.tier0Merges,
+          filesWritten: [],
+        };
+
+        if (apply) {
+          let subjectQuads: Map<string, Quad[]>;
+          try {
+            subjectQuads = await parseBySubject(result.turtle);
+          } catch (err: unknown) {
+            printError(
+              `Failed to parse the reconciled Turtle: ${err instanceof Error ? err.message : String(err)}. ` +
+                `The pod is unchanged.`,
+              globalOpts,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          const buckets = new Map<string, Quad[][]>();
+          for (const [, quads] of subjectQuads) {
+            const key = routeTypeKey(quads);
+            const bucket = buckets.get(key);
+            if (bucket) bucket.push(quads);
+            else buckets.set(key, [quads]);
+          }
+
+          // Every target is a REGISTERED bucket, which `readPodBuckets` already
+          // guarantees for `filesRead` and the routing table guarantees for the
+          // rest. Each is written with `combine: incoming`: the merged result is
+          // a complete replacement of the records it covers, so the file's prior
+          // content is discarded rather than added to.
+          //
+          // A bucket that was read but received nothing IS still written, and
+          // emptied. That is a file whose records all routed elsewhere, and
+          // leaving it holding its pre-merge copies would duplicate every one of
+          // them.
+          const keysByRel = new Map<string, string>();
+          for (const { key, rel } of registeredBuckets()) keysByRel.set(rel, key);
+          const targets = new Set<string>(filesRead);
+          for (const key of buckets.keys()) {
+            const info = DATA_TYPES[key];
+            if (info) targets.add(`${info.directory}/${info.filename}`);
+          }
+
+          const failed: string[] = [];
+          for (const rel of [...targets].sort()) {
+            const key = keysByRel.get(rel);
+            if (!key) continue;
+            const quads = (buckets.get(key) ?? []).flat();
+            const target = path.join(podDir, ...rel.split('/'));
+            if (quads.length === 0 && !fsSync.existsSync(target)) continue;
+            try {
+              await mergeIntoBucket(target, quads, dek, { combine: (_existing, incoming) => incoming });
+              report.filesWritten.push(rel);
+            } catch (e: unknown) {
+              printError(
+                `Refusing to write ${rel}: ${e instanceof Error ? e.message : String(e)}`,
+                globalOpts,
+              );
+              failed.push(rel);
+            }
+          }
+
+          // Conflicts this run raised go through the SAME queue every other
+          // conflict does, so `pod conflicts` and `pod resolve` see them.
+          const pendingConflicts: PendingConflict[] = (
+            result.report.unresolvedConflicts as Array<{
+              recordType: string;
+              matchedOn: string;
+              sources?: string[];
+              candidateUris?: string[];
+              label?: string;
+            }>
+          ).map((c) => ({
+            uri: `urn:uuid:conflict-${randomUUID()}`,
+            conflictId: generateConflictId(c.recordType, c.matchedOn),
+            recordType: c.recordType,
+            detectedAt: new Date(),
+            candidateRecordUris: c.candidateUris ?? [],
+            label: c.label,
+            sourceA: c.sources?.[0],
+            sourceB: c.sources?.[1],
+          }));
+          const conflictsFile = path.join(podDir, 'settings', 'pending-conflicts.ttl');
+          if (pendingConflicts.length > 0 || fsSync.existsSync(conflictsFile)) {
+            await writePendingConflicts(podDir, pendingConflicts, dek);
+          }
+
+          if (result.report.tier0Merges.length > 0) {
+            appendTier0Journal(podDir, result.report.tier0Merges, 'pod reconcile --apply', dek);
+          }
+
+          report.applied = true;
+          if (failed.length > 0) process.exitCode = 1;
+        }
+
+        if (options.report) {
+          await fs.writeFile(options.report, toJsonText(report), 'utf-8');
+        }
+
+        printResult(globalOpts.json ? report : renderTextReport(report), globalOpts);
+      },
+    );
+}

--- a/src/commands/reconcile.ts
+++ b/src/commands/reconcile.ts
@@ -33,6 +33,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import { printResult, printError, printVerbose, type OutputOptions } from '../lib/output.js';
 import { runReconciliation } from '../lib/reconciler.js';
+import { toJsonText } from '../lib/json-output.js';
 
 // ---------------------------------------------------------------------------
 // Command registration
@@ -107,7 +108,7 @@ export function registerReconcileCommand(program: Command): void {
       };
 
       if (options.report) {
-        writeFileSync(options.report, JSON.stringify(reportData, null, 2));
+        writeFileSync(options.report, toJsonText(reportData));
         console.error(`Report written to: ${options.report}`);
       }
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -35,6 +35,7 @@ import {
 import { shortenIRI } from '../lib/turtle-parser.js';
 import { isPodEncrypted, resolveDek, PodDecryptError } from '../lib/pod-encryption.js';
 import { obtainPassphrase } from '../lib/passphrase.js';
+import { toJsonText } from '../lib/json-output.js';
 
 /** ANSI color codes for terminal output */
 const colors = {
@@ -267,7 +268,7 @@ export function registerValidateCommand(program: Command): void {
       // Check if path exists
       if (!fs.existsSync(targetPath)) {
         if (globalOpts.json) {
-          console.log(JSON.stringify({ error: `Path not found: ${targetPath}` }, null, 2));
+          console.log(toJsonText({ error: `Path not found: ${targetPath}` }));
         } else {
           console.error(`${colors.red}ERROR${colors.reset}: Path not found: ${targetPath}`);
         }
@@ -288,7 +289,7 @@ export function registerValidateCommand(program: Command): void {
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         if (globalOpts.json) {
-          console.log(JSON.stringify({ error: msg }, null, 2));
+          console.log(toJsonText({ error: msg }));
         } else {
           console.error(`${colors.red}ERROR${colors.reset}: ${msg}`);
         }
@@ -308,7 +309,7 @@ export function registerValidateCommand(program: Command): void {
           const msg =
             e instanceof PodDecryptError ? e.message : e instanceof Error ? e.message : String(e);
           if (globalOpts.json) {
-            console.log(JSON.stringify({ error: `Cannot read encrypted pod: ${msg}` }, null, 2));
+            console.log(toJsonText({ error: `Cannot read encrypted pod: ${msg}` }));
           } else {
             console.error(`${colors.red}ERROR${colors.reset}: Cannot read encrypted pod: ${msg}`);
           }
@@ -325,7 +326,7 @@ export function registerValidateCommand(program: Command): void {
         filesToValidate = findTurtleFiles(targetPath);
         if (filesToValidate.length === 0) {
           if (globalOpts.json) {
-            console.log(JSON.stringify({ error: `No .ttl files found in ${targetPath}` }, null, 2));
+            console.log(toJsonText({ error: `No .ttl files found in ${targetPath}` }));
           } else {
             console.error(`${colors.yellow}WARNING${colors.reset}: No .ttl files found in ${targetPath}`);
           }
@@ -336,7 +337,7 @@ export function registerValidateCommand(program: Command): void {
       } else if (stat.isFile()) {
         if (!targetPath.endsWith('.ttl')) {
           if (globalOpts.json) {
-            console.log(JSON.stringify({ error: `Not a Turtle file: ${targetPath}` }, null, 2));
+            console.log(toJsonText({ error: `Not a Turtle file: ${targetPath}` }));
           } else {
             console.error(`${colors.red}ERROR${colors.reset}: Not a Turtle file (expected .ttl): ${targetPath}`);
           }
@@ -346,7 +347,7 @@ export function registerValidateCommand(program: Command): void {
         filesToValidate = [targetPath];
       } else {
         if (globalOpts.json) {
-          console.log(JSON.stringify({ error: `Not a file or directory: ${targetPath}` }, null, 2));
+          console.log(toJsonText({ error: `Not a file or directory: ${targetPath}` }));
         } else {
           console.error(`${colors.red}ERROR${colors.reset}: Not a file or directory: ${targetPath}`);
         }
@@ -406,7 +407,7 @@ export function registerValidateCommand(program: Command): void {
 
       // Output JSON
       if (globalOpts.json) {
-        console.log(JSON.stringify(results, null, 2));
+        console.log(toJsonText(results));
       } else {
         // Print summary for multiple files
         if (results.length > 1) {

--- a/src/lib/json-output.ts
+++ b/src/lib/json-output.ts
@@ -1,0 +1,150 @@
+/**
+ * The JSON boundary. ONE encoder, and it is a GUARANTEE rather than a
+ * passthrough.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * MEASURED on a real pod: `pod query --all --edges --json` wrote 3.7 MB to
+ * stdout, exited 0, wrote nothing to stderr, and `jq` refused to parse a byte of
+ * it. The same binary against a synthetic pod produced pure output, so the
+ * emitter looked correct and the failure looked like the user's.
+ *
+ * The cause is one code unit. Turtle admits `\uXXXX` escapes, so a pod literal
+ * can hold an UNPAIRED surrogate; nothing on the read path rejects it, and
+ * `JSON.stringify` — well-formed since ES2019 — faithfully re-emits it as the
+ * escape `\ud800`. That text round-trips through `JSON.parse` and loads in
+ * Python, and jq rejects the whole document:
+ *
+ *     jq: parse error: Invalid \uXXXX\uXXXX surrogate pair escape
+ *
+ * So "it came out of JSON.stringify" is not a guarantee that the bytes are
+ * readable by the tools this output is piped into. Two of three parsers
+ * accepting is exactly how a corrupt 3.7 MB payload looks healthy.
+ *
+ * WHY REPLACE AND NOT REJECT
+ * --------------------------
+ * A lone surrogate has NO encoding in UTF-8. It is not a character that was
+ * transported badly; it is half of one, and the other half does not exist
+ * anywhere to be recovered. There is nothing to preserve, so the only honest
+ * options are to fail the command or to substitute U+FFFD REPLACEMENT CHARACTER,
+ * which is the substitution every UTF-8 decoder in the stack would make anyway
+ * the moment these bytes were written. Failing the command would make one
+ * damaged literal cost a user their entire export, and the damage is in the pod
+ * either way — so: substitute, and let the record still be readable.
+ *
+ * WHY THE VALUE AND NOT THE TEXT
+ * ------------------------------
+ * Repairing the emitted TEXT means deciding, mid-string, whether a `\` begins an
+ * escape or is itself escaped, and getting that wrong corrupts well-formed
+ * documents. Repairing the DATA cannot make that mistake. The cost is a second
+ * encode, paid only when {@link needsRepair} says the first one produced
+ * something a parser can reject — so the ordinary case is one `JSON.stringify`
+ * and one regex test, and its output is byte-identical to what it always was.
+ *
+ * WHAT IS DELIBERATELY NOT TOUCHED
+ * --------------------------------
+ * C0 control characters (U+0000–U+001F) are already escaped by `JSON.stringify`
+ * as the escapes `\u0000` / `\n` / `\t`, which is RFC 8259 conformant and accepted
+ * parser; re-encoding them would be churn. U+007F (DEL) is not a C0 control and
+ * RFC 8259 does not require escaping it, so it is emitted raw, as it always was.
+ * Bytes that were invalid UTF-8 on the way IN have already become U+FFFD at
+ * decode time, long before this module sees them.
+ */
+
+/** Matches any surrogate code unit, paired or not. Cheap over-approximation. */
+const ANY_SURROGATE = /[\uD800-\uDFFF]/;
+
+/**
+ * Matches a `\uXXXX` escape naming a surrogate code unit, ANYWHERE in the text,
+ * including inside a sequence of escaped backslashes it does not actually begin.
+ *
+ * Over-matching is the point: this only decides whether the repair pass RUNS,
+ * and the repair pass is a no-op on data that needs none. Under-matching would
+ * ship the defect, so the test is written to be a strict superset of the
+ * condition rather than an exact one.
+ */
+const ANY_SURROGATE_ESCAPE = /\\u[dD][89abAB][0-9a-fA-F]{2}/;
+
+/**
+ * Whether encoded JSON text may contain something a conforming parser rejects.
+ *
+ * False means the text is already RFC 8259 valid and is returned untouched.
+ */
+export function needsRepair(json: string): boolean {
+  return ANY_SURROGATE_ESCAPE.test(json) || ANY_SURROGATE.test(json);
+}
+
+/**
+ * Replace every unpaired surrogate code unit in a string with U+FFFD.
+ *
+ * Well-formed pairs are copied through as pairs, so astral characters (emoji,
+ * rarer CJK, the whole SMP) survive intact — the repair must not cost a user
+ * their real characters to fix a broken one.
+ */
+export function sanitizeJsonString(s: string): string {
+  if (!ANY_SURROGATE.test(s)) return s;
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += s[i] + s[i + 1];
+        i++;
+      } else {
+        out += '�';
+      }
+      continue;
+    }
+    if (c >= 0xdc00 && c <= 0xdfff) {
+      out += '�';
+      continue;
+    }
+    out += s[i];
+  }
+  return out;
+}
+
+/**
+ * Deep-repair a JSON DATA tree: every string value and every object KEY.
+ *
+ * Keys matter as much as values and are the half a value-only sanitizer misses.
+ * `pod query --edges` keys parts of its projection on IRIs and predicate strings
+ * read straight out of the pod, so a damaged literal reaches the output as a key
+ * on exactly the surface the defect was measured on.
+ *
+ * Intended for a tree that has already been through `JSON.parse`, so the only
+ * inhabitants are string / number / boolean / null / array / plain object. Run
+ * on a live object graph it would flatten anything with a `toJSON` (a Date), and
+ * {@link toJsonText} is careful to encode FIRST for exactly that reason.
+ */
+export function sanitizeForJson(value: unknown): unknown {
+  if (typeof value === 'string') return sanitizeJsonString(value);
+  if (Array.isArray(value)) return value.map((v) => sanitizeForJson(v));
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[sanitizeJsonString(k)] = sanitizeForJson(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * THE DOOR every JSON-emitting surface goes through: encode `value` as text that
+ * is RFC 8259 valid and well-formed UTF-8.
+ *
+ * Byte-identical to `JSON.stringify(value, null, indent)` whenever that output
+ * was already valid, which is the overwhelmingly common case.
+ *
+ * Returns the empty string for input `JSON.stringify` declines to encode at all
+ * (`undefined`, a function, a symbol), rather than the literal text "undefined",
+ * which is not JSON and is what a `--json` consumer would otherwise be handed.
+ */
+export function toJsonText(value: unknown, indent: number = 2): string {
+  const first = JSON.stringify(value, null, indent);
+  if (first === undefined) return '';
+  if (!needsRepair(first)) return first;
+  return JSON.stringify(sanitizeForJson(JSON.parse(first)), null, indent);
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -2,8 +2,14 @@
  * Output formatting utilities for consistent CLI output.
  *
  * Supports both human-readable text and machine-readable JSON output modes.
+ *
+ * Every JSON encode here goes through {@link toJsonText} rather than
+ * `JSON.stringify`, because a pod literal can hold an unpaired surrogate and
+ * `JSON.stringify` re-emits it as an escape that jq rejects and the whole
+ * document with it. See `lib/json-output.ts` for the measurement.
  */
 
+import { toJsonText } from './json-output.js';
 
 export interface OutputOptions {
   json: boolean;
@@ -15,7 +21,7 @@ export interface OutputOptions {
  */
 export function formatOutput(data: unknown, opts: OutputOptions): string {
   if (opts.json) {
-    return JSON.stringify(data, null, 2);
+    return toJsonText(data);
   }
 
   if (typeof data === 'string') {
@@ -62,7 +68,7 @@ export function printResult(data: unknown, opts: OutputOptions): void {
  */
 export function printError(message: string, opts: OutputOptions): void {
   if (opts.json) {
-    console.error(JSON.stringify({ error: message }));
+    console.error(toJsonText({ error: message }, 0));
   } else {
     console.error(`ERROR: ${message}`);
   }
@@ -83,7 +89,7 @@ export function printErrorDetail(
   opts: OutputOptions,
 ): void {
   if (opts.json) {
-    console.error(JSON.stringify({ error: message, ...detail }));
+    console.error(toJsonText({ error: message, ...detail }, 0));
   } else {
     console.error(`ERROR: ${message}`);
   }
@@ -98,7 +104,7 @@ export function printErrorDetail(
  */
 export function printWarning(message: string, opts: OutputOptions): void {
   if (opts.json) {
-    console.error(JSON.stringify({ warning: message }));
+    console.error(toJsonText({ warning: message }, 0));
   } else {
     console.error(`WARNING: ${message}`);
   }
@@ -110,7 +116,7 @@ export function printWarning(message: string, opts: OutputOptions): void {
 export function printVerbose(message: string, opts: OutputOptions): void {
   if (opts.verbose) {
     if (opts.json) {
-      console.error(JSON.stringify({ debug: message }));
+      console.error(toJsonText({ debug: message }, 0));
     } else {
       console.error(`[verbose] ${message}`);
     }

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -72,6 +72,41 @@ export interface ReconcilerInput {
   existingPod?: boolean;
 }
 
+/**
+ * One record as it stood BEFORE a tier-0 merge discarded it: everything needed
+ * to put it back.
+ *
+ * Content-complete on purpose. A tier-0 merge is defined over records whose
+ * content is identical, so in principle the survivor IS the restoration and only
+ * the IRI and the provenance axis would need keeping. That reasoning is correct
+ * and it is not what gets written, because it is only correct as long as the
+ * tier-0 predicate is exactly what it is today. An undo that depends on the
+ * merge rule having been right is not an undo.
+ */
+export interface Tier0DiscardedRecord {
+  uri: string;
+  type: string;
+  /** INGESTION axis at the time of the merge. */
+  sourceSystem: string;
+  /** ORIGIN axis. Always a known (`org:` / `ns:`) value: tier 0 requires it. */
+  sourceIdentity?: string;
+  /** Every property the record carried, verbatim, keyed by predicate IRI. */
+  properties: Record<string, Array<{ value: string; datatype?: string; isIri?: boolean }>>;
+}
+
+/** One applied tier-0 merge, as the audit journal records it. */
+export interface Tier0Merge {
+  /** The record that survived and now stands for all of them. */
+  canonicalUri: string;
+  recordType: string;
+  /** What made them one record, e.g. `loinc:2951-2@2031-05-20T09:14:00Z`. */
+  matchedOn: string;
+  /** The distinct known origins that contributed. Always two or more. */
+  origins: string[];
+  /** Everything merged away, restorable. */
+  discarded: Tier0DiscardedRecord[];
+}
+
 export interface ReconcilerResult {
   turtle: string;
   report: {
@@ -110,6 +145,17 @@ export interface ReconcilerResult {
        */
       identityCollisionsSplit: number;
       finalRecordCount: number;
+      /**
+       * Of the merges above, how many met the TIER 0 predicate: cross-source
+       * exact lab duplication. A subset of `exactDuplicatesRemoved`, never
+       * disjoint from it — the same merge counted twice, once as a merge and
+       * once as the narrow, audited class of merge it belongs to.
+       *
+       * Every one of these is itemized in `report.tier0Merges` with the IRIs and
+       * the discarded content, which is what makes the class reversible rather
+       * than merely counted.
+       */
+      tier0MergesApplied: number;
       /** Subjects preserved verbatim because their type is not reconcilable. */
       passthroughSubjects: number;
       /**
@@ -122,6 +168,11 @@ export interface ReconcilerResult {
     };
     transformations: object[];
     unresolvedConflicts: object[];
+    /**
+     * Every tier-0 merge this run applied, itemized. Empty on a run that applied
+     * none, which is the ordinary case.
+     */
+    tier0Merges: Tier0Merge[];
   };
 }
 
@@ -616,10 +667,11 @@ function normalizeEdgeValue(
 export function recordContentFingerprint(
   r: ParsedRecord,
   resolveRef?: (raw: string) => string | null,
+  ignored: ReadonlySet<string> = COLLISION_IGNORED_PREDICATES,
 ): string {
   const parts: string[] = [];
   for (const [pred, vals] of r.properties) {
-    if (COLLISION_IGNORED_PREDICATES.has(pred)) continue;
+    if (ignored.has(pred)) continue;
     for (const v of vals) {
       const value = normalizeEdgeValue(v.value, resolveRef);
       if (value === undefined) continue;  // an unresolvable edge is never persisted
@@ -1251,6 +1303,178 @@ function classifyGroup(
 }
 
 // ---------------------------------------------------------------------------
+// Tier 0: the one duplicate class that is safe to merge with nobody watching
+// ---------------------------------------------------------------------------
+//
+// THE RULING
+// ----------
+// Cross-source EXACT lab duplication merges silently rather than raising a
+// question. Two organizations reporting one draw is the single most common thing
+// a multi-source pod contains, and asking a person to confirm each one is not
+// caution — it is a queue nobody finishes, which is how the genuinely
+// disagreeing pairs (the ones a conflict queue exists for) end up buried among
+// hundreds of identical ones.
+//
+// The class is drawn NARROWLY on purpose, and every clause below is doing work:
+//
+//   SAME LOINC        the two records are answering the same question.
+//   SAME INSTANT      and not the same DAY. Day-level is what the ordinary lab
+//                     matcher uses, and it is right to: a same-day repeat draw is
+//                     a real second measurement, and merging it destroys data.
+//                     Tier 0 will not take that risk, so a record whose date
+//                     carries no time of day is not eligible at all.
+//   IDENTICAL CONTENT byte-equal on every predicate that is not provenance
+//                     bookkeeping. Not "within tolerance" — a tolerance is a
+//                     judgement, and a judgement is what tier 0 is not allowed to
+//                     make. Anything that differs by any amount stays a
+//                     near-duplicate and is reported.
+//   DIFFERENT KNOWN   both records must state an ORIGIN, both origins must name
+//   ORIGINS           a real organization (`org:` / `ns:`), and they must differ.
+//                     This is the clause that makes the class safe: one source
+//                     does not restate one result twice inside one export, so two
+//                     identical results from two ORGANIZATIONS is a re-sync,
+//                     while two from ONE source may be two real measurements.
+//                     `transport:` and absent origins are UNKNOWN, not different,
+//                     and are excluded — the conservative fallback stays exactly
+//                     as it was for every pod written before origins existed.
+//
+// Measured over 144 candidate groups at a 22% duplicate base rate: zero false
+// positives.
+//
+// WHAT SILENT DOES NOT MEAN
+// -------------------------
+// It does not mean unrecorded. Every tier-0 merge is itemized in the run report
+// and journaled into the pod with the discarded records' full content, so the
+// class is auditable after the fact and reversible without the originals. Silent
+// is about not INTERRUPTING, not about not TELLING.
+
+/** True when a date literal states a time of day, not just a day. */
+function statesTimeOfDay(value: string | undefined): boolean {
+  return typeof value === 'string' && /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value);
+}
+
+/**
+ * What "identical content" means for tier 0: everything
+ * {@link COLLISION_IGNORED_PREDICATES} already treats as bookkeeping, plus the
+ * provenance CLASS.
+ *
+ * `clinical:provenanceClass` says how a copy REACHED the pod — a direct FHIR
+ * pull, a pharmacy claim, a user's own entry. Two organizations reporting one
+ * draw differ on it as a matter of course, and that difference is the very thing
+ * the tier-0 clause about different origins is already reading. Counting it as
+ * content too would mean the class almost never applies where it is most needed
+ * (the cross-provenance guard, which flags exactly this difference), leaving the
+ * exemption above true in principle and dead in practice.
+ *
+ * It is added HERE and not to `COLLISION_IGNORED_PREDICATES`, which answers a
+ * different question — whether two records that claim one IRI are materially
+ * different — and whose membership changes identity-collision splitting for
+ * every record type. The two sets agreeing on most of their contents is not a
+ * reason to make them one set.
+ */
+const TIER0_IGNORED_PREDICATES: ReadonlySet<string> = new Set<string>([
+  ...COLLISION_IGNORED_PREDICATES,
+  NS.clinical + 'provenanceClass',
+]);
+
+/**
+ * Whether a whole matched group is tier 0.
+ *
+ * Group-level rather than pair-level because a group is what gets merged: a
+ * third record joining two tier-0 twins is a third organization's copy only if
+ * IT also satisfies every clause, and if it does not, the whole group leaves the
+ * class. Requiring the property of every member is what stops one qualifying
+ * pair from carrying an unqualified record along with it.
+ */
+/*
+ * THREE OF THE CLAUSES BELOW ARE REDUNDANT TODAY, AND ARE KEPT ON PURPOSE.
+ *
+ * Measured by mutation: deleting the lab-only check, the same-LOINC check, or
+ * the same-instant EQUALITY check each leaves the whole suite green, because
+ * each is implied by something else in the function as it currently stands.
+ *
+ *   lab-only        a non-lab record carries no `health:testCode`, so the
+ *                   next clause already rejects it.
+ *   same LOINC      the content fingerprint covers `health:testCode`, so two
+ *   same instant    records with equal fingerprints already agree on both.
+ *   (equality)
+ *
+ * They are written out anyway because each is a separate clause of the ruling
+ * and the redundancy is CONTINGENT, not structural: it holds only while
+ * {@link TIER0_IGNORED_PREDICATES} contains neither predicate. Adding
+ * `health:testCode` or `health:performedDate` to that set, which is an ordinary
+ * one-line change someone could make for a defensible reason, would silently
+ * widen the class to merge different tests or different draws. A clause that
+ * states its own condition cannot be undone that way.
+ *
+ * `statesTimeOfDay` is NOT in this list. It is about the FORM of the value
+ * rather than the equality of two values, nothing else implies it, and dropping
+ * it goes red.
+ */
+function isTier0Group(records: ParsedRecord[], fingerprint: (r: ParsedRecord) => string): boolean {
+  if (records.length < 2) return false;
+  const origins = new Set<string>();
+  let sharedCode: string | undefined;
+  let sharedInstant: string | undefined;
+  let sharedFingerprint: string | undefined;
+
+  for (const r of records) {
+    if (r.type !== 'health:LabResultRecord') return false;
+
+    const code = getProp(r, NS.health + 'testCode');
+    if (!code) return false;
+    const bare = codeFromUri(code);
+    if (sharedCode === undefined) sharedCode = bare;
+    else if (sharedCode !== bare) return false;
+
+    const performed = getProp(r, NS.health + 'performedDate');
+    if (!statesTimeOfDay(performed)) return false;
+    if (sharedInstant === undefined) sharedInstant = performed;
+    else if (sharedInstant !== performed) return false;
+
+    if (!isKnownOrigin(r.sourceIdentity)) return false;
+    origins.add(r.sourceIdentity as string);
+
+    const fp = fingerprint(r);
+    if (sharedFingerprint === undefined) sharedFingerprint = fp;
+    else if (sharedFingerprint !== fp) return false;
+  }
+
+  // EVERY origin distinct, which is the different-origins clause. Stated once,
+  // here, rather than also as an early return inside the loop: a duplicate
+  // origin is exactly a set smaller than the record count, so the two spellings
+  // were the same test written twice and the early one could be deleted with no
+  // test noticing.
+  return origins.size === records.length;
+}
+
+/** The audit record for one applied tier-0 merge. */
+function describeTier0Merge(g: Group, res: Resolution): Tier0Merge {
+  const code = getProp(g.records[0], NS.health + 'testCode');
+  const instant = getProp(g.records[0], NS.health + 'performedDate') ?? '';
+  return {
+    canonicalUri: res.canonical.uri,
+    recordType: g.records[0].type,
+    matchedOn: `loinc:${code ? codeFromUri(code) : '(none)'}@${instant}`,
+    origins: g.records.map((r) => r.sourceIdentity as string).sort(),
+    discarded: g.records
+      .filter((r) => r.uri !== res.canonical.uri)
+      .map((r) => ({
+        uri: r.uri,
+        type: r.type,
+        sourceSystem: r.sourceSystem,
+        sourceIdentity: r.sourceIdentity,
+        properties: Object.fromEntries(
+          [...r.properties].map(([pred, vals]) => [
+            pred,
+            vals.map((v) => ({ value: v.value, datatype: v.datatype, isIri: v.isIri })),
+          ]),
+        ),
+      })),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Resolution
 // ---------------------------------------------------------------------------
 
@@ -1261,6 +1485,8 @@ interface Group {
   matchedOn: string;
   conflictField?: string;
   conflictValues?: Record<string, string>;
+  /** True when every member satisfies the tier-0 predicate. See {@link isTier0Group}. */
+  tier0?: boolean;
 }
 
 interface Resolution {
@@ -1348,7 +1574,18 @@ function resolveGroup(
   // more than one provenance class, flag for review instead of silently merging
   // across provenance. Only affects the merge match types; existing conflicts
   // already flag.
-  if (!allowCrossProvenanceMerge && (g.matchType === 'near_duplicate' || g.matchType === 'exact_duplicate')) {
+  //
+  // TIER 0 IS EXEMPT, and this is the clause where the ruling has teeth. The
+  // guard's question is "could these two be different things?", and for a tier-0
+  // group that question is already answered by construction: same LOINC, same
+  // INSTANT, byte-identical content, two different named organizations. A
+  // provenance class differing across them describes how each copy reached the
+  // pod, which is exactly what two organizations reporting one draw looks like —
+  // so under this guard every cross-source duplicate, the commonest and most
+  // benign thing a multi-source pod holds, became a question. Exempting the
+  // class is the difference between a queue a person finishes and one they
+  // abandon with the real disagreements still in it.
+  if (!allowCrossProvenanceMerge && !g.tier0 && (g.matchType === 'near_duplicate' || g.matchType === 'exact_duplicate')) {
     const provenanceClasses = new Set(
       g.records.map(r => getProp(r, NS.clinical + 'provenanceClass')).filter((v): v is string => !!v),
     );
@@ -1767,15 +2004,57 @@ export async function runReconciliation(
     const existingUris = new Set(existingRecords.map(r => r.uri));
     const newRecords = allRecords.filter(r => !r.fromExistingPod && !existingUris.has(r.uri));
 
-    // Build a type index over existing records only
-    const existingIndex = new Map<string, ParsedRecord[]>();
-    for (const r of existingRecords) {
-      const bucket = existingIndex.get(r.type);
+    // THE PASS ORDERING. ONE pass, seeded by new records, over candidates drawn
+    // from BOTH pools.
+    //
+    // WHAT WAS HERE, AND WHY IT COULD NOT BE PATCHED
+    // ---------------------------------------------
+    // Two passes ran in sequence: a cross-batch pass (each new record against
+    // existing records) and then a within-batch pass (new against new). The
+    // first one called `assigned.add(a.uri)` on EVERY new record, matched or
+    // not, so by the time the second pass ran there was no unassigned new record
+    // left for it to seed from. The second pass and its same-source guard site
+    // were unreachable — structurally dead code, not a rare path — and the
+    // consequence was that a batch's own internal duplicates imported
+    // un-reconciled whenever the pod had any content at all, which is every
+    // import after the first. The single-batch path merged the very same pair:
+    // measured 3 records against 1 on identical inputs.
+    //
+    // Two smaller repairs were considered and rejected, because each fixes the
+    // symptom and leaves a different pair un-merged:
+    //
+    //   DEFER ASSIGNMENT (only assign new records that actually matched) lets
+    //   the within-batch pass see the leftovers, but a new record that DID match
+    //   an existing one is still assigned, so it can no longer absorb its own
+    //   in-batch twin. Pod {gamma}, batch {alpha, beta} where all three are one
+    //   result: alpha+gamma merge, beta is left over, 2 records where 1 is right.
+    //
+    //   WITHIN-BATCH FIRST inverts the same problem. alpha+beta merge, then both
+    //   are assigned, so neither is ever compared against gamma. Again 2.
+    //
+    // Both are guard patches on an ordering that should not exist. A record's
+    // membership in a group is one question, and asking it in two half-passes
+    // over two disjoint candidate pools cannot answer it. So the two passes
+    // become ONE, with the candidate list being the union of the pools, which
+    // makes this path the SAME algorithm the single-batch path below runs — the
+    // whole reason the two disagreed.
+    //
+    // WHAT STAYS DELIBERATELY RESTRICTED
+    // ----------------------------------
+    // Only new records SEED a group. An existing record is a candidate but never
+    // a seed, so two records already in the pod are still never compared with
+    // each other. That restriction is not an oversight to be fixed here: pod
+    // content is reconciled by `pod reconcile`, a mutation a person asks for and
+    // sees a report from first, not as an invisible side effect of importing an
+    // unrelated file. Import remains additive with respect to what the pod
+    // already holds.
+    const candidateIndex = new Map<string, ParsedRecord[]>();
+    for (const r of [...newRecords, ...existingRecords]) {
+      const bucket = candidateIndex.get(r.type);
       if (bucket) bucket.push(r);
-      else existingIndex.set(r.type, [r]);
+      else candidateIndex.set(r.type, [r]);
     }
 
-    // Cross-batch pass: match each new record against same-type existing records
     for (const a of newRecords) {
       if (assigned.has(a.uri)) continue;
       if (a.type === 'coverage:InsurancePlan') {
@@ -1788,45 +2067,22 @@ export async function runReconciliation(
       let matchedOn = '';
       let bestConf = 1.0;
 
-      const candidates = existingIndex.get(a.type) ?? [];
+      const candidates = candidateIndex.get(a.type) ?? [];
       for (const b of candidates) {
-        if (assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
-        const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
-        const threshold = getMatchThreshold(a, b);
-        if (match && confidence >= threshold) {
-          matched.push(b);
-          assigned.add(b.uri);
-          if (!matchedOn) { matchedOn = mo; bestConf = confidence; }
-        }
-      }
-      assigned.add(a.uri);
-
-      if (matched.length === 1) {
-        groups.push({ matchType: 'pass_through', confidence: 1.0, records: matched, matchedOn: '' });
-      } else {
-        const { matchType, conflictField, conflictValues } = classifyGroup(matched, labTol, resolver);
-        groups.push({ matchType, confidence: bestConf, records: matched, matchedOn, conflictField, conflictValues });
-      }
-    }
-
-    // Within-batch pass: pairwise loop over newRecords only (existing-pod records
-    // that are the same organization's same ingestion never match each other; see
-    // sameSourceStatement)
-    for (let i = 0; i < newRecords.length; i++) {
-      const a = newRecords[i];
-      if (assigned.has(a.uri)) continue;
-      if (a.type === 'coverage:InsurancePlan') {
-        // Already handled above; skip if already assigned
-        continue;
-      }
-
-      const matched: ParsedRecord[] = [a];
-      let matchedOn = '';
-      let bestConf = 1.0;
-
-      for (let j = i + 1; j < newRecords.length; j++) {
-        const b = newRecords[j];
-        if (assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
+        // `b === a` is new here, because the seed is now in its own candidate
+        // list and a record matched against itself would form a merge group of
+        // one record with itself: same count out, but the survivor restated as
+        // the winner of a merge that never happened, with `mergedFrom` pointing
+        // at itself.
+        //
+        // It is also, measured, REDUNDANT: `sameSourceStatement(a, a)` is
+        // unconditionally true (one record trivially shares its own ingestion
+        // label and its own origin), so the next clause already rejects the
+        // self-pair and deleting this one leaves the suite green. Kept because
+        // it is the direct statement of the condition, it matches the
+        // single-batch loop below, and it does not depend on a guard about
+        // SOURCES happening to also exclude identity.
+        if (b === a || assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -1912,9 +2168,47 @@ export async function runReconciliation(
   for (const g of groups) for (const r of g.records) groupedRecords.add(r);
   const duplicateSubjectsDropped = allRecords.length - groupedRecords.size;
 
+  // Tier-0 classification, BEFORE resolution, because resolveGroup reads it.
+  // The fingerprint is memoized: it is a SHA-256 over the record's whole property
+  // set and a group asks for it once per member.
+  const fingerprintCache = new Map<ParsedRecord, string>();
+  const fingerprintOf = (r: ParsedRecord): string => {
+    let fp = fingerprintCache.get(r);
+    if (fp === undefined) {
+      fp = recordContentFingerprint(r, referenceResolver, TIER0_IGNORED_PREDICATES);
+      fingerprintCache.set(r, fp);
+    }
+    return fp;
+  };
+  for (const g of groups) {
+    if (g.matchType === 'pass_through') continue;
+    g.tier0 = isTier0Group(g.records, fingerprintOf);
+  }
+
   // Resolve
   const allowCrossProvenanceMerge = options?.allowCrossProvenanceMerge ?? true;
   const resolutions = groups.map(g => resolveGroup(g, trustScores, defaultTrust, allowCrossProvenanceMerge));
+
+  // The tier-0 journal: what merged, what it merged away, and enough of the
+  // discarded records to put them back.
+  //
+  // `resolved` is checked and is UNREACHABLE TODAY, deliberately. A tier-0 group
+  // is a set of byte-identical lab records, so `classifyGroup` always calls it an
+  // exact duplicate, and the only rule that could have left an exact duplicate
+  // unresolved is the cross-provenance guard, which tier 0 is now exempt from.
+  // So no group can currently reach here with `resolved === false`, and deleting
+  // the check would pass every test. It stays because of what this list MEANS:
+  // an entry is the claim "these records were merged away, and here is what they
+  // held". A future match type that leaves a tier-0 group for review would, with
+  // the check gone, journal records that are still in the pod, and the journal
+  // would start describing merges that never happened. That is a worse failure
+  // than a redundant condition.
+  const tier0Merges: Tier0Merge[] = [];
+  for (let i = 0; i < groups.length; i++) {
+    const g = groups[i];
+    if (!g.tier0 || !resolutions[i].resolved || g.records.length < 2) continue;
+    tier0Merges.push(describeTier0Merge(g, resolutions[i]));
+  }
 
   // Edge re-dangling repair: map every subject discarded
   // in a merge to its survivor, then rewrite matching edge objects at serialization.
@@ -1944,6 +2238,10 @@ export async function runReconciliation(
       conflictValues: g.conflictValues,
       resolved: res.resolved,
       documentType: getProp(g.records[0], NS.cascade + 'documentType'),
+      // Only stated when true, so every existing consumer of this object and
+      // every recorded fixture of it is byte-unchanged on a run with no tier-0
+      // merge, which is the ordinary run.
+      ...(g.tier0 ? { tier0: true } : {}),
     };
 
     if (!res.resolved && (g.matchType === 'exact_duplicate' || g.matchType === 'near_duplicate')) {
@@ -2000,11 +2298,13 @@ export async function runReconciliation(
         conflictsUnresolved: unresolved,
         identityCollisionsSplit: identityCollisions.length,
         finalRecordCount: groups.length,
+        tier0MergesApplied: tier0Merges.length,
         passthroughSubjects: passthroughSubjectKeys.size,
         edgeObjectsRewritten,
       },
       transformations,
       unresolvedConflicts: unresolvedList,
+      tier0Merges,
     },
   };
 }

--- a/src/lib/tier0-journal.ts
+++ b/src/lib/tier0-journal.ts
@@ -1,0 +1,136 @@
+/**
+ * The tier-0 audit journal: what a silent merge is allowed to be silent ABOUT.
+ *
+ * The tier-0 ruling (see `lib/reconciler.ts`) lets one narrow class of duplicate
+ * merge without asking anyone: cross-source EXACT lab duplication. That is a
+ * deliberate loss of a question, and it is only defensible if the merge is still
+ * a fact the pod holds afterwards. So "silent" is scoped precisely:
+ *
+ *   NOT INTERRUPTING   no conflict is queued, no prompt is raised, the import or
+ *                      the reconcile completes.
+ *   STILL RECORDED     every merge is appended here with its canonical IRI, the
+ *                      IRIs it absorbed, the origins involved, and the FULL
+ *                      content of every record it discarded.
+ *
+ * The second half is what makes the first half a decision rather than a data
+ * loss. A person who disagrees with the ruling, or with one application of it,
+ * can find every merge it ever made and reconstruct exactly what was there.
+ *
+ * WHY JSON AND NOT TURTLE
+ * -----------------------
+ * Because this is not a claim about the patient. A pod's Turtle says what is
+ * true of a person's health; a journal says what this tool did to the pod, which
+ * is bookkeeping about the store and does not belong in the clinical graph.
+ * Writing it as Turtle would also mean minting vocabulary to describe it, and
+ * vocabulary is authored in `spec/` and synced here — inventing terms locally to
+ * describe a local operation is how unvalidatable predicates end up in pods.
+ *
+ * It goes through the pod's resource layer, so on an encrypted pod the journal
+ * is ciphertext like everything else under `settings/`: it holds record content
+ * by design, and content that was worth encrypting in the bucket is worth
+ * encrypting here.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readResource, writeResource } from './pod-encryption.js';
+import { toJsonText } from './json-output.js';
+import type { Tier0Merge } from './reconciler.js';
+
+/** Pod-relative location of the journal. */
+export const TIER0_JOURNAL_RELATIVE_PATH = 'settings/tier0-merge-journal.json';
+
+/** One appended entry: a run, and the merges it applied. */
+export interface Tier0JournalEntry {
+  /** When the run that applied these merges completed. */
+  appliedAt: string;
+  /** Which verb applied them, e.g. `pod import` or `pod reconcile --apply`. */
+  appliedBy: string;
+  /** The ruling this entry was written under, so a later reader can tell. */
+  rule: 'tier-0-cross-source-exact-lab-duplicate';
+  merges: Tier0Merge[];
+}
+
+export interface Tier0Journal {
+  entries: Tier0JournalEntry[];
+}
+
+function journalPath(podDir: string): string {
+  return path.join(podDir, ...TIER0_JOURNAL_RELATIVE_PATH.split('/'));
+}
+
+/**
+ * Read the journal. A pod that has never had a tier-0 merge has no journal, and
+ * that is an empty journal, not an error.
+ *
+ * A journal that EXISTS and cannot be read is a different thing and throws:
+ * "there were no silent merges" and "I cannot tell you what was merged away" are
+ * opposite answers and must not share one.
+ */
+export function readTier0Journal(podDir: string, dek?: Buffer): Tier0Journal {
+  const p = journalPath(podDir);
+  if (!fs.existsSync(p)) return { entries: [] };
+  const raw = readResource(p, dek);
+  const parsed = JSON.parse(raw) as Partial<Tier0Journal>;
+  return { entries: Array.isArray(parsed.entries) ? parsed.entries : [] };
+}
+
+/**
+ * Append one run's tier-0 merges. A no-op when there are none, so an ordinary
+ * import never creates the file.
+ *
+ * Returns the number of merges appended.
+ */
+export function appendTier0Journal(
+  podDir: string,
+  merges: Tier0Merge[],
+  appliedBy: string,
+  dek?: Buffer,
+): number {
+  if (merges.length === 0) return 0;
+  const existing = readTier0Journal(podDir, dek);
+  const entry: Tier0JournalEntry = {
+    appliedAt: new Date().toISOString(),
+    appliedBy,
+    rule: 'tier-0-cross-source-exact-lab-duplicate',
+    merges,
+  };
+  const p = journalPath(podDir);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  writeResource(p, toJsonText({ entries: [...existing.entries, entry] }), dek);
+  return merges.length;
+}
+
+/**
+ * Every record any tier-0 merge ever discarded, newest run last.
+ *
+ * This is the reversibility surface: a caller that wants to undo reads these and
+ * has the complete pre-merge records without needing the pod's history, the
+ * original import files, or the tier-0 rule to have been right.
+ */
+export function tier0DiscardedRecords(journal: Tier0Journal): Array<{
+  runAppliedAt: string;
+  canonicalUri: string;
+  discardedUri: string;
+  properties: Record<string, Array<{ value: string; datatype?: string; isIri?: boolean }>>;
+}> {
+  const out: Array<{
+    runAppliedAt: string;
+    canonicalUri: string;
+    discardedUri: string;
+    properties: Record<string, Array<{ value: string; datatype?: string; isIri?: boolean }>>;
+  }> = [];
+  for (const entry of journal.entries) {
+    for (const merge of entry.merges) {
+      for (const d of merge.discarded) {
+        out.push({
+          runAppliedAt: entry.appliedAt,
+          canonicalUri: merge.canonicalUri,
+          discardedUri: d.uri,
+          properties: d.properties,
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/tests/identity-chokepoint.test.ts
+++ b/tests/identity-chokepoint.test.ts
@@ -117,6 +117,13 @@ const EVENT_IDENTITY_ALLOWLIST: ReadonlyArray<{ file: string; why: string }> = [
     why: 'The user-resolution record URI: one per decision a person made, stamped with resolvedAt.',
   },
   {
+    file: 'commands/pod/reconcile.ts',
+    why:
+      'The pending-conflict record URI, for the same reason as commands/pod/import.ts: the ' +
+      'conflict is deduped on the DETERMINISTIC generateConflictId(recordType, matchedOn), and ' +
+      'the urn identifies one detection event. Reconciling twice detects the same conflict twice.',
+  },
+  {
     file: 'lib/advisory/applier.ts',
     why:
       'PROV activity IRIs for one advisory application. A prov:Activity is an occurrence by ' +

--- a/tests/json-output-purity.test.ts
+++ b/tests/json-output-purity.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The JSON boundary is a GUARANTEE, not a passthrough.
+ *
+ * MEASURED, on a real pod: `pod query --all --edges --json` wrote 3.7 MB to
+ * stdout, exited 0, wrote nothing to stderr, and `jq` refused to parse a byte of
+ * it. A synthetic pod through the same binary was pure, so the emitter looked
+ * fine and the defect looked like the user's.
+ *
+ * The cause is one code unit. Turtle admits `\uXXXX` escapes, so a pod literal
+ * may hold an UNPAIRED surrogate; nothing on the read path rejects it, and
+ * `JSON.stringify` (well-formed, ES2019) faithfully re-emits it as the escape
+ * `\ud800`. That text is accepted by `JSON.parse` and by Python's `json`, and
+ * REJECTED by jq:
+ *
+ *     jq: parse error: Invalid \uXXXX\uXXXX surrogate pair escape
+ *
+ * So "we round-tripped it through JSON.stringify" is not a guarantee that the
+ * bytes are readable by the tools people actually pipe this into. The guarantee
+ * has to be stated and tested against those tools, which is what this file is:
+ * every JSON-emitting surface, over a fixture built to contain every hostile
+ * class we know of, checked with jq AND python AND JSON.parse. One parser
+ * accepting is not the bar; a lone surrogate passes two of the three.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { toJsonText, sanitizeForJson } from '../src/lib/json-output.js';
+import { formatOutput } from '../src/lib/output.js';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+
+/** Run one CLI invocation in-process, capturing stdout and the exit code. */
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+
+  const chunks: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    chunks.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: chunks.join('\n'), exitCode };
+}
+
+// ---------------------------------------------------------------------------
+// The hostile fixture
+// ---------------------------------------------------------------------------
+
+const LONE_HIGH = String.fromCharCode(0xd800);
+const LONE_LOW = String.fromCharCode(0xdfff);
+/** A low surrogate BEFORE a high one: two code units, no valid pair. */
+const REVERSED_PAIR = String.fromCharCode(0xdfff) + String.fromCharCode(0xd800);
+/** A well-formed pair (U+1F9EC, DNA). Must survive intact. */
+const VALID_PAIR = '\u{1F9EC}';
+/** C0 controls, plus DEL, which is not C0 and is emitted raw. */
+const CONTROLS = 'a' + String.fromCharCode(0x00, 0x01, 0x1f) + 'b' + String.fromCharCode(0x7f) + 'c';
+/** What invalid UTF-8 input bytes become once Node decodes them as utf-8. */
+const DECODED_INVALID_UTF8 = Buffer.from([0xff, 0xfe, 0x80, 0x41]).toString('utf-8');
+
+/** Every hostile class in one value, including in an object KEY. */
+function hostileFixture(): unknown {
+  return {
+    records: [
+      { iri: 'urn:uuid:a', value: `lab result ${LONE_HIGH} truncated` },
+      { iri: 'urn:uuid:b', value: `${LONE_LOW}${REVERSED_PAIR}` },
+      { iri: 'urn:uuid:c', value: CONTROLS },
+      { iri: 'urn:uuid:d', value: DECODED_INVALID_UTF8 },
+      { iri: 'urn:uuid:e', value: `keep ${VALID_PAIR} intact` },
+    ],
+    // A hostile OBJECT KEY. A value-only sanitizer misses this entirely.
+    [`edge${LONE_HIGH}key`]: ['urn:uuid:a'],
+    counts: { total: 5, nested: { deep: [{ s: LONE_HIGH }] } },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The three parsers
+// ---------------------------------------------------------------------------
+
+const tmp = mkdtempSync(join(tmpdir(), 'cascade-json-purity-'));
+let fixtureSeq = 0;
+
+/** Write `text` to a file and return its path (each call gets a fresh path). */
+function toFile(text: string): string {
+  const p = join(tmp, `payload-${fixtureSeq++}.json`);
+  writeFileSync(p, text, 'utf-8');
+  return p;
+}
+
+function jqAccepts(text: string): { ok: boolean; detail: string } {
+  try {
+    execFileSync('jq', ['-e', '.', toFile(text)], { stdio: ['ignore', 'ignore', 'pipe'] });
+    return { ok: true, detail: '' };
+  } catch (e: unknown) {
+    const err = e as { stderr?: Buffer; status?: number };
+    // `jq -e .` exits 1 for a valid document whose result is null/false. That is
+    // not a parse failure, and this fixture is an object, so treat only a real
+    // error as a rejection.
+    return { ok: false, detail: err.stderr?.toString() ?? String(e) };
+  }
+}
+
+function pythonAccepts(text: string): { ok: boolean; detail: string } {
+  try {
+    execFileSync('python3', ['-c', 'import json,sys; json.load(open(sys.argv[1]))', toFile(text)], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    return { ok: true, detail: '' };
+  } catch (e: unknown) {
+    const err = e as { stderr?: Buffer };
+    return { ok: false, detail: err.stderr?.toString() ?? String(e) };
+  }
+}
+
+function jsonParseAccepts(text: string): { ok: boolean; detail: string } {
+  try {
+    JSON.parse(text);
+    return { ok: true, detail: '' };
+  } catch (e: unknown) {
+    return { ok: false, detail: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** All three, as one assertion, so a single-parser pass cannot look like a pass. */
+function assertEveryParserAccepts(text: string, what: string): void {
+  const jq = jqAccepts(text);
+  const py = pythonAccepts(text);
+  const js = jsonParseAccepts(text);
+  expect(
+    { jq: jq.ok, python: py.ok, jsonParse: js.ok },
+    `${what} was not accepted by every JSON parser.\n` +
+      `  jq:         ${jq.ok ? 'ok' : jq.detail.trim()}\n` +
+      `  python3:    ${py.ok ? 'ok' : py.detail.trim()}\n` +
+      `  JSON.parse: ${js.ok ? 'ok' : js.detail.trim()}`,
+  ).toEqual({ jq: true, python: true, jsonParse: true });
+}
+
+// ---------------------------------------------------------------------------
+
+describe('the JSON encoder guarantee', () => {
+  it('is measurably needed: raw JSON.stringify of the fixture is rejected by jq', () => {
+    // The premise. If this ever stops being true the guarantee is still wanted,
+    // but the reason recorded above has changed and a person should know.
+    const raw = JSON.stringify(hostileFixture(), null, 2);
+    const jq = jqAccepts(raw);
+    expect(jq.ok, 'plain JSON.stringify is now accepted by jq; the recorded defect has changed shape').toBe(false);
+    expect(jq.detail).toMatch(/surrogate/i);
+    // ...and the other two accept it, which is why this was invisible.
+    expect(jsonParseAccepts(raw).ok).toBe(true);
+    expect(pythonAccepts(raw).ok).toBe(true);
+  });
+
+  it('toJsonText output is accepted by jq AND python AND JSON.parse', () => {
+    assertEveryParserAccepts(toJsonText(hostileFixture()), 'toJsonText');
+  });
+
+  it('formatOutput --json output is accepted by all three', () => {
+    const text = formatOutput(hostileFixture(), { json: true, verbose: false });
+    assertEveryParserAccepts(text, 'formatOutput({json:true})');
+  });
+
+  it('replaces every lone surrogate with U+FFFD, in values AND in keys', () => {
+    const out = JSON.parse(toJsonText(hostileFixture())) as {
+      records: Array<{ value: string }>;
+      counts: { nested: { deep: Array<{ s: string }> } };
+      [k: string]: unknown;
+    };
+    expect(out.records[0].value).toBe('lab result � truncated');
+    expect(out.records[1].value).toBe('���');
+    expect(out.counts.nested.deep[0].s).toBe('�');
+    expect(Object.keys(out)).toContain('edge�key');
+  });
+
+  it('leaves well-formed content byte-identical to JSON.stringify', () => {
+    // The guarantee is a repair, not a re-encoding. Anything already valid must
+    // come out unchanged, or every consumer of every --json surface sees churn.
+    const clean = { a: 1, b: 'plain', c: [true, null, 'emoji \u{1F9EC}'], 'ünïcode': { d: 'é' } };
+    expect(toJsonText(clean)).toBe(JSON.stringify(clean, null, 2));
+  });
+
+  it('preserves valid surrogate pairs, C0 escapes and decoded-invalid-UTF-8 sentinels', () => {
+    const out = JSON.parse(toJsonText(hostileFixture())) as { records: Array<{ value: string }> };
+    expect(out.records[4].value).toBe(`keep ${VALID_PAIR} intact`);
+    expect(out.records[2].value).toBe(CONTROLS);
+    expect(out.records[3].value).toBe(DECODED_INVALID_UTF8);
+  });
+
+  it('emits well-formed UTF-8 bytes: no unpaired surrogate survives the encode', () => {
+    // The byte-level statement of the same guarantee. A lone surrogate has NO
+    // UTF-8 encoding, so a text that still contains one cannot be written to a
+    // file or a socket without the runtime substituting something.
+    const text = toJsonText(hostileFixture());
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text)).toBe(false);
+    expect(Buffer.from(text, 'utf-8').toString('utf-8')).toBe(text);
+  });
+
+  it('sanitizeForJson is a no-op on data that needs no repair', () => {
+    const clean = { a: [1, 'x', null], b: { c: true } };
+    expect(sanitizeForJson(clean)).toEqual(clean);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end, on the surface the defect was measured on
+// ---------------------------------------------------------------------------
+//
+// The unit tests above pin the encoder. This one pins that `pod query` REACHES
+// it, over a pod whose Turtle carries the hostile literal — which is the whole
+// chain, and the only version of this test that would have caught the original
+// defect. Turtle admits `\uXXXX` escapes and N3 decodes `\uD800` into a live
+// unpaired surrogate (verified), so the pod below is a faithful small copy of
+// the real one, and every byte of it is synthetic.
+
+describe('pod query --all --edges --json over a pod holding hostile literals', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  });
+
+  it('emits output every JSON parser accepts', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cascade-hostile-pod-'));
+    tmpDirs.push(dir);
+    const podDir = join(dir, 'pod');
+
+    const init = await runCli(['pod', 'init', podDir]);
+    expect(init.exitCode).toBe(0);
+
+    // A lab bucket whose literals carry a lone surrogate (both halves, and a
+    // reversed pair), a DEL, and a well-formed astral pair that must survive.
+    writeFileSync(
+      join(podDir, 'clinical', 'lab-results.ttl'),
+      [
+        '@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .',
+        '@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .',
+        '',
+        '<urn:uuid:hostile-lab-1> a health:LabResultRecord ;',
+        '    health:testName "Sodium \\uD800 truncated" ;',
+        '    health:testCode <http://loinc.org/rdf#2951-2> ;',
+        '    health:performedDate "2031-05-20" ;',
+        '    health:resultValue "141.0" ;',
+        '    cascade:sourceSystem "hostile-batch" .',
+        '',
+        '<urn:uuid:hostile-lab-2> a health:LabResultRecord ;',
+        '    health:testName "Potassium \\uDFFF\\uD800 reversed \\u007F \\uD83E\\uDDEC" ;',
+        '    health:testCode <http://loinc.org/rdf#2823-3> ;',
+        '    health:performedDate "2031-05-20" ;',
+        '    health:resultValue "4.1" ;',
+        '    cascade:sourceSystem "hostile-batch" .',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const q = await runCli(['--json', 'pod', 'query', podDir, '--all', '--edges']);
+    expect(q.exitCode).toBe(0);
+    expect(q.stdout.length).toBeGreaterThan(0);
+    assertEveryParserAccepts(q.stdout, 'pod query --all --edges --json');
+
+    // The record is still THERE and still readable. Repairing must not be a
+    // quiet way of dropping the record that carried the damage.
+    const parsed = JSON.parse(q.stdout) as Record<string, unknown>;
+    const flat = JSON.stringify(parsed);
+    expect(flat).toContain('Sodium');
+    expect(flat).toContain('Potassium');
+    // The valid astral pair survived; the broken halves became U+FFFD.
+    expect(flat).toContain(VALID_PAIR);
+    expect(flat).toContain('�');
+  });
+});

--- a/tests/pod-read-conformance.test.ts
+++ b/tests/pod-read-conformance.test.ts
@@ -338,6 +338,23 @@ const VERBS: Record<string, VerbSpec> = {
     // state of your pod" about files it never opened.
     strayOutcome: 'fatal',
   },
+  reconcile: {
+    category: 'read',
+    // The DEFAULT is a dry run, which reads every record bucket and writes
+    // nothing, so the read matrix is exactly the right battery for it. The
+    // --apply half has its own suite (pod-reconcile.test.ts).
+    argv: (pod) => ['--json', 'pod', 'reconcile', pod],
+    successExit: 0,
+    // The pod's real record count, in this verb's own vocabulary. A keyless or
+    // partial read cannot reach this number, so it cannot pass hollow.
+    successMustContain: '"recordsBefore": 4',
+    strayTarget: 'clinical/medications.ttl',
+    // Fatal, for the doctor reasoning: every count this verb prints is a claim
+    // about the WHOLE record set ("these are the duplicates", "nothing would
+    // merge"), and a file that was never opened could hold a third copy. A
+    // confident report over a partial read is a wrong answer, not a small one.
+    strayOutcome: 'fatal',
+  },
   export: {
     category: 'read',
     // D-CLI-2: an encrypted pod is refused before any read, in EVERY scenario,

--- a/tests/pod-reconcile.test.ts
+++ b/tests/pod-reconcile.test.ts
@@ -1,0 +1,536 @@
+/**
+ * `cascade pod reconcile` — the verb that can clean up a pod's OWN duplicates.
+ *
+ * WHAT IT IS FOR
+ * --------------
+ * `pod import --reconcile-existing` compares arriving records against stored
+ * ones and, deliberately, never compares two stored records with each other. So
+ * duplicates already IN a pod were permanent: no sequence of imports would ever
+ * look at them. This verb is the same reconciler pointed at pod content.
+ *
+ * WHAT THESE TESTS HOLD
+ * ---------------------
+ * Mostly the SAFETY, because the risky half of this verb is not the matching
+ * (that machinery is tested to death elsewhere) but the fact that it rewrites
+ * records the user did not just hand over:
+ *
+ *   - dry run is the DEFAULT, and a dry run leaves the pod byte-identical;
+ *   - --apply is what mutates, and it only merges what the dry run reported;
+ *   - an unreadable bucket refuses the WHOLE mutation, because a merged result
+ *     that is missing those records would delete them if written;
+ *   - conflicts go into the same queue `pod conflicts` reads;
+ *   - tier-0 merges are journaled so they can be undone.
+ *
+ * All fixture data is synthetic and PHI-free.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Parser } from 'n3';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { readTier0Journal, TIER0_JOURNAL_RELATIVE_PATH } from '../src/lib/tier0-journal.js';
+
+const INSTANT = '2031-05-20T09:14:00Z';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/**
+ * The record SUBJECTS a bucket holds.
+ *
+ * Deliberately not a string search for the IRI. A merged-away subject is still
+ * NAMED by the survivor's `cascade:mergedFrom` / `prov:wasDerivedFrom` lineage,
+ * which is the point of that lineage and is left dangling by design — so
+ * "the file contains this IRI" is true of a record that no longer exists, and a
+ * containment check would read a correct merge as a failed one.
+ */
+function recordSubjects(bucketPath: string): string[] {
+  const ttl = fs.readFileSync(bucketPath, 'utf-8');
+  return [
+    ...new Set(
+      new Parser({ format: 'Turtle' })
+        .parse(ttl)
+        .filter((q) => q.predicate.value === RDF_TYPE)
+        .map((q) => q.subject.value),
+    ),
+  ].sort();
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+async function makePod(): Promise<string> {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-pod-reconcile-'));
+  dirs.push(d);
+  const podDir = path.join(d, 'pod');
+  const init = await runCli(['pod', 'init', podDir]);
+  expect(init.exitCode).toBe(0);
+  return podDir;
+}
+
+const PREFIXES = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+`;
+
+interface LabOpts {
+  uri: string;
+  batch: string;
+  origin?: string;
+  performed?: string;
+  value?: string;
+  name?: string;
+  loinc?: string;
+}
+
+function labRecord(o: LabOpts): string {
+  const origin = o.origin ? `  cascade:sourceIdentity "${o.origin}" ;\n` : '';
+  return `<${o.uri}> a health:LabResultRecord ;
+  cascade:sourceSystem "${o.batch}" ;
+${origin}  health:testCode <http://loinc.org/rdf#${o.loinc ?? '2951-2'}> ;
+  health:testName "${o.name ?? 'Sodium'}" ;
+  health:performedDate "${o.performed ?? INSTANT}" ;
+  health:resultValue "${o.value ?? '141'}" .
+`;
+}
+
+/** Write a lab bucket holding the given records. */
+function writeLabs(podDir: string, records: string[]): void {
+  fs.writeFileSync(
+    path.join(podDir, 'clinical', 'lab-results.ttl'),
+    PREFIXES + '\n' + records.join('\n'),
+    'utf-8',
+  );
+}
+
+/** A pod holding two cross-source copies of one draw: the tier-0 shape. */
+async function podWithCrossSourceDuplicate(): Promise<string> {
+  const podDir = await makePod();
+  writeLabs(podDir, [
+    labRecord({ uri: 'urn:uuid:lab-a', batch: 'Stonebridge export', origin: 'org:stonebridge' }),
+    labRecord({ uri: 'urn:uuid:lab-b', batch: 'Larkfield export', origin: 'org:larkfield' }),
+  ]);
+  return podDir;
+}
+
+// ---------------------------------------------------------------------------
+
+describe('pod reconcile: the pod-only gap it closes', () => {
+  it('finds duplicates that an import can never reach', async () => {
+    // The premise. `pod import --reconcile-existing` deliberately never compares
+    // two stored records, so importing an unrelated file leaves the pair alone;
+    // `pod reconcile` is the only thing that sees it.
+    const podDir = await podWithCrossSourceDuplicate();
+    const before = fs.readFileSync(path.join(podDir, 'clinical', 'lab-results.ttl'), 'utf-8');
+
+    const unrelated = path.join(path.dirname(podDir), 'unrelated.ttl');
+    fs.writeFileSync(
+      unrelated,
+      PREFIXES +
+        '\n' +
+        labRecord({ uri: 'urn:uuid:lab-other', batch: 'Other', loinc: '2160-0', name: 'Creatinine' }),
+      'utf-8',
+    );
+    await runCli(['pod', 'import', podDir, unrelated]);
+    const afterImport = fs.readFileSync(path.join(podDir, 'clinical', 'lab-results.ttl'), 'utf-8');
+    expect(afterImport).toContain('lab-a');
+    expect(afterImport).toContain('lab-b');
+
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout) as { summary: { tier0MergesApplied: number }; recordsBefore: number };
+    expect(report.summary.tier0MergesApplied).toBe(1);
+    expect(before.length).toBeGreaterThan(0);
+  });
+});
+
+describe('pod reconcile: dry run is the default', () => {
+  it('reports what WOULD merge and writes nothing', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    const bucket = path.join(podDir, 'clinical', 'lab-results.ttl');
+    const before = fs.readFileSync(bucket, 'utf-8');
+
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir]);
+    expect(r.exitCode).toBe(0);
+
+    const report = JSON.parse(r.stdout) as {
+      applied: boolean;
+      recordsBefore: number;
+      recordsAfter: number;
+      filesWritten: string[];
+      summary: { exactDuplicatesRemoved: number };
+    };
+    expect(report.applied).toBe(false);
+    expect(report.recordsBefore).toBe(2);
+    expect(report.recordsAfter).toBe(1);
+    expect(report.summary.exactDuplicatesRemoved).toBe(1);
+    expect(report.filesWritten).toEqual([]);
+
+    // THE assertion. A report-first verb that quietly wrote would be worse than
+    // one that never claimed to be report-first.
+    expect(fs.readFileSync(bucket, 'utf-8')).toBe(before);
+    expect(fs.existsSync(path.join(podDir, TIER0_JOURNAL_RELATIVE_PATH))).toBe(false);
+  });
+
+  it('says so in words, and says how to apply', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    const r = await runCli(['pod', 'reconcile', podDir]);
+    expect(r.stdout).toContain('DRY RUN');
+    expect(r.stdout).toContain('Nothing was written');
+    expect(r.stdout).toContain('--apply');
+  });
+
+  it('counts records the same way before and after, including non-reconcilable ones', async () => {
+    // The number a person reads to decide whether to run --apply is
+    // "N in, M out", so a fabricated gap between them is the worst thing this
+    // report can print.
+    //
+    // The reconciler's own `finalRecordCount` is the number of GROUPS, and only
+    // reconcilable types are ever grouped. A pod's documents, reports and
+    // profile pass through as subjects the matcher never sees, so reporting that
+    // against a subject count of the input made a pod where NOTHING merged read
+    // "3 records in, 2 records out" (measured: 4 in, 3 out on the conformance
+    // fixture). Both counts are taken over record subjects in the actual Turtle.
+    const podDir = await makePod();
+    writeLabs(podDir, [
+      labRecord({ uri: 'urn:uuid:lab-a', batch: 'b1', origin: 'org:stonebridge' }),
+      labRecord({
+        uri: 'urn:uuid:lab-x',
+        batch: 'b1',
+        origin: 'org:stonebridge',
+        loinc: '2160-0',
+        name: 'Creatinine',
+        value: '1.1',
+      }),
+    ]);
+    // clinical:LaboratoryReport is not a reconcilable type: it passes through.
+    fs.writeFileSync(
+      path.join(podDir, 'clinical', 'documents.ttl'),
+      `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+
+<urn:uuid:report-1> a clinical:LaboratoryReport ;
+  cascade:sourceSystem "b1" ;
+  clinical:documentDate "2031-05-20" .
+`,
+      'utf-8',
+    );
+
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout) as { recordsBefore: number; recordsAfter: number };
+    expect(report.recordsBefore).toBe(3);
+    expect(report.recordsAfter).toBe(3);
+  });
+
+  it('is a clean no-op on a pod with nothing to reconcile', async () => {
+    const podDir = await makePod();
+    writeLabs(podDir, [
+      labRecord({ uri: 'urn:uuid:lab-a', batch: 'b1', origin: 'org:stonebridge' }),
+      labRecord({
+        uri: 'urn:uuid:lab-x',
+        batch: 'b1',
+        origin: 'org:stonebridge',
+        loinc: '2160-0',
+        name: 'Creatinine',
+        value: '1.1',
+      }),
+    ]);
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout) as { recordsBefore: number; recordsAfter: number };
+    expect(report.recordsBefore).toBe(2);
+    expect(report.recordsAfter).toBe(2);
+  });
+});
+
+describe('pod reconcile --apply', () => {
+  it('merges the pair the dry run reported, and only that', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    const dry = JSON.parse((await runCli(['--json', 'pod', 'reconcile', podDir])).stdout) as {
+      recordsAfter: number;
+    };
+
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir, '--apply']);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout) as { applied: boolean; filesWritten: string[]; recordsAfter: number };
+    expect(report.applied).toBe(true);
+    expect(report.filesWritten).toContain('clinical/lab-results.ttl');
+    // The apply run produced the record count the dry run promised.
+    expect(report.recordsAfter).toBe(dry.recordsAfter);
+
+    const survivors = recordSubjects(path.join(podDir, 'clinical', 'lab-results.ttl'));
+    expect(survivors).toHaveLength(1);
+    expect(['urn:uuid:lab-a', 'urn:uuid:lab-b']).toContain(survivors[0]);
+  });
+
+  it('journals the tier-0 merge with the discarded record, so it can be undone', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+
+    const journal = readTier0Journal(podDir);
+    expect(journal.entries).toHaveLength(1);
+    expect(journal.entries[0].appliedBy).toBe('pod reconcile --apply');
+    const merge = journal.entries[0].merges[0];
+    expect(merge.origins).toEqual(['org:larkfield', 'org:stonebridge']);
+    expect(merge.discarded).toHaveLength(1);
+
+    // The retained content is complete enough to restore the record.
+    const props = merge.discarded[0].properties;
+    expect(props['https://ns.cascadeprotocol.org/health/v1#resultValue'][0].value).toBe('141');
+    expect(props['https://ns.cascadeprotocol.org/health/v1#performedDate'][0].value).toBe(INSTANT);
+
+    // And the record it names really is the one gone from the pod.
+    const subjects = recordSubjects(path.join(podDir, 'clinical', 'lab-results.ttl'));
+    expect(subjects).not.toContain(merge.discarded[0].uri);
+    expect(subjects).toContain(merge.canonicalUri);
+  });
+
+  it('is idempotent: a second apply finds nothing left to merge', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+    const second = await runCli(['--json', 'pod', 'reconcile', podDir, '--apply']);
+    const report = JSON.parse(second.stdout) as {
+      recordsBefore: number;
+      recordsAfter: number;
+      summary: { exactDuplicatesRemoved: number; tier0MergesApplied: number };
+    };
+    expect(report.recordsBefore).toBe(1);
+    expect(report.recordsAfter).toBe(1);
+    expect(report.summary.exactDuplicatesRemoved).toBe(0);
+    expect(report.summary.tier0MergesApplied).toBe(0);
+    // The journal did not grow a second, empty entry.
+    expect(readTier0Journal(podDir).entries).toHaveLength(1);
+  });
+
+  it('raises unmergeable disagreements through the pod conflict queue', async () => {
+    const podDir = await makePod();
+    // Two sources, same drug, different doses: the flagship conflict, never a
+    // silent merge.
+    fs.writeFileSync(
+      path.join(podDir, 'clinical', 'medications.ttl'),
+      `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+
+<urn:uuid:med-a> a clinical:Medication ;
+  cascade:sourceSystem "Stonebridge export" ;
+  cascade:sourceIdentity "org:stonebridge" ;
+  clinical:drugName "Lisinopril" ;
+  clinical:dosage "10 mg" .
+
+<urn:uuid:med-b> a clinical:Medication ;
+  cascade:sourceSystem "Larkfield export" ;
+  cascade:sourceIdentity "org:larkfield" ;
+  clinical:drugName "Lisinopril" ;
+  clinical:dosage "20 mg" .
+`,
+      'utf-8',
+    );
+
+    const dry = JSON.parse((await runCli(['--json', 'pod', 'reconcile', podDir])).stdout) as {
+      summary: { conflictsUnresolved: number };
+      groups: Array<{ resolved: boolean; recordType: string }>;
+    };
+    expect(dry.summary.conflictsUnresolved).toBe(1);
+    expect(dry.groups.some((g) => !g.resolved)).toBe(true);
+
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+    const conflicts = await runCli(['pod', 'conflicts', podDir, '--format', 'json']);
+    const listed = JSON.parse(conflicts.stdout) as Array<{ recordType: string }>;
+    expect(listed).toHaveLength(1);
+
+    // Both doses survive: an unresolved conflict must not lose a value.
+    const after = fs.readFileSync(path.join(podDir, 'clinical', 'medications.ttl'), 'utf-8');
+    expect(after).toContain('10 mg');
+    expect(after).toContain('20 mg');
+  });
+});
+
+describe('pod reconcile: refusing to do damage', () => {
+  it('refuses the WHOLE mutation when a record file cannot be read', async () => {
+    // The failure that matters most. An unreadable bucket's records are absent
+    // from the merged result, so writing that result back would DELETE them.
+    // Half-applying is worse than not applying.
+    const podDir = await podWithCrossSourceDuplicate();
+    const broken = path.join(podDir, 'clinical', 'conditions.ttl');
+    fs.writeFileSync(broken, 'this is not turtle at all <<<>>> @@@\n', 'utf-8');
+    const labsBefore = fs.readFileSync(path.join(podDir, 'clinical', 'lab-results.ttl'), 'utf-8');
+    const brokenBefore = fs.readFileSync(broken, 'utf-8');
+
+    const r = await runCli(['pod', 'reconcile', podDir, '--apply']);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('clinical/conditions.ttl');
+    expect(r.stderr).toContain('The pod is unchanged.');
+
+    // Nothing moved. Not the readable bucket, not the broken one.
+    expect(fs.readFileSync(path.join(podDir, 'clinical', 'lab-results.ttl'), 'utf-8')).toBe(labsBefore);
+    expect(fs.readFileSync(broken, 'utf-8')).toBe(brokenBefore);
+    expect(fs.existsSync(path.join(podDir, TIER0_JOURNAL_RELATIVE_PATH))).toBe(false);
+  });
+
+  it('refuses the DRY RUN too, because a partial read makes every count wrong', async () => {
+    // Not just the write. Every number this verb prints is a claim about the
+    // pod's whole record set: "these two are the only duplicates" is only true
+    // if nothing unread is a third copy. A confident report over a partial read
+    // is not a smaller answer, it is a wrong one.
+    const podDir = await podWithCrossSourceDuplicate();
+    fs.writeFileSync(path.join(podDir, 'clinical', 'conditions.ttl'), 'not turtle <<<\n', 'utf-8');
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('clinical/conditions.ttl');
+    // And it must not have printed a report that looks like an answer.
+    expect(r.stdout).not.toContain('recordsBefore');
+  });
+
+  it('ignores an UNREGISTERED .ttl in a record directory entirely', async () => {
+    // A pod legitimately keeps notes, analyses and literature as .ttl under
+    // clinical/. This verb REPLACES the files it covers, so a stray that it read
+    // would have its subjects swept into the merged result, where routing has no
+    // bucket for them and files them under passthrough: the note gets relocated
+    // as a side effect of reconciling records. So strays are not read, not
+    // written, and not a reason to fail.
+    //
+    // Deliberately VALID Turtle. An unparseable stray would be skipped anyway
+    // and would prove nothing about the rule; only a readable one can show that
+    // the exclusion is by registration and not by accident.
+    const podDir = await podWithCrossSourceDuplicate();
+    const stray = path.join(podDir, 'clinical', 'field-notes.ttl');
+    fs.writeFileSync(
+      stray,
+      '@prefix ex: <http://example.org/> .\n<urn:uuid:note-1> a ex:FieldNote ; ex:text "kept" .\n',
+      'utf-8',
+    );
+    const strayBefore = fs.readFileSync(stray, 'utf-8');
+
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir, '--apply']);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout) as {
+      applied: boolean;
+      filesRead: string[];
+      filesWritten: string[];
+    };
+    expect(report.applied).toBe(true);
+    expect(report.filesRead).not.toContain('clinical/field-notes.ttl');
+    expect(report.filesWritten).not.toContain('clinical/field-notes.ttl');
+
+    // Byte-identical, and its subject was not relocated into any bucket.
+    expect(fs.readFileSync(stray, 'utf-8')).toBe(strayBefore);
+    for (const f of fs.readdirSync(path.join(podDir, 'clinical'))) {
+      if (f === 'field-notes.ttl') continue;
+      expect(fs.readFileSync(path.join(podDir, 'clinical', f), 'utf-8')).not.toContain('note-1');
+    }
+  });
+
+  it('exits 2 when the pod cannot be opened at all', async () => {
+    const r = await runCli(['pod', 'reconcile', path.join(os.tmpdir(), 'cascade-no-such-pod-xyz')]);
+    expect(r.exitCode).toBe(2);
+  });
+});
+
+describe('pod import applies and journals tier-0 merges too', () => {
+  it('merges a batch-internal cross-source duplicate and records it', async () => {
+    // Both halves of the ruling on the path that actually carries traffic.
+    //
+    // The two copies arrive in ONE import, into a pod that already holds an
+    // unrelated record. That is precisely the shape the fast path used to drop:
+    // the cross-batch pass assigned every new record before the new-against-new
+    // pass could seed from any of them, so a batch's own internal duplicates
+    // imported un-reconciled whenever the pod had content — which is every
+    // import after the first.
+    const podDir = await makePod();
+    writeLabs(podDir, [
+      labRecord({ uri: 'urn:uuid:lab-pre', batch: 'Earlier', loinc: '2160-0', name: 'Creatinine', value: '1.1' }),
+    ]);
+
+    const batch = path.join(path.dirname(podDir), 'cross-source-batch.ttl');
+    fs.writeFileSync(
+      batch,
+      PREFIXES +
+        '\n' +
+        labRecord({ uri: 'urn:uuid:lab-a', batch: 'Household export', origin: 'org:stonebridge' }) +
+        '\n' +
+        labRecord({ uri: 'urn:uuid:lab-b', batch: 'Household export', origin: 'org:larkfield' }),
+      'utf-8',
+    );
+
+    const imp = await runCli(['pod', 'import', podDir, batch]);
+    expect(imp.exitCode).toBe(0);
+
+    // One survivor from the pair, plus the pre-existing unrelated record.
+    const subjects = recordSubjects(path.join(podDir, 'clinical', 'lab-results.ttl'));
+    expect(subjects).toContain('urn:uuid:lab-pre');
+    expect(subjects.filter((s) => s === 'urn:uuid:lab-a' || s === 'urn:uuid:lab-b')).toHaveLength(1);
+
+    // Silent, but not unrecorded: warned on stderr and journaled with the
+    // discarded record.
+    expect(imp.stderr).toContain('merged automatically');
+    const journal = readTier0Journal(podDir);
+    expect(journal.entries).toHaveLength(1);
+    expect(journal.entries[0].appliedBy).toBe('pod import');
+    expect(journal.entries[0].merges[0].discarded).toHaveLength(1);
+    expect(
+      journal.entries[0].merges[0].discarded[0].properties[
+        'https://ns.cascadeprotocol.org/health/v1#resultValue'
+      ][0].value,
+    ).toBe('141');
+  });
+});
+
+describe('pod reconcile: the report surface', () => {
+  it('writes the same report to --report as JSON', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    const reportPath = path.join(path.dirname(podDir), 'reconcile-report.json');
+    await runCli(['pod', 'reconcile', podDir, '--report', reportPath]);
+    const written = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as {
+      applied: boolean;
+      tier0Merges: Array<{ canonicalUri: string }>;
+    };
+    expect(written.applied).toBe(false);
+    expect(written.tier0Merges).toHaveLength(1);
+  });
+
+  it('names the cross-source duplicate in human-readable output', async () => {
+    const podDir = await podWithCrossSourceDuplicate();
+    const r = await runCli(['pod', 'reconcile', podDir]);
+    expect(r.stdout).toContain('cross-source exact lab duplicates');
+    expect(r.stdout).toContain('org:larkfield');
+    expect(r.stdout).toContain('org:stonebridge');
+    expect(r.stdout).toContain(TIER0_JOURNAL_RELATIVE_PATH);
+  });
+});

--- a/tests/reconciler-tier0.test.ts
+++ b/tests/reconciler-tier0.test.ts
@@ -1,0 +1,445 @@
+/**
+ * TIER 0: the one duplicate class allowed to merge without asking, and the
+ * boundary around it.
+ *
+ * THE RULING
+ * ----------
+ * Cross-source EXACT lab duplication merges silently. Two organizations
+ * reporting one draw is the commonest thing a multi-source pod holds, and
+ * queueing a question for each one does not produce caution — it produces a
+ * queue nobody finishes, with the genuinely disagreeing pairs buried in it.
+ * Measured over 144 candidate groups at a 22% duplicate base rate: zero false
+ * positives.
+ *
+ * WHAT THESE TESTS ARE FOR
+ * ------------------------
+ * The value of a narrow rule is entirely in the narrowness, so most of this file
+ * is the NEGATIVE cases. Each one removes a single clause and asserts the class
+ * closes: same day but different instants, one value different, one origin
+ * unknown, both origins the same. A tier-0 test suite that only proved the happy
+ * path would pass just as well against a rule that merged everything.
+ *
+ * And two positive obligations, which are the price of merging silently: the
+ * merge is LOGGED (itemized, with IRIs) and REVERSIBLE (the discarded records'
+ * full content is retained). Silent means not interrupting, not unrecorded.
+ *
+ * All data is synthetic and PHI-free.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Parser } from 'n3';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runReconciliation } from '../src/lib/reconciler.js';
+import {
+  appendTier0Journal,
+  readTier0Journal,
+  tier0DiscardedRecords,
+  TIER0_JOURNAL_RELATIVE_PATH,
+} from '../src/lib/tier0-journal.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const PREFIXES = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+`;
+
+/** The exact instant both copies of the tier-0 draw state. */
+const INSTANT = '2031-05-20T09:14:00Z';
+
+interface LabOpts {
+  uri: string;
+  batch?: string;
+  origin?: string;
+  /** Defaults to the shared exact instant. Pass a bare date to leave the class. */
+  performed?: string;
+  value?: string;
+  loinc?: string;
+  provenanceClass?: string;
+}
+
+/** One lab record, parameterised on every clause of the tier-0 predicate. */
+function lab(o: LabOpts): string {
+  const lines = [
+    `<${o.uri}> a health:LabResultRecord ;`,
+    `  cascade:sourceSystem "${o.batch ?? 'Household export'}" ;`,
+  ];
+  if (o.origin) lines.push(`  cascade:sourceIdentity "${o.origin}" ;`);
+  if (o.provenanceClass) lines.push(`  clinical:provenanceClass "${o.provenanceClass}" ;`);
+  lines.push(
+    `  health:testCode <http://loinc.org/rdf#${o.loinc ?? '2951-2'}> ;`,
+    `  health:testName "Sodium" ;`,
+    `  health:performedDate "${o.performed ?? INSTANT}" ;`,
+    `  health:resultValue "${o.value ?? '141'}" .`,
+  );
+  return `${PREFIXES}${lines.join('\n')}\n`;
+}
+
+function recordSubjects(ttl: string): string[] {
+  return [
+    ...new Set(
+      new Parser({ format: 'Turtle' })
+        .parse(ttl)
+        .filter((q) => q.predicate.value === RDF_TYPE)
+        .map((q) => q.subject.value),
+    ),
+  ].sort();
+}
+
+/** The canonical tier-0 pair: one draw, two organizations, byte-identical. */
+function tier0Pair(): Array<{ content: string; systemName: string }> {
+  return [
+    { content: lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge' }), systemName: 'Household export' },
+    { content: lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield' }), systemName: 'Household export' },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// The class
+// ---------------------------------------------------------------------------
+
+describe('tier 0: cross-source exact lab duplication', () => {
+  it('merges the pair, reports it as tier 0, and raises no conflict', async () => {
+    const r = await runReconciliation(tier0Pair());
+    expect(recordSubjects(r.turtle).length).toBe(1);
+    expect(r.report.summary.tier0MergesApplied).toBe(1);
+    expect(r.report.summary.conflictsUnresolved).toBe(0);
+  });
+
+  it('itemizes the merge with the surviving IRI and every IRI it absorbed', async () => {
+    // The LOG half of the obligation. A count alone cannot be audited: it says
+    // something happened without saying to what.
+    const r = await runReconciliation(tier0Pair());
+    const [merge] = r.report.tier0Merges;
+    expect(r.report.tier0Merges).toHaveLength(1);
+    expect(['urn:uuid:lab-a', 'urn:uuid:lab-b']).toContain(merge.canonicalUri);
+    expect(merge.discarded).toHaveLength(1);
+    expect(merge.discarded[0].uri).not.toBe(merge.canonicalUri);
+    expect(['urn:uuid:lab-a', 'urn:uuid:lab-b']).toContain(merge.discarded[0].uri);
+    expect(merge.origins).toEqual(['org:larkfield', 'org:stonebridge']);
+    expect(merge.matchedOn).toBe(`loinc:2951-2@${INSTANT}`);
+  });
+
+  it('retains enough of the discarded record to put it back', async () => {
+    // The REVERSIBLE half. Content-complete deliberately: an undo that only works
+    // if the merge rule was right is not an undo.
+    const r = await runReconciliation(tier0Pair());
+    const discarded = r.report.tier0Merges[0].discarded[0];
+    const props = discarded.properties;
+    expect(props['https://ns.cascadeprotocol.org/health/v1#resultValue'][0].value).toBe('141');
+    expect(props['https://ns.cascadeprotocol.org/health/v1#performedDate'][0].value).toBe(INSTANT);
+    expect(props['https://ns.cascadeprotocol.org/health/v1#testName'][0].value).toBe('Sodium');
+    // The origin axis is what distinguished the two copies, so it must survive
+    // the merge that collapsed them: without it the restored record cannot say
+    // which organization it came from.
+    expect(discarded.sourceIdentity).toMatch(/^org:(stonebridge|larkfield)$/);
+    expect(discarded.type).toBe('health:LabResultRecord');
+  });
+
+  it('merges even under the conservative cross-provenance guard', async () => {
+    // The clause with teeth. `allowCrossProvenanceMerge: false` exists to stop
+    // silent merges ACROSS provenance classes, and two organizations reporting
+    // one draw is precisely what differing provenance classes look like — so
+    // under that guard every benign cross-source duplicate became a question.
+    const inputs = [
+      {
+        content: lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge', provenanceClass: 'imported' }),
+        systemName: 'Household export',
+      },
+      {
+        content: lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield', provenanceClass: 'healthKitFHIR' }),
+        systemName: 'Household export',
+      },
+    ];
+    const guarded = await runReconciliation(inputs, { allowCrossProvenanceMerge: false });
+    expect(recordSubjects(guarded.turtle).length).toBe(1);
+    expect(guarded.report.summary.tier0MergesApplied).toBe(1);
+    expect(guarded.report.summary.conflictsUnresolved).toBe(0);
+  });
+
+  it('leaves the guard doing its job for everything that is NOT tier 0', async () => {
+    // The contrast that proves the exemption is an exemption and not a removal.
+    // Same two provenance classes, same two origins, but the values differ inside
+    // lab tolerance: a near-duplicate, not an exact one, so the class does not
+    // apply and the guard still flags.
+    const inputs = [
+      {
+        content: lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge', provenanceClass: 'imported' }),
+        systemName: 'Household export',
+      },
+      {
+        content: lab({
+          uri: 'urn:uuid:lab-b',
+          origin: 'org:larkfield',
+          provenanceClass: 'healthKitFHIR',
+          value: '141.2',
+        }),
+        systemName: 'Household export',
+      },
+    ];
+    const guarded = await runReconciliation(inputs, { allowCrossProvenanceMerge: false });
+    expect(guarded.report.summary.tier0MergesApplied).toBe(0);
+    expect(guarded.report.summary.conflictsUnresolved).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The boundary. Each case removes exactly one clause.
+// ---------------------------------------------------------------------------
+
+describe('tier 0 closes when any single clause fails', () => {
+  /** Run a pair and return only what the tier-0 machinery said about it. */
+  async function tier0Count(a: string, b: string): Promise<number> {
+    const r = await runReconciliation([
+      { content: a, systemName: 'Household export' },
+      { content: b, systemName: 'Household export' },
+    ]);
+    return r.report.summary.tier0MergesApplied;
+  }
+
+  it('is NOT tier 0 on the same DAY at different instants', async () => {
+    // The clause that costs the most and is worth the most. A same-day repeat
+    // draw is a real second measurement; the day-level matcher may still group
+    // these for review, but tier 0 will not merge them unasked.
+    expect(
+      await tier0Count(
+        lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge', performed: '2031-05-20T09:14:00Z' }),
+        lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield', performed: '2031-05-20T16:02:00Z' }),
+      ),
+    ).toBe(0);
+  });
+
+  it('is NOT tier 0 when the date states only a day', async () => {
+    // "Never day-level" is a property of the DATA, not only of the comparison.
+    // Two records that agree on "2031-05-20" agree on a day, and a day is not an
+    // instant however exactly the strings match.
+    expect(
+      await tier0Count(
+        lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge', performed: '2031-05-20' }),
+        lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield', performed: '2031-05-20' }),
+      ),
+    ).toBe(0);
+  });
+
+  it('is NOT tier 0 when any content differs, however slightly', async () => {
+    expect(
+      await tier0Count(
+        lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge', value: '141' }),
+        lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield', value: '141.2' }),
+      ),
+    ).toBe(0);
+  });
+
+  /**
+   * Run a pair that is GUARANTEED to be compared, and return the tier-0 count.
+   *
+   * The batch labels differ, which matters more than it looks. `sameSourceStatement`
+   * returns early on differing `cascade:sourceSystem`, so the pair is always
+   * admitted to the matcher; under ONE shared label a record with an unknown
+   * origin is held out by the guard and never grouped at all. A boundary test
+   * written that way measures the GUARD and says nothing about the tier-0
+   * predicate, and would pass with the whole known-origin clause deleted.
+   * (Measured: that is exactly what happened, and the clause survived mutation.)
+   */
+  async function tier0CountCompared(a: string, b: string): Promise<number> {
+    const r = await runReconciliation([
+      { content: a, systemName: 'batch-1' },
+      { content: b, systemName: 'batch-2' },
+    ]);
+    // The premise: they really were grouped. Without this the test can pass by
+    // the records never meeting, which is the failure mode above.
+    expect(recordSubjects(r.turtle).length, 'the pair was never compared').toBe(1);
+    return r.report.summary.tier0MergesApplied;
+  }
+
+  it('is NOT tier 0 when one origin is absent, though the records still merge', async () => {
+    // Pre-v3.5 records carry no origin at all. Two unknowns are not two
+    // organizations. The pair still merges by the ordinary lab rules; what it
+    // does not get is the silent, journaled tier-0 treatment.
+    expect(
+      await tier0CountCompared(
+        lab({ uri: 'urn:uuid:lab-a', batch: 'batch-1', origin: 'org:stonebridge' }),
+        lab({ uri: 'urn:uuid:lab-b', batch: 'batch-2' }),
+      ),
+    ).toBe(0);
+  });
+
+  it('is NOT tier 0 when an origin is a transport-tier value', async () => {
+    // `transport:` is the producer saying it could not tell. Reading it as an
+    // origin is the exact confusion the scheme prefix exists to prevent.
+    expect(
+      await tier0CountCompared(
+        lab({ uri: 'urn:uuid:lab-a', batch: 'batch-1', origin: 'org:stonebridge' }),
+        lab({ uri: 'urn:uuid:lab-b', batch: 'batch-2', origin: 'transport:Household export' }),
+      ),
+    ).toBe(0);
+  });
+
+  it('is NOT tier 0 when BOTH origins are absent', async () => {
+    expect(
+      await tier0CountCompared(
+        lab({ uri: 'urn:uuid:lab-a', batch: 'batch-1' }),
+        lab({ uri: 'urn:uuid:lab-b', batch: 'batch-2' }),
+      ),
+    ).toBe(0);
+  });
+
+  it('is NOT tier 0 when both copies share ONE origin', async () => {
+    // One source does not restate one result twice inside one export, so two
+    // identical records under one origin may be two real measurements. Different
+    // origins is the whole safety argument; same origin removes it.
+    expect(
+      await tier0CountCompared(
+        lab({ uri: 'urn:uuid:lab-a', batch: 'batch-1', origin: 'org:stonebridge' }),
+        lab({ uri: 'urn:uuid:lab-b', batch: 'batch-2', origin: 'org:stonebridge' }),
+      ),
+    ).toBe(0);
+  });
+
+  it('is NOT tier 0 for a non-lab record type', async () => {
+    const condition = (uri: string, origin: string): string =>
+      `${PREFIXES}<${uri}> a health:ConditionRecord ;
+  cascade:sourceSystem "Household export" ;
+  cascade:sourceIdentity "${origin}" ;
+  health:snomedCode <http://snomed.info/id/44054006> ;
+  health:conditionName "Type 2 diabetes" .
+`;
+    expect(
+      await tier0Count(
+        condition('urn:uuid:cond-a', 'org:stonebridge'),
+        condition('urn:uuid:cond-b', 'org:larkfield'),
+      ),
+    ).toBe(0);
+  });
+
+  it('closes for the WHOLE group when a third record that JOINED it does not qualify', async () => {
+    // Group-level, not pair-level. Two qualifying records must not carry an
+    // unqualified third into a silent merge on their coat-tails.
+    //
+    // The third record has to actually reach the group for this to measure
+    // anything, and getting that wrong is easy: a record with no origin is held
+    // out by the same-source guard and never compared at all, so the group would
+    // be the original qualifying PAIR and would rightly stay tier 0. This third
+    // copy therefore carries its own known origin (so the guard admits it) and a
+    // day-only date (so the day-level lab matcher groups it, and the tier-0
+    // instant clause rejects it).
+    const r = await runReconciliation([
+      { content: lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge' }), systemName: 'Household export' },
+      { content: lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield' }), systemName: 'Household export' },
+      {
+        content: lab({ uri: 'urn:uuid:lab-c', origin: 'org:brightwater', performed: '2031-05-20' }),
+        systemName: 'Household export',
+      },
+    ]);
+    // All three grouped, and the group is not tier 0.
+    expect(recordSubjects(r.turtle).length).toBe(1);
+    expect(r.report.summary.tier0MergesApplied).toBe(0);
+  });
+
+  it('does not group a record the same-source guard holds out, and stays tier 0', async () => {
+    // The contrast for the case above, and the reason it is worded the way it
+    // is. A third copy with NO origin is never compared with anything under the
+    // shared batch label, so it is not in the group; the qualifying pair is still
+    // a qualifying pair, and the unattributed record survives on its own.
+    const r = await runReconciliation([
+      { content: lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge' }), systemName: 'Household export' },
+      { content: lab({ uri: 'urn:uuid:lab-b', origin: 'org:larkfield' }), systemName: 'Household export' },
+      { content: lab({ uri: 'urn:uuid:lab-c' }), systemName: 'Household export' },
+    ]);
+    expect(recordSubjects(r.turtle).length).toBe(2);
+    expect(r.report.summary.tier0MergesApplied).toBe(1);
+  });
+
+  it('reports nothing at all on a run with no tier-0 group', async () => {
+    const r = await runReconciliation([
+      { content: lab({ uri: 'urn:uuid:lab-a', origin: 'org:stonebridge', performed: '2031-05-20' }), systemName: 'b1' },
+    ]);
+    expect(r.report.summary.tier0MergesApplied).toBe(0);
+    expect(r.report.tier0Merges).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The journal
+// ---------------------------------------------------------------------------
+
+describe('the tier-0 journal', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function mkPod(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-tier0-'));
+    dirs.push(d);
+    fs.mkdirSync(path.join(d, 'settings'), { recursive: true });
+    return d;
+  }
+
+  it('does not exist on a pod that has had no tier-0 merge', () => {
+    const pod = mkPod();
+    expect(readTier0Journal(pod).entries).toEqual([]);
+    expect(appendTier0Journal(pod, [], 'pod import')).toBe(0);
+    expect(fs.existsSync(path.join(pod, TIER0_JOURNAL_RELATIVE_PATH))).toBe(false);
+  });
+
+  it('appends across runs rather than replacing', async () => {
+    // An audit log that a second run overwrites is not an audit log.
+    const pod = mkPod();
+    const r = await runReconciliation(tier0Pair());
+    appendTier0Journal(pod, r.report.tier0Merges, 'pod import');
+    appendTier0Journal(pod, r.report.tier0Merges, 'pod reconcile --apply');
+    const journal = readTier0Journal(pod);
+    expect(journal.entries).toHaveLength(2);
+    expect(journal.entries.map((e) => e.appliedBy)).toEqual(['pod import', 'pod reconcile --apply']);
+    expect(journal.entries.every((e) => e.rule === 'tier-0-cross-source-exact-lab-duplicate')).toBe(true);
+  });
+
+  it('yields the discarded records back, content intact', async () => {
+    const pod = mkPod();
+    const r = await runReconciliation(tier0Pair());
+    appendTier0Journal(pod, r.report.tier0Merges, 'pod import');
+    const restorable = tier0DiscardedRecords(readTier0Journal(pod));
+    expect(restorable).toHaveLength(1);
+    expect(restorable[0].discardedUri).toMatch(/^urn:uuid:lab-[ab]$/);
+    expect(
+      restorable[0].properties['https://ns.cascadeprotocol.org/health/v1#resultValue'][0].value,
+    ).toBe('141');
+  });
+
+  it('is valid JSON on disk', () => {
+    // It goes through the RFC 8259 encoder like every other JSON this tool
+    // writes: the journal holds record CONTENT, which is exactly where a hostile
+    // literal lives.
+    const pod = mkPod();
+    appendTier0Journal(
+      pod,
+      [
+        {
+          canonicalUri: 'urn:uuid:kept',
+          recordType: 'health:LabResultRecord',
+          matchedOn: `loinc:2951-2@${INSTANT}`,
+          origins: ['org:larkfield', 'org:stonebridge'],
+          discarded: [
+            {
+              uri: 'urn:uuid:gone',
+              type: 'health:LabResultRecord',
+              sourceSystem: 'Household export',
+              sourceIdentity: 'org:larkfield',
+              properties: {
+                'https://ns.cascadeprotocol.org/health/v1#testName': [
+                  { value: `Sodium ${String.fromCharCode(0xd800)} draw` },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      'pod import',
+    );
+    const raw = fs.readFileSync(path.join(pod, TIER0_JOURNAL_RELATIVE_PATH), 'utf-8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+    expect(raw).not.toMatch(/\\ud[89abAB][0-9a-fA-F]{2}/);
+  });
+});

--- a/tests/source-identity.test.ts
+++ b/tests/source-identity.test.ts
@@ -401,26 +401,25 @@ describe('the same-source guard reads the ORIGIN, not the transport', () => {
     expect(await survivingRecords(first, second, 'Household export', 'Household export')).toBe(2);
   });
 
-  it('records that the fast path never compares two NEW records with each other, whatever the guard says', async () => {
-    // MEASURED, twice, and pinned so the day either half changes is visible.
+  it('reaches the same answer on the fast path as on the single-batch path', async () => {
+    // THE TWO PATHS MUST AGREE, and this is the two-sided measurement of it.
     //
-    // `runReconciliation` has two matching paths and picks the
-    // `--reconcile-existing` fast path when an input is marked
-    // `existingPod: true` (the flag the cross-batch sweep introduced; the old
-    // `systemName` convention was overwritten by every pod record's own triple
-    // and never selected it). On that path, the cross-batch pass assigns EVERY
-    // new record — matched or not — before the new-against-new pass runs, so
-    // that pass's guard site is unreachable and two duplicates arriving in ONE
-    // import are never compared with each other, whatever the same-source guard
-    // would have said about them. That is a property of the pass ordering, not
-    // of the origin axis, and it is pinned here rather than fixed here.
+    // What this test used to pin was the DISAGREEMENT. `runReconciliation` picks
+    // the `--reconcile-existing` fast path when an input is marked
+    // `existingPod: true`, and that path ran a cross-batch pass that assigned
+    // EVERY new record, matched or not, before the new-against-new pass could
+    // seed from any of them. So the second pass and its same-source guard site
+    // were unreachable, and two duplicates arriving in ONE import were never
+    // compared with each other whenever the pod held anything — while the SAME
+    // pair through the single-batch path merged. Measured: 3 records against 1
+    // on identical inputs.
     //
-    // The second half is the contrast that shows what is at stake: the SAME two
-    // records through the single-batch path DO merge, because the guard reads
-    // their two different known origins under the shared batch label and admits
-    // the comparison (the P07-SHARED-LABEL semantics). The fast path and the
-    // single-batch path disagreeing about a batch's internal duplicates is a
-    // real gap, and it is tracked; this test is the measurement.
+    // The two passes are now one pass whose candidate list is the union of both
+    // pools, so the fast path runs the single-batch algorithm restricted to
+    // new-record seeds. Both halves below are kept, and they are what makes this
+    // pin two-sided: the fast path merging the pair is the fix, and the
+    // single-batch path still merging it is the guarantee that the fix did not
+    // arrive by loosening the guard.
     const pod = `${RECON_PREFIXES}
 <urn:uuid:lab-already-in-pod> a health:LabResultRecord ;
   health:testCode <http://loinc.org/rdf#2160-0> ;
@@ -431,13 +430,14 @@ describe('the same-source guard reads the ORIGIN, not the transport', () => {
     const alpha = labTtl('urn:uuid:lab-alpha-x', { batch: 'Household export', origin: 'org:stonebridge' });
     const beta = labTtl('urn:uuid:lab-beta-x', { batch: 'Household export', origin: 'org:larkfield' });
 
-    // Fast path: pod content present. The duplicate pair survives un-compared.
+    // Fast path: pod content present. The batch's internal duplicate merges, and
+    // the unrelated pod record (a different LOINC) passes through untouched.
     const fast = await runReconciliation([
       { content: pod, systemName: 'existing-pod', existingPod: true },
       { content: alpha, systemName: 'Household export' },
       { content: beta, systemName: 'Household export' },
     ]);
-    expect(recordSubjects(parse(fast.turtle)).length).toBe(3);
+    expect(recordSubjects(parse(fast.turtle)).length).toBe(2);
 
     // Single-batch path: same pair, no pod content. The guard admits, they merge.
     const single = await runReconciliation([
@@ -445,6 +445,91 @@ describe('the same-source guard reads the ORIGIN, not the transport', () => {
       { content: beta, systemName: 'Household export' },
     ]);
     expect(recordSubjects(parse(single.turtle)).length).toBe(1);
+  });
+
+  it('merges a batch duplicate and a pod duplicate into ONE record, not two', async () => {
+    // The case that rules out both of the smaller repairs the ordering comment
+    // names. Three copies of one result: one already in the pod, two arriving in
+    // one batch under three different known origins.
+    //
+    //   deferring assignment  -> alpha absorbs the pod copy, beta is left over: 2
+    //   within-batch first    -> alpha absorbs beta, neither meets the pod copy: 2
+    //
+    // One pass over the union of both pools is the only arrangement that reaches
+    // 1, which is why the fix is an ordering decision rather than a guard patch.
+    const podCopy = labTtl('urn:uuid:lab-in-pod-y', { batch: 'Earlier import', origin: 'org:brightwater' });
+    const alpha = labTtl('urn:uuid:lab-alpha-y', { batch: 'Household export', origin: 'org:stonebridge' });
+    const beta = labTtl('urn:uuid:lab-beta-y', { batch: 'Household export', origin: 'org:larkfield' });
+
+    const result = await runReconciliation([
+      { content: podCopy, systemName: 'existing-pod', existingPod: true },
+      { content: alpha, systemName: 'Household export' },
+      { content: beta, systemName: 'Household export' },
+    ]);
+    expect(recordSubjects(parse(result.turtle)).length).toBe(1);
+  });
+
+  it('never matches a record against itself now that the seed is its own candidate', async () => {
+    // The cost of merging the two passes into one. The seed record is now IN the
+    // candidate list it walks, and `doRecordsMatch(a, a)` is a perfect match, so
+    // nothing about the record's CONTENT stops it grouping with itself.
+    //
+    // What this pins is the OUTCOME, not one line: no phantom merge, whichever
+    // clause is doing the work. That distinction is load bearing here, because
+    // two clauses currently do it. `b === a` states the condition directly, and
+    // `sameSourceStatement(a, a)` is unconditionally true and would reject the
+    // self-pair on its own, so neither is individually mutation-visible. The
+    // property is worth a test regardless: the record COUNT is unchanged either
+    // way, so a regression here would show up not as a lost record but as a
+    // survivor carrying `mergedFrom` pointing at itself and a report counting a
+    // duplicate that does not exist.
+    const pod = `${RECON_PREFIXES}
+<urn:uuid:lab-already-in-pod> a health:LabResultRecord ;
+  health:testCode <http://loinc.org/rdf#2160-0> ;
+  health:testName "Creatinine" ;
+  health:performedDate "2031-05-20" ;
+  health:resultValue "1.1" .
+`;
+    const lone = labTtl('urn:uuid:lab-lone', { batch: 'Household export', origin: 'org:stonebridge' });
+    const result = await runReconciliation([
+      { content: pod, systemName: 'existing-pod', existingPod: true },
+      { content: lone, systemName: 'Household export' },
+    ]);
+
+    expect(recordSubjects(parse(result.turtle)).length).toBe(2);
+    // Nothing merged, so nothing may CLAIM to have merged.
+    expect(result.report.summary.exactDuplicatesRemoved).toBe(0);
+    expect(result.report.summary.nearDuplicatesMerged).toBe(0);
+    expect(result.report.transformations).toEqual([]);
+    const triples = parse(result.turtle);
+    expect(values(triples, 'https://ns.cascadeprotocol.org/core/v1#mergedFrom')).toEqual([]);
+    expect(values(triples, 'https://ns.cascadeprotocol.org/core/v1#reconciliationStatus')).toEqual([
+      'canonical',
+    ]);
+  });
+
+  it('still never compares two records that were both already in the pod', async () => {
+    // The restriction the single pass deliberately KEEPS. Only new records seed
+    // a group, so an import cannot silently reconcile pod content against itself
+    // as a side effect of importing an unrelated file. `pod reconcile` is where
+    // that mutation is asked for, reported first, and applied on purpose.
+    const podA = labTtl('urn:uuid:lab-pod-a', { batch: 'Earlier import', origin: 'org:stonebridge' });
+    const podB = labTtl('urn:uuid:lab-pod-b', { batch: 'Earlier import', origin: 'org:larkfield' });
+    const unrelated = `${RECON_PREFIXES}
+<urn:uuid:lab-unrelated> a health:LabResultRecord ;
+  cascade:sourceSystem "New import" ;
+  health:testCode <http://loinc.org/rdf#2160-0> ;
+  health:testName "Creatinine" ;
+  health:performedDate "2031-05-20" ;
+  health:resultValue "1.1" .
+`;
+    const result = await runReconciliation([
+      { content: podA, systemName: 'existing-pod', existingPod: true },
+      { content: podB, systemName: 'existing-pod', existingPod: true },
+      { content: unrelated, systemName: 'New import' },
+    ]);
+    // Two pod duplicates + the unrelated new record. The pod pair is untouched.
+    expect(recordSubjects(parse(result.turtle)).length).toBe(3);
   });
 
   it('does not treat an origin difference on one IRI as an identity collision', async () => {


### PR DESCRIPTION
Four changes to how duplicates are found, merged and reported, plus a guarantee at the JSON boundary.

## Scope

**1. A pod can now be reconciled against itself: `cascade pod reconcile <pod-dir>`.**
`pod import --reconcile-existing` compares arriving records against stored ones and deliberately
never compares two stored records with each other. That restriction is right for an import, since
rewriting records the user did not just hand over should not be a side effect of importing an
unrelated file, but it meant duplicates already IN a pod were permanent: nothing ever compared them,
so no sequence of imports could clear them.

The new verb is the same reconciler and the same conflict machinery pointed at pod content, named
honestly as the mutation it is. Dry run is the DEFAULT: it reads the pod, runs the full
reconciliation, prints what WOULD merge and what WOULD be raised for review, writes nothing, and
exits 0. `--apply` is a separate typed decision made after reading that report. `--json` gives the
same report machine readable and `--report <file>` writes it to disk. Unresolved conflicts go into
the same `settings/pending-conflicts.ttl` queue `pod conflicts` and `pod resolve` already read.

Two safety properties are pinned rather than assumed. A registered record file it cannot read ends
the run at exit 2, in the DRY RUN as much as under `--apply`: every count the verb prints is a claim
about the pod's WHOLE record set, and a file that was never opened could hold a third copy, so a
confident report over a partial read is a wrong answer rather than a small one. And it reads and
writes ONLY registered record buckets, because the merged result is a complete replacement of what
it covers, and sweeping an unregistered `.ttl` (a pod legitimately keeps notes and analyses under
`clinical/`) would relocate that file's subjects into a passthrough bucket as a side effect. The
verb is registered in the pod read-conformance matrix as a read verb and runs all five of its
scenarios.

**2. Tier 0: cross-source exact lab duplication merges without raising a conflict, logged and
reversible.** Two organizations reporting one draw is the commonest thing a multi-source pod holds,
and queueing a question for each one does not produce caution, it produces a queue nobody finishes
with the genuinely disagreeing pairs buried in it. The class is drawn narrowly and every clause is
load bearing: same LOINC, the same exact INSTANT (never day level, because a same-day repeat draw is
a real second measurement), byte-identical content on every non-provenance predicate, and two
DIFFERENT origins that both name a real organization. `transport:` and absent origins are unknown
rather than different and are excluded, so a pod written before origins existed reconciles exactly
as it did before. Measured across 144 candidate groups at a 22% duplicate base rate: zero false
positives.

Silent means not interrupting, not unrecorded. Every tier-0 merge is counted as
`tier0MergesApplied`, itemized in `report.tier0Merges` with the surviving IRI and every IRI it
absorbed, and appended to `settings/tier0-merge-journal.json` with the FULL content of each
discarded record. Tier-0 groups are exempt from the opt-in cross-provenance guard, which otherwise
flagged every benign cross-source duplicate, since two organizations reporting one draw differ on
provenance class as a matter of course. `clinical:provenanceClass` is excluded from tier 0's
definition of "identical content" for the same reason, in a set of its own rather than by widening
`COLLISION_IGNORED_PREDICATES`, which answers a different question for every record type.

**3. The fast-path pass-ordering decision.** See below.

**4. `--json` output is guaranteed RFC 8259 valid.** Measured: `pod query --all --edges --json`
emitted 3.7 MB with exit 0 and empty stderr that jq refused to parse, while a synthetic control on
the same binary was pure. Turtle admits `\uXXXX` escapes, so a pod literal can hold an UNPAIRED
surrogate; nothing on the read path rejects it, and `JSON.stringify` (well-formed since ES2019)
faithfully re-emits it as `\ud800`, which `JSON.parse` accepts, Python's `json` accepts, and jq
rejects with `Invalid \uXXXX\uXXXX surrogate pair escape`. Two of three parsers accepting is exactly
how a corrupt payload looks healthy.

All JSON now goes through one encoder (`src/lib/json-output.ts`) that replaces unpaired surrogates
with U+FFFD in string values AND in object keys. Repair runs only when a cheap test says the encoded
text may contain something a parser rejects, so already-valid output is byte-identical to what it
was. Routed: `pod query`, `pod conflicts`, `validate`, `advisory`, the `--report` files from
`pod import` and `reconcile`, the `pod extract` sidecars, and the shared error/warning envelopes.

## The pass-ordering decision, and why it is not a guard patch

On the `--reconcile-existing` fast path, which is the DEFAULT, the cross-batch pass called
`assigned.add()` on EVERY new record, matched or not, before the new-against-new pass ran. That pass
had no unassigned record left to seed from, so it and its same-source guard site were structurally
dead code, and a batch's own internal duplicates imported un-reconciled whenever the pod held any
content, which is every import after the first. The single-batch path merged the same pair: 3
records against 1 on identical inputs.

Two smaller repairs were considered and rejected, because each fixes one pair and leaves a different
pair un-merged. Take three copies of one result, one already in the pod and two arriving in one
batch:

- **Defer assignment** (assign only new records that matched) lets the within-batch pass see the
  leftovers, but a new record that DID match a stored one is still assigned, so it can no longer
  absorb its own in-batch twin. Result: 2 records where 1 is right.
- **Within-batch first** inverts the same problem. The two batch copies merge, both are assigned,
  and neither is ever compared against the stored copy. Again 2.

Both are guard patches on an ordering that should not exist. A record's membership in a group is one
question, and asking it in two half-passes over two disjoint candidate pools cannot answer it. So
the two passes are now ONE pass whose candidate list is the union of both pools, which makes the
fast path run the same algorithm the single-batch path runs, restricted so that only new records
SEED a group. That restriction is kept deliberately: two records already in the pod are still never
compared during an import, which is now what `pod reconcile` exists to do on purpose.

The two-sided pin (`tests/source-identity.test.ts`, "records that the fast path never compares two
NEW records with each other") is updated in the same commit to assert the new behavior, keeping both
halves so the fix cannot have arrived by loosening the guard. Three tests were added around it: the
three-copy case that rules out both rejected repairs, the preserved pod-versus-pod restriction, and
a self-match test (the seed is now in its own candidate list, so a record can group with itself).

## Mutation table

Each load-bearing line was hand-flipped, the diff confirmed non-empty, `dist/` rebuilt, and the FULL
suite run. Round 1 ran 18; five of those did not compile (all `TS6133` unused-variable, which is a
tsc verdict rather than a test one) and were rewritten compile-clean for round 2, along with the
round-1 survivors after each was addressed.

| Mutation | RED tests |
|---|---|
| `toJsonText` stops repairing: emit raw `JSON.stringify` output | 5 |
| lone HIGH surrogate passed through instead of replaced | 5 |
| object KEYS left unsanitized (values only) | 3 |
| `formatOutput` bypasses the encoder chokepoint | 2 |
| fast-path candidate pool reverts to existing-pod records only | 3 |
| self-match guard `b === a` removed from the merged pass | 0 (equivalent mutant, explained) |
| tier-0 instant clause neutralized (day-level dates admitted) | 1 |
| tier-0 known-origin clause dropped (transport / absent admitted) | 2 |
| tier-0 DIFFERENT-origins clause dropped (same origin admitted) | 1 |
| tier-0 exemption from the cross-provenance guard removed | 1 |
| `provenanceClass` counted as tier-0 content again | 1 |
| tier-0 journal records groups that did NOT actually merge | 0 (unreachable guard, kept knowingly) |
| tier-0 identical-content clause dropped | 2 |
| tier-0 same-LOINC clause dropped | 0 (equivalent mutant, explained) |
| tier-0 lab-only clause dropped | 0 (equivalent mutant, explained) |
| journal replaces instead of appending | 1 |
| unreadable record file no longer refuses the run | 4 |
| dry run writes anyway (`--apply` gate neutralized) | 4 |
| reconcile reads every `.ttl` under the data dirs, not just registered buckets | 1 |
| `recordsAfter` reverts to `finalRecordCount` (drops passthrough subjects) | 1 |
| `pod import` stops journaling its tier-0 merges | 1 |

Round 1 produced five survivors. Every one was investigated rather than reported as covered, and
they split three ways:

**Real coverage gaps, now closed.**

- *Tier-0 known-origin clause* survived because the boundary tests used ONE shared batch label,
  where `sameSourceStatement` holds an unknown-origin record out of the comparison entirely. Those
  tests were measuring the GUARD and would have passed with the whole clause deleted. Rewritten to
  use differing labels, with an assertion that the pair really was grouped. Now 2 RED.
- *`recordsAfter` reverts to `finalRecordCount`* survived because every fixture pod held only
  reconcilable records, so group count and subject count agreed. A pod with a non-reconcilable
  record (a lab report) makes them differ, which is how the fabricated "3 in, 2 out" arose in the
  first place. Test added. Now 1 RED.
- *Write targets include non-bucket files* was fixed at the source rather than test-covered: reads
  and writes are now restricted to registered record buckets, so the hazard cannot arise. The
  replacement mutation (sweep every `.ttl` again) is 1 RED.

**Equivalent mutants, code simplified or documented.**

- *Different-origins clause dropped* duplicated the `origins.size === records.length` check at the
  end of the same function. The redundant early return is deleted rather than test-covered.
- *Same-LOINC* and *lab-only* clauses are implied by the content fingerprint and by the
  `testCode`-present check respectively, so neither is individually mutation-visible. They are kept
  and documented, because the redundancy is CONTINGENT: adding `health:testCode` to
  `TIER0_IGNORED_PREDICATES`, an ordinary one-line change, would silently widen the class.
- *Self-match guard* is redundant with `sameSourceStatement(a, a)`, which is unconditionally true.
  Kept (it states the condition directly and matches the single-batch loop) and documented. Its test
  was reworded to pin the observable property rather than claim to pin that line.

**One honest survivor, kept knowingly.**

- *Tier-0 journal records groups that did not merge.* A tier-0 group is always classified an exact
  duplicate and is exempt from the only rule that could leave one unresolved, so the `resolved`
  check is unreachable today and deleting it passes every test. It stays, with a comment saying
  exactly that, because an entry in that list is the claim "these records were merged away": a
  future match type that leaves a tier-0 group for review would, without it, journal records that
  are still in the pod.

## Suite

Baseline at branch point: **2216 passed / 0 failed / 0 skipped** (138 files).
At HEAD of this branch: **2269 passed / 0 failed / 0 skipped** (141 files).
53 tests added, zero skips, no test deleted or weakened.

`npx tsc --noEmit` clean.

## CHANGELOG

Added under an `## [Unreleased]` heading covering the new verb, the tier-0 ruling with its logging
and reversibility guarantee, the pass-ordering fix, and the RFC 8259 encoder guarantee. No version
bump. README documents the new verb.
