### PR TITLE
fix(cli): make the pending-conflict queue trustworthy end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,60 @@ rows kept, rows cleared by merge, rows orphaned, rows after, with the conflict i
 two. A decision queue changing size is a fact the user is told rather than one they discover by
 diffing a settings file.
 
+**`pod resolve --by <actorIri>` records who answered a conflict, and `pod conflicts --resolved` reads
+the decisions back.**
+`settings/user-resolutions.ttl` carried WHEN a conflict was answered (`cascade:resolvedAt`) and never
+by whom, and no verb listed the file at all, so a decision was write-only. `--by` mirrors
+`pod annotate --by`: it writes `prov:wasAttributedTo` on the `cascade:UserResolution`, refuses an IRI
+that could not be written back before the pod is opened, and is optional, so omitting it leaves the
+row exactly as it was written before. `pod conflicts --resolved` emits the decision log (conflict id,
+timestamp, choice, kept and discarded record IRIs, note, actor when present) as text or with
+`--format json`. It exits 0 whenever the read succeeded: exit 1 is a CI signal about UNANSWERED
+questions, and a decision log carries no such signal.
+
+**`pod import --report` carries the pending-conflict disposition.**
+The same block `pod reconcile --json` reports, on the verb that runs a reconciliation pass of its
+own. Stated on a dry run too, where it is a preview of what the queue would look like.
+
 ### Fixed
+
+**A raised conflict now names the two ORIGINS its sides came from, and keeps both of their values.**
+Conflict rows were labelled with `cascade:sourceSystem`, the INGESTION axis. A pod-internal
+`pod reconcile` reads every record back through one door, so both sides of a row arrived under one
+string and the row said it twice; and for a record stating no `cascade:sourceSystem` of its own,
+that string was the bucket path, so a dose disagreement between two organizations printed
+`Source A: clinical/medications.ttl` / `Source B: clinical/medications.ttl`.
+
+The second half lost data rather than merely failing to show it: the reconciler's map of the two
+sides' values was keyed on that same string, so the two entries collapsed into one and only the
+value assigned second survived. A levothyroxine disagreement between "50 mcg" and "75 mcg" reached
+the pod as the single clause `clinical/medications.ttl: "75 mcg"`, with the surviving record's own
+value gone.
+
+Sides are now keyed and labelled by ORIGIN (`cascade:sourceIdentity` through the shared
+`sourceLabel` derivation, falling back to the stated EHR name and then to the record IRI), and
+carried as an ORDERED list that cannot collapse whatever the labels are. The reconciliation report
+now states both axes: `sources` is unchanged and still the ingestion batch, `origins` is the new
+fact. Matching, the same-source guard, merge ranking and identity minting are untouched, and the
+pathology corpus scorecard is unmoved.
+
+**A conflict row stays reviewable after its candidates merge.**
+The row kept both candidate record IRIs, and a value or status conflict that resolves absorbs the
+losing record, so a consumer following the two IRIs to show "this side says X, that side says Y"
+found one of them gone. The disagreement is now written onto the row at raise time: the field in
+dispute (`cascade:conflictField`), each side's value (`cascade:valueA` / `cascade:valueB`) beside
+each side's origin, and which candidate survived (`cascade:survivingRecord`). These are additive app
+bookkeeping in the namespace the file already uses, not protocol vocabulary; rows written before
+them still parse with the new fields absent, and `pod conflicts --format json` emits them.
+
+**`pod import` no longer discards pending conflicts it did not raise.**
+`writePendingConflicts` replaces the file wholesale and import called it with the run's own
+conflicts alone, so any import at all, including one that touched none of a pending row's records,
+erased every question already in the queue. It is the defect `pod reconcile` was given a disposition
+for, and import now goes through that same computation: pre-existing rows are kept, cleared by
+merge, or orphaned and named, and the counts reach `--report`. A queue file that exists and cannot
+be read refuses the import at exit 2 rather than being overwritten unseen. The `legacyConflictIds`
+docstring, which asserted the wholesale rewrite as intended design, is corrected.
 
 **One health system now resolves to ONE display label whichever transport carried it.**
 `cascade:sourceIdentity` already converged. `clinical:sourceEHR` did not: the C-CDA path labelled

--- a/src/commands/pod/conflicts.ts
+++ b/src/commands/pod/conflicts.ts
@@ -1,23 +1,45 @@
 /**
- * cascade pod conflicts <pod-dir>
+ * cascade pod conflicts <pod-dir> [--resolved]
  *
- * List unresolved conflicts in a pod.
- * Reads settings/pending-conflicts.ttl and displays them.
+ * Read the pod's conflict store. Without `--resolved` that is the QUEUE of
+ * unanswered questions (`settings/pending-conflicts.ttl`); with it, the LOG of
+ * answered ones (`settings/user-resolutions.ttl`).
  *
  * Exit codes:
- *   0 — no unresolved conflicts (text mode)
+ *   0 — no unresolved conflicts (text mode), or any successful `--resolved` read
  *   1 — unresolved conflicts present (text mode; useful for CI)
- *   2 — the conflicts file exists but could NOT be read
+ *   2 — a conflict-store file exists but could NOT be read
  *
  * The third one is the point. `settings/` is inside the encrypted set, so on an
  * encrypted pod this file is ciphertext; without the DEK the Turtle parse failed
  * and the failure was swallowed into an empty list, so the command printed
  * "No unresolved conflicts" and exited 0 with the conflict sitting right there.
  * "None" and "could not tell" must not share an answer.
+ *
+ * WHY `--resolved` AND NOT A `pod resolutions` VERB
+ * -------------------------------------------------
+ * The queue and the decision log are two halves of one store: a row moves from
+ * the first to the second when `pod resolve` answers it, and both live under
+ * `settings/` behind the same DEK. A separate verb would have needed its own
+ * copy of the pod resolution, the DEK resolution, and — the part that matters —
+ * the "this is NOT the same as having none" wording that the encrypted-pod
+ * defect above exists to enforce. A second copy of that sentence is how one of
+ * them softens. So there is one verb over the store and a flag that says which
+ * half.
+ *
+ * Exit code 1 is NOT borrowed for the log. It is a CI signal about UNANSWERED
+ * questions, and a decision log carries no such signal: a log with entries is
+ * not a problem, it is the record of problems already handled. `--resolved`
+ * therefore exits 0 whenever the read succeeded, empty or not.
  */
 
 import { Command } from 'commander';
-import { loadPendingConflicts, ConflictStoreError } from '../../lib/user-resolutions.js';
+import {
+  loadPendingConflicts,
+  loadUserResolutions,
+  ConflictStoreError,
+  type UserResolution,
+} from '../../lib/user-resolutions.js';
 import { resolvePodDir, resolvePodDekIfEncrypted } from './helpers.js';
 import { printError, type OutputOptions } from '../../lib/output.js';
 import { toJsonText } from '../../lib/json-output.js';
@@ -26,12 +48,18 @@ import { shellCommand } from '../../lib/shell-quote.js';
 export function registerConflictsCommand(podProgram: Command, program: Command): void {
   podProgram
     .command('conflicts')
-    .description('List unresolved conflicts in a pod')
+    .description('List unresolved conflicts in a pod (--resolved for the decision log)')
     .argument('<pod-dir>', 'Path to the Cascade Pod directory')
     .option('--format <format>', 'Output format: text or json', 'text')
-    .action(async (podDirArg: string, options: { format: string }) => {
+    .option('--resolved', 'List recorded decisions instead of the unanswered queue', false)
+    .action(async (podDirArg: string, options: { format: string; resolved?: boolean }) => {
       const globalOpts = program.opts() as OutputOptions;
       const podDir = resolvePodDir(podDirArg);
+
+      if (options.resolved === true) {
+        await listResolutions(podDir, podDirArg, options.format, globalOpts);
+        return;
+      }
 
       let conflicts;
       try {
@@ -60,8 +88,14 @@ export function registerConflictsCommand(podProgram: Command, program: Command):
         for (let i = 0; i < conflicts.length; i++) {
           const c = conflicts[i];
           console.log(`${i + 1}. ${c.recordType}`);
-          if (c.sourceA) console.log(`   Source A: ${c.sourceA}`);
-          if (c.sourceB) console.log(`   Source B: ${c.sourceB}`);
+          if (c.conflictField) console.log(`   Field: ${c.conflictField}`);
+          // Each side's value is printed WITH its origin, because the pair is
+          // what makes the row answerable: one candidate record may have been
+          // absorbed by the merge that raised this, and following its IRI would
+          // find nothing.
+          if (c.sourceA) console.log(`   Source A: ${c.sourceA}${c.valueA !== undefined ? ` — "${c.valueA}"` : ''}`);
+          if (c.sourceB) console.log(`   Source B: ${c.sourceB}${c.valueB !== undefined ? ` — "${c.valueB}"` : ''}`);
+          if (c.survivingRecordUri) console.log(`   Surviving record: ${c.survivingRecordUri}`);
           console.log(`   Conflict ID: ${c.conflictId}`);
           console.log(`   Detected: ${c.detectedAt.toISOString()}`);
           console.log(
@@ -74,4 +108,72 @@ export function registerConflictsCommand(podProgram: Command, program: Command):
         process.exit(1);
       }
     });
+}
+
+/**
+ * The decision log: every conflict someone has already answered.
+ *
+ * Sorted by `resolvedAt`, oldest first, so the output reads as a history rather
+ * than as whatever order the store happened to hold. `loadUserResolutions` is
+ * keyed by conflict id and holds one row per conflict, which is the same shape
+ * `pod resolve` writes under, so this reports decisions and not attempts.
+ */
+async function listResolutions(
+  podDir: string,
+  podDirArg: string,
+  format: string,
+  globalOpts: OutputOptions,
+): Promise<void> {
+  let decisions: Map<string, UserResolution>;
+  try {
+    const dek = await resolvePodDekIfEncrypted(podDir);
+    decisions = await loadUserResolutions(podDir, dek);
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    printError(
+      err instanceof ConflictStoreError
+        ? `Could not read the recorded decisions in ${podDir}: ${detail}. ` +
+            `This is NOT the same as no decisions having been made.`
+        : `Could not open the pod at ${podDir}: ${detail}`,
+      globalOpts,
+    );
+    process.exit(2);
+  }
+
+  const rows = [...decisions.values()]
+    .sort((a, b) => a.resolvedAt.getTime() - b.resolvedAt.getTime())
+    .map((r) => ({
+      conflictId: r.conflictId,
+      resolvedAt: r.resolvedAt.toISOString(),
+      resolution: r.resolution,
+      keptRecordUri: r.keptRecordUri,
+      discardedRecordUris: r.discardedRecordUris,
+      // Omitted rather than nulled when unstated: "nobody recorded who" and
+      // "attributed to nobody" are different claims.
+      ...(r.userNote ? { userNote: r.userNote } : {}),
+      ...(r.actorIri ? { actorIri: r.actorIri } : {}),
+    }));
+
+  if (format === 'json') {
+    console.log(toJsonText(rows));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log(`No recorded conflict decisions in pod at ${podDirArg}`);
+    return;
+  }
+
+  console.log(`${rows.length} recorded decision${rows.length > 1 ? 's' : ''} in pod at ${podDirArg}\n`);
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    console.log(`${i + 1}. ${r.conflictId}`);
+    console.log(`   Decision: ${r.resolution}`);
+    console.log(`   Recorded: ${r.resolvedAt}`);
+    if (r.actorIri) console.log(`   By: ${r.actorIri}`);
+    if (r.keptRecordUri) console.log(`   Kept: ${r.keptRecordUri}`);
+    for (const d of r.discardedRecordUris) console.log(`   Discarded: ${d}`);
+    if (r.userNote) console.log(`   Note: ${r.userNote}`);
+    console.log();
+  }
 }

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -47,10 +47,19 @@ import {
 } from './helpers.js';
 import {
   writePendingConflicts,
-  generateConflictId,
+  loadPendingConflicts,
+  pendingConflictFromRaised,
   type PendingConflict,
+  type RaisedConflict,
 } from '../../lib/user-resolutions.js';
-import { randomUUID } from 'node:crypto';
+// The disposition is imported from the reconcile verb rather than reimplemented
+// here on purpose. Two copies of "what happens to a row of the review queue" is
+// how import came to have none: the rule lived in one verb, the other kept its
+// wholesale rewrite, and the two drifted without anything failing.
+import {
+  disposePendingConflicts,
+  type PendingConflictDisposition,
+} from './reconcile.js';
 import {
   isPodEncrypted,
   resolveDek,
@@ -79,6 +88,18 @@ interface ImportReport {
     existingRecordsLoaded?: number;
     summary?: object;
   };
+  /**
+   * What this import did to the queue of conflicts a person still has to answer.
+   *
+   * The same block `pod reconcile --json` reports, and it is here for the same
+   * reason: this file is a user-decision queue, and an import rewrites it. "N
+   * items left your review queue" is a fact the user is told, not one they
+   * discover by diffing a settings file.
+   *
+   * Absent when no reconciliation pass ran, which is the one case where the
+   * queue provably cannot change and the file is not written at all.
+   */
+  pendingConflicts?: PendingConflictDisposition;
   filesWritten: Array<{
     path: string;
     recordsAdded: number;
@@ -717,6 +738,11 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       // Count of record-to-record edge objects the reconciler redirected from a
       // merged-away subject to its survivor.
       let reconciledEdgeRewrites = 0;
+      // What this import does to the queue of questions a person has not
+      // answered. Undefined when no reconciliation ran, which is the one case
+      // where the queue provably cannot change: nothing merged, so no row's
+      // meaning moved, and the file is not touched.
+      let pendingDisposition: PendingConflictDisposition | undefined;
 
       // Load existing pod data as an implicit source 0 when --reconcile-existing is set
       let existingInputs: ReconcilerInput[] = [];
@@ -765,24 +791,53 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           );
         }
 
-        // Persist unresolved conflicts to settings/pending-conflicts.ttl
+        // The review queue is read BEFORE anything about it is decided, and a
+        // queue that exists and cannot be read ends the run. Under a real import
+        // the file is rewritten, so a run that could not read it would be
+        // overwriting a set of unanswered questions it never saw; in a dry run
+        // the report would be claiming a disposition it never computed. Nothing
+        // has been written to the pod at this point, so stopping here leaves it
+        // exactly as it was.
+        let existingConflicts: PendingConflict[];
+        try {
+          existingConflicts = await loadPendingConflicts(podDir, dek);
+        } catch (err: unknown) {
+          printError(
+            `Could not read settings/pending-conflicts.ttl: ` +
+              `${err instanceof Error ? err.message : String(err)}. Refusing to import into ` +
+              `${podDir}: this import would rewrite a review queue it cannot read. ` +
+              `The pod is unchanged.`,
+            globalOpts,
+          );
+          process.exitCode = 2;
+          return;
+        }
+
+        // A conflict this run raises goes through the same mapping every other
+        // verb uses, so the row carries the disagreement itself and not only a
+        // pair of record IRIs, one of which the merge below may absorb.
+        const raisedConflicts: PendingConflict[] = (
+          reconcileResult.report.unresolvedConflicts as RaisedConflict[]
+        ).map((c) => pendingConflictFromRaised(c));
+
+        // THE FIX. `writePendingConflicts` replaces the file wholesale, and this
+        // call site handed it the run's OWN conflicts and nothing else — so an
+        // import that touched none of a pending row's records erased that row
+        // anyway. It is the same defect `pod reconcile` was given a disposition
+        // for, and it goes through the same one: every pre-existing row is KEPT
+        // (its candidates are still distinct records), CLEARED BY MERGE (its
+        // candidates became one, so the merge answered it), or ORPHANED (its
+        // candidates are not in the pod, so nothing can act on it) — and the
+        // counts are reported rather than left to be discovered by diffing a
+        // settings file.
+        const { disposition, queue: finalConflicts } = disposePendingConflicts(
+          existingConflicts,
+          raisedConflicts,
+          mergedTurtle,
+        );
+        pendingDisposition = disposition;
+
         if (!dryRun) {
-          const pendingConflicts: PendingConflict[] = (reconcileResult.report.unresolvedConflicts as Array<{
-            recordType: string;
-            matchedOn: string;
-            sources?: string[];
-            candidateUris?: string[];
-            label?: string;
-          }>).map((c) => ({
-            uri: `urn:uuid:conflict-${randomUUID()}`,
-            conflictId: generateConflictId(c.recordType, c.matchedOn),
-            recordType: c.recordType,
-            detectedAt: new Date(),
-            candidateRecordUris: c.candidateUris ?? [],
-            label: c.label,
-            sourceA: c.sources?.[0],
-            sourceB: c.sources?.[1],
-          }));
           // With the DEK: on a sealed pod this file holds record types, source
           // EHR names and candidate record IRIs, and it used to be written back
           // in the clear on every import.
@@ -793,11 +848,19 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
           // rewritten when the list is empty, because "no conflicts remain" has
           // to be able to CLEAR stale entries from an earlier import.
           const conflictsFile = path.join(podDir, 'settings', 'pending-conflicts.ttl');
-          if (pendingConflicts.length > 0 || (await fileExists(conflictsFile))) {
-            await writePendingConflicts(podDir, pendingConflicts, dek);
+          if (finalConflicts.length > 0 || (await fileExists(conflictsFile))) {
+            await writePendingConflicts(podDir, finalConflicts, dek);
           }
-          if (pendingConflicts.length > 0) {
-            printVerbose(`  ${pendingConflicts.length} unresolved conflict(s) written to settings/pending-conflicts.ttl`, globalOpts);
+          if (raisedConflicts.length > 0) {
+            printVerbose(`  ${raisedConflicts.length} unresolved conflict(s) written to settings/pending-conflicts.ttl`, globalOpts);
+          }
+          if (disposition.orphaned > 0) {
+            printWarning(
+              `${disposition.orphaned} pending conflict(s) left your review queue because their ` +
+                `candidate records are no longer in the pod and no merge in this import explains ` +
+                `it: ${disposition.orphanedIds.join(', ')}.`,
+              globalOpts,
+            );
           }
 
           // Tier-0 merges applied WITHOUT asking. Journaled with the discarded
@@ -1177,6 +1240,11 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
               summary: reconciliationSummary,
             }
           : { enabled: false },
+        // Stated on a dry run too, and it is honest there: the disposition is
+        // computed from the reconciled text, which the dry run produces, so the
+        // preview says what the queue WOULD look like rather than going quiet
+        // about a file it is about to rewrite.
+        ...(pendingDisposition ? { pendingConflicts: pendingDisposition } : {}),
         filesWritten,
         typeCounts,
         bucketsRefused,

--- a/src/commands/pod/reconcile.ts
+++ b/src/commands/pod/reconcile.ts
@@ -65,10 +65,10 @@ import { mergeIntoBucket, derelativizeQuads, relBaseFor } from '../../lib/bucket
 import {
   writePendingConflicts,
   loadPendingConflicts,
-  generateConflictId,
+  pendingConflictFromRaised,
   type PendingConflict,
+  type RaisedConflict,
 } from '../../lib/user-resolutions.js';
-import { randomUUID } from 'node:crypto';
 import {
   appendTier0Journal,
   appendTier0Undo,
@@ -107,7 +107,19 @@ export interface ReconcileGroupReport {
   resolved: boolean;
   /** True for the narrow, silently-mergeable cross-source exact lab class. */
   tier0: boolean;
+  /** INGESTION axis: the import batch each record of the group arrived in. */
   sources: string[];
+  /**
+   * ORIGIN axis: which organization each record came from, one per record, in
+   * the same order as `sources`.
+   *
+   * Reported separately rather than replacing `sources` because the two are
+   * different facts and both are worth having. A pod-internal run reads every
+   * record through one door, so `sources` is legitimately one repeated string
+   * there — which is fine as an answer to "how did this get here" and useless as
+   * an answer to "who says what".
+   */
+  origins: string[];
 }
 
 /**
@@ -200,7 +212,7 @@ export interface ReconcileReport {
 }
 
 /** A disposition for a pod where nothing was read and nothing can change. */
-function emptyDisposition(before = 0): PendingConflictDisposition {
+export function emptyDisposition(before = 0): PendingConflictDisposition {
   return {
     before,
     raised: 0,
@@ -448,7 +460,7 @@ function countRecordsIn(inputs: ReconcilerInput[]): number {
  * else in the pod may reference. A conflict does not become newer by being
  * noticed again.
  */
-function disposePendingConflicts(
+export function disposePendingConflicts(
   existing: readonly PendingConflict[],
   raised: readonly PendingConflict[],
   reconciledTurtle: string,
@@ -1115,23 +1127,8 @@ export function registerReconcileSubcommand(podProgram: Command, program: Comman
         // the queue would look like, which is the whole reason the verb reports
         // before it writes.
         const raisedConflicts: PendingConflict[] = (
-          result.report.unresolvedConflicts as Array<{
-            recordType: string;
-            matchedOn: string;
-            sources?: string[];
-            candidateUris?: string[];
-            label?: string;
-          }>
-        ).map((c) => ({
-          uri: `urn:uuid:conflict-${randomUUID()}`,
-          conflictId: generateConflictId(c.recordType, c.matchedOn),
-          recordType: c.recordType,
-          detectedAt: new Date(),
-          candidateRecordUris: c.candidateUris ?? [],
-          label: c.label,
-          sourceA: c.sources?.[0],
-          sourceB: c.sources?.[1],
-        }));
+          result.report.unresolvedConflicts as RaisedConflict[]
+        ).map((c) => pendingConflictFromRaised(c));
         const { disposition, queue: finalConflicts } = disposePendingConflicts(
           existingConflicts,
           raisedConflicts,
@@ -1148,6 +1145,7 @@ export function registerReconcileSubcommand(podProgram: Command, program: Comman
             resolved: boolean;
             tier0?: boolean;
             sources?: string[];
+            origins?: string[];
           }>
         ).map((t) => ({
           type: t.type,
@@ -1158,6 +1156,7 @@ export function registerReconcileSubcommand(podProgram: Command, program: Comman
           resolved: t.resolved,
           tier0: t.tier0 === true,
           sources: t.sources ?? [],
+          origins: t.origins ?? [],
         }));
 
         const report: ReconcileReport = {

--- a/src/commands/pod/resolve.ts
+++ b/src/commands/pod/resolve.ts
@@ -1,9 +1,16 @@
 /**
  * cascade pod resolve <pod-dir> --conflict <id> --keep <source-a|source-b|both>
+ *                     [--note <text>] [--by <actorIri>]
  *
  * Record a conflict resolution decision in the pod.
  * Saves the decision to settings/user-resolutions.ttl and removes the
  * resolved conflict from settings/pending-conflicts.ttl.
+ *
+ * `--by` attributes the decision (`prov:wasAttributedTo`), mirroring
+ * `pod annotate --by`. It is optional: the log recorded WHEN a conflict was
+ * answered and never by whom, which is unattributable on a pod more than one
+ * person touches, but an absent actor stays absent rather than being guessed at.
+ * Read the log back with `pod conflicts <pod-dir> --resolved`.
  *
  * Honors the global --json flag: with --json it emits a single machine-readable
  * result object (and JSON errors) instead of human-readable text. Every other
@@ -23,6 +30,7 @@ import { resolvePodDir, resolvePodDekIfEncrypted } from './helpers.js';
 import { printResult, printError, type OutputOptions } from '../../lib/output.js';
 import { randomUUID } from 'node:crypto';
 import { shellCommand } from '../../lib/shell-quote.js';
+import { assertWritableIri } from '../../lib/bucket-write.js';
 
 export function registerResolveCommand(podProgram: Command, program: Command): void {
   podProgram
@@ -32,7 +40,8 @@ export function registerResolveCommand(podProgram: Command, program: Command): v
     .requiredOption('--conflict <id>', 'Conflict ID to resolve (from cascade pod conflicts)')
     .requiredOption('--keep <choice>', 'Which source to keep: source-a, source-b, both')
     .option('--note <text>', 'Optional note about your decision')
-    .action(async (podDirArg: string, options: { conflict: string; keep: string; note?: string }) => {
+    .option('--by <actorIri>', 'Optional actor IRI (prov:wasAttributedTo)')
+    .action(async (podDirArg: string, options: { conflict: string; keep: string; note?: string; by?: string }) => {
       const globalOpts = program.opts() as OutputOptions;
       const podDir = resolvePodDir(podDirArg);
 
@@ -41,6 +50,21 @@ export function registerResolveCommand(podProgram: Command, program: Command): v
       if (!validChoices.includes(options.keep)) {
         printError(`Invalid --keep value. Must be one of: ${validChoices.join(', ')}`, globalOpts);
         process.exit(1);
+      }
+
+      // Before the pod is opened, let alone written. An IRI carrying a character
+      // Turtle forbids inside <...> serializes into a decision log the next read
+      // cannot parse, and this store's own contract is that an unreadable file is
+      // never silently replaced — so one accepted typo would take the decision
+      // log out of service with no repair path. `pod annotate --by` refuses the
+      // same input at the same point, and for the same reason.
+      if (options.by !== undefined) {
+        try {
+          assertWritableIri(options.by, '--by');
+        } catch (err: unknown) {
+          printError(err instanceof Error ? err.message : String(err), globalOpts);
+          process.exit(1);
+        }
       }
 
       const resolution: ResolutionChoice =
@@ -103,6 +127,7 @@ export function registerResolveCommand(podProgram: Command, program: Command): v
         keptRecordUri,
         discardedRecordUris,
         userNote: options.note,
+        actorIri: options.by,
       }, dek);
 
       // Remove the conflict from the pending list
@@ -119,6 +144,10 @@ export function registerResolveCommand(podProgram: Command, program: Command): v
             keptRecordUri,
             discardedRecordUris,
             remainingConflicts: remaining.length,
+            // Only when there is one. A `null` here would read as "recorded, and
+            // the author is nobody", which is a different claim from "recorded,
+            // and nobody said who".
+            ...(options.by ? { actorIri: options.by } : {}),
           },
           globalOpts,
         );

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -19,7 +19,12 @@ import { normalizeMedName, normalizeDose, normalizeFrequency, type DrugNameNorma
 import { medicationCodeKeys, sharedMedicationCodeKey, extractCodeValue } from './code-keys.js';
 import { cascadeTerminologyResolver } from './terminology.js';
 import { relBase, relBaseFor, derelativizeQuads } from './bucket-write.js';
-import { SOURCE_IDENTITY_PREDICATE, isKnownOrigin } from './source-identity.js';
+import {
+  SOURCE_IDENTITY_PREDICATE,
+  isKnownOrigin,
+  sourceLabel,
+  type SourceIdentityTier,
+} from './source-identity.js';
 
 // Re-export so existing consumers of the reconciler's normalizeMedName keep
 // working. The canonical definition now lives in ./medication-normalize.ts
@@ -703,6 +708,15 @@ export interface IdentityCollision {
   /** Source systems involved, deduplicated, in the order first seen. */
   sourceSystems: string[];
   /**
+   * ORIGIN labels involved, deduplicated, in the order first seen.
+   *
+   * The same axis {@link conflictOriginLabel} renders for every other conflict
+   * row. An identity collision raised through the same queue would otherwise be
+   * the one row whose two sides are named by the ingestion batch, which is the
+   * axis the colliding records most often agree on.
+   */
+  origins: string[];
+  /**
    * Predicates the colliding records DISAGREE on, sorted.
    *
    * The answer to the only question a person resolving this conflict has ("what
@@ -823,6 +837,7 @@ export function splitIdentityCollisions(
         recordType: bucket[0].type,
         resultingUris: [uri, ...distinct.slice(1).map((fp) => target.get(fp)!)],
         sourceSystems: [...new Set(bucket.map((r) => r.sourceSystem))],
+        origins: [...new Set(bucket.map(conflictOriginLabel))],
         differingPredicates: differingPredicates(bucket, resolveRef),
       });
     }
@@ -1222,11 +1237,96 @@ function doRecordsMatch(a: ParsedRecord, b: ParsedRecord, tol: number, resolver?
 
 type MatchType = 'exact_duplicate' | 'near_duplicate' | 'status_conflict' | 'value_conflict' | 'pass_through';
 
+/**
+ * ONE side of a disagreement: whose it is, what it says, and which record said
+ * it.
+ *
+ * WHY THIS IS A LIST AND NOT A MAP
+ * -------------------------------
+ * It used to be `Record<sourceSystem, value>`, and a map keyed on a string the
+ * two sides can SHARE loses one of them. `sourceSystem` is the INGESTION axis —
+ * the import-batch label — and a pod-internal reconcile reads every record back
+ * through one door, so on that path the two sides routinely arrive under one
+ * label (or, for a record stating none, under the bucket path the reader
+ * defaulted to). Two entries collapse to one, and the value that survives is
+ * whichever was assigned second. Measured: a dose disagreement between "50 mcg"
+ * and "75 mcg" reached the pod as the single clause `batch: "75 mcg"`, with the
+ * canonical record's own value gone.
+ *
+ * An ordered list cannot collapse, whatever the labels turn out to be. The label
+ * is then free to be the thing that actually distinguishes the sides — the
+ * ORIGIN — without the correctness of "both values survive" depending on the two
+ * origins being distinct.
+ */
+export interface ConflictSide {
+  /** The ORIGIN label for this side. See {@link conflictOriginLabel}. */
+  origin: string;
+  /** This side's value of the conflicting field. */
+  value: string;
+  /** The record IRI the value was read from. */
+  recordUri: string;
+}
+
+/**
+ * How a conflict row NAMES one of its sides.
+ *
+ * The axis is the ORIGIN (`cascade:sourceIdentity`), rendered through the shared
+ * {@link sourceLabel} derivation, and it is chosen for the same reason the
+ * same-source guard reads it: it is the only one of the three source-shaped
+ * facts that says WHICH ORGANIZATION a record came from. The guard has already
+ * used it to decide these two records are comparable at all, so a row that then
+ * labels both sides with the ingestion batch is describing the pair by the one
+ * axis on which they agreed.
+ *
+ * The cascade mirrors `sourceLabel`'s own, and each step is a weaker claim:
+ *
+ *   1. A stated origin. `org:` renders as the canonical organization display
+ *      name, which is what makes one system's two transports render as one row
+ *      rather than two. `ns:` and `transport:` name no organization, so the
+ *      label falls to what the record itself states.
+ *   2. `clinical:sourceEHR`, for a record written before origins existed. Not an
+ *      origin claim, and it can be split by transport — but it is what that pod
+ *      has, and it is legible.
+ *   3. THE RECORD IRI. Reached when nothing named a source at all. Deliberately
+ *      not a constant like "unknown": two sides labelled "unknown" are the
+ *      collapse this whole change is about, one level down, and an IRI is unique
+ *      by construction. It is ugly on screen and it is honest, which is the
+ *      right trade for a case that means "this pod never recorded where this
+ *      came from".
+ *
+ * REPORT SURFACE ONLY. Nothing here feeds matching, the same-source guard, merge
+ * ranking or identity minting; it decides what a row SAYS, never what happens to
+ * the records.
+ */
+function conflictOriginLabel(r: ParsedRecord): string {
+  const value = r.sourceIdentity;
+  const stated = getProp(r, NS.clinical + 'sourceEHR');
+  if (typeof value === 'string' && value.length > 0) {
+    const tier: SourceIdentityTier = value.startsWith('org:')
+      ? 'organization'
+      : value.startsWith('ns:')
+        ? 'namespace'
+        : 'transport';
+    const label = sourceLabel({ value, tier }, stated);
+    if (label) return label;
+  }
+  const bare = typeof stated === 'string' ? stated.trim() : '';
+  return bare || r.uri;
+}
+
+/** The two sides of a two-record disagreement, in record order. */
+function conflictSides(a: ParsedRecord, b: ParsedRecord, valueA: string, valueB: string): ConflictSide[] {
+  return [
+    { origin: conflictOriginLabel(a), value: valueA, recordUri: a.uri },
+    { origin: conflictOriginLabel(b), value: valueB, recordUri: b.uri },
+  ];
+}
+
 function classifyGroup(
   records: ParsedRecord[],
   tol: number,
   resolver?: DrugNameNormalizer,
-): { matchType: MatchType; conflictField?: string; conflictValues?: Record<string, string> } {
+): { matchType: MatchType; conflictField?: string; conflictSides?: ConflictSide[] } {
   if (records.length < 2) return { matchType: 'pass_through' };
   const [a, b] = records;
 
@@ -1234,20 +1334,20 @@ function classifyGroup(
     const sA = getProp(a, NS.health + 'status');
     const sB = getProp(b, NS.health + 'status');
     if (sA && sB && sA !== sB)
-      return { matchType: 'status_conflict', conflictField: 'health:status', conflictValues: { [a.sourceSystem]: sA, [b.sourceSystem]: sB } };
+      return { matchType: 'status_conflict', conflictField: 'health:status', conflictSides: conflictSides(a, b, sA, sB) };
   }
   if (a.type === 'health:AllergyRecord') {
     const sA = getProp(a, NS.health + 'allergySeverity');
     const sB = getProp(b, NS.health + 'allergySeverity');
     if (sA && sB && sA !== sB)
-      return { matchType: 'value_conflict', conflictField: 'health:allergySeverity', conflictValues: { [a.sourceSystem]: sA, [b.sourceSystem]: sB } };
+      return { matchType: 'value_conflict', conflictField: 'health:allergySeverity', conflictSides: conflictSides(a, b, sA, sB) };
   }
   if (a.type === 'health:LabResultRecord') {
     const vA = parseFloat(getProp(a, NS.health + 'resultValue') ?? 'NaN');
     const vB = parseFloat(getProp(b, NS.health + 'resultValue') ?? 'NaN');
     if (!isNaN(vA) && !isNaN(vB)) {
       const diff = Math.abs(vA - vB) / Math.max(Math.abs(vA), 0.001);
-      if (diff > tol) return { matchType: 'value_conflict', conflictField: 'health:resultValue', conflictValues: { [a.sourceSystem]: String(vA), [b.sourceSystem]: String(vB) } };
+      if (diff > tol) return { matchType: 'value_conflict', conflictField: 'health:resultValue', conflictSides: conflictSides(a, b, String(vA), String(vB)) };
       if (diff > 0)   return { matchType: 'near_duplicate' };
     }
   }
@@ -1262,10 +1362,12 @@ function classifyGroup(
       return {
         matchType: 'status_conflict',
         conflictField: 'clinical:status',
-        conflictValues: {
-          [a.sourceSystem]: getProp(a, NS.clinical + 'status') ?? '(none)',
-          [b.sourceSystem]: getProp(b, NS.clinical + 'status') ?? '(none)',
-        },
+        conflictSides: conflictSides(
+          a,
+          b,
+          getProp(a, NS.clinical + 'status') ?? '(none)',
+          getProp(b, NS.clinical + 'status') ?? '(none)',
+        ),
       };
     }
 
@@ -1278,7 +1380,7 @@ function classifyGroup(
       return {
         matchType: 'value_conflict',
         conflictField: 'clinical:dosage',
-        conflictValues: { [a.sourceSystem]: doseA as string, [b.sourceSystem]: doseB as string },
+        conflictSides: conflictSides(a, b, doseA as string, doseB as string),
       };
     }
     const freqA = getProp(a, NS.clinical + 'frequency') ?? getProp(a, NS.health + 'frequency');
@@ -1287,7 +1389,7 @@ function classifyGroup(
       return {
         matchType: 'value_conflict',
         conflictField: 'clinical:frequency',
-        conflictValues: { [a.sourceSystem]: freqA as string, [b.sourceSystem]: freqB as string },
+        conflictSides: conflictSides(a, b, freqA as string, freqB as string),
       };
     }
 
@@ -1484,7 +1586,7 @@ interface Group {
   records: ParsedRecord[];
   matchedOn: string;
   conflictField?: string;
-  conflictValues?: Record<string, string>;
+  conflictSides?: ConflictSide[];
   /** True when every member satisfies the tier-0 predicate. See {@link isTier0Group}. */
   tier0?: boolean;
 }
@@ -1807,8 +1909,12 @@ async function serializeGroups(
         emit(makeQuad(subj, namedNode(NS.cascade + 'mergedSources'), literal(res.mergedSystems.join(', '))));
         emit(makeQuad(subj, namedNode(NS.cascade + 'conflictResolution'), literal(res.strategy)));
         if (g.conflictField) emit(makeQuad(subj, namedNode(NS.cascade + 'conflictField'), literal(g.conflictField)));
-        if (g.conflictValues) {
-          const valDesc = Object.entries(g.conflictValues).map(([s, v]) => `${s}: "${v}"`).join(' vs ');
+        if (g.conflictSides && g.conflictSides.length > 0) {
+          // Rendered from the ORDERED sides, so the clause count always equals
+          // the side count. Building this string from a map keyed on the sides'
+          // labels is what dropped one side's value whenever the two labels
+          // matched, which on a pod-internal run was every time.
+          const valDesc = g.conflictSides.map((s) => `${s.origin}: "${s.value}"`).join(' vs ');
           emit(makeQuad(subj, namedNode(NS.cascade + 'conflictValues'), literal(valDesc)));
         }
       }
@@ -2096,8 +2202,8 @@ export async function runReconciliation(
       if (matched.length === 1) {
         groups.push({ matchType: 'pass_through', confidence: 1.0, records: matched, matchedOn: '' });
       } else {
-        const { matchType, conflictField, conflictValues } = classifyGroup(matched, labTol, resolver);
-        groups.push({ matchType, confidence: bestConf, records: matched, matchedOn, conflictField, conflictValues });
+        const { matchType, conflictField, conflictSides } = classifyGroup(matched, labTol, resolver);
+        groups.push({ matchType, confidence: bestConf, records: matched, matchedOn, conflictField, conflictSides });
       }
     }
 
@@ -2150,8 +2256,8 @@ export async function runReconciliation(
       if (matched.length === 1) {
         groups.push({ matchType: 'pass_through', confidence: 1.0, records: matched, matchedOn: '' });
       } else {
-        const { matchType, conflictField, conflictValues } = classifyGroup(matched, labTol, resolver);
-        groups.push({ matchType, confidence: bestConf, records: matched, matchedOn, conflictField, conflictValues });
+        const { matchType, conflictField, conflictSides } = classifyGroup(matched, labTol, resolver);
+        groups.push({ matchType, confidence: bestConf, records: matched, matchedOn, conflictField, conflictSides });
       }
     }
   }
@@ -2231,11 +2337,25 @@ export async function runReconciliation(
       type: g.matchType,
       recordType: g.records[0].type,
       canonicalUri: res.canonical.uri,
+      // TWO source axes, reported side by side because they answer different
+      // questions and one of them used to be asked to answer both. `sources` is
+      // INGESTION: which import batch each record arrived in, unchanged and
+      // still the right answer to "how did this get here". `origins` is which
+      // ORGANIZATION each record came from, which is what a conflict row has to
+      // name for its two sides to be told apart.
       sources: g.records.map(r => r.sourceSystem),
+      origins: g.records.map(conflictOriginLabel),
       matchedOn: g.matchedOn,
       strategy: res.strategy,
       conflictField: g.conflictField,
-      conflictValues: g.conflictValues,
+      conflictSides: g.conflictSides,
+      // The map form, kept so a consumer written against it goes on working. It
+      // is DERIVED from the sides rather than being the primary record, and it
+      // still cannot represent two sides that share an origin label — which is
+      // exactly why the sides above are the thing anything new should read.
+      conflictValues: g.conflictSides
+        ? Object.fromEntries(g.conflictSides.map((s) => [s.origin, s.value]))
+        : undefined,
       resolved: res.resolved,
       documentType: getProp(g.records[0], NS.cascade + 'documentType'),
       // Only stated when true, so every existing consumer of this object and
@@ -2275,6 +2395,7 @@ export async function runReconciliation(
       recordType: c.recordType,
       canonicalUri: c.mintedUri,
       sources: c.sourceSystems,
+      origins: c.origins,
       matchedOn: `identity-collision:${c.mintedUri}`,
       strategy: 'split_unresolved',
       resolved: false,

--- a/src/lib/user-resolutions.ts
+++ b/src/lib/user-resolutions.ts
@@ -106,8 +106,42 @@ export interface UserResolution {
   keptRecordUri: string;
   discardedRecordUris: string[];
   userNote?: string;
+  /**
+   * WHO made this decision (`prov:wasAttributedTo`), when they said so.
+   *
+   * Optional, and its absence is not a gap to be filled in later by guessing.
+   * The log recorded WHEN a conflict was answered and never by whom, which on a
+   * pod more than one person touches makes a decision unattributable after the
+   * fact. `pod annotate --by` already writes this predicate for a note; a
+   * decision about which of two clinical facts stands is at least as
+   * attributable, so it takes the same flag and writes the same triple.
+   */
+  actorIri?: string;
 }
 
+/**
+ * One unanswered question in `settings/pending-conflicts.ttl`.
+ *
+ * WHY THE ROW CARRIES THE DISAGREEMENT AND NOT ONLY POINTERS TO IT
+ * ---------------------------------------------------------------
+ * The row used to be a pair of candidate record IRIs and little else, on the
+ * assumption that a consumer wanting to show the two sides would dereference
+ * them. That assumption does not survive the run that raises the row: a value or
+ * status conflict that the reconciler settles ABSORBS the losing record into the
+ * survivor, so one of the two IRIs points at a record that is no longer in the
+ * pod. Measured at full scale: a re-import raised seven medication
+ * disagreements, and every one of them was un-reviewable for exactly this
+ * reason.
+ *
+ * So the substance is written onto the row at raise time — the field in dispute,
+ * each side's value, each side's origin, and which candidate survived. These are
+ * APP BOOKKEEPING in the same namespace and style the file already uses, not
+ * protocol vocabulary: they describe the state of a review queue, not a clinical
+ * fact about the patient, and nothing outside this tool reads them.
+ *
+ * Every one of them is OPTIONAL, and reads tolerate their absence: a pod holding
+ * rows written by an earlier CLI still parses, with the new fields undefined.
+ */
 export interface PendingConflict {
   uri: string;             // urn:uuid:conflict-{conflictId}
   conflictId: string;
@@ -116,8 +150,88 @@ export interface PendingConflict {
   candidateRecordUris: string[];
   // Human-readable summary fields (for display)
   label?: string;          // e.g. "Hypertension"
-  sourceA?: string;        // source system name
+  /**
+   * The two sides' ORIGIN labels: which organization each came from, rendered
+   * through the shared source-identity derivation.
+   *
+   * These used to be the INGESTION label (the import batch), which on a
+   * pod-internal reconcile is one string for every record read out of the pod —
+   * so both sides of the row said the same thing and named nothing a person
+   * could act on.
+   */
+  sourceA?: string;
   sourceB?: string;
+  /** The predicate the two sides disagree on, e.g. `clinical:dosage`. */
+  conflictField?: string;
+  /** What the `sourceA` side says. */
+  valueA?: string;
+  /** What the `sourceB` side says. */
+  valueB?: string;
+  /**
+   * Which candidate record is still in the pod under its own IRI after the run
+   * that raised this row. The other candidate may have been absorbed by a merge,
+   * which is the whole reason the values above are on the row at all.
+   */
+  survivingRecordUri?: string;
+}
+
+/**
+ * A conflict as the RECONCILER describes it, before it becomes a queue row.
+ *
+ * Structural on purpose: it names the fields of the reconciler's own
+ * `unresolvedConflicts` entries without importing its types, so the queue store
+ * does not depend on the reconciler. Every field is optional except the two the
+ * conflict id is computed from, because an identity collision and a value
+ * conflict are both raised through here and they carry different things.
+ */
+export interface RaisedConflict {
+  recordType: string;
+  matchedOn: string;
+  /** The record that survives the run, when one of the candidates does. */
+  canonicalUri?: string;
+  candidateUris?: string[];
+  label?: string;
+  /** ORIGIN labels, one per record, in record order. */
+  origins?: string[];
+  /** INGESTION labels, one per record. The fallback when no origin is stated. */
+  sources?: string[];
+  conflictField?: string;
+  conflictSides?: Array<{ origin: string; value: string; recordUri: string }>;
+}
+
+/**
+ * Turn one raised conflict into the queue row that records it.
+ *
+ * ONE function because there are two callers — `pod reconcile` and the
+ * reconciliation pass inside `pod import` — and they were two copies of the same
+ * mapping. A row that carries the disagreement is only useful if EVERY verb that
+ * raises one writes it the same way, and a second copy is how one of them
+ * silently stops.
+ */
+export function pendingConflictFromRaised(
+  c: RaisedConflict,
+  detectedAt: Date = new Date(),
+): PendingConflict {
+  const sides = c.conflictSides ?? [];
+  return {
+    uri: `urn:uuid:conflict-${randomUUID()}`,
+    conflictId: generateConflictId(c.recordType, c.matchedOn),
+    recordType: c.recordType,
+    detectedAt,
+    candidateRecordUris: c.candidateUris ?? [],
+    label: c.label,
+    // Taken from the SIDES when there are sides, so `sourceA` and `valueA` are
+    // guaranteed to describe the same record rather than two lists that happen
+    // to be ordered alike. Origin next, and the ingestion label only as a last
+    // resort: a run whose records state no origin still names its sides with
+    // something, and a pod written before origins existed reads as it did.
+    sourceA: sides[0]?.origin ?? c.origins?.[0] ?? c.sources?.[0],
+    sourceB: sides[1]?.origin ?? c.origins?.[1] ?? c.sources?.[1],
+    conflictField: c.conflictField,
+    valueA: sides[0]?.value,
+    valueB: sides[1]?.value,
+    survivingRecordUri: c.canonicalUri,
+  };
 }
 
 /**
@@ -149,10 +263,18 @@ export function generateConflictId(recordType: string, matchedOn: string): strin
  *      `settings/user-resolutions.ttl` is keyed by conflict id and cannot hold
  *      two rows under one key.
  *
- * `settings/pending-conflicts.ttl` re-keys itself, because every import rewrites
- * it wholesale from the run's own conflicts; `pod resolve` matches the id the
- * user pasted against that file, so it needs nothing from here. What does NOT
- * re-key itself is the decision log: a row recorded before this change carries
+ * `settings/pending-conflicts.ttl` does NOT need anything from here either, but
+ * for a different reason than this comment used to give. It said the file
+ * re-keys itself "because every import rewrites it wholesale from the run's own
+ * conflicts" — which described the wholesale rewrite as the intended design when
+ * it was the defect: an import that touched none of a row's records dropped that
+ * row anyway. Both `pod reconcile` and `pod import` now put every pre-existing
+ * row through a disposition (kept / cleared by merge / orphaned), so a row can
+ * SURVIVE a run under the id it was written with. It still needs no legacy
+ * lookup, because `pod resolve` matches the id the user pasted against whatever
+ * that file literally holds. What does NOT re-key itself is the decision log:
+ * `settings/user-resolutions.ttl` is keyed by conflict id, and a row recorded
+ * before the id formula changed carries
  * the id from the old formula forever, and a lookup by the new id would miss it.
  * This function is how such a row is still found.
  *
@@ -252,6 +374,7 @@ export async function loadUserResolutions(
             keptRecordUri,
             discardedRecordUris: discardedBySubject.get(uri) ?? [],
             userNote: props.get(NS.cascade + 'userNote'),
+            actorIri: props.get(NS.prov + 'wasAttributedTo'),
           });
         }
         resolve(map);
@@ -319,6 +442,9 @@ async function writeUserResolutions(
       if (res.userNote) {
         writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'userNote'), literal(res.userNote)));
       }
+      if (res.actorIri) {
+        writer.addQuad(makeQuad(subj, namedNode(NS.prov + 'wasAttributedTo'), namedNode(res.actorIri)));
+      }
     }
 
     writer.end((err, result) => {
@@ -366,6 +492,22 @@ export async function writePendingConflicts(
       if (conflict.label) writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'label'), literal(conflict.label)));
       if (conflict.sourceA) writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'sourceA'), literal(conflict.sourceA)));
       if (conflict.sourceB) writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'sourceB'), literal(conflict.sourceB)));
+      // The substance of the disagreement, so the row stays answerable after the
+      // run that raised it absorbed one of its candidate records. Every one is
+      // written only when known, which is what keeps a row from an earlier CLI
+      // and a row from this one the same shape apart from what is actually here.
+      if (conflict.conflictField) {
+        writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'conflictField'), literal(conflict.conflictField)));
+      }
+      if (conflict.valueA !== undefined) {
+        writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'valueA'), literal(conflict.valueA)));
+      }
+      if (conflict.valueB !== undefined) {
+        writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'valueB'), literal(conflict.valueB)));
+      }
+      if (conflict.survivingRecordUri) {
+        writer.addQuad(makeQuad(subj, namedNode(NS.cascade + 'survivingRecord'), namedNode(conflict.survivingRecordUri)));
+      }
     }
 
     writer.end((err, result) => {
@@ -431,6 +573,13 @@ export async function loadPendingConflicts(
             label: (props.get(NS.cascade + 'label') ?? [])[0],
             sourceA: (props.get(NS.cascade + 'sourceA') ?? [])[0],
             sourceB: (props.get(NS.cascade + 'sourceB') ?? [])[0],
+            // Absent on every row written before these existed, and `undefined`
+            // is the right answer for those: the disagreement was never
+            // recorded, so the row says so rather than inventing a value.
+            conflictField: (props.get(NS.cascade + 'conflictField') ?? [])[0],
+            valueA: (props.get(NS.cascade + 'valueA') ?? [])[0],
+            valueB: (props.get(NS.cascade + 'valueB') ?? [])[0],
+            survivingRecordUri: (props.get(NS.cascade + 'survivingRecord') ?? [])[0],
           });
         }
         resolve(conflicts);

--- a/tests/identity-chokepoint.test.ts
+++ b/tests/identity-chokepoint.test.ts
@@ -104,24 +104,17 @@ const EVENT_IDENTITY_ALLOWLIST: ReadonlyArray<{ file: string; why: string }> = [
   },
   {
     file: 'lib/user-resolutions.ts',
-    why: 're-exports randomUUID for the resolve/import commands below; contains no call of its own.',
-  },
-  {
-    file: 'commands/pod/import.ts',
     why:
-      'The pending-conflict record URI. The conflict itself is deduped on the DETERMINISTIC ' +
-      'generateConflictId(recordType, matchedOn); the urn is the id of one detection event.',
+      'The pending-conflict record URI, minted in pendingConflictFromRaised(). The conflict ' +
+      'itself is deduped on the DETERMINISTIC generateConflictId(recordType, matchedOn); the ' +
+      'urn identifies one detection event, and detecting the same conflict twice is two events. ' +
+      'Both raising verbs (pod reconcile, the pass inside pod import) go through this one ' +
+      'function, so neither of them mints anything of its own — which is why they are no longer ' +
+      'on this list. It also re-exports randomUUID for commands/pod/resolve.ts.',
   },
   {
     file: 'commands/pod/resolve.ts',
     why: 'The user-resolution record URI: one per decision a person made, stamped with resolvedAt.',
-  },
-  {
-    file: 'commands/pod/reconcile.ts',
-    why:
-      'The pending-conflict record URI, for the same reason as commands/pod/import.ts: the ' +
-      'conflict is deduped on the DETERMINISTIC generateConflictId(recordType, matchedOn), and ' +
-      'the urn identifies one detection event. Reconciling twice detects the same conflict twice.',
   },
   {
     file: 'lib/advisory/applier.ts',

--- a/tests/pod-import-pending-conflict-disposition.test.ts
+++ b/tests/pod-import-pending-conflict-disposition.test.ts
@@ -1,0 +1,221 @@
+/**
+ * `pod import` must not silently empty the review queue.
+ *
+ * THE SAME DEFECT THE RECONCILE VERB ALREADY FIXED, ONE VERB OVER
+ * ---------------------------------------------------------------
+ * `settings/pending-conflicts.ttl` is a user-decision queue: each row is a
+ * question the tool declined to answer and handed to a person, and `pod resolve`
+ * looks rows up in it by id. `writePendingConflicts` replaces that file
+ * wholesale, and import called it with the run's OWN conflicts and nothing else.
+ * So any import at all — including one that touched none of the records a
+ * pending row is about — erased every question already in the queue.
+ *
+ * `pod reconcile` was given a disposition for exactly this: each pre-existing
+ * row is KEPT (two or more of its candidates are still distinct records), or
+ * CLEARED BY MERGE (its candidates became one record, so the merge answered it),
+ * or ORPHANED (its candidates are not in the pod at all, so nothing can act on
+ * it) — and the counts are reported rather than left to be discovered by
+ * diffing a settings file. Import runs a reconciliation pass of its own and has
+ * to go through the same door.
+ *
+ * The dangerous case is the first one, and it is what this file leads with: a
+ * question about records that are still there, still different, and now silently
+ * un-asked.
+ *
+ * All fixture data is synthetic.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import {
+  writePendingConflicts,
+  loadPendingConflicts,
+  type PendingConflict,
+} from '../src/lib/user-resolutions.js';
+
+const INSTANT = '2031-05-20T09:14:00Z';
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* commander exitOverride: the exit code is read below */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+const PREFIXES = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+`;
+
+function labRecord(uri: string, value: string): string {
+  // ONE origin for both, which is what makes them incomparable: the same-source
+  // guard declines to merge two records one organization stated, so both survive
+  // any reconciliation and the question about them stays open.
+  return `<${uri}> a health:LabResultRecord ;
+  cascade:sourceSystem "Brightwater export" ;
+  cascade:sourceIdentity "org:brightwater" ;
+  health:testCode <http://loinc.org/rdf#2160-0> ;
+  health:testName "Creatinine" ;
+  health:performedDate "${INSTANT}" ;
+  health:resultValue "${value}" .
+`;
+}
+
+/** A pod holding two un-mergeable labs and one open question about them. */
+async function podWithStandingQuestion(): Promise<{ podDir: string; tempDir: string }> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-import-queue-'));
+  dirs.push(tempDir);
+  const podDir = path.join(tempDir, 'pod');
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+
+  fs.writeFileSync(
+    path.join(podDir, 'clinical', 'lab-results.ttl'),
+    PREFIXES + '\n' + labRecord('urn:uuid:lab-standing-a', '1.1') + '\n' + labRecord('urn:uuid:lab-standing-b', '1.4'),
+    'utf-8',
+  );
+
+  const row: PendingConflict = {
+    uri: 'urn:uuid:conflict-standing',
+    conflictId: 'standing',
+    recordType: 'health:LabResultRecord',
+    detectedAt: new Date('2031-01-01T00:00:00Z'),
+    candidateRecordUris: ['urn:uuid:lab-standing-a', 'urn:uuid:lab-standing-b'],
+    label: 'Creatinine',
+    sourceA: 'Brightwater',
+    sourceB: 'Brightwater',
+  };
+  await writePendingConflicts(podDir, [row]);
+  return { podDir, tempDir };
+}
+
+/** An import batch about something else entirely. */
+function unrelatedBatch(tempDir: string): string {
+  const file = path.join(tempDir, 'unrelated.ttl');
+  fs.writeFileSync(
+    file,
+    PREFIXES +
+      `
+<urn:uuid:med-sertraline> a clinical:Medication ;
+  cascade:sourceIdentity "org:larkfield" ;
+  clinical:sourceEHR "Larkfield" ;
+  clinical:drugName "Sertraline" ;
+  clinical:dosage "50 mg" ;
+  clinical:status "active" .
+`,
+    'utf-8',
+  );
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+
+describe('pod import: the review queue is disposed of, not overwritten', () => {
+  it('KEEPS a pending conflict the imported batch never touched', async () => {
+    const { podDir, tempDir } = await podWithStandingQuestion();
+    const batch = unrelatedBatch(tempDir);
+
+    const r = await runCli(['pod', 'import', podDir, batch, '--source-system', 'larkfield']);
+    expect(r.exitCode).toBe(0);
+
+    const after = await loadPendingConflicts(podDir);
+    expect(after.map((c) => c.conflictId)).toContain('standing');
+
+    // The SAME row, not a re-raise: the subject IRI and the detection time the
+    // user may already have seen are preserved, and `pod resolve` finds it.
+    const kept = after.find((c) => c.conflictId === 'standing') as PendingConflict;
+    expect(kept.uri).toBe('urn:uuid:conflict-standing');
+    expect(kept.detectedAt.toISOString()).toBe('2031-01-01T00:00:00.000Z');
+  });
+
+  it('reports the disposition in the import report, and the arithmetic closes', async () => {
+    const { podDir, tempDir } = await podWithStandingQuestion();
+    const batch = unrelatedBatch(tempDir);
+    const reportPath = path.join(tempDir, 'report.json');
+
+    await runCli(['pod', 'import', podDir, batch, '--source-system', 'larkfield', '--report', reportPath]);
+
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as {
+      pendingConflicts: {
+        before: number;
+        raised: number;
+        kept: number;
+        clearedByMerge: number;
+        orphaned: number;
+        after: number;
+        clearedIds: string[];
+        orphanedIds: string[];
+      };
+    };
+    const d = report.pendingConflicts;
+    expect(d.before).toBe(1);
+    expect(d.kept).toBe(1);
+    expect(d.clearedByMerge).toBe(0);
+    expect(d.orphaned).toBe(0);
+    // Every row before this run is accounted for by exactly one outcome.
+    expect(d.kept + d.clearedByMerge + d.orphaned).toBe(d.before);
+    // And what is on disk afterwards is what the report said would be.
+    expect((await loadPendingConflicts(podDir)).length).toBe(d.after);
+  });
+
+  it('ORPHANS a row whose candidate records are not in the pod, and names it', async () => {
+    const { podDir, tempDir } = await podWithStandingQuestion();
+    await writePendingConflicts(podDir, [
+      {
+        uri: 'urn:uuid:conflict-vanished',
+        conflictId: 'vanished',
+        recordType: 'health:LabResultRecord',
+        detectedAt: new Date('2031-01-01T00:00:00Z'),
+        candidateRecordUris: ['urn:uuid:lab-gone-1', 'urn:uuid:lab-gone-2'],
+      },
+    ]);
+    const batch = unrelatedBatch(tempDir);
+    const reportPath = path.join(tempDir, 'report.json');
+
+    await runCli(['pod', 'import', podDir, batch, '--source-system', 'larkfield', '--report', reportPath]);
+
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as {
+      pendingConflicts: { orphaned: number; orphanedIds: string[] };
+    };
+    expect(report.pendingConflicts.orphaned).toBe(1);
+    expect(report.pendingConflicts.orphanedIds).toEqual(['vanished']);
+    expect((await loadPendingConflicts(podDir)).map((c) => c.conflictId)).not.toContain('vanished');
+  });
+});

--- a/tests/pod-reconcile-conflict-origins.test.ts
+++ b/tests/pod-reconcile-conflict-origins.test.ts
@@ -1,0 +1,264 @@
+/**
+ * What a raised conflict row SAYS, and whether it is still answerable later.
+ *
+ * TWO DEFECTS, ONE ROW
+ * --------------------
+ * A pod-internal `pod reconcile` reads its records back out of the pod, so every
+ * record's INGESTION label is whatever the pod restated (or, for a record that
+ * states none, the bucket path the reader defaulted to). Both sides of a
+ * conflict therefore arrived under one string, and the row said so twice:
+ *
+ *     Source A: clinical/medications.ttl
+ *     Source B: clinical/medications.ttl
+ *
+ * which names nothing a person can act on. The second defect is the one that
+ * loses data rather than merely failing to show it: the reconciler's map of the
+ * two sides' VALUES was keyed by that same string, so the two entries collapsed
+ * into one and whichever side was written second was the only value that
+ * survived into `cascade:conflictValues`. A dose disagreement between "50 mcg"
+ * and "75 mcg" reached the pod as the single clause `batch: "75 mcg"`.
+ *
+ * The axis that actually distinguishes the two sides is the ORIGIN
+ * (`cascade:sourceIdentity`, rendered through `sourceLabel`), which is exactly
+ * the axis the same-source guard already uses to decide the two are comparable
+ * at all. So the row is keyed and labelled by origin, and both values survive.
+ *
+ * AND THE ROW HAS TO OUTLIVE THE MERGE
+ * ------------------------------------
+ * A conflict row keeps both candidate IRIs, but a value conflict that resolves
+ * absorbs the losing record: a consumer that follows the two IRIs to show the
+ * user "this side says X, that side says Y" finds one of them gone. So the
+ * substance of the disagreement is written ONTO the row at raise time, and this
+ * file asserts it is there after the apply that removed one of the candidates.
+ *
+ * All fixture data is synthetic.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import { loadPendingConflicts, type PendingConflict } from '../src/lib/user-resolutions.js';
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch {
+    /* commander exitOverride: the exit code is read below */
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+async function makePod(): Promise<string> {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-conflict-origins-'));
+  dirs.push(d);
+  const podDir = path.join(d, 'pod');
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+  return podDir;
+}
+
+const PREFIXES = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+`;
+
+/**
+ * Two organizations' copies of one drug, disagreeing on dose, under ONE batch
+ * label. The shared batch label is the point: it is what a pod-internal read
+ * produces, and it is what used to be printed as both sides of the row.
+ */
+function medsPod(podDir: string): void {
+  fs.writeFileSync(
+    path.join(podDir, 'clinical', 'medications.ttl'),
+    PREFIXES +
+      `
+<urn:uuid:med-meridian> a clinical:Medication ;
+  cascade:sourceSystem "one-batch" ;
+  cascade:sourceIdentity "org:meridian" ;
+  clinical:sourceEHR "Meridian" ;
+  clinical:drugName "Levothyroxine" ;
+  clinical:dosage "50 mcg" ;
+  clinical:status "active" .
+
+<urn:uuid:med-stonebridge> a clinical:Medication ;
+  cascade:sourceSystem "one-batch" ;
+  cascade:sourceIdentity "org:stonebridge" ;
+  clinical:sourceEHR "Stonebridge" ;
+  clinical:drugName "Levothyroxine" ;
+  clinical:dosage "75 mcg" ;
+  clinical:status "active" .
+`,
+    'utf-8',
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('a raised conflict names the two ORIGINS, not the batch they share', () => {
+  it('gives sourceA and sourceB the two distinct origin labels', async () => {
+    const podDir = await makePod();
+    medsPod(podDir);
+    expect((await runCli(['pod', 'reconcile', podDir, '--apply'])).exitCode).toBe(0);
+
+    const [row] = await loadPendingConflicts(podDir);
+    expect(row).toBeDefined();
+    // Not "one-batch" twice. These are `sourceLabel(org:meridian)` and
+    // `sourceLabel(org:stonebridge)`, the same derivation every source-scoped
+    // surface in the pod already renders.
+    expect([row.sourceA, row.sourceB].sort()).toEqual(['Meridian', 'Stonebridge']);
+  });
+
+  it('carries BOTH sides values into the reconciled record, not one', async () => {
+    // The collapse: a map keyed by the shared batch label holds one entry, and
+    // the losing side's value is the one that is silently dropped.
+    const podDir = await makePod();
+    medsPod(podDir);
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+
+    const meds = fs.readFileSync(path.join(podDir, 'clinical', 'medications.ttl'), 'utf-8');
+    expect(meds).toContain('conflictValues');
+    expect(meds).toContain('50 mcg');
+    expect(meds).toContain('75 mcg');
+    expect(meds).not.toContain('one-batch: ');
+  });
+
+  it('reports the origin axis alongside the ingestion axis', async () => {
+    const podDir = await makePod();
+    medsPod(podDir);
+    const r = await runCli(['--json', 'pod', 'reconcile', podDir, '--apply']);
+    const report = JSON.parse(r.stdout) as {
+      groups: Array<{ type: string; sources: string[]; origins: string[] }>;
+    };
+    const g = report.groups.find((x) => x.type === 'value_conflict');
+    expect(g).toBeDefined();
+    // `sources` is unchanged: it is the INGESTION axis and it really is one
+    // batch. `origins` is the new, different fact.
+    expect(g!.sources).toEqual(['one-batch', 'one-batch']);
+    expect([...g!.origins].sort()).toEqual(['Meridian', 'Stonebridge']);
+  });
+
+  it('falls back to the record IRI when a record states no origin at all', async () => {
+    // A pod written before origins existed. Two indistinguishable labels would
+    // put the collapse straight back, so the row falls back to something that
+    // is unique by construction.
+    const podDir = await makePod();
+    fs.writeFileSync(
+      path.join(podDir, 'clinical', 'medications.ttl'),
+      PREFIXES +
+        `
+<urn:uuid:med-old-a> a clinical:Medication ;
+  clinical:drugName "Omeprazole" ;
+  clinical:dosage "20 mg" ;
+  clinical:status "active" .
+
+<urn:uuid:med-old-b> a clinical:Medication ;
+  cascade:sourceSystem "second-batch" ;
+  clinical:drugName "Omeprazole" ;
+  clinical:dosage "40 mg" ;
+  clinical:status "active" .
+`,
+      'utf-8',
+    );
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+
+    const [row] = await loadPendingConflicts(podDir);
+    expect(row).toBeDefined();
+    expect(row.sourceA).not.toBe(row.sourceB);
+    expect([row.sourceA, row.sourceB].sort()).toEqual([
+      'urn:uuid:med-old-a',
+      'urn:uuid:med-old-b',
+    ]);
+  });
+});
+
+describe('a raised conflict row stays reviewable after its candidates merge', () => {
+  it('records the field, both values, both origins and the survivor ON the row', async () => {
+    const podDir = await makePod();
+    medsPod(podDir);
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+
+    const [row] = await loadPendingConflicts(podDir);
+    expect(row.conflictField).toBe('clinical:dosage');
+    expect([row.valueA, row.valueB].sort()).toEqual(['50 mcg', '75 mcg']);
+    // Whichever candidate the reconciler kept: the consumer needs to know which
+    // of the two IRIs it can still dereference.
+    expect(row.candidateRecordUris).toContain(row.survivingRecordUri as string);
+  });
+
+  it('survives the round trip through the file, so `pod conflicts` can show it', async () => {
+    const podDir = await makePod();
+    medsPod(podDir);
+    await runCli(['pod', 'reconcile', podDir, '--apply']);
+
+    const r = await runCli(['pod', 'conflicts', podDir, '--format', 'json']);
+    const rows = JSON.parse(r.stdout) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].conflictField).toBe('clinical:dosage');
+    expect([rows[0].valueA, rows[0].valueB].sort()).toEqual(['50 mcg', '75 mcg']);
+    expect(rows[0].survivingRecordUri).toBeTruthy();
+    expect([rows[0].sourceA, rows[0].sourceB].sort()).toEqual(['Meridian', 'Stonebridge']);
+  });
+
+  it('reads a row written before these predicates existed', async () => {
+    // Backward compatibility is not optional: a pod carrying rows from an
+    // earlier CLI must still parse, with the new fields simply absent.
+    const podDir = await makePod();
+    fs.writeFileSync(
+      path.join(podDir, 'settings', 'pending-conflicts.ttl'),
+      `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:uuid:conflict-legacy> a cascade:PendingConflict ;
+  cascade:conflictId "legacy-row" ;
+  cascade:recordType "clinical:Medication" ;
+  cascade:detectedAt "2031-01-01T00:00:00.000Z"^^xsd:dateTime ;
+  cascade:candidateRecords <urn:uuid:legacy-a>, <urn:uuid:legacy-b> ;
+  cascade:sourceA "Meridian" ;
+  cascade:sourceB "Stonebridge" .
+`,
+      'utf-8',
+    );
+
+    const rows = await loadPendingConflicts(podDir);
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as PendingConflict;
+    expect(row.conflictId).toBe('legacy-row');
+    expect(row.sourceA).toBe('Meridian');
+    expect(row.conflictField).toBeUndefined();
+    expect(row.valueA).toBeUndefined();
+    expect(row.survivingRecordUri).toBeUndefined();
+  });
+});

--- a/tests/pod-resolve-actor.test.ts
+++ b/tests/pod-resolve-actor.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Who answered a conflict, and how anyone finds out afterwards.
+ *
+ * `settings/user-resolutions.ttl` is the decision log: the record that a person
+ * looked at two disagreeing copies of a fact and said which one stands. It
+ * carried WHEN (`cascade:resolvedAt`) and never WHO, and no verb listed it at
+ * all — so a decision was write-only, and on a pod several people touch there
+ * was no way to ask "who decided this, and when". `pod annotate` already takes
+ * `--by <actorIri>` and writes `prov:wasAttributedTo`; a decision is at least as
+ * attributable as a note, so it takes the same flag and writes the same
+ * predicate.
+ *
+ * The flag is OPTIONAL and its absence is exactly today's behaviour: no actor
+ * triple, nothing else moved. An unattributed decision is honest, and inventing
+ * an actor for one would be worse than leaving the axis empty.
+ *
+ * The read path is `pod conflicts --resolved`, which is argued for in the PR:
+ * one verb over the conflict store, one pod argument, one DEK resolution, one
+ * set of "could not read" wording. The queue and the log are the two halves of
+ * the same file pair and the flag is what says which half.
+ *
+ * All fixture data is synthetic.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerPodCommand } from '../src/commands/pod/index.js';
+import {
+  writePendingConflicts,
+  loadUserResolutions,
+  type PendingConflict,
+} from '../src/lib/user-resolutions.js';
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const program = new Command();
+  program
+    .name('cascade')
+    .exitOverride()
+    .option('--verbose', 'Verbose output', false)
+    .option('--json', 'Output JSON', false);
+  registerPodCommand(program);
+
+  const out: string[] = [];
+  const err: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    out.push(a.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    err.push(a.map(String).join(' '));
+  });
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+  // `pod resolve` and `pod conflicts` end a failed run with `process.exit(n)`,
+  // which vitest replaces with a throw. Swallowing that throw would report every
+  // refusal as a success, so the code is read back out of it.
+  let thrownExit: number | undefined;
+  try {
+    await program.parseAsync(['node', 'cascade', ...args]);
+  } catch (e: unknown) {
+    const m = /process\.exit unexpectedly called with "(\d+)"/.exec(
+      e instanceof Error ? e.message : String(e),
+    );
+    if (m) thrownExit = Number(m[1]);
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  const exitCode = thrownExit ?? (typeof process.exitCode === 'number' ? process.exitCode : 0);
+  process.exitCode = 0;
+  return { stdout: out.join('\n'), stderr: err.join('\n'), exitCode };
+}
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function row(conflictId: string): PendingConflict {
+  return {
+    uri: `urn:uuid:conflict-${conflictId}`,
+    conflictId,
+    recordType: 'clinical:Medication',
+    detectedAt: new Date('2031-01-01T00:00:00Z'),
+    candidateRecordUris: [`urn:uuid:med-${conflictId}-a`, `urn:uuid:med-${conflictId}-b`],
+    label: 'Levothyroxine',
+    sourceA: 'Meridian',
+    sourceB: 'Stonebridge',
+  };
+}
+
+async function podWithQueue(ids: string[] = ['dose-disagreement']): Promise<string> {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-resolve-actor-'));
+  dirs.push(d);
+  const podDir = path.join(d, 'pod');
+  expect((await runCli(['pod', 'init', podDir])).exitCode).toBe(0);
+  await writePendingConflicts(podDir, ids.map(row));
+  return podDir;
+}
+
+const ACTOR = 'https://example.org/people/care-coordinator';
+
+// ---------------------------------------------------------------------------
+
+describe('pod resolve --by: a decision carries its author', () => {
+  it('writes prov:wasAttributedTo when --by is given', async () => {
+    const podDir = await podWithQueue();
+    const r = await runCli([
+      'pod', 'resolve', podDir,
+      '--conflict', 'dose-disagreement',
+      '--keep', 'source-a',
+      '--by', ACTOR,
+    ]);
+    expect(r.exitCode).toBe(0);
+
+    const log = fs.readFileSync(path.join(podDir, 'settings', 'user-resolutions.ttl'), 'utf-8');
+    expect(log).toContain('wasAttributedTo');
+    expect(log).toContain(ACTOR);
+
+    const decisions = await loadUserResolutions(podDir);
+    expect(decisions.get('dose-disagreement')?.actorIri).toBe(ACTOR);
+  });
+
+  it('writes no actor triple when --by is omitted', async () => {
+    // The absence is the point: an unattributed decision stays unattributed
+    // rather than acquiring a fabricated author.
+    const podDir = await podWithQueue();
+    expect(
+      (await runCli(['pod', 'resolve', podDir, '--conflict', 'dose-disagreement', '--keep', 'source-b']))
+        .exitCode,
+    ).toBe(0);
+
+    const log = fs.readFileSync(path.join(podDir, 'settings', 'user-resolutions.ttl'), 'utf-8');
+    expect(log).not.toContain('wasAttributedTo');
+    const decisions = await loadUserResolutions(podDir);
+    expect(decisions.get('dose-disagreement')?.actorIri).toBeUndefined();
+  });
+
+  it('refuses an actor IRI that could not be written back', async () => {
+    // A space inside <...> produces a file the next read cannot parse, which
+    // would take the decision log out of service permanently.
+    const podDir = await podWithQueue();
+    const r = await runCli([
+      'pod', 'resolve', podDir,
+      '--conflict', 'dose-disagreement',
+      '--keep', 'source-a',
+      '--by', 'https://example.org/care coordinator',
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('Invalid IRI for --by');
+    expect(fs.existsSync(path.join(podDir, 'settings', 'user-resolutions.ttl'))).toBe(false);
+  });
+});
+
+describe('pod conflicts --resolved: the decision log can be read back', () => {
+  it('emits the answered conflicts as JSON, actor included', async () => {
+    const podDir = await podWithQueue(['dose-disagreement', 'status-disagreement']);
+    await runCli([
+      'pod', 'resolve', podDir,
+      '--conflict', 'dose-disagreement',
+      '--keep', 'source-a',
+      '--by', ACTOR,
+      '--note', 'Pharmacy confirmed the current dose.',
+    ]);
+
+    const r = await runCli(['pod', 'conflicts', podDir, '--resolved', '--format', 'json']);
+    expect(r.exitCode).toBe(0);
+    const log = JSON.parse(r.stdout) as Array<{
+      conflictId: string;
+      resolvedAt: string;
+      resolution: string;
+      keptRecordUri: string;
+      discardedRecordUris: string[];
+      userNote?: string;
+      actorIri?: string;
+    }>;
+    expect(log).toHaveLength(1);
+    expect(log[0].conflictId).toBe('dose-disagreement');
+    expect(log[0].resolution).toBe('kept-source-a');
+    expect(log[0].keptRecordUri).toBe('urn:uuid:med-dose-disagreement-a');
+    expect(log[0].discardedRecordUris).toEqual(['urn:uuid:med-dose-disagreement-b']);
+    expect(log[0].userNote).toBe('Pharmacy confirmed the current dose.');
+    expect(log[0].actorIri).toBe(ACTOR);
+    expect(typeof log[0].resolvedAt).toBe('string');
+  });
+
+  it('exits 0 on an empty log, and does not borrow the queue exit code', async () => {
+    // Plain `pod conflicts` exits 1 when rows are pending, which is a CI signal
+    // about UNANSWERED questions. A decision log carries no such signal, so
+    // reading it is always a plain success.
+    const podDir = await podWithQueue();
+    const r = await runCli(['pod', 'conflicts', podDir, '--resolved', '--format', 'json']);
+    expect(r.exitCode).toBe(0);
+    expect(JSON.parse(r.stdout)).toEqual([]);
+  });
+
+  it('lists the decision in text mode too', async () => {
+    const podDir = await podWithQueue();
+    await runCli([
+      'pod', 'resolve', podDir, '--conflict', 'dose-disagreement', '--keep', 'both', '--by', ACTOR,
+    ]);
+    const r = await runCli(['pod', 'conflicts', podDir, '--resolved']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('dose-disagreement');
+    expect(r.stdout).toContain('kept-both');
+    expect(r.stdout).toContain(ACTOR);
+  });
+});


### PR DESCRIPTION
The pending-conflict queue is a user-decision store: each row is a question the tool declined to
answer and handed to a person, and `pod resolve` looks rows up in it by id. Four things were wrong
with it end to end, and each one broke a different link in the same chain: a raised row could not
name its two sides, could not show what they said, could not survive an unrelated import, and could
not say who answered it.

## 1. A raised conflict names the two ORIGINS, and keeps both of their values

Conflict rows were labelled with `cascade:sourceSystem`, the INGESTION axis. A pod-internal
`pod reconcile` reads every record back through one door, so both sides arrived under one string and
the row said it twice. For a record stating no `cascade:sourceSystem` of its own, that string is the
bucket path the reader defaulted to. Observed on a two-organization fixture pod, before:

```
sourceA: 'clinical/medications.ttl', sourceB: 'clinical/medications.ttl'
```

The second half lost data rather than merely failing to show it. The reconciler's map of the two
sides' values was keyed on that same string, so the two entries collapsed into one and only the
value assigned second survived. The same run, before, wrote into the pod:

```
cascade:conflictValues "clinical/medications.ttl: \"75 mcg\""
```

The surviving record's own value (50 mcg) is not in that string. After:

```
cascade:conflictValues "Meridian: \"50 mcg\" vs Stonebridge: \"75 mcg\""
sourceA: 'Meridian', sourceB: 'Stonebridge'
```

Sides are keyed and labelled by ORIGIN (`cascade:sourceIdentity` through the existing `sourceLabel`
derivation in `src/lib/source-identity.ts`, falling back to the stated EHR name and then to the
record IRI), and carried as an ORDERED list rather than a map, so both values survive whatever the
two labels turn out to be. The reconciliation report now states both axes side by side: `sources` is
byte-unchanged and still the ingestion batch, `origins` is the new fact.

**This is a report and queue surface only.** Matching, the same-source guard, merge ranking and
identity minting are untouched. Proof: the pathology corpus scorecard (`P07`, `P07-SHARED-LABEL`,
`P08` precision and recall over merge pairs) is unmoved, and the corpus's four-conflict scenario
raises the same four conflicts with the same pairings and the same values, with only the labels
changed:

```
before  p09b-med-chains-beta: "100 mcg ..." vs p09a-med-chains-alpha: "75 mcg ..."
after   Ridgecrest: "100 mcg ..."           vs Harborview: "75 mcg ..."
```

## 2. The row stays reviewable after its candidates merge

A row kept both candidate record IRIs, and a value or status conflict that resolves ABSORBS the
losing record, so a consumer following the two IRIs to show the user "this side says X, that side
says Y" finds one of them gone.

The substance is now written onto the row at raise time as additive bookkeeping predicates in the
namespace and style `settings/pending-conflicts.ttl` already uses: `cascade:conflictField`,
`cascade:valueA`, `cascade:valueB` beside the existing `cascade:sourceA` / `cascade:sourceB`, and
`cascade:survivingRecord`. App bookkeeping about the state of a review queue, not a clinical fact, so
no spec change. Reads are backward compatible: a row written before these predicates parses with the
new fields undefined, and there is a test for exactly that. `pod conflicts --format json` emits them.

Both raising verbs go through one `pendingConflictFromRaised()`, replacing two copies of the mapping.
That also removes the only `randomUUID` call in each command module, so two entries of the identity
chokepoint allowlist became dead and are deleted (its no-dead-entries gate caught this).

## 3. `pod import` routes the queue through the disposition

`writePendingConflicts` replaces the file wholesale, and import called it with the run's own
conflicts alone. Any import at all, including one that touched none of a pending row's records,
erased every question already in the queue. It is the same defect `pod reconcile` was given a
disposition for. Import now uses that same computation: pre-existing rows are KEPT (two or more
candidates still distinct), CLEARED BY MERGE (candidates became one record), or ORPHANED (candidates
not in the pod at all, counted and named, plus a warning). `--report` gains the same
`pendingConflicts` block, stated on a dry run too. A queue file that exists and cannot be read
refuses the import at exit 2 rather than being overwritten unseen.

The `legacyConflictIds` docstring asserted the wholesale rewrite as intended design. Corrected.

## 4. Decisions carry an actor and can be read back

`pod resolve --by <actorIri>` writes `prov:wasAttributedTo` on the `cascade:UserResolution`,
mirroring `pod annotate --by` including its pre-open `assertWritableIri` refusal. The flag is
optional and omitting it leaves the row byte-identical to what was written before.

**Read path: `pod conflicts --resolved`, not a new `pod resolutions` verb.** The queue and the
decision log are two halves of one store: a row moves from the first to the second when `pod resolve`
answers it, both live under `settings/` behind the same DEK, and a separate verb would have needed
its own copy of the pod resolution, the DEK resolution, and the "this is NOT the same as having
none" wording that the encrypted-pod defect exists to enforce. A second copy of that sentence is how
one of them softens. Exit code 1 is deliberately NOT borrowed: it is a CI signal about UNANSWERED
questions, and a decision log with entries is the record of problems already handled, so `--resolved`
exits 0 whenever the read succeeded.

## Verification

Baseline on `origin/main` at this checkout: **145 files, 2366 tests, 2366 pass, 0 fail, 0 skip.**
After: **148 files, 2382 tests, 2382 pass, 0 fail, 0 skip** (+3 files, +16 tests, all new here).

Every behavioural change was observed RED first: 14 of the 16 new tests failed against the current
code before any source edit, including `expected [ 'clinical/medications.ttl', ... ] to deeply equal
[ 'urn:uuid:med-old-a', ... ]` and `expected [] to include 'standing'`. The two that passed at RED
are the backward-compatibility read and the `--by`-omitted case, which must pass before and after.

Eleven mutation flips, each with a confirmed non-empty diff, a build whose exit code was checked
(vitest does not typecheck, and about twenty tests spawn `dist/`), the FULL suite, and a revert
verified green. Table in the comments.

All fixture data is synthetic.
