### PR TITLE
fix(cli): import the dates the source stated, and answer pod query with records only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+**`pod query --include-bookkeeping`, and the default that made it necessary.**
+`--all` swept every `.ttl` a pod holds except a short list of plumbing files, and
+`settings/pending-conflicts.ttl` and `settings/user-resolutions.ttl` were not on that list. So the
+pod's own paperwork about its records was returned AS records: every unresolved conflict and every
+decision the user had already recorded arrived in the `other` bucket beside the medications, undated
+and with no origin, and the pod grew one more of them each time a conflict was detected or resolved.
+A consumer that renders query output as health records rendered the paperwork as mystery records.
+
+Bookkeeping subjects are now excluded from the record output by default and returned by
+`--include-bookkeeping`, which exists because the queue is real data a conflict UI has to be able to
+ask for. The rule is stated over `rdf:type` rather than over filenames, because what makes a
+`cascade:PendingConflict` not a record is what it IS, and a path list only excludes the files someone
+remembered to add to it. The enumeration is `BOOKKEEPING_TYPE_IRIS` in `src/lib/pod-read.ts`:
+`cascade:PendingConflict`, `cascade:UserResolution`, `solid:TypeIndex`, `solid:TypeRegistration`,
+`pim:ConfigurationFile`.
+
+A file that held nothing but bookkeeping produces no bucket at all rather than a bucket reporting
+zero, so a pod with conflicts looks like a pod without them instead of growing an empty "Other"
+section. For a pod that holds no bookkeeping the output is byte-identical with the flag and without
+it. `pod conflicts`, `pod resolve`, `pod reconcile` and `validate` read the settings files directly
+and are unaffected.
+
 **`cascade pod reconcile <pod-dir> --undo`: the tier-0 journal is now replayable.**
 Tier 0 merges one narrow class of duplicate without asking anyone, and the argument for that is not
 that the rule is always right but that the merge stays a fact the pod holds: every one is written to
@@ -89,6 +111,45 @@ for, and import now goes through that same computation: pre-existing rows are ke
 merge, or orphaned and named, and the counts reach `--report`. A queue file that exists and cannot
 be read refuses the import at exit 2 rather than being overwritten unseen. The `legacyConflictIds`
 docstring, which asserted the wholesale rewrite as intended design, is corrected.
+**A C-CDA encounter now imports with the time the document stated.**
+`sections/encounters.ts` read `<effectiveTime>` only to build the record's IDENTITY. The one date
+triple it wrote was `health:effectiveDate` as an untyped literal, on a predicate the Encounter shapes
+do not look at, and `<high>` was never read at any site. `clinical:EncounterTemporalShape` asks for
+`clinical:encounterStart`, `clinical:encounterEnd` or `clinical:encounterDate` and the converter
+wrote none of the three, so EVERY encounter the C-CDA path produced fired the "should carry a start,
+an end or an encounter date" warning, including the ones whose Encounters section states the visit
+times outright. Measured on a real export: 123 of 123 encounters.
+
+Each of the three shapes an Encounters section uses now gets the triple that says what it says, and
+the literals go through `ccdaDateQuad`, the same typed-date chokepoint the labs, problems,
+immunizations and vitals handlers use, so an encounter's precision rule is not a fifth opinion. An
+interval becomes a start and an end, a single value becomes an encounter date, and an encounter the
+document never dated stays undated: FHIR R4 `Encounter.period` is 0..1, and inventing a day to
+silence a warning is the fabrication the date module exists to refuse. Across the committed fixture
+corpus the warning family falls from 7 to 1, and the remaining one is the undated case.
+
+The identity input is deliberately unchanged: the same field, in the same order, formatted the same
+way, because an encounter IRI that moves is a duplicate visit on every pod that already holds the
+record plus a dangling `clinical:hasEncounter` edge from everything that pointed at it. Golden pins
+in `tests/ccda-encounter-dates.test.ts` hold that, measured against the converter before the change.
+Both call sites are covered: the Encounters section and the `<entryRelationship>` form the Results
+walk uses.
+
+**A prescription that states only `authoredOn` no longer imports undated.**
+`convertMedicationStatement` already treated `authoredOn` as the record's date where it counted most,
+as the FIRST input to the subject IRI, and never wrote it as a triple: `health:startDate` came only
+from `effectivePeriod.start` or `effectiveDateTime`. A `MedicationRequest` carrying `authoredOn` and
+no effective date is the ordinary shape of a prescription order, so the ordinary prescription reached
+the pod with NO date predicate at all, undated in every consumer and keyed on a date the record did
+not state. Across the committed FHIR fixtures, medications carrying a date rise from 7 of 32 to 31 of
+32; the remaining one states no date of any kind.
+
+The fallback order is deliberately not the identity order. Identity takes `authoredOn` first because
+the date an order was written survives a re-export unchanged, and reordering it would re-mint every
+medication in every existing pod. The triple takes it last because a stated effective period is when
+the patient took the drug while `authoredOn` is when a clinician typed it. Golden pins over 353 typed
+subjects across 21 FHIR fixtures, regenerated from a separate checkout of the previous release, hold
+that no record IRI moved.
 
 **One health system now resolves to ONE display label whichever transport carried it.**
 `cascade:sourceIdentity` already converged. `clinical:sourceEHR` did not: the C-CDA path labelled

--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ Both are additive and deterministic: `--all` without `--edges` is unchanged, and
 the same invocation always produces byte-identical output. The JSON contract is
 documented in [docs/2026-07-16-graph-query-json-shapes.md](docs/2026-07-16-graph-query-json-shapes.md).
 
+`pod query` answers with the pod's RECORDS. The pod's own bookkeeping about those
+records — `cascade:PendingConflict`, `cascade:UserResolution`, `solid:TypeIndex`,
+`solid:TypeRegistration`, `pim:ConfigurationFile` — is excluded from the record
+output, because a note about two records is not a third record. Tooling that wants
+the conflict queue asks for it:
+
+```bash
+cascade --json pod query ./my-pod --all --include-bookkeeping
+```
+
+A pod holding no bookkeeping produces byte-identical output with the flag and
+without it. `pod conflicts`, `pod resolve`, `pod reconcile` and `validate` read the
+settings files directly and are unaffected either way.
+
 ## Exit codes
 
 Every command answers with one of three codes: `0` success, `1` user or input

--- a/src/commands/pod/query.ts
+++ b/src/commands/pod/query.ts
@@ -20,6 +20,17 @@
  *
  * The decrypt-vs-parse weighting lives in the read layer's `PodReadLedger`, so
  * this command states the rule by using it rather than by restating it.
+ *
+ * WHAT COUNTS AS A RECORD
+ * -----------------------
+ * Not everything a pod stores as Turtle is a record. `--all` used to sweep
+ * `settings/pending-conflicts.ttl` and `settings/user-resolutions.ttl` into the
+ * `other` bucket, so the pod's own paperwork about its records was returned AS
+ * records — undated, origin-less, and one more of them every time a conflict was
+ * detected or a decision recorded. Bookkeeping subjects are excluded by default
+ * and available under `--include-bookkeeping`, which exists because the queue is
+ * real data that a conflict UI has to be able to ask for. The enumeration and
+ * its reasoning live in `lib/pod-read.ts` (`BOOKKEEPING_TYPE_IRIS`).
  */
 
 import type { Command } from 'commander';
@@ -44,9 +55,11 @@ import {
   discoverTtlFiles,
   unreadableFilesMessage,
   skippedFilesMessage,
+  isBookkeepingRecordType,
   PodReadLedger,
   type PodReader,
   type PodReadFailure,
+  type PodRecord,
 } from '../../lib/pod-read.js';
 import { expandCurie } from '../../lib/turtle-parser.js';
 import { loadPodGraph, recordEdges, neighborhood } from './graph.js';
@@ -67,6 +80,28 @@ function classifyExtraBucket(relPath: string, baseName: string): string {
     return 'ai-extracted';
   }
   return 'other';
+}
+
+/**
+ * Drop the pod's own bookkeeping subjects, unless the caller asked for them.
+ *
+ * `pod query` answers with the pod's RECORDS. `settings/pending-conflicts.ttl`
+ * and `settings/user-resolutions.ttl` are notes ABOUT records, and `--all` swept
+ * them in: every unresolved conflict and every decision the user had recorded
+ * came back beside the medications, undated, with no origin, one more of them
+ * per decision taken. A consumer that renders query output as health records
+ * rendered paperwork as mystery records.
+ *
+ * Applied at the point the records become output, BEFORE the bucket's `count` is
+ * taken and before the extra-file sweep's empty-bucket check, so an excluded
+ * bucket is absent rather than present-and-zero. A pod holding no bookkeeping
+ * gets byte-identical output either way, which is nearly every pod.
+ *
+ * `lib/pod-read.ts` owns the enumeration and the reasoning for each entry.
+ */
+function withoutBookkeeping(records: PodRecord[], include: boolean): PodRecord[] {
+  if (include) return records;
+  return records.filter((r) => !isBookkeepingRecordType(r.type));
 }
 
 /**
@@ -136,6 +171,13 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
       [] as string[],
     )
     .option('--edges', 'With --all, add a record-to-record edge projection to the output')
+    .option(
+      '--include-bookkeeping',
+      "Also return the pod's own bookkeeping subjects (cascade:PendingConflict, " +
+        'cascade:UserResolution, solid:TypeIndex, solid:TypeRegistration, ' +
+        'pim:ConfigurationFile). These are notes ABOUT records, not records, and ' +
+        'are excluded by default; ask for them when building a conflict queue',
+    )
     .action(
       async (
         podDir: string,
@@ -163,6 +205,7 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
           hops?: string;
           edge?: string[];
           edges?: boolean;
+          includeBookkeeping?: boolean;
         },
       ) => {
         const globalOpts = program.opts() as OutputOptions;
@@ -308,7 +351,10 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
             // one of these — a key that will not open it, or bytes that are not
             // Turtle — leaves the count unknown, and unknown is not zero.
             const read = reader.readRecords(filePath);
-            const records = read.ok ? read.value.records : [];
+            const records = withoutBookkeeping(
+              read.ok ? read.value.records : [],
+              options.includeBookkeeping === true,
+            );
             const error = read.ok ? undefined : read.failure.reason;
             if (!read.ok) ledger.record(read.failure);
 
@@ -342,7 +388,14 @@ export function registerQuerySubcommand(pod: Command, program: Command): void {
             // stray file, not a broken pod — a pod holds notes, investigations
             // and reports too — so the ledger reports it and steps over it.
             const read = reader.readRecords(extraFile);
-            const records = read.ok ? read.value.records : [];
+            // Filtered BEFORE the empty-file skip below, so a file that held
+            // nothing but bookkeeping produces no bucket at all rather than an
+            // `other` bucket reporting zero. A pod without conflicts has never
+            // shown one, and a pod with them must not start.
+            const records = withoutBookkeeping(
+              read.ok ? read.value.records : [],
+              options.includeBookkeeping === true,
+            );
             const error = read.ok ? undefined : read.failure.reason;
             if (!read.ok) ledger.record(read.failure);
             if (records.length === 0) continue;

--- a/src/lib/ccda-converter/sections/encounters.ts
+++ b/src/lib/ccda-converter/sections/encounters.ts
@@ -7,9 +7,18 @@
  * (sections/labs.ts), which links each lab panel to the visit it was collected
  * in via clinical:hasEncounter. Both paths therefore produce identical,
  * dedupe-safe encounter records (encounter completeness).
+ *
+ * The `<effectiveTime>` was read here for IDENTITY long before it was read for
+ * CONTENT: the record's key had the visit's day in it while the record itself
+ * carried no start, no end and no encounter date, so every encounter this
+ * converter produced was undated to the shapes and to every consumer. It now
+ * states its time, through the same typed-date helper the other section
+ * handlers use, and its identity is computed from the same field in the same
+ * order as before so that no existing encounter re-mints.
  */
 
 import { NS } from '../../fhir-converter/types.js';
+import { ccdaDateQuad } from '../dates.js';
 import { listOf } from '../multivalued.js';
 import { ccdaRecordUri, ccdaSourceId } from '../record-identity.js';
 import { DataFactory } from 'n3';
@@ -61,6 +70,33 @@ function formatCcdaDate(dateVal: string): string {
 }
 
 /**
+ * The raw `@value` of one HL7 TS element, under either attribute spelling the
+ * C-CDA parser can hand back.
+ */
+function tsValue(el: any): unknown {
+  if (el === null || el === undefined) return undefined;
+  return el?.['@_value'] ?? el?.value;
+}
+
+/**
+ * The three ways an `<encounter>` states WHEN, split apart.
+ *
+ * A C-CDA Encounters section writes an interval (`<low>`/`<high>`) for a visit
+ * with a start and an end, and a single `@value` for one stated as a day. Both
+ * are ordinary and both were being read for identity only, so every encounter
+ * this converter produced was undated as far as the shapes and every consumer
+ * were concerned.
+ */
+function encounterTimes(enc: any): { low: unknown; high: unknown; single: unknown } {
+  const effTime = enc?.effectiveTime ?? {};
+  return {
+    low: tsValue(effTime?.low),
+    high: tsValue(effTime?.high),
+    single: tsValue(effTime),
+  };
+}
+
+/**
  * Build one clinical:Encounter record from a C-CDA <encounter> element, or null
  * when the element carries no usable identity (no id, type, or date — a bare
  * reference rather than a real definition).
@@ -79,10 +115,14 @@ export function buildEncounterRecord(
   const codeEl = enc?.code ?? {};
   const displayName = encounterDisplayName(codeEl);
 
-  const effTime = enc?.effectiveTime ?? {};
-  const dateVal =
-    effTime?.['@_value'] ?? effTime?.value ?? effTime?.low?.['@_value'] ?? effTime?.low?.value ?? '';
-  const dateStr = formatCcdaDate(dateVal);
+  const { low, high, single } = encounterTimes(enc);
+  // IDENTITY INPUT, UNCHANGED. Same field, same order, same day-precision
+  // formatting as before the encounter learned to state its time: an encounter
+  // IRI that moves is a duplicate visit on every pod that already holds the
+  // record, plus a dangling clinical:hasEncounter edge from everything that
+  // pointed at it.
+  const dateVal = single ?? low ?? '';
+  const dateStr = formatCcdaDate(dateVal as string);
 
   const sourceId = ccdaSourceId(enc?.id);
 
@@ -107,7 +147,32 @@ export function buildEncounterRecord(
   quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Encounter')));
   quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
   if (displayName) quads.push(makeQuad(subj, namedNode(NS.cascade + 'encounterType'), literal(displayName)));
+  // Kept, unchanged and untyped, because the reconciler reads
+  // health:effectiveDate. Moving a record's date out from under a matcher in the
+  // same change that gives it a second one is two changes wearing one commit.
   if (dateStr) quads.push(makeQuad(subj, namedNode(NS.health + 'effectiveDate'), literal(dateStr)));
+
+  // WHEN THE VISIT WAS, said so the shapes and every consumer can see it.
+  //
+  // clinical:EncounterTemporalShape asks for encounterStart, encounterEnd or
+  // encounterDate; this handler wrote none of the three, so every encounter the
+  // C-CDA path produced fired its Warning — including the ones whose section
+  // states the times outright. `<high>` was not read at any site.
+  //
+  // Each triple states exactly what the document stated and nothing else: an
+  // interval becomes a start and an end, a single value becomes a date, and a
+  // source that gave neither gets neither. The literals go through ccdaDateQuad,
+  // the same typed-date chokepoint the labs, problems, immunizations and vitals
+  // handlers use, so an encounter's precision rule is not a fifth opinion.
+  for (const [predicate, raw] of [
+    [NS.clinical + 'encounterStart', low],
+    [NS.clinical + 'encounterEnd', high],
+    [NS.clinical + 'encounterDate', single],
+  ] as const) {
+    const q = ccdaDateQuad(uri, predicate, raw, warnings);
+    if (q) quads.push(q);
+  }
+
   if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
 
   return { subject: uri, quads };

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -168,11 +168,29 @@ export function convertMedicationStatement(resource: any): ConversionResult & { 
     }
   }
 
-  // Effective period
+  // Effective period, and the order date when there is no effective period.
+  //
+  // `authoredOn` was already treated as this record's date where it counted most
+  // — it is the FIRST input to the subject IRI, ten lines up — and was never
+  // written as a triple. A MedicationRequest carrying `authoredOn` and no
+  // effective date is the ordinary shape of a prescription order, so the
+  // ordinary prescription imported with NO date predicate: undated in every
+  // consumer, invisible to anything that places records in time, and keyed on a
+  // date the record did not state.
+  //
+  // The fallback ORDER here is deliberately not the identity order. Identity
+  // takes `authoredOn` first because the date an order was written is the value
+  // that survives a re-export unchanged, and reordering it would re-mint every
+  // medication in every existing pod. The triple takes it LAST because an
+  // effective period is when the patient took the drug, while `authoredOn` is
+  // when a clinician typed it — preferring the typing date over a stated period
+  // would be a downgrade. Two orders, two different questions.
   if (resource.effectivePeriod?.start) {
     quads.push(tripleDateTime(subjectUri, NS.health + 'startDate', resource.effectivePeriod.start));
   } else if (resource.effectiveDateTime) {
     quads.push(tripleDateTime(subjectUri, NS.health + 'startDate', resource.effectiveDateTime));
+  } else if (resource.authoredOn) {
+    quads.push(tripleDateTime(subjectUri, NS.health + 'startDate', resource.authoredOn));
   }
   if (resource.effectivePeriod?.end) {
     quads.push(tripleDateTime(subjectUri, NS.health + 'endDate', resource.effectivePeriod.end));

--- a/src/lib/pod-read.ts
+++ b/src/lib/pod-read.ts
@@ -417,6 +417,80 @@ export function isRegisteredRecordFile(podRelPath: string): boolean {
   return REGISTERED_RECORD_FILES.has(podRelPath.split(/[\\/]/).join('/'));
 }
 
+// ─── Bookkeeping subjects ─────────────────────────────────────────────────────
+
+/**
+ * The rdf:types that are the pod's PAPERWORK ABOUT records rather than records.
+ *
+ * WHY AN ENUMERATION AND NOT A PATH RULE
+ * --------------------------------------
+ * `pod query --all` excluded the two type-index files from its sweep BY PATH, so
+ * `settings/pending-conflicts.ttl` and `settings/user-resolutions.ttl` — added
+ * later, under the same directory — were swept in and returned as records. Every
+ * unresolved conflict and every decision the user had already recorded came back
+ * beside the medications, undated and with no origin, and the pod grew one more
+ * of them per decision. A path list only excludes the files someone remembered
+ * to add to it; a `cascade:PendingConflict` is not a record because of what it
+ * IS, and that stays true wherever it is written.
+ *
+ * WHAT IS ON THE LIST, AND WHY EACH ONE
+ * -------------------------------------
+ *   cascade:PendingConflict  a conflict the reconciler could not settle, waiting
+ *                            for the user. A note ABOUT two records.
+ *   cascade:UserResolution   the decision the user made about one. A note about
+ *                            a note about two records.
+ *   solid:TypeIndex          the pod's map of what lives where.
+ *   solid:TypeRegistration   one entry in that map.
+ *   pim:ConfigurationFile    `settings/preferences`, the root of private config.
+ *
+ * The last three are already excluded from `pod query --all` by filename and
+ * from {@link extractRecords} as structural types. They are restated here so the
+ * rule is about the subject and not about which of two mechanisms happened to
+ * catch it first — the exact gap the conflict store fell through.
+ *
+ * WHAT IS DELIBERATELY NOT ON IT
+ * ------------------------------
+ * `cascade:PatientProfile` and `clinical:ClinicalDocument` are records: one is
+ * the pod owner, the other is a document the pod holds. Neither is paperwork
+ * about other records, and both are things a person querying their pod expects
+ * to see. Provenance nodes (`prov:`) are not here either: they are not subjects
+ * with types of their own in the record files, and {@link extractRecords}
+ * already drops them.
+ *
+ * `settings/tier0-merge-journal.json` needs no entry: it is JSON, so no `.ttl`
+ * sweep reaches it.
+ */
+export const BOOKKEEPING_TYPE_IRIS: readonly string[] = [
+  CASCADE_NAMESPACES.cascade + 'PendingConflict',
+  CASCADE_NAMESPACES.cascade + 'UserResolution',
+  'http://www.w3.org/ns/solid/terms#TypeIndex',
+  'http://www.w3.org/ns/solid/terms#TypeRegistration',
+  'http://www.w3.org/ns/pim/space#ConfigurationFile',
+];
+
+/**
+ * The same list as {@link PodRecord.type} carries it.
+ *
+ * A record's `type` has already been through `shortenIRI`, so the comparison is
+ * made on the shortened form of both sides rather than by re-deriving the
+ * prefix here. Both sides go through the SAME function, so an unprefixed IRI
+ * still matches itself.
+ */
+const BOOKKEEPING_RECORD_TYPES: ReadonlySet<string> = new Set(
+  BOOKKEEPING_TYPE_IRIS.map((iri) => shortenIRI(iri)),
+);
+
+/**
+ * Is this record's type one the pod keeps about its own records?
+ *
+ * Takes the `type` of a {@link PodRecord} (a CURIE such as
+ * `core:PendingConflict`), so a caller filters the records it already has
+ * without reaching back into the store.
+ */
+export function isBookkeepingRecordType(recordType: string): boolean {
+  return BOOKKEEPING_RECORD_TYPES.has(recordType);
+}
+
 /**
  * Collects a sweep's read failures and sorts them by the rule above, so no
  * caller restates it and no caller quietly softens it.

--- a/test-fixtures/ccda-encounter-dates.xml
+++ b/test-fixtures/ccda-encounter-dates.xml
@@ -14,6 +14,15 @@
     ENC-UNDATED  - no effectiveTime. A referenced-only encounter, which must stay
                    undated: FHIR R4 Encounter.period is 0..1 and inventing a day
                    for it would be a fabrication, not a fix.
+    ENC-BOTH     - an @value AND a low/high interval, on three different days.
+                   Vendors do emit both.
+    (id-less)    - the same double-stated time on an encounter with NO <id>, so
+                   its identity falls through to type + date. This is the ONLY
+                   shape in the corpus where the ORDER the identity key reads
+                   @value and low in is observable: with an <id> present the id
+                   decides and the date is never consulted, and with only one of
+                   the two times present both orders read the same value. Without
+                   it, reversing that order moves no IRI and no test notices.
 
   Authored for this repository. No content is derived from a real record.
 -->
@@ -91,6 +100,29 @@
               <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
               <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-UNDATED"/>
               <code code="99212" displayName="Office Outpatient Visit 10 Minutes" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+            </encounter>
+          </entry>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-BOTH"/>
+              <code code="99215" displayName="Office Outpatient Visit 40 Minutes" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+              <effectiveTime value="20251104">
+                <low value="20251101"/>
+                <high value="20251102"/>
+              </effectiveTime>
+            </encounter>
+          </entry>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <code code="99204" displayName="Telehealth Follow Up Visit" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+              <effectiveTime value="20251208">
+                <low value="20251205"/>
+                <high value="20251206"/>
+              </effectiveTime>
             </encounter>
           </entry>
         </section>

--- a/test-fixtures/ccda-encounter-dates.xml
+++ b/test-fixtures/ccda-encounter-dates.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic C-CDA Encounters section (templateId 2.16.840.1.113883.10.20.22.2.22)
+  carrying the two effectiveTime shapes a real Encounters section uses, plus the
+  one that legitimately carries no time at all:
+
+    ENC-INTERVAL - <effectiveTime><low/><high/></effectiveTime>, second precision
+                   with a zone offset. The ordinary shape for a visit that
+                   started and ended.
+    ENC-SINGLE   - <effectiveTime value="YYYYMMDD"/>, day precision. The ordinary
+                   shape for a visit stated as a date rather than a span.
+    ENC-LOW-ONLY - an interval with only a <low/>. A visit that started and whose
+                   end the source did not state.
+    ENC-UNDATED  - no effectiveTime. A referenced-only encounter, which must stay
+                   undated: FHIR R4 Encounter.period is 0..1 and inventing a day
+                   for it would be a fabrication, not a fix.
+
+  Authored for this repository. No content is derived from a real record.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-DATES-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Encounter Date Fixture</title>
+  <effectiveTime value="20260327120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.4.1" extension="000-00-0000"/>
+      <patient>
+        <name use="L"><given>Jane</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.3.88.11.32.1"/>
+        <name>Fixture Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+          <code code="46240-8" displayName="History of encounters" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Encounters</title>
+          <text>Four visits, stated four ways.</text>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-INTERVAL"/>
+              <code code="99213" displayName="Office Outpatient Visit 15 Minutes" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+              <effectiveTime>
+                <low value="20250612093000-0400"/>
+                <high value="20250612101500-0400"/>
+              </effectiveTime>
+            </encounter>
+          </entry>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-SINGLE"/>
+              <code code="99214" displayName="Office Outpatient Visit 25 Minutes" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+              <effectiveTime value="20250718"/>
+            </encounter>
+          </entry>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-LOW-ONLY"/>
+              <code code="99285" displayName="Emergency Dept Visit" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+              <effectiveTime>
+                <low value="20250903"/>
+              </effectiveTime>
+            </encounter>
+          </entry>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-UNDATED"/>
+              <code code="99212" displayName="Office Outpatient Visit 10 Minutes" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test-fixtures/fhir-medication-dates-bundle.json
+++ b/test-fixtures/fhir-medication-dates-bundle.json
@@ -1,0 +1,128 @@
+{
+  "resourceType": "Bundle",
+  "id": "medication-dates-bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "mr-authored-only-with-id",
+        "status": "active",
+        "intent": "order",
+        "authoredOn": "2025-04-09",
+        "subject": { "reference": "Patient/pt-dates-1" },
+        "medicationCodeableConcept": {
+          "text": "Levothyroxine 50 mcg",
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "966224",
+              "display": "Levothyroxine Sodium 0.05 MG Oral Tablet"
+            }
+          ]
+        },
+        "dosageInstruction": [{ "text": "1 tablet by mouth once daily" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "status": "active",
+        "intent": "order",
+        "authoredOn": "2025-05-21T08:15:00-05:00",
+        "subject": { "reference": "Patient/pt-dates-1" },
+        "medicationCodeableConcept": {
+          "text": "Omeprazole 20 mg",
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "7646",
+              "display": "Omeprazole 20 MG Delayed Release Oral Capsule"
+            }
+          ]
+        },
+        "dosageInstruction": [{ "text": "1 capsule by mouth once daily before breakfast" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "mr-authored-and-effective",
+        "status": "active",
+        "intent": "order",
+        "authoredOn": "2025-06-02",
+        "effectivePeriod": { "start": "2025-06-04", "end": "2025-09-04" },
+        "subject": { "reference": "Patient/pt-dates-1" },
+        "medicationCodeableConcept": {
+          "text": "Sertraline 50 mg",
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "312940",
+              "display": "Sertraline 50 MG Oral Tablet"
+            }
+          ]
+        },
+        "dosageInstruction": [{ "text": "1 tablet by mouth once daily" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "ms-effective-datetime",
+        "status": "active",
+        "effectiveDateTime": "2025-02-14",
+        "subject": { "reference": "Patient/pt-dates-1" },
+        "medicationCodeableConcept": {
+          "text": "Metformin 500 mg",
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "861007",
+              "display": "Metformin hydrochloride 500 MG Oral Tablet"
+            }
+          ]
+        },
+        "dosage": [{ "text": "1 tablet by mouth twice daily with meals" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "status": "active",
+        "effectivePeriod": { "start": "2025-01-07" },
+        "subject": { "reference": "Patient/pt-dates-1" },
+        "medicationCodeableConcept": {
+          "text": "Atorvastatin 10 mg",
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "617312",
+              "display": "Atorvastatin 10 MG Oral Tablet"
+            }
+          ]
+        },
+        "dosage": [{ "text": "1 tablet by mouth at bedtime" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "ms-no-date-at-all",
+        "status": "active",
+        "subject": { "reference": "Patient/pt-dates-1" },
+        "medicationCodeableConcept": {
+          "text": "Cetirizine 10 mg",
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1014676",
+              "display": "Cetirizine hydrochloride 10 MG Oral Tablet"
+            }
+          ]
+        },
+        "dosage": [{ "text": "1 tablet by mouth as needed" }]
+      }
+    }
+  ]
+}

--- a/tests/ccda-encounter-dates.test.ts
+++ b/tests/ccda-encounter-dates.test.ts
@@ -1,0 +1,261 @@
+/**
+ * A C-CDA encounter must import with the time the document stated.
+ *
+ * WHAT WAS WRONG
+ * --------------
+ * `sections/encounters.ts` read `<effectiveTime>` only to build the record's
+ * IDENTITY, and the single date triple it emitted was
+ * `health:effectiveDate "2025-06-12"` — an untyped literal on a predicate the
+ * Encounter shapes do not look at. `clinical:EncounterTemporalShape` asks for
+ * `clinical:encounterStart`, `clinical:encounterEnd` or `clinical:encounterDate`
+ * and the converter wrote none of them, so EVERY C-CDA encounter fired the
+ * Warning-severity "should carry a start, an end or an encounter date" — on
+ * documents whose Encounters section states the visit times perfectly well.
+ * `<high>` was never read at all, in any path.
+ *
+ * WHAT IT DOES NOW
+ * ----------------
+ * The three shapes an Encounters section actually uses each get the triple that
+ * says what they say, through `ccdaDateQuad` — the same typed-date chokepoint the
+ * labs, problems, immunizations and vitals handlers use, so an encounter's
+ * precision rule is the document's precision rule and not a fifth opinion:
+ *
+ *   <effectiveTime><low/><high/></effectiveTime>  -> encounterStart + encounterEnd
+ *   <effectiveTime value="..."/>                  -> encounterDate
+ *   <effectiveTime><low/></effectiveTime>         -> encounterStart only
+ *   (no effectiveTime)                            -> nothing, and the Warning stands
+ *
+ * The last line is not an oversight. FHIR R4 `Encounter.period` is 0..1 and a
+ * referenced-only visit legitimately has no time; inventing one to silence a
+ * warning is the fabrication the whole date module exists to refuse.
+ *
+ * WHAT DELIBERATELY DID NOT CHANGE
+ * --------------------------------
+ * The identity input. `ccdaRecordUri` is still handed the same day string from
+ * the same `effectiveTime` field in the same order, so no encounter re-mints and
+ * no pod acquires a duplicate. The golden pins at the bottom are that claim,
+ * measured against the converter BEFORE this change.
+ *
+ * `health:effectiveDate` is still written, unchanged, because the reconciler
+ * reads it and a record's date must not move underneath a matcher in the same
+ * commit that gives it a second one.
+ *
+ * Every fixture is synthetic and authored for this repository.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, '../test-fixtures');
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+const HEALTH = 'https://ns.cascadeprotocol.org/health/v1#';
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
+const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
+const XSD_DATETIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
+
+const TEMPORAL_WARNING = 'start, an end or an encounter date';
+
+async function convertFixture(name: string): Promise<Quad[]> {
+  const xml = fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
+  const result = await convertCcda(xml, {
+    sourceSystem: 'TestSystem',
+    importedAt: '2026-01-01T00:00:00Z',
+  });
+  expect(result.errors, `conversion errors: ${result.errors.join(', ')}`).toHaveLength(0);
+  return new Parser().parse(result.output);
+}
+
+/** Every clinical:Encounter subject, keyed by the source id it carries. */
+function encountersBySourceId(quads: Quad[]): Map<string, string> {
+  const isEncounter = new Set(
+    quads
+      .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === CLINICAL + 'Encounter')
+      .map((q) => q.subject.value),
+  );
+  const bySourceId = new Map<string, string>();
+  for (const q of quads) {
+    if (q.predicate.value !== CASCADE + 'sourceRecordId') continue;
+    if (!isEncounter.has(q.subject.value)) continue;
+    bySourceId.set(q.object.value.split(':').pop() as string, q.subject.value);
+  }
+  return bySourceId;
+}
+
+/** One subject's object for a predicate, as {value, datatype}, or undefined. */
+function typedObject(
+  quads: Quad[],
+  subject: string,
+  predicate: string,
+): { value: string; datatype: string } | undefined {
+  const q = quads.find((x) => x.subject.value === subject && x.predicate.value === predicate);
+  if (!q) return undefined;
+  return {
+    value: q.object.value,
+    datatype: (q.object as { datatype?: { value: string } }).datatype?.value ?? '(not a literal)',
+  };
+}
+
+describe('C-CDA Encounters section — the visit imports with its time', () => {
+  it('states an interval as a typed encounterStart and encounterEnd', async () => {
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    const subject = encountersBySourceId(quads).get('ENC-INTERVAL');
+    expect(subject, 'the interval encounter must be minted at all').toBeTruthy();
+
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterStart')).toEqual({
+      value: '2025-06-12T09:30:00-04:00',
+      datatype: XSD_DATETIME,
+    });
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterEnd')).toEqual({
+      value: '2025-06-12T10:15:00-04:00',
+      datatype: XSD_DATETIME,
+    });
+    // A span is a span. Restating its start as a bare "date" as well would give
+    // two answers to "when was this visit" that a consumer has to choose between.
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterDate')).toBeUndefined();
+  });
+
+  it('states a single effectiveTime as an encounterDate at the source precision', async () => {
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    const subject = encountersBySourceId(quads).get('ENC-SINGLE');
+    expect(subject).toBeTruthy();
+
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterDate')).toEqual({
+      value: '2025-07-18',
+      datatype: XSD_DATE,
+    });
+    // No invented midnight, and no span the document never stated.
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterStart')).toBeUndefined();
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterEnd')).toBeUndefined();
+  });
+
+  it('states a low-only interval as a start with no invented end', async () => {
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    const subject = encountersBySourceId(quads).get('ENC-LOW-ONLY');
+    expect(subject).toBeTruthy();
+
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterStart')).toEqual({
+      value: '2025-09-03',
+      datatype: XSD_DATE,
+    });
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterEnd')).toBeUndefined();
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterDate')).toBeUndefined();
+  });
+
+  it('leaves an encounter the document never dated undated', async () => {
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    const subject = encountersBySourceId(quads).get('ENC-UNDATED');
+    expect(subject).toBeTruthy();
+
+    for (const p of ['encounterStart', 'encounterEnd', 'encounterDate']) {
+      expect(typedObject(quads, subject!, CLINICAL + p), p).toBeUndefined();
+    }
+  });
+
+  it('keeps writing health:effectiveDate, which the reconciler reads', async () => {
+    // Pinned because the new triples are ADDITIVE. Dropping this one in the same
+    // commit would move a date out from under a matcher that reads it, and the
+    // suite would still be green on everything above.
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    const byId = encountersBySourceId(quads);
+    expect(typedObject(quads, byId.get('ENC-INTERVAL')!, HEALTH + 'effectiveDate')?.value).toBe(
+      '2025-06-12',
+    );
+    expect(typedObject(quads, byId.get('ENC-SINGLE')!, HEALTH + 'effectiveDate')?.value).toBe(
+      '2025-07-18',
+    );
+  });
+
+  it('dates the encounter nested inside a lab observation by the same rule', async () => {
+    // sections/labs.ts reuses buildEncounterRecord for the <entryRelationship>
+    // form real exports bury the visit in. One rule, both paths — asserted here
+    // because a fix applied at the Encounters-section call site only would leave
+    // this path exactly as broken and every test above green.
+    const quads = await convertFixture('ccda-encounter-panel.xml');
+    const subject = encountersBySourceId(quads).get('VISIT-778899');
+    expect(subject).toBeTruthy();
+
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterStart')).toEqual({
+      value: '2025-03-10T08:30:00-07:00',
+      datatype: XSD_DATETIME,
+    });
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterEnd')).toEqual({
+      value: '2025-03-10T09:00:00-07:00',
+      datatype: XSD_DATETIME,
+    });
+  });
+});
+
+describe('C-CDA Encounters section — SHACL', () => {
+  it('collapses the temporal warning to the one encounter that has no time', async () => {
+    const xml = fs.readFileSync(path.join(FIXTURES, 'ccda-encounter-dates.xml'), 'utf-8');
+    const result = await convertCcda(xml, {
+      sourceSystem: 'TestSystem',
+      importedAt: '2026-01-01T00:00:00Z',
+    });
+    const { store, shapeFiles } = loadShapes();
+    const validation = validateTurtle(result.output, store, shapeFiles, 'ccda-encounter-dates.xml');
+
+    const temporal = validation.results.filter((r) => String(r.message).includes(TEMPORAL_WARNING));
+    // 4 of 4 before this change; 1 of 4 after, and that one is the encounter the
+    // document genuinely left undated.
+    expect(
+      temporal.length,
+      temporal.map((r) => `  ${r.severity}: ${r.message}`).join('\n'),
+    ).toBe(1);
+
+    const violations = validation.results.filter((r) => r.severity === 'violation');
+    expect(violations, violations.map((v) => `  ${v.property}: ${v.message}`).join('\n')).toHaveLength(0);
+  });
+
+  it('leaves the nested-encounter fixture with no temporal warning at all', async () => {
+    const xml = fs.readFileSync(path.join(FIXTURES, 'ccda-encounter-panel.xml'), 'utf-8');
+    const result = await convertCcda(xml, {
+      sourceSystem: 'TestSystem',
+      importedAt: '2026-01-01T00:00:00Z',
+    });
+    const { store, shapeFiles } = loadShapes();
+    const validation = validateTurtle(result.output, store, shapeFiles, 'ccda-encounter-panel.xml');
+    const temporal = validation.results.filter((r) => String(r.message).includes(TEMPORAL_WARNING));
+    expect(temporal.map((r) => r.message)).toEqual([]);
+  });
+});
+
+describe('golden pins: no encounter IRI moves when the dates start being stated', () => {
+  /**
+   * HOW THESE WERE OBTAINED, because a golden pin copied out of the run it
+   * constrains proves nothing: they are the IRIs the C-CDA converter at
+   * origin/main mints from these fixtures, read out of a build of origin/main
+   * BEFORE any of this change existed.
+   *
+   * An encounter IRI that moves is a duplicate visit on every pod that already
+   * holds it, and every clinical:hasEncounter edge pointing at the old one is
+   * dangling. Nothing in the change above should be able to do that — the date
+   * reaches `ccdaRecordUri` through the same field, formatted the same way — and
+   * "should not be able to" is what a golden pin is for.
+   */
+  it('mints the pre-change IRIs for the Encounters-section fixture', async () => {
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    expect(Object.fromEntries(encountersBySourceId(quads))).toEqual({
+      'ENC-INTERVAL': 'urn:uuid:dadac7e3-af72-562d-ba43-df13518d1857',
+      'ENC-SINGLE': 'urn:uuid:dca04918-11ea-556c-a45a-840cbb9639f8',
+      'ENC-LOW-ONLY': 'urn:uuid:46501fee-3168-5b55-9a4f-01109cf91529',
+      'ENC-UNDATED': 'urn:uuid:30a1e368-177b-55f0-8467-09f82deddee0',
+    });
+  });
+
+  it('mints the pre-change IRI for the nested-encounter fixture', async () => {
+    const quads = await convertFixture('ccda-encounter-panel.xml');
+    expect(encountersBySourceId(quads).get('VISIT-778899')).toBe(
+      'urn:uuid:3ea1a023-9cf8-55e4-8f79-53fe664cece6',
+    );
+  });
+});

--- a/tests/ccda-encounter-dates.test.ts
+++ b/tests/ccda-encounter-dates.test.ts
@@ -90,6 +90,21 @@ function encountersBySourceId(quads: Quad[]): Map<string, string> {
   return bySourceId;
 }
 
+/** The clinical:Encounter subject carrying a given encounterType. */
+function encounterByType(quads: Quad[], type: string): string | undefined {
+  const isEncounter = new Set(
+    quads
+      .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === CLINICAL + 'Encounter')
+      .map((q) => q.subject.value),
+  );
+  return quads.find(
+    (q) =>
+      q.predicate.value === CASCADE + 'encounterType' &&
+      q.object.value === type &&
+      isEncounter.has(q.subject.value),
+  )?.subject.value;
+}
+
 /** One subject's object for a predicate, as {value, datatype}, or undefined. */
 function typedObject(
   quads: Quad[],
@@ -150,6 +165,18 @@ describe('C-CDA Encounters section — the visit imports with its time', () => {
     expect(typedObject(quads, subject!, CLINICAL + 'encounterDate')).toBeUndefined();
   });
 
+  it('states every time an encounter carrying both an @value and an interval gave', async () => {
+    // Vendors emit both. Each triple says one thing the document said; none of
+    // them is derived from another, so there is nothing here to choose between.
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    const subject = encountersBySourceId(quads).get('ENC-BOTH');
+    expect(subject).toBeTruthy();
+
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterStart')?.value).toBe('2025-11-01');
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterEnd')?.value).toBe('2025-11-02');
+    expect(typedObject(quads, subject!, CLINICAL + 'encounterDate')?.value).toBe('2025-11-04');
+  });
+
   it('leaves an encounter the document never dated undated', async () => {
     const quads = await convertFixture('ccda-encounter-dates.xml');
     const subject = encountersBySourceId(quads).get('ENC-UNDATED');
@@ -205,7 +232,7 @@ describe('C-CDA Encounters section — SHACL', () => {
     const validation = validateTurtle(result.output, store, shapeFiles, 'ccda-encounter-dates.xml');
 
     const temporal = validation.results.filter((r) => String(r.message).includes(TEMPORAL_WARNING));
-    // 4 of 4 before this change; 1 of 4 after, and that one is the encounter the
+    // 5 of 5 before this change; 1 of 5 after, and that one is the encounter the
     // document genuinely left undated.
     expect(
       temporal.length,
@@ -241,6 +268,16 @@ describe('golden pins: no encounter IRI moves when the dates start being stated'
    * dangling. Nothing in the change above should be able to do that — the date
    * reaches `ccdaRecordUri` through the same field, formatted the same way — and
    * "should not be able to" is what a golden pin is for.
+   *
+   * WHAT THESE COULD NOT SEE, AND WHY THE FIXTURE GREW A SIXTH ENCOUNTER.
+   * Reversing `single ?? low` to `low ?? single` — the one line the identity
+   * claim rests on — left the FULL suite green. Two reasons, and both had to be
+   * removed: an encounter carrying an `<id>` is keyed on the id and its date is
+   * never consulted, and an encounter carrying only ONE of `@value` / `low`
+   * reads the same value under either order. Every encounter in every fixture
+   * was one or the other. The id-less "Telehealth Follow Up Visit" below states
+   * both times AND has no id, so the two orders mint different keys and this pin
+   * is what says which of them is correct.
    */
   it('mints the pre-change IRIs for the Encounters-section fixture', async () => {
     const quads = await convertFixture('ccda-encounter-dates.xml');
@@ -249,7 +286,17 @@ describe('golden pins: no encounter IRI moves when the dates start being stated'
       'ENC-SINGLE': 'urn:uuid:dca04918-11ea-556c-a45a-840cbb9639f8',
       'ENC-LOW-ONLY': 'urn:uuid:46501fee-3168-5b55-9a4f-01109cf91529',
       'ENC-UNDATED': 'urn:uuid:30a1e368-177b-55f0-8467-09f82deddee0',
+      'ENC-BOTH': 'urn:uuid:ae7579e5-abeb-5004-bd54-2ead0edf9723',
     });
+  });
+
+  it('keys the id-less encounter on the @value, not on the interval low', async () => {
+    // The order pin. Under `low ?? single` this subject is a different IRI, and
+    // it is the only record in the repository for which that is true.
+    const quads = await convertFixture('ccda-encounter-dates.xml');
+    expect(encounterByType(quads, 'Telehealth Follow Up Visit')).toBe(
+      'urn:uuid:d9906703-7c75-5ad1-86ff-5adadad1d760',
+    );
   });
 
   it('mints the pre-change IRI for the nested-encounter fixture', async () => {

--- a/tests/fhir-medication-dates.test.ts
+++ b/tests/fhir-medication-dates.test.ts
@@ -1,0 +1,192 @@
+/**
+ * A prescription that states only when it was written must not import undated.
+ *
+ * WHAT WAS WRONG
+ * --------------
+ * `convertMedicationStatement` already knew `authoredOn` is a medication's date:
+ * it feeds the subject IRI, as `authoredOn ?? effectivePeriod.start`. But the
+ * date TRIPLE was emitted only from `effectivePeriod.start` / `effectiveDateTime`,
+ * so a MedicationRequest carrying `authoredOn` and nothing else — the ordinary
+ * shape of a prescription order — reached the pod with no date predicate at all.
+ * Undated in every consumer, invisible to anything that places records in time,
+ * and keyed on a date the record itself did not state.
+ *
+ * WHAT IT DOES NOW
+ * ----------------
+ * `authoredOn` becomes `health:startDate` when the resource states no effective
+ * date, through `tripleDateTime` — the same helper the two branches above it use,
+ * so the new triple is typed and precision-handled exactly like its siblings
+ * rather than by a fourth rule.
+ *
+ * THE ORDER IS DELIBERATELY NOT THE IDENTITY ORDER
+ * ------------------------------------------------
+ * Identity reads `authoredOn` FIRST; the triple reads it LAST. That is not an
+ * oversight to be tidied up:
+ *
+ *   - The identity key wants the most stable value across re-exports, and the
+ *     date a prescription was written never moves. Changing that order would
+ *     re-mint every medication in every existing pod.
+ *   - The triple wants what the record MEANS by "started". When a resource
+ *     states an effective period, the period is when the patient took the drug;
+ *     `authoredOn` is when a clinician typed it. Preferring the order date over
+ *     a stated effective period would be a downgrade.
+ *
+ * So the two orders differ, on purpose, and the golden pins below are the proof
+ * that adding the triple moved no key.
+ *
+ * Every fixture is synthetic and authored for this repository.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+import { convert } from '../src/lib/fhir-converter/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, '../test-fixtures');
+const BUNDLE = path.join(FIXTURES, 'fhir-medication-dates-bundle.json');
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const HEALTH = 'https://ns.cascadeprotocol.org/health/v1#';
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
+const XSD_DATETIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
+
+async function convertBundle(): Promise<Quad[]> {
+  const input = fs.readFileSync(BUNDLE, 'utf-8');
+  const result = await convert(input, 'fhir', 'cascade', 'turtle', 'medication-dates');
+  return new Parser().parse(result.output);
+}
+
+/** Medication subject IRI, keyed by the drug name the record displays. */
+function medicationsByDrug(quads: Quad[]): Map<string, string> {
+  const isMed = new Set(
+    quads
+      .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === CLINICAL + 'Medication')
+      .map((q) => q.subject.value),
+  );
+  const byDrug = new Map<string, string>();
+  for (const q of quads) {
+    if (q.predicate.value !== CLINICAL + 'drugName') continue;
+    if (!isMed.has(q.subject.value)) continue;
+    byDrug.set(q.object.value, q.subject.value);
+  }
+  return byDrug;
+}
+
+function objectsOf(quads: Quad[], subject: string, predicate: string): { value: string; datatype: string }[] {
+  return quads
+    .filter((q) => q.subject.value === subject && q.predicate.value === predicate)
+    .map((q) => ({
+      value: q.object.value,
+      datatype: (q.object as { datatype?: { value: string } }).datatype?.value ?? '(not a literal)',
+    }));
+}
+
+describe('FHIR medications — authoredOn is a date the record states', () => {
+  it('gives a MedicationRequest with only authoredOn a startDate', async () => {
+    const quads = await convertBundle();
+    const subject = medicationsByDrug(quads).get('Levothyroxine 50 mcg');
+    expect(subject, 'the order must be minted at all').toBeTruthy();
+
+    expect(objectsOf(quads, subject!, HEALTH + 'startDate')).toEqual([
+      { value: '2025-04-09T00:00:00Z', datatype: XSD_DATETIME },
+    ]);
+  });
+
+  it('gives an id-less MedicationRequest with only authoredOn a startDate too', async () => {
+    // The id-less case matters separately: without a resource.id the record's
+    // identity is built from its own content, so this is the resource where a
+    // careless fix is most likely to disturb the key.
+    const quads = await convertBundle();
+    const subject = medicationsByDrug(quads).get('Omeprazole 20 mg');
+    expect(subject).toBeTruthy();
+
+    expect(objectsOf(quads, subject!, HEALTH + 'startDate')).toEqual([
+      { value: '2025-05-21T08:15:00-05:00', datatype: XSD_DATETIME },
+    ]);
+  });
+
+  it('prefers a stated effective period over the order date, and states it once', async () => {
+    // Sertraline carries BOTH. The period is when the patient takes the drug;
+    // authoredOn is when a clinician typed it. A record that emitted both would
+    // give two answers to "when did this start", and the maxCount on the shape
+    // would not be the thing that noticed.
+    const quads = await convertBundle();
+    const subject = medicationsByDrug(quads).get('Sertraline 50 mg');
+    expect(subject).toBeTruthy();
+
+    expect(objectsOf(quads, subject!, HEALTH + 'startDate')).toEqual([
+      { value: '2025-06-04T00:00:00Z', datatype: XSD_DATETIME },
+    ]);
+    expect(objectsOf(quads, subject!, HEALTH + 'endDate')).toEqual([
+      { value: '2025-09-04T00:00:00Z', datatype: XSD_DATETIME },
+    ]);
+  });
+
+  it('leaves a medication that states no date of any kind undated', async () => {
+    const quads = await convertBundle();
+    const subject = medicationsByDrug(quads).get('Cetirizine 10 mg');
+    expect(subject).toBeTruthy();
+    expect(objectsOf(quads, subject!, HEALTH + 'startDate')).toEqual([]);
+    expect(objectsOf(quads, subject!, HEALTH + 'endDate')).toEqual([]);
+  });
+
+  it('does not disturb the two paths that already worked', async () => {
+    const quads = await convertBundle();
+    const byDrug = medicationsByDrug(quads);
+    expect(objectsOf(quads, byDrug.get('Metformin 500 mg')!, HEALTH + 'startDate')).toEqual([
+      { value: '2025-02-14T00:00:00Z', datatype: XSD_DATETIME },
+    ]);
+    expect(objectsOf(quads, byDrug.get('Atorvastatin 10 mg')!, HEALTH + 'startDate')).toEqual([
+      { value: '2025-01-07T00:00:00Z', datatype: XSD_DATETIME },
+    ]);
+  });
+
+  it('leaves every medication in the fixture carrying at most one startDate', async () => {
+    // The whole-bundle form of the assertion above. A second `quads.push` added
+    // beside the first rather than in the `else if` chain passes every named
+    // case and fails here.
+    const quads = await convertBundle();
+    for (const [drug, subject] of medicationsByDrug(quads)) {
+      expect(objectsOf(quads, subject, HEALTH + 'startDate').length, drug).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+/**
+ * THE NEGATIVE CLAIM, and the one that had to be proved before this could ship:
+ * emitting the date moved NO record identity.
+ *
+ * A medication IRI that moves is a duplicate on every pod that already holds the
+ * record, invisible until someone counts. `medicationUri` is not reached by the
+ * change — the emission sits well below it and reads the same resource fields —
+ * but "is not reached by" is exactly what a golden pin exists to check, because
+ * a test that compares two computed values passes just as happily when both have
+ * moved.
+ *
+ * HOW THESE VALUES WERE OBTAINED: they are the IRIs the FHIR converter at
+ * origin/main mints from this bundle, read out of a detached checkout of
+ * origin/main BEFORE the emission existed. Three of the six resources below —
+ * Levothyroxine, Omeprazole, Cetirizine — carried no date triple at all in that
+ * run, which is the defect; their keys are pinned here unchanged.
+ */
+describe('golden pins: no medication IRI moves when authoredOn starts being stated', () => {
+  it('mints the pre-change IRIs for every medication in the bundle', async () => {
+    const quads = await convertBundle();
+    expect(Object.fromEntries(medicationsByDrug(quads))).toEqual({
+      // MedicationRequest, authoredOn only, WITH a resource.id.
+      'Levothyroxine 50 mcg': 'urn:uuid:99cc4be1-40ee-514f-9669-2de4f49c4528',
+      // MedicationRequest, authoredOn only, NO resource.id: keyed on content.
+      'Omeprazole 20 mg': 'urn:uuid:71ea3165-09bf-5227-8de7-17ca551371de',
+      // Both dates present: the key takes authoredOn, the triple takes the period.
+      'Sertraline 50 mg': 'urn:uuid:1c468983-157c-55bb-a289-010bb27f5bb8',
+      'Metformin 500 mg': 'urn:uuid:e0f84d35-cc98-5b6c-a544-9bf86d44314b',
+      'Atorvastatin 10 mg': 'urn:uuid:2cbb94df-3291-535e-9114-7013d91b89c6',
+      // No date at all: the identity door falls through to content.
+      'Cetirizine 10 mg': 'urn:uuid:5c628737-cd13-5230-b9ef-b360cfbede0f',
+    });
+  });
+});

--- a/tests/pod-query-bookkeeping.test.ts
+++ b/tests/pod-query-bookkeeping.test.ts
@@ -1,0 +1,242 @@
+/**
+ * `pod query` answers with the pod's RECORDS. The pod's paperwork about those
+ * records is not one of them.
+ *
+ * WHAT WAS WRONG
+ * --------------
+ * `--all` sweeps every `.ttl` in the pod that is not on a short exclusion list of
+ * plumbing files, and `settings/pending-conflicts.ttl` and
+ * `settings/user-resolutions.ttl` were not on it. So every unresolved conflict
+ * and every decision the user had already recorded came back as a record, in the
+ * `other` bucket, with no date and no origin, alongside the medications. A
+ * consumer that treats query output as health records renders paperwork as
+ * mystery records, and acquires one more of them every time a conflict is
+ * detected or resolved.
+ *
+ * WHAT IT DOES NOW
+ * ----------------
+ * Bookkeeping SUBJECTS are excluded from the record output by default and
+ * returned by `--include-bookkeeping`, which is there because the queue is real
+ * data that real tooling wants — a conflict UI has to be able to ask for it.
+ *
+ * The rule is stated over rdf:type, not over filenames: what makes a
+ * cascade:PendingConflict not a record is that it is a note about records, and
+ * that stays true wherever it is stored. `BOOKKEEPING_TYPE_IRIS` in
+ * `lib/pod-read.ts` is the enumeration.
+ *
+ * Every fixture is synthetic and authored for this repository.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+
+function cli(args: string[]): { out: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 120000 });
+  return { out: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+/** One synthetic medication, parameterised on the axes a dose conflict needs. */
+function medTtl(slug: string, drugName: string, rxnorm: string, dosage: string): string {
+  return `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+
+<urn:cascade:med:${slug}> a clinical:Medication ;
+    clinical:drugName "${drugName}" ;
+    clinical:rxNormCode <https://ns.cascadeprotocol.org/rxnorm/${rxnorm}> ;
+    clinical:dosage "${dosage}" ;
+    clinical:status "active" ;
+    cascade:dataProvenance cascade:Imported ;
+    cascade:schemaVersion "1.9" .
+`;
+}
+
+interface QueryPayload {
+  pod: string;
+  dataTypes: Record<
+    string,
+    { count: number; file: string; records: Array<{ id: string; type: string }> }
+  >;
+}
+
+function queryAll(podDir: string, extra: string[] = []): QueryPayload {
+  const r = cli(['--json', 'pod', 'query', podDir, '--all', ...extra]);
+  expect(r.status, `pod query failed:\n${r.out}`).toBe(0);
+  return JSON.parse(r.out) as QueryPayload;
+}
+
+/** Every record type the query returned, across every bucket, sorted. */
+function typesReturned(payload: QueryPayload): string[] {
+  return Object.values(payload.dataTypes)
+    .flatMap((b) => b.records.map((rec) => rec.type))
+    .sort();
+}
+
+let root: string;
+/** A pod holding three medications, ONE unresolved conflict and ONE resolution. */
+let podDir: string;
+/** The same pod's shape with no bookkeeping at all, for the byte-stability check. */
+let cleanPodDir: string;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-query-bookkeeping-'));
+  podDir = path.join(root, 'pod');
+  cleanPodDir = path.join(root, 'clean-pod');
+
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing — run `npm run build` before `npm test`.');
+  }
+
+  const write = (name: string, ttl: string): string => {
+    const p = path.join(root, `${name}.ttl`);
+    fs.writeFileSync(p, ttl, 'utf-8');
+    return p;
+  };
+
+  const levoA = write('levo-a', medTtl('levo-a', 'Levothyroxine 50 mcg', '966224', '50 mcg'));
+  const levoB = write('levo-b', medTtl('levo-b', 'Levothyroxine 75 mcg', '966224', '75 mcg'));
+  const sertA = write('sert-a', medTtl('sert-a', 'Sertraline 50 mg', '312940', '50 mg'));
+  const sertB = write('sert-b', medTtl('sert-b', 'Sertraline 100 mg', '312940', '100 mg'));
+  const omepA = write('omep-a', medTtl('omep-a', 'Omeprazole 20 mg', '7646', '20 mg'));
+
+  expect(cli(['pod', 'init', podDir]).status).toBe(0);
+  // Two disagreeing doses of one drug raise a conflict; resolving it writes
+  // settings/user-resolutions.ttl. A SECOND disagreement afterwards leaves
+  // settings/pending-conflicts.ttl populated too, so both files carry a row.
+  for (const f of [levoA, levoB]) {
+    expect(cli(['pod', 'import', podDir, f, '--reconcile-existing']).status).toBe(0);
+  }
+  const conflicts = cli(['pod', 'conflicts', podDir, '--format', 'json']);
+  const rows = JSON.parse(conflicts.out) as Array<{ conflictId: string }>;
+  expect(rows.length, `expected one levothyroxine conflict:\n${conflicts.out}`).toBe(1);
+  expect(
+    cli(['pod', 'resolve', podDir, '--conflict', rows[0].conflictId, '--keep', 'source-a']).status,
+  ).toBe(0);
+  for (const f of [sertA, sertB]) {
+    expect(cli(['pod', 'import', podDir, f, '--reconcile-existing']).status).toBe(0);
+  }
+
+  // The control pod: same command sequence, no disagreement, so no bookkeeping.
+  expect(cli(['pod', 'init', cleanPodDir]).status).toBe(0);
+  expect(cli(['pod', 'import', cleanPodDir, omepA, '--reconcile-existing']).status).toBe(0);
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('pod query --all: the pod holds the bookkeeping this test is about', () => {
+  it('wrote both settings files, so the assertions below are not vacuous', () => {
+    // Without this, a change that stopped WRITING the conflict queue would make
+    // every test in this file pass while destroying the feature they guard.
+    const pending = fs.readFileSync(path.join(podDir, 'settings', 'pending-conflicts.ttl'), 'utf-8');
+    const resolutions = fs.readFileSync(
+      path.join(podDir, 'settings', 'user-resolutions.ttl'),
+      'utf-8',
+    );
+    expect(pending).toContain('PendingConflict');
+    expect(resolutions).toContain('UserResolution');
+  });
+});
+
+describe('pod query --all: paperwork is not a record', () => {
+  it('returns neither a pending conflict nor a resolution by default', () => {
+    const types = typesReturned(queryAll(podDir));
+    expect(types).not.toContain('core:PendingConflict');
+    expect(types).not.toContain('core:UserResolution');
+    // The medications are still all there: this excludes bookkeeping, not files.
+    expect(types).toEqual(['clinical:Medication', 'clinical:Medication']);
+  });
+
+  it('leaves no empty bucket behind where the bookkeeping used to be counted', () => {
+    // The `other` bucket existed ONLY because those two files landed in it. A
+    // filter applied after the bucket was built would leave `other: {count: 0}`,
+    // which is a different lie: a consumer renders an empty "Other" section that
+    // a pod without conflicts never shows.
+    const payload = queryAll(podDir);
+    expect(Object.keys(payload.dataTypes).sort()).toEqual(['medications']);
+    for (const [name, bucket] of Object.entries(payload.dataTypes)) {
+      expect(bucket.count, name).toBe(bucket.records.length);
+    }
+  });
+
+  it('returns both, with their properties, under --include-bookkeeping', () => {
+    const payload = queryAll(podDir, ['--include-bookkeeping']);
+    const types = typesReturned(payload);
+    expect(types).toContain('core:PendingConflict');
+    expect(types).toContain('core:UserResolution');
+
+    // Opting in must return the paperwork USABLE, not merely present.
+    const paperwork = Object.values(payload.dataTypes)
+      .flatMap((b) => b.records)
+      .filter((r) => r.type === 'core:PendingConflict' || r.type === 'core:UserResolution');
+    expect(paperwork).toHaveLength(2);
+    for (const rec of paperwork) {
+      const props = (rec as unknown as { properties: Record<string, string> }).properties;
+      expect(Object.keys(props), rec.type).toContain('core:conflictId');
+    }
+  });
+
+  it('counts what it returns, in both modes', () => {
+    for (const extra of [[], ['--include-bookkeeping']]) {
+      const payload = queryAll(podDir, extra);
+      for (const [name, bucket] of Object.entries(payload.dataTypes)) {
+        expect(bucket.count, `${name} with ${JSON.stringify(extra)}`).toBe(bucket.records.length);
+      }
+    }
+  });
+
+  it('changes nothing at all about a pod that holds no bookkeeping', () => {
+    // The byte-stability claim, stated as a claim rather than as a hope: for the
+    // overwhelming majority of pods this flag must be invisible.
+    const withoutFlag = JSON.stringify(queryAll(cleanPodDir));
+    const withFlag = JSON.stringify(queryAll(cleanPodDir, ['--include-bookkeeping']));
+    expect(withoutFlag).toBe(withFlag);
+    expect(typesReturned(JSON.parse(withoutFlag) as QueryPayload)).toEqual(['clinical:Medication']);
+  });
+
+  it('documents the flag in --help', () => {
+    const help = cli(['pod', 'query', '--help']).out;
+    expect(help).toContain('--include-bookkeeping');
+  });
+});
+
+describe('the verbs that read FILES are unaffected', () => {
+  it('pod conflicts still returns the unresolved conflict', () => {
+    // `pod query` is not how the conflict queue is read, and this is the check
+    // that the exclusion did not reach the command whose entire job it is.
+    const r = cli(['pod', 'conflicts', podDir, '--format', 'json']);
+    expect(r.status, r.out).not.toBe(2);
+    const rows = JSON.parse(r.out) as Array<{ conflictId: string; recordType: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].recordType).toBe('clinical:Medication');
+  });
+
+  it('validate still reads the settings files and reports on them', () => {
+    const r = cli(['--json', 'validate', podDir]);
+    const files = JSON.parse(r.out) as Array<{ file: string }>;
+    const names = files.map((f) => path.basename(f.file));
+    expect(names).toContain('pending-conflicts.ttl');
+    expect(names).toContain('user-resolutions.ttl');
+  });
+
+  it('reconcile still reads the records AND the conflict queue', () => {
+    // Dry run by default, so this reports without writing. Both numbers matter:
+    // `recordsBefore` is the record file it reads, `pendingConflicts.before` is
+    // the settings file — the one this change makes `pod query` stop returning.
+    const r = cli(['--json', 'pod', 'reconcile', podDir]);
+    expect(r.status, r.out).toBe(0);
+    const report = JSON.parse(r.out) as {
+      recordsBefore: number;
+      pendingConflicts: { before: number };
+    };
+    expect(report.recordsBefore).toBeGreaterThan(0);
+    expect(report.pendingConflicts.before).toBe(1);
+  });
+});


### PR DESCRIPTION
Three converter-honesty fixes: two records that imported with dates the source
had stated, and one query that answered with the pod's own paperwork.

## 1. A C-CDA encounter now imports with its time

`sections/encounters.ts` read `<effectiveTime>` only to build the record's
IDENTITY. The one date triple it wrote was `health:effectiveDate` as an untyped
literal, on a predicate the Encounter shapes do not look at, and `<high>` was
never read at any site. `clinical:EncounterTemporalShape` asks for
`clinical:encounterStart`, `clinical:encounterEnd` or `clinical:encounterDate`
and the converter wrote none of the three, so every encounter the C-CDA path
produced fired the "should carry a start, an end or an encounter date" warning,
including the ones whose Encounters section states the visit times outright.

Each of the three shapes an Encounters section uses now gets the triple that
says what it says, through `ccdaDateQuad`, the same typed-date chokepoint the
labs, problems, immunizations and vitals handlers use. An interval becomes a
start and an end, a single value becomes an encounter date, and an encounter
the document never dated stays undated: FHIR R4 `Encounter.period` is 0..1, and
inventing a day to silence a warning is the fabrication the date module exists
to refuse.

Both call sites are covered, the Encounters section and the
`<entryRelationship>` form the Results walk uses.

## 2. A prescription that states only `authoredOn` no longer imports undated

`convertMedicationStatement` already treated `authoredOn` as the record's date
where it counted most, as the first input to the subject IRI, and never wrote it
as a triple: `health:startDate` came only from `effectivePeriod.start` or
`effectiveDateTime`. A `MedicationRequest` carrying `authoredOn` and no
effective date is the ordinary shape of a prescription order, so the ordinary
prescription reached the pod with no date predicate at all.

The fallback order is deliberately not the identity order. Identity takes
`authoredOn` first because the date an order was written survives a re-export
unchanged, and reordering it would re-mint every medication in every existing
pod. The triple takes it last because a stated effective period is when the
patient took the drug while `authoredOn` is when a clinician typed it.

## 3. `pod query` stops returning the pod's bookkeeping as records

`--all` swept every `.ttl` a pod holds except a short list of plumbing files,
and `settings/pending-conflicts.ttl` and `settings/user-resolutions.ttl` were
not on that list. So every unresolved conflict and every decision the user had
already recorded came back in the `other` bucket beside the medications, undated
and with no origin, one more of them each time a conflict was detected or
resolved.

Bookkeeping subjects are excluded from the record output by default and returned
by `--include-bookkeeping`, which exists because the queue is real data a
conflict UI has to be able to ask for. The rule is stated over `rdf:type`, not
over filenames: a path list only excludes the files someone remembered to add to
it, which is exactly how the conflict store fell through one.
`BOOKKEEPING_TYPE_IRIS` in `src/lib/pod-read.ts` enumerates
`cascade:PendingConflict`, `cascade:UserResolution`, `solid:TypeIndex`,
`solid:TypeRegistration` and `pim:ConfigurationFile`, with the reasoning for each
and for what is deliberately not on it.

The filter runs before a bucket's count is taken and before the extra-file
sweep's empty check, so a file holding nothing but bookkeeping produces no bucket
rather than a bucket reporting zero. For a pod holding no bookkeeping the output
is byte-identical with the flag and without it. `pod conflicts`, `pod resolve`,
`pod reconcile` and `validate` read the settings files directly and are asserted
unaffected.

## Measurements

Across the 41 committed FHIR and C-CDA fixtures, converted and validated on this
branch and on the previous release:

| | before | after |
|---|---|---|
| encounter temporal warnings | 9 | 1 |
| `clinical:encounterStart` | 16 | 23 |
| `clinical:encounterEnd` | 16 | 20 |
| `clinical:encounterDate` | 0 | 3 |
| `health:startDate` | 11 | 35 |
| `sh:Violation` results | 7 | 7 |

The remaining encounter warning is the fixture entry the document genuinely left
undated. Medications carrying a date rise from 7 of 32 to 31 of 32; the remaining
one states no date of any kind.

Suite: 145 files / 2366 tests before, 148 files / 2395 tests after. Zero
failures and zero skips in both. The pathology corpus expectations, its
known-outcome ledger and its reconciliation baseline are byte-unchanged: no
scenario's record census, merge count, conflict count, edge count or violation
count moved, and every ledger entry still matches the behaviour it records.

## Identity

Neither converter change may re-mint a record. Both claims are held by golden
pins whose values were regenerated from a separate checkout of the previous
release and compared byte for byte: 353 typed subjects across 21 FHIR fixtures,
173 typed subjects across 21 C-CDA fixtures, all identical.

The C-CDA fixture carries an id-less encounter stating both an `@value` and a
`low` on different days. It is there because reversing `single ?? low` to
`low ?? single`, the one line the identity claim rests on, initially left the
FULL suite green: an encounter with an `<id>` is keyed on the id and never
consults its date, and an encounter stating only one of the two times reads the
same value under either order. Every encounter in every fixture was one or the
other, so the line that must not move was the line nothing held. With the id-less
case present that flip is red.

## Verification

Every behavioural line was flipped, rebuilt with the rc checked, and run against
the full suite:

| flip | observed |
|---|---|
| drop `encounterStart` emission | 4 red |
| `encounterEnd` falls back to `low` | 1 red |
| drop `encounterDate` emission | 2 red |
| reverse the identity date order | 2 red |
| drop the retained `health:effectiveDate` | 2 red |
| remove the `authoredOn` fallback | 2 red |
| emit `authoredOn` unconditionally | 2 red |
| bookkeeping filter keeps everything | 2 red |
| `--include-bookkeeping` ignored | 1 red |
| drop `UserResolution` from the enumeration | 2 red |
| drop `PendingConflict` from the enumeration | 2 red |
| filter applied after the empty-bucket check | 1 red |
