### PR TITLE
Route the checkup supplement class, type what add-record writes, and stop derived edges faking conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.20.0] - 2026-08-18
+
+### Added
+
+**`pod add-record --type checkup:SupplementSummary` now has somewhere to write.**
+The data-type map registered `clinical:Supplement` and nothing else, so adding a supplement by hand
+failed outright with `No known bucket for type checkup:SupplementSummary` and there was no way to
+record one at all. `checkup:SupplementSummary` is the patient-facing spelling, and the one carrying
+`checkup:regulatoryStatus`, the classification that separates a dietary supplement or an OTC product
+from an FDA-approved medication; its SHACL shape has shipped in this package the whole time and only
+the route was missing. It is registered against the SAME `wellness/supplements.ttl` the importer
+spelling uses, so "show me the supplements" stays one read and a reader does not have to know which
+vocabulary the writer happened to use. `pod query --supplements`, `pod query --all` and `pod info`
+all reach it, and `cascade validate` selects `SupplementSummaryShape` and reports nothing.
+
+### Fixed
+
+**`pod add-record` writes the datatype the vocabulary declares, instead of a bare string.**
+Values arrive as strings, because JSON and a shell both hand one over, and every one of them was
+written as a plain literal. A supplement carrying a boolean, a date and a decimal produced five
+`sh:datatype` violations from `cascade validate` on a file that still reported PASS, because the
+checkup shapes raise datatype at Info. Beyond the report, the pod held dates that sort lexically by
+luck and decimals nothing could sum without re-deriving a schema the pod does not carry, and it
+disagreed with itself: the same properties written by an IMPORT arrived correctly typed.
+
+The literal is now built at one chokepoint (`src/lib/shape-datatypes.ts`) from the `sh:datatype` the
+BUNDLED SHAPES declare for the property, so the writer and the validator cannot disagree and no
+hand-maintained table of datatypes exists here to drift from `spec/` on the next sync. A property no
+shape declares stays a plain string literal. `xsd:string` stays the short form, since RDF 1.1 makes
+a plain literal `xsd:string` already. Lexical values are preserved exactly, so `"12.50"` does not
+become `12.5` and a date is not shifted through a timezone. A value that cannot be its declared
+datatype (a boolean given as `maybe`, a date given as `2026-02-30`) is REFUSED and nothing is
+written, rather than coerced or silently written untyped: the same stance the command already takes
+on an unwritable IRI, because the input is the only place either is still fixable. Two invariants
+are pinned as tripwires for the next vocabulary sync: every datatype the shapes declare has a
+lexical-form check, and no property is declared with two different datatypes.
+
+**A DERIVED reference edge no longer reads as evidence that a re-import is a different record.**
+`clinical:parsedIndicationReference` and `clinical:linkedCondition` are stated by no source. The
+literal-lifting pass derives them at the END of an import, from a reason the converter captured or
+from the UUIDs packed into a `clinical:linkedConditionIds` literal. Reconciliation runs BEFORE that
+pass, so the two copies of one record it compares were caught at different stages of one pipeline:
+the copy read back out of the POD is post-lift and carries the derived edge (or carries nothing,
+because the reason matched no condition and the pass dropped it), while the copy from the BATCH is
+pre-lift and carries an opaque placeholder holding the reason's codes, or nothing at all.
+
+Compared as written, those never agree. So the content fingerprint declared them materially
+different records that the identity layer had put on one IRI: a false identity collision, a split
+onto a second IRI, and an unresolved conflict labelled `differs on
+clinical:parsedIndicationReference` for two records identical in everything a source ever said,
+source record id included. Measured on the reason-code fixture: three false conflicts, and a pod
+that grew from 6 records to 9 on the second import of ONE unchanged file, and again on the third.
+A record carrying linked-condition ids reproduced the same defect on `clinical:linkedCondition`.
+
+Both sides are now put through the SAME derivation, and what is compared is the edge set the lift
+will actually write. This is deliberately not an ignore-list: dropping the predicates from the
+fingerprint would remove the false conflicts and the true ones with them, so two records whose
+parsed indications genuinely point at different conditions would compare equal and one would be
+discarded as a duplicate. Both directions are pinned by tests. The derivation is the lift's own
+(`buildDerivedReferenceResolver`), exported rather than reimplemented, because a second copy would
+drift and drift here is indistinguishable from the defect. `DERIVED_REFERENCE_PREDICATES` is the
+chokepoint the next derived edge family joins, and a test fails if a predicate is added to it
+without a re-derivation to match.
+
+---
+
 ## [0.19.0] - 2026-08-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"

--- a/src/commands/pod/add-record.ts
+++ b/src/commands/pod/add-record.ts
@@ -14,6 +14,14 @@
  * --json arg, or from the CASCADE_RECORD_JSON environment variable when --json
  * is omitted (useful for large payloads).
  *
+ * Every value is given as a string, and the LITERAL it becomes is decided by
+ * the datatype the bundled shapes declare for that property (see
+ * `lib/shape-datatypes.ts`): `checkup:supplementIsActive "true"` is written as
+ * an `xsd:boolean`, `checkup:supplementStartDate` as an `xsd:date`,
+ * `checkup:patientCost` as an `xsd:decimal`. A property no shape declares stays
+ * a plain string literal, and a value that cannot be its declared datatype is
+ * refused before anything is written.
+ *
  * --json result (global --json flag):
  *   { added: true, recordUri, type }
  */
@@ -26,6 +34,7 @@ import { printResult, printError, printVerbose, type OutputOptions } from '../..
 import { DATA_TYPES, resolvePodDir, fileExists, type DataTypeInfo } from './helpers.js';
 import { resolvePodDek, mintUri } from '../../lib/annotations.js';
 import { mergeIntoBucket, KNOWN_PREFIXES, assertWritableIri } from '../../lib/bucket-write.js';
+import { typedLiteralForPredicate } from '../../lib/shape-datatypes.js';
 
 const { namedNode, literal, quad: makeQuad } = DataFactory;
 
@@ -178,7 +187,24 @@ export function registerAddRecordSubcommand(pod: Command, program: Command): voi
           process.exitCode = 1;
           return;
         }
-        newQuads.push(makeQuad(subject, namedNode(predicateIri), literal(String(value))));
+        // The value arrives as a string whatever its type: JSON hands one over
+        // and so does a shell. The literal it becomes is decided by what the
+        // bundled shapes DECLARE the property to be, so a boolean, a date or a
+        // decimal lands typed instead of as a bare string the validator then
+        // objects to. A value that cannot be its declared datatype is refused
+        // here, before anything is written.
+        let object;
+        try {
+          object = typedLiteralForPredicate(predicateIri, String(value));
+        } catch (e: unknown) {
+          printError(
+            `${e instanceof Error ? e.message : String(e)} (property "${curie}")`,
+            globalOpts,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        newQuads.push(makeQuad(subject, namedNode(predicateIri), object));
       }
       // Source axis: who reported it (self) — and a real attribution triple.
       newQuads.push(makeQuad(

--- a/src/lib/capabilities/enrichment.ts
+++ b/src/lib/capabilities/enrichment.ts
@@ -125,6 +125,7 @@ export const COMMAND_ENRICHMENT: EnrichmentTable = {
       'Enforced at run time, not by the parser: the record properties are mandatory. Pass them as the propsJson positional argument — a JSON object of { "<curie>": "<value>" } — or set CASCADE_RECORD_JSON, which is the better route for a large payload. With neither, the command exits 1 with "No properties provided."',
       '--type takes a CURIE whose prefix is one of cascade/core, health, clinical, coverage, checkup, pots, workbench, fhir, and whose class must map to a known bucket file (e.g. health:ConditionRecord, clinical:Medication). An unmapped type is refused rather than guessed.',
       'The record is written as cascade:SelfReported and workbench:Unverified, attributed to --by if given and otherwise to the pod owner\'s WebID.',
+      'Property values are given as strings, and each is written as the datatype the bundled SHACL shapes declare for that property: a checkup:supplementIsActive of "true" becomes an xsd:boolean, a checkup:supplementStartDate an xsd:date, a checkup:patientCost an xsd:decimal. A property no shape declares stays a plain string literal. A value that cannot be its declared datatype (a boolean given as "maybe", a date given as "2026-02-30") is refused and nothing is written.',
     ],
   },
 

--- a/src/lib/literal-lifting.ts
+++ b/src/lib/literal-lifting.ts
@@ -45,11 +45,29 @@ const { namedNode, quad: makeQuad } = DataFactory;
 // Predicates and types this pass reads and writes
 // ---------------------------------------------------------------------------
 
-const LINKED_CONDITION_IDS = NS.clinical + 'linkedConditionIds';
-const LINKED_CONDITION = NS.clinical + 'linkedCondition';
-const PARSED_INDICATION_REFERENCE = NS.clinical + 'parsedIndicationReference';
-const INDICATION_REFERENCE = NS.clinical + 'indicationReference';
+export const LINKED_CONDITION_IDS = NS.clinical + 'linkedConditionIds';
+export const LINKED_CONDITION = NS.clinical + 'linkedCondition';
+export const PARSED_INDICATION_REFERENCE = NS.clinical + 'parsedIndicationReference';
+export const INDICATION_REFERENCE = NS.clinical + 'indicationReference';
 const RDF_TYPE = NS.rdf + 'type';
+
+/**
+ * Predicates whose object this pass DERIVES rather than reads: the record never
+ * states them, so their presence and their value are both a function of the
+ * record's other content plus the conditions in scope.
+ *
+ * That makes them useless as evidence of what a record IS, and actively
+ * misleading to anything that compares two copies of one record: this pass runs
+ * at the END of an import, so a copy read back out of the pod carries the
+ * derived edge and a freshly converted copy of the same record does not carry
+ * it yet. Any comparison that reads them literally therefore sees two different
+ * records where there is one. `lib/reconciler.ts` re-derives both sides through
+ * {@link buildDerivedReferenceResolver} instead of comparing the spellings.
+ */
+export const DERIVED_REFERENCE_PREDICATES: ReadonlySet<string> = new Set<string>([
+  PARSED_INDICATION_REFERENCE,
+  LINKED_CONDITION,
+]);
 
 /**
  * rdf:type values that mark a record as a condition, across every producer:
@@ -92,7 +110,7 @@ const CONDITION_NAME_PREDICATES = [
  * rather than through the FHIR converter, so they arrive with no coded candidate
  * attached and only the name fallback can resolve them.
  */
-const INDICATION_TEXT_PREDICATES = [
+export const INDICATION_TEXT_PREDICATES = [
   NS.clinical + 'indication',
   NS.clinical + 'reasonForUse',
   'https://ns.cascadeprotocol.org/checkup/v1#reasonForUse',
@@ -300,6 +318,92 @@ function candidateCount(set: Set<string> | undefined, exclude?: string): number 
   return [...set].filter((s) => s !== exclude).length;
 }
 
+/**
+ * The UUIDs a `clinical:linkedConditionIds` literal packs.
+ *
+ * Checkup emits comma-separated lowercased UUIDs; the deprecated property's own
+ * comment says space-separated. Accept both, plus stray semicolons, rather than
+ * trusting either wording. Exported so the reconciler splits the literal
+ * exactly the way this pass does: a second, subtly different split would
+ * re-derive a different edge set and put the false conflicts straight back.
+ */
+export function splitLinkedConditionIds(value: string): string[] {
+  return value
+    .split(/[\s,;]+/)
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// The derivation, as a resolver both this pass and the reconciler can call
+// ---------------------------------------------------------------------------
+
+/** The outcome of asking which condition a derived reference names. */
+export interface ConditionMatch {
+  /** The single condition subject that matched, or null when none did. */
+  target: string | null;
+  /** True when more than one candidate matched, so no edge may be written. */
+  ambiguous: boolean;
+}
+
+/**
+ * The derivation rules of this pass, bound to one set of conditions in scope.
+ *
+ * There is exactly ONE definition of "which condition does this reason name",
+ * and both callers go through it. The reconciler needs the answer to compare
+ * two copies of a record without seeing the pipeline stage they were caught at
+ * as a difference in content; this pass needs it to write the edge. A second
+ * implementation on either side would drift, and drift here reads as a
+ * spurious conflict on every re-import.
+ */
+export interface DerivedReferenceResolver {
+  /** The condition a converter-captured coded reason names, if exactly one. */
+  matchParsedIndication(subject: string, payload: ParsedIndicationPayload): ConditionMatch;
+  /** The condition a bare free-text reason literal names, if exactly one. */
+  matchIndicationText(subject: string, text: string): ConditionMatch;
+  /** The condition a `linkedConditionIds` UUID names, if exactly one. */
+  matchLinkedConditionId(subject: string, id: string): string | null;
+}
+
+/** Build the resolver over the condition records present in `quads`. */
+export function buildDerivedReferenceResolver(quads: Quad[]): DerivedReferenceResolver {
+  const index = buildConditionIndex(quads);
+
+  return {
+    matchParsedIndication(subject, payload) {
+      // Code-first: exact coding identity against the condition's own code.
+      // Measured on a real provider export, this is the signal that works;
+      // normalized-name matching alone resolved nothing there.
+      let ambiguous = false;
+      for (const code of payload.codes) {
+        const bucket = index.byCode.get(code);
+        if (candidateCount(bucket, subject) > 1) { ambiguous = true; continue; }
+        const sole = soleCandidate(bucket, subject);
+        if (sole) return { target: sole, ambiguous };
+      }
+      // Fallback: exact normalized-name equality (never substring, which would
+      // trade precision for recall on clinical names).
+      if (payload.text) {
+        const bucket = index.byName.get(normalizeName(payload.text));
+        if (candidateCount(bucket, subject) > 1) ambiguous = true;
+        const sole = soleCandidate(bucket, subject);
+        if (sole) return { target: sole, ambiguous };
+      }
+      return { target: null, ambiguous };
+    },
+
+    matchIndicationText(subject, text) {
+      const bucket = index.byName.get(normalizeName(text));
+      const target = soleCandidate(bucket, subject);
+      return { target, ambiguous: target === null && candidateCount(bucket, subject) > 1 };
+    },
+
+    matchLinkedConditionId(subject, id) {
+      return soleCandidate(index.byUuid.get(id), subject);
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // The pass
 // ---------------------------------------------------------------------------
@@ -313,7 +417,7 @@ function candidateCount(set: Set<string> | undefined, exclude?: string): number 
  */
 export function liftTrappedLiterals(quads: Quad[]): { quads: Quad[]; stats: LiteralLiftSummary } {
   const stats = emptyLiftSummary();
-  const index = buildConditionIndex(quads);
+  const resolver = buildDerivedReferenceResolver(quads);
 
   // Edges already present, so a re-import (or a record that already states an
   // indication) never produces a duplicate or a redundant parsed restatement.
@@ -361,30 +465,9 @@ export function liftTrappedLiterals(quads: Quad[]): { quads: Quad[]; stats: Lite
       }
       const subject = q.subject.value;
 
-      // Code-first: exact coding identity against the condition's own code.
-      // Measured on a real provider export, this is the signal that works;
-      // normalized-name matching alone resolved nothing there.
-      let matched: string | null = null;
-      let sawAmbiguous = false;
-      for (const code of payload.codes) {
-        const bucket = index.byCode.get(code);
-        const n = candidateCount(bucket, subject);
-        if (n > 1) { sawAmbiguous = true; continue; }
-        const sole = soleCandidate(bucket, subject);
-        if (sole) { matched = sole; break; }
-      }
-
-      // Fallback: exact normalized-name equality (never substring, which would
-      // trade precision for recall on clinical names).
-      if (!matched && payload.text) {
-        const bucket = index.byName.get(normalizeName(payload.text));
-        const n = candidateCount(bucket, subject);
-        if (n > 1) sawAmbiguous = true;
-        matched = soleCandidate(bucket, subject);
-      }
-
+      const { target: matched, ambiguous } = resolver.matchParsedIndication(subject, payload);
       if (!matched) {
-        if (sawAmbiguous) stats.parsedIndication.ambiguous++;
+        if (ambiguous) stats.parsedIndication.ambiguous++;
         else stats.parsedIndication.unmatched++;
         continue;
       }
@@ -407,15 +490,8 @@ export function liftTrappedLiterals(quads: Quad[]): { quads: Quad[]; stats: Lite
     // alongside it.
     if (q.predicate.value === LINKED_CONDITION_IDS && q.object.termType === 'Literal') {
       const subject = q.subject.value;
-      // Checkup emits comma-separated lowercased UUIDs; the deprecated
-      // property's own comment says space-separated. Accept both, plus stray
-      // semicolons, rather than trusting either wording.
-      const ids = q.object.value
-        .split(/[\s,;]+/)
-        .map((s) => s.trim().toLowerCase())
-        .filter(Boolean);
-      for (const id of ids) {
-        const target = soleCandidate(index.byUuid.get(id), subject);
+      for (const id of splitLinkedConditionIds(q.object.value)) {
+        const target = resolver.matchLinkedConditionId(subject, id);
         if (!target) {
           stats.linkedCondition.unresolved++;
           continue;
@@ -439,11 +515,9 @@ export function liftTrappedLiterals(quads: Quad[]): { quads: Quad[]; stats: Lite
       !hasCodedCandidate.has(q.subject.value)
     ) {
       const subject = q.subject.value;
-      const bucket = index.byName.get(normalizeName(q.object.value));
-      const n = candidateCount(bucket, subject);
-      const target = soleCandidate(bucket, subject);
+      const { target, ambiguous } = resolver.matchIndicationText(subject, q.object.value);
       if (!target) {
-        if (n > 1) stats.parsedIndication.ambiguous++;
+        if (ambiguous) stats.parsedIndication.ambiguous++;
         else stats.parsedIndication.unmatched++;
       } else {
         const key = edgeKey(subject, PARSED_INDICATION_REFERENCE, target);

--- a/src/lib/pod-data-types.ts
+++ b/src/lib/pod-data-types.ts
@@ -104,9 +104,25 @@ export const DATA_TYPES: Record<string, DataTypeInfo> = {
     directory: 'wellness',
     filename: 'sleep.ttl',
   },
+  // Two vocabularies spell a supplement, and both route HERE rather than to two
+  // files. `clinical:Supplement` is the importer's spelling; the checkup
+  // vocabulary's `checkup:SupplementSummary` is the patient-facing one, which
+  // carries the regulatory classification (dietary supplement / OTC drug /
+  // homeopathic / herbal) that separates a supplement from an FDA-approved
+  // medication, and which is what a person adding their own supplement writes.
+  //
+  // It was registered nowhere, so `pod add-record --type
+  // checkup:SupplementSummary` failed outright with "No known bucket for type"
+  // and there was no way to record a supplement by hand at all. Filing it beside
+  // `clinical:Supplement` (rather than in a checkup-only file) is what keeps
+  // "show me the supplements" one read: a reader asking that question must not
+  // have to know which of two vocabularies the writer happened to use.
   supplements: {
     label: 'Supplements',
-    rdfTypes: [CASCADE_NAMESPACES.clinical + 'Supplement'],
+    rdfTypes: [
+      CASCADE_NAMESPACES.clinical + 'Supplement',
+      CASCADE_NAMESPACES.checkup + 'SupplementSummary',
+    ],
     directory: 'wellness',
     filename: 'supplements.ttl',
   },

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -15,6 +15,18 @@ import {
   decodeReferencePlaceholder,
   isReferencePlaceholder,
 } from './fhir-converter/reference-resolution.js';
+import {
+  buildDerivedReferenceResolver,
+  decodeParsedIndicationPlaceholder,
+  isParsedIndicationPlaceholder,
+  splitLinkedConditionIds,
+  DERIVED_REFERENCE_PREDICATES,
+  INDICATION_REFERENCE,
+  INDICATION_TEXT_PREDICATES,
+  LINKED_CONDITION,
+  LINKED_CONDITION_IDS,
+  PARSED_INDICATION_REFERENCE,
+} from './literal-lifting.js';
 import { normalizeMedName, normalizeDose, normalizeFrequency, type DrugNameNormalizer } from './medication-normalize.js';
 import { medicationCodeKeys, sharedMedicationCodeKey, extractCodeValue } from './code-keys.js';
 import { cascadeTerminologyResolver } from './terminology.js';
@@ -659,6 +671,133 @@ function normalizeEdgeValue(
   return resolveRef?.(decodeReferencePlaceholder(value)) ?? undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Derived reference predicates
+// ---------------------------------------------------------------------------
+
+/**
+ * The values a record WOULD carry on a derived reference predicate, computed
+ * from the record's own stated content rather than read off it.
+ *
+ * WHY A DERIVED EDGE CANNOT BE COMPARED AS WRITTEN
+ * ------------------------------------------------
+ * `clinical:parsedIndicationReference` and `clinical:linkedCondition` are not
+ * stated by any source. `liftTrappedLiterals` derives them at the END of an
+ * import, from a reason the converter captured or from the UUIDs a Checkup
+ * export packs into `clinical:linkedConditionIds`. Reconciliation runs BEFORE
+ * that pass, so the two copies of one record it is asked to compare were caught
+ * at different stages of the same pipeline:
+ *
+ *   - the copy read back out of the POD is post-lift, and carries the derived
+ *     edge pointing at a real subject (`urn:uuid:...`), or carries no such edge
+ *     at all because the reason matched nothing and the pass dropped it;
+ *   - the copy from the BATCH is pre-lift, and carries either an opaque
+ *     `urn:cascade:parsed-indication:` placeholder holding the reason's codes,
+ *     or nothing yet on `clinical:linkedCondition` because the pass has not run.
+ *
+ * Compared as written, those never agree. Every re-import of a record with a
+ * reason therefore read as two materially different records sharing one IRI:
+ * a false identity collision, a split into a second IRI, and an unresolved
+ * conflict whose label was "differs on clinical:parsedIndicationReference" for
+ * two records byte-identical in everything a source ever said, source record id
+ * included. Measured on the reason-code fixture: three false conflicts and a
+ * pod that grew from 6 records to 9 on the second import of ONE unchanged file,
+ * and one more on `clinical:linkedCondition` for a record carrying
+ * linked-condition ids.
+ *
+ * WHY RE-DERIVING IS THE FIX RATHER THAN IGNORING THE PREDICATE
+ * ------------------------------------------------------------
+ * Dropping these predicates from the fingerprint would make the false conflicts
+ * go away and take the true ones with them: two records whose parsed
+ * indications genuinely point at DIFFERENT conditions would then compare equal,
+ * and one of them would be silently discarded as a duplicate. So both sides are
+ * put through the same derivation instead, and what is compared is the edge set
+ * the lift will actually write. Identical inputs give identical sets; different
+ * indications give different sets and still conflict.
+ *
+ * The derivation is the lift's own (see `buildDerivedReferenceResolver`), not a
+ * second copy of it, because a second copy would drift and drift here is
+ * indistinguishable from the defect.
+ */
+export type DerivedReferenceValues = (record: ParsedRecord, predicate: string) => string[];
+
+/**
+ * Build the re-derivation over the conditions present in `quads` (every input
+ * of the run: the pod's own records and the batch's alike, so a reason resolves
+ * against the same condition set whichever side asks).
+ */
+export function buildDerivedReferenceValues(
+  quads: Quad[],
+  resolveRef?: (raw: string) => string | null,
+): DerivedReferenceValues {
+  const resolver = buildDerivedReferenceResolver(quads);
+
+  const resolvedValues = (record: ParsedRecord, predicate: string): string[] => {
+    const out: string[] = [];
+    for (const v of record.properties.get(predicate) ?? []) {
+      const normalized = normalizeEdgeValue(v.value, resolveRef);
+      if (normalized !== undefined) out.push(normalized);
+    }
+    return out;
+  };
+
+  return (record, predicate): string[] => {
+    const out = new Set<string>();
+
+    if (predicate === PARSED_INDICATION_REFERENCE) {
+      // A reason the record ALSO states outright suppresses its parsed
+      // restatement, exactly as the lift's `existingEdges` seeding does. Without
+      // this, a record carrying both `reasonReference` and `reasonCode` for one
+      // condition derives an edge on one side that the pod's copy correctly does
+      // not hold.
+      const stated = new Set(resolvedValues(record, INDICATION_REFERENCE));
+
+      let sawPlaceholder = false;
+      for (const v of record.properties.get(PARSED_INDICATION_REFERENCE) ?? []) {
+        if (isParsedIndicationPlaceholder(v.value)) {
+          sawPlaceholder = true;
+          const payload = decodeParsedIndicationPlaceholder(v.value);
+          if (!payload) continue;
+          const { target } = resolver.matchParsedIndication(record.uri, payload);
+          if (target) out.add(target);
+          continue;
+        }
+        const normalized = normalizeEdgeValue(v.value, resolveRef);
+        if (normalized !== undefined) out.add(normalized);
+      }
+
+      // The free-text path, which is the only one a Turtle-passthrough record
+      // (Checkup's `reasonForUse`, or an earlier import's `clinical:indication`)
+      // has. The lift skips it for a record whose reason already arrived as a
+      // coded candidate, so this does too.
+      if (!sawPlaceholder) {
+        for (const textPredicate of INDICATION_TEXT_PREDICATES) {
+          for (const v of record.properties.get(textPredicate) ?? []) {
+            const { target } = resolver.matchIndicationText(record.uri, v.value);
+            if (target) out.add(target);
+          }
+        }
+      }
+
+      for (const s of stated) out.delete(s);
+      return [...out].sort();
+    }
+
+    if (predicate === LINKED_CONDITION) {
+      for (const value of resolvedValues(record, LINKED_CONDITION)) out.add(value);
+      for (const v of record.properties.get(LINKED_CONDITION_IDS) ?? []) {
+        for (const id of splitLinkedConditionIds(v.value)) {
+          const target = resolver.matchLinkedConditionId(record.uri, id);
+          if (target) out.add(target);
+        }
+      }
+      return [...out].sort();
+    }
+
+    return [];
+  };
+}
+
 /**
  * A content fingerprint for one parsed record: SHA-256 over its
  * (predicate, value, datatype) triples, sorted, with
@@ -673,10 +812,15 @@ export function recordContentFingerprint(
   r: ParsedRecord,
   resolveRef?: (raw: string) => string | null,
   ignored: ReadonlySet<string> = COLLISION_IGNORED_PREDICATES,
+  derived?: DerivedReferenceValues,
 ): string {
   const parts: string[] = [];
   for (const [pred, vals] of r.properties) {
     if (ignored.has(pred)) continue;
+    // A derived reference is contributed by the block below, re-derived from the
+    // record's own content, so whichever spelling it happens to carry right now
+    // is skipped here.
+    if (derived && DERIVED_REFERENCE_PREDICATES.has(pred)) continue;
     for (const v of vals) {
       const value = normalizeEdgeValue(v.value, resolveRef);
       if (value === undefined) continue;  // an unresolvable edge is never persisted
@@ -684,6 +828,16 @@ export function recordContentFingerprint(
       // makes grep and ripgrep classify it as binary and silently skip the whole
       // file, which is how a defect in this very module went unfound.
       parts.push(`${pred}\u0000${value}\u0000${v.datatype ?? ''}`);
+    }
+  }
+  // Iterated over the PREDICATE SET rather than over the record's own keys, so a
+  // copy that does not carry the derived edge YET still contributes the edges it
+  // implies. That absence is the whole asymmetry: without this the pre-lift copy
+  // has no entry where the post-lift copy has one, and the two never agree.
+  if (derived) {
+    for (const pred of DERIVED_REFERENCE_PREDICATES) {
+      if (ignored.has(pred)) continue;
+      for (const value of derived(r, pred)) parts.push(`${pred}\u0000${value}\u0000`);
     }
   }
   parts.sort();
@@ -747,8 +901,17 @@ function collisionSplitUri(mintedUri: string, fingerprint: string): string {
 function differingPredicates(
   bucket: ParsedRecord[],
   resolveRef?: (raw: string) => string | null,
+  derived?: DerivedReferenceValues,
 ): string[] {
   const normalize = (r: ParsedRecord, pred: string): string | undefined => {
+    // A derived reference is re-derived on BOTH sides, for the same reason the
+    // fingerprint re-derives it. Reporting the raw spellings here would name a
+    // predicate the fingerprint no longer disagrees on, which is worse than the
+    // old behaviour: a conflict row explaining a difference that is not there.
+    if (derived && DERIVED_REFERENCE_PREDICATES.has(pred)) {
+      const values = derived(r, pred);
+      return values.length > 0 ? values.join(', ') : undefined;
+    }
     const vals = r.properties.get(pred);
     if (!vals) return undefined;
     const normalized = vals
@@ -760,6 +923,13 @@ function differingPredicates(
   const preds = new Set<string>();
   for (const r of bucket) for (const p of r.properties.keys()) {
     if (!COLLISION_IGNORED_PREDICATES.has(p)) preds.add(p);
+  }
+  // A derived predicate is considered even when no record in the bucket carries
+  // it yet, since one side may only imply it.
+  if (derived) {
+    for (const p of DERIVED_REFERENCE_PREDICATES) {
+      if (!COLLISION_IGNORED_PREDICATES.has(p)) preds.add(p);
+    }
   }
   const out: string[] = [];
   for (const p of preds) {
@@ -785,6 +955,7 @@ function differingPredicates(
 export function splitIdentityCollisions(
   records: ParsedRecord[],
   resolveRef?: (raw: string) => string | null,
+  derived?: DerivedReferenceValues,
 ): {
   records: ParsedRecord[];
   collisions: IdentityCollision[];
@@ -803,7 +974,9 @@ export function splitIdentityCollisions(
   const collisions: IdentityCollision[] = [];
   const collisionGroupByUri = new Map<string, string>();
   const fingerprints = new Map<ParsedRecord, string>();
-  for (const r of records) fingerprints.set(r, recordContentFingerprint(r, resolveRef));
+  for (const r of records) {
+    fingerprints.set(r, recordContentFingerprint(r, resolveRef, COLLISION_IGNORED_PREDICATES, derived));
+  }
 
   let current = records;
   for (let round = 0; round < 8; round++) {
@@ -838,7 +1011,7 @@ export function splitIdentityCollisions(
         resultingUris: [uri, ...distinct.slice(1).map((fp) => target.get(fp)!)],
         sourceSystems: [...new Set(bucket.map((r) => r.sourceSystem))],
         origins: [...new Set(bucket.map(conflictOriginLabel))],
-        differingPredicates: differingPredicates(bucket, resolveRef),
+        differingPredicates: differingPredicates(bucket, resolveRef, derived),
       });
     }
 
@@ -2000,7 +2173,14 @@ export async function runReconciliation(
   // reason it is passed above: a stated edge arrives resolved from the pod and as
   // a placeholder from the new input, and without normalizing the two spellings
   // every re-import of an edge-bearing record reads as a collision.
-  const split = splitIdentityCollisions(allRecords, referenceResolver);
+  // The same re-derivation both halves of the collision check need: what
+  // `liftTrappedLiterals` WILL write on each record's derived reference
+  // predicates, computed over every input of this run. Built here so the pod's
+  // post-lift copy and the batch's pre-lift copy of one record are compared on
+  // the same footing rather than on the pipeline stage each was caught at.
+  const derivedReferenceValues = buildDerivedReferenceValues(allInputQuads, referenceResolver);
+
+  const split = splitIdentityCollisions(allRecords, referenceResolver, derivedReferenceValues);
   allRecords = split.records;
   const identityCollisions = split.collisions;
 
@@ -2281,7 +2461,9 @@ export async function runReconciliation(
   const fingerprintOf = (r: ParsedRecord): string => {
     let fp = fingerprintCache.get(r);
     if (fp === undefined) {
-      fp = recordContentFingerprint(r, referenceResolver, TIER0_IGNORED_PREDICATES);
+      fp = recordContentFingerprint(
+        r, referenceResolver, TIER0_IGNORED_PREDICATES, derivedReferenceValues,
+      );
       fingerprintCache.set(r, fp);
     }
     return fp;

--- a/src/lib/shape-datatypes.ts
+++ b/src/lib/shape-datatypes.ts
@@ -1,0 +1,274 @@
+/**
+ * The datatype a Cascade property is DECLARED to carry, read from the bundled
+ * SHACL shapes, plus the one place a user-supplied string is turned into the
+ * RDF literal that declaration calls for.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `cascade pod add-record` takes every property value as a string, because JSON
+ * and a shell both hand it one. It then wrote every one of them as a PLAIN
+ * literal. So a pod could hold
+ *
+ *     checkup:supplementIsActive "true" ;
+ *     checkup:supplementStartDate "2026-01-15" ;
+ *     checkup:patientCost "12.50" ;
+ *
+ * where the vocabulary declares `xsd:boolean`, `xsd:date` and `xsd:decimal`.
+ * Nothing in the record says so, which has three consequences that compound:
+ *
+ *   1. `cascade validate` reports a `sh:datatype` violation for every one of
+ *      them. They are Info-severity on the checkup shapes, so the file still
+ *      PASSES and the defect is easy to walk past, but the violations are real,
+ *      and the same properties on a shape that raises datatype at Warning would
+ *      fail the pod outright.
+ *   2. A consumer cannot compare or order the values without guessing. A date
+ *      held as a plain string sorts lexically by luck, and a decimal held as a
+ *      plain string cannot be summed at all without re-parsing it against a
+ *      schema the pod does not carry.
+ *   3. The pod disagrees with itself: the same property written by an IMPORT
+ *      arrives correctly typed (the converters build typed terms), so one pod
+ *      can hold both spellings of one property and no reader can tell which is
+ *      canonical.
+ *
+ * WHY THE SHAPES ARE THE SOURCE
+ * -----------------------------
+ * The alternative is a hand-maintained table of property datatypes in this
+ * repository, which is a second copy of something `spec/` already owns and
+ * which would drift from it silently on the next vocabulary sync. The bundled
+ * shapes ARE the synced copy, they are already loaded by `cascade validate`,
+ * and they declare the datatype on the same `sh:path` the writer is about to
+ * use. Reading the declaration from them means the writer and the validator can
+ * never disagree about what a property is.
+ *
+ * WHAT IS DELIBERATELY NOT DONE
+ * -----------------------------
+ * A value whose lexical form does not fit its declared datatype is REFUSED, not
+ * coerced and not silently written untyped. Coercion invents data ("yes" is not
+ * a boolean, and guessing that it means `true` is a decision the pod cannot
+ * later distinguish from the patient having said `true`), and writing it
+ * untyped reproduces the very defect this module removes while looking like it
+ * succeeded. Refusal is the stance `add-record` already takes on an unwritable
+ * IRI, for the same reason: the input is the only place this is still fixable.
+ */
+
+import { DataFactory } from 'n3';
+import type { Literal } from 'n3';
+import { loadShapes } from './shacl-validator.js';
+import { findIllegalIriChar } from './bucket-write.js';
+
+const { literal, namedNode } = DataFactory;
+
+const SH = 'http://www.w3.org/ns/shacl#';
+const SH_PATH = `${SH}path`;
+const SH_DATATYPE = `${SH}datatype`;
+
+export const XSD = 'http://www.w3.org/2001/XMLSchema#';
+
+/** `http://www.w3.org/2001/XMLSchema#boolean` -> `xsd:boolean`. */
+export function shortDatatype(iri: string): string {
+  return iri.startsWith(XSD) ? `xsd:${iri.slice(XSD.length)}` : iri;
+}
+
+/**
+ * Raised when a value cannot be the datatype its property declares. Carries the
+ * pieces a caller needs to build its own message, not only a rendered string.
+ */
+export class DatatypeMismatchError extends Error {
+  constructor(
+    readonly predicateIri: string,
+    readonly datatypeIri: string,
+    readonly value: string,
+  ) {
+    super(
+      `Value ${JSON.stringify(value)} is not a valid ${shortDatatype(datatypeIri)}. ` +
+        `The bundled shapes declare ${predicateIri} as ${shortDatatype(datatypeIri)}, ` +
+        `so writing it as given would put a literal in the pod that the pod's own ` +
+        `vocabulary rejects. Nothing was written.`,
+    );
+    this.name = 'DatatypeMismatchError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The declaration map
+// ---------------------------------------------------------------------------
+
+/** Every `sh:datatype` declared for each plain-predicate `sh:path`, unfiltered. */
+function scanDeclarations(): Map<string, Set<string>> {
+  const { store } = loadShapes();
+  const byPath = new Map<string, Set<string>>();
+
+  for (const q of store.getQuads(null, namedNode(SH_PATH), null, null)) {
+    // Only a plain predicate path can be routed by a writer holding one CURIE.
+    // Sequence and alternative paths are RDF lists, and a value written under
+    // one of them is not a single property assignment.
+    if (q.object.termType !== 'NamedNode') continue;
+    for (const d of store.getObjects(q.subject, namedNode(SH_DATATYPE), null)) {
+      if (d.termType !== 'NamedNode') continue;
+      let set = byPath.get(q.object.value);
+      if (!set) byPath.set(q.object.value, (set = new Set()));
+      set.add(d.value);
+    }
+  }
+  return byPath;
+}
+
+let cachedMap: Map<string, string> | undefined;
+
+/**
+ * Every property IRI the bundled shapes declare a single `sh:datatype` for.
+ *
+ * A property declared with two DIFFERENT datatypes across shapes is omitted
+ * rather than resolved by precedence: the writer would then have to pick one,
+ * and picking wrongly writes a literal the other shape rejects. Measured on the
+ * shapes bundled at the time of writing, no such property exists, so the
+ * exclusion is a guard rather than behaviour anyone relies on, and the typed
+ * literal tests assert the count stays zero so a vocabulary sync that
+ * introduces one is visible rather than silent.
+ *
+ * Cached: the shapes graph is roughly 13k quads and a CLI invocation reads it
+ * once.
+ */
+export function shapeDeclaredDatatypes(): Map<string, string> {
+  if (cachedMap) return cachedMap;
+
+  const out = new Map<string, string>();
+  for (const [predicate, datatypes] of scanDeclarations()) {
+    if (datatypes.size !== 1) continue;
+    out.set(predicate, [...datatypes][0]);
+  }
+  cachedMap = out;
+  return out;
+}
+
+/** Properties the shapes declare with more than one datatype, sorted. */
+export function ambiguouslyDeclaredProperties(): string[] {
+  return [...scanDeclarations()]
+    .filter(([, datatypes]) => datatypes.size > 1)
+    .map(([predicate]) => predicate)
+    .sort();
+}
+
+/** The datatype IRI declared for `predicateIri`, or undefined if none is. */
+export function declaredDatatype(predicateIri: string): string | undefined {
+  return shapeDeclaredDatatypes().get(predicateIri);
+}
+
+// ---------------------------------------------------------------------------
+// Lexical forms
+// ---------------------------------------------------------------------------
+
+/** Whether (year, month, day) names a day that exists in the proleptic calendar. */
+function isCalendarDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1) return false;
+  const lengths = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const max = month === 2 && leap ? 29 : lengths[month - 1];
+  return day <= max;
+}
+
+const DATE_RE = /^(-?\d{4,})-(\d{2})-(\d{2})(Z|[+-]\d{2}:\d{2})?$/;
+const DATETIME_RE =
+  /^(-?\d{4,})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/;
+
+function validDate(v: string): boolean {
+  const m = DATE_RE.exec(v);
+  return m !== null && isCalendarDate(Number(m[1]), Number(m[2]), Number(m[3]));
+}
+
+function validDateTime(v: string): boolean {
+  const m = DATETIME_RE.exec(v);
+  if (!m) return false;
+  if (!isCalendarDate(Number(m[1]), Number(m[2]), Number(m[3]))) return false;
+  const [hour, minute, second] = [Number(m[4]), Number(m[5]), Number(m[6])];
+  // 24:00:00 is the one legal hour-24 form in XML Schema.
+  if (hour === 24) return minute === 0 && second === 0;
+  return hour < 24 && minute < 60 && second < 60;
+}
+
+const LONG_MIN = -(2n ** 63n);
+const LONG_MAX = 2n ** 63n - 1n;
+
+function validLong(v: string): boolean {
+  if (!/^[+-]?\d+$/.test(v)) return false;
+  const n = BigInt(v);
+  return n >= LONG_MIN && n <= LONG_MAX;
+}
+
+function validBase64(v: string): boolean {
+  const compact = v.replace(/\s+/g, '');
+  return compact.length % 4 === 0 && /^[A-Za-z0-9+/]*={0,2}$/.test(compact);
+}
+
+/**
+ * An anyURI may be relative and may be empty; what it may not contain is a
+ * character Turtle cannot carry inside an IRI. Delegated to the bucket writer's
+ * own rule rather than restated, so the two cannot drift. The value here is a
+ * LITERAL and so is not itself subject to Turtle's IRIREF production, but a
+ * value typed anyURI exists to be dereferenced, and one holding a space or a
+ * control character is not a URI any consumer can use.
+ */
+function validAnyUri(v: string): boolean {
+  return findIllegalIriChar(v) === undefined;
+}
+
+/**
+ * Lexical-form check per XML Schema Part 2, one entry per datatype the bundled
+ * shapes actually declare.
+ *
+ * The map is closed on purpose. A datatype with no entry here is REFUSED rather
+ * than stamped unchecked, so a vocabulary sync that introduces one surfaces as
+ * a refusal on a real write instead of as a pod full of literals nothing ever
+ * checked. The typed literal tests assert that every datatype the bundled
+ * shapes declare has an entry, so that refusal is caught in CI first.
+ */
+const LEXICAL_FORMS: Record<string, (v: string) => boolean> = {
+  [`${XSD}string`]: () => true,
+  [`${XSD}boolean`]: (v) => /^(true|false|1|0)$/.test(v),
+  [`${XSD}decimal`]: (v) => /^[+-]?(\d+(\.\d*)?|\.\d+)$/.test(v),
+  [`${XSD}integer`]: (v) => /^[+-]?\d+$/.test(v),
+  [`${XSD}nonNegativeInteger`]: (v) => /^\+?\d+$/.test(v),
+  [`${XSD}long`]: validLong,
+  [`${XSD}double`]: (v) =>
+    /^(INF|-INF|NaN)$/.test(v) || /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?$/.test(v),
+  [`${XSD}date`]: validDate,
+  [`${XSD}dateTime`]: validDateTime,
+  [`${XSD}anyURI`]: validAnyUri,
+  [`${XSD}base64Binary`]: validBase64,
+};
+
+/** Datatypes this module knows how to check, sorted, for the coverage tripwire. */
+export function checkedDatatypes(): string[] {
+  return Object.keys(LEXICAL_FORMS).sort();
+}
+
+// ---------------------------------------------------------------------------
+// The chokepoint
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the literal term for one user-supplied property value.
+ *
+ * A property the shapes declare a datatype for gets that datatype stamped on
+ * the term. Everything else stays a plain literal, which is what an undeclared
+ * property means: nothing has said what it is, so the writer must not invent an
+ * answer.
+ *
+ * `xsd:string` is written as a plain literal rather than an explicit
+ * `^^xsd:string`, because RDF 1.1 defines a plain literal to BE `xsd:string`
+ * and the two are the same term. Writing the long form would rewrite every
+ * existing string-valued bucket on its next merge for no semantic gain.
+ *
+ * @throws {DatatypeMismatchError} when the value is not a legal lexical form
+ *         for the declared datatype, or when the declared datatype has no
+ *         lexical-form check here.
+ */
+export function typedLiteralForPredicate(predicateIri: string, value: string): Literal {
+  const datatype = declaredDatatype(predicateIri);
+  if (datatype === undefined || datatype === `${XSD}string`) return literal(value);
+
+  const check = LEXICAL_FORMS[datatype];
+  if (!check || !check(value)) throw new DatatypeMismatchError(predicateIri, datatype, value);
+
+  return literal(value, namedNode(datatype));
+}

--- a/test-fixtures/derived-reference-linked-conditions.ttl
+++ b/test-fixtures/derived-reference-linked-conditions.ttl
@@ -1,0 +1,23 @@
+# Synthetic fixture for the DERIVED reference edge `clinical:linkedCondition`.
+#
+# One condition and one medication that names it through the deprecated
+# `clinical:linkedConditionIds` literal. The edge itself is never stated: the
+# import's literal-lifting pass derives it, which happens AFTER reconciliation,
+# so re-importing this file is the shape that used to raise a false identity
+# collision labelled "differs on clinical:linkedCondition".
+#
+# Both records carry a source record id, so the two arrivals are the SAME
+# record by every axis a source states.
+
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+
+<urn:uuid:aaaaaaaa-0000-4000-8000-000000000001> a health:ConditionRecord ;
+    health:conditionName "Hyperlipidemia" ;
+    health:sourceRecordId "cond-1" ;
+    health:snomedCode <http://snomed.info/sct/55822004> .
+
+<urn:uuid:bbbbbbbb-0000-4000-8000-000000000001> a clinical:Medication ;
+    clinical:drugName "simvastatin" ;
+    clinical:sourceRecordId "med-1" ;
+    clinical:linkedConditionIds "aaaaaaaa-0000-4000-8000-000000000001" .

--- a/tests/pod-add-record-typed-literals.test.ts
+++ b/tests/pod-add-record-typed-literals.test.ts
@@ -1,0 +1,285 @@
+/**
+ * A value `pod add-record` writes must land as the datatype its property is
+ * declared to have.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * `add-record` takes every property value as a string, because JSON and a shell
+ * both hand it one, and it wrote every one of them as a PLAIN literal:
+ *
+ *     checkup:supplementIsActive "true" ;
+ *     checkup:supplementStartDate "2026-01-15" ;
+ *     checkup:patientCost "12.50" ;
+ *     checkup:doctorAware "false" ;
+ *
+ * The checkup vocabulary declares those `xsd:boolean`, `xsd:date`,
+ * `xsd:decimal` and `xsd:boolean`. Measured against the pre-fix build, one
+ * five-property supplement produced FIVE `sh:datatype` violations from
+ * `cascade validate` (patientCost is constrained by two shapes and reports
+ * twice). They are Info severity on the checkup shapes, so the file still
+ * reported PASS and the defect was easy to walk past, but the pod held dates
+ * that sort lexically by luck and decimals that cannot be summed without
+ * re-deriving a schema the pod does not carry, and the SAME properties written
+ * by an import arrived correctly typed, so one pod could hold both spellings of
+ * one property with nothing to say which was canonical.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT
+ *   - `stamps the declared datatype` FAILS: the serialized bucket holds
+ *     `checkup:supplementIsActive "true"`, not a typed boolean.
+ *   - `validates with nothing to report` FAILS with 5 Info results.
+ *   - `refuses a value that cannot be its declared datatype` FAILS: "maybe" was
+ *     accepted and written.
+ *
+ * The declaration is read from the BUNDLED SHAPES rather than from a table in
+ * this repo, so the two invariant tests at the bottom guard the reading: every
+ * datatype the shapes declare must have a lexical-form check, and no property
+ * may be declared with two different datatypes. Both are tripwires for the next
+ * vocabulary sync.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { Parser } from 'n3';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  XSD,
+  ambiguouslyDeclaredProperties,
+  checkedDatatypes,
+  declaredDatatype,
+  shapeDeclaredDatatypes,
+  typedLiteralForPredicate,
+  DatatypeMismatchError,
+} from '../src/lib/shape-datatypes.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+const CHECKUP = 'https://ns.cascadeprotocol.org/checkup/v1#';
+
+const roots: string[] = [];
+
+function cli(args: string[]): { output: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 180000 });
+  return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+/**
+ * The fixture bucket: one supplement summary carrying a value of every
+ * non-string datatype the class declares.
+ */
+const MIXED_DATATYPE_PROPS = {
+  'checkup:supplementName': 'Synthetic Kelp Blend',
+  'checkup:regulatoryStatus': 'dietarySupplement',
+  'checkup:supplementIsActive': 'true',
+  'checkup:doctorAware': 'false',
+  'checkup:supplementStartDate': '2026-01-15',
+  'checkup:patientCost': '12.50',
+};
+
+function podWithMixedDatatypes(): { podDir: string; bucket: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'typed-lit-'));
+  roots.push(root);
+  const podDir = path.join(root, 'pod');
+
+  expect(cli(['pod', 'init', podDir]).status).toBe(0);
+  const add = cli([
+    '--json', 'pod', 'add-record', podDir,
+    '--type', 'checkup:SupplementSummary',
+    '--json', JSON.stringify(MIXED_DATATYPE_PROPS),
+  ]);
+  expect(add.status, add.output).toBe(0);
+
+  return { podDir, bucket: path.join(podDir, 'wellness', 'supplements.ttl') };
+}
+
+/** The datatype IRI of the object of `predicate`, as the WRITTEN file holds it. */
+function writtenDatatype(turtle: string, predicate: string): string | undefined {
+  const quads = new Parser({ format: 'Turtle' }).parse(turtle);
+  const q = quads.find((x) => x.predicate.value === predicate);
+  if (!q || q.object.termType !== 'Literal') return undefined;
+  return q.object.datatype.value;
+}
+
+function writtenValue(turtle: string, predicate: string): string | undefined {
+  const quads = new Parser({ format: 'Turtle' }).parse(turtle);
+  return quads.find((x) => x.predicate.value === predicate)?.object.value;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing. Run `npm run build` before `npm test`.');
+  }
+});
+
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+describe('pod add-record writes the datatype the shapes declare', () => {
+  it('stamps xsd:boolean, xsd:date and xsd:decimal on the values that need them', () => {
+    const { bucket } = podWithMixedDatatypes();
+    const turtle = fs.readFileSync(bucket, 'utf-8');
+
+    expect(writtenDatatype(turtle, `${CHECKUP}supplementIsActive`)).toBe(`${XSD}boolean`);
+    expect(writtenDatatype(turtle, `${CHECKUP}doctorAware`)).toBe(`${XSD}boolean`);
+    expect(writtenDatatype(turtle, `${CHECKUP}supplementStartDate`)).toBe(`${XSD}date`);
+    expect(writtenDatatype(turtle, `${CHECKUP}patientCost`)).toBe(`${XSD}decimal`);
+  });
+
+  it('preserves the lexical value exactly as given', () => {
+    // Typing must not reformat. "12.50" becoming "12.5" would silently rewrite
+    // what the patient entered, and a date normalized through a Date object
+    // would shift by a timezone.
+    const { bucket } = podWithMixedDatatypes();
+    const turtle = fs.readFileSync(bucket, 'utf-8');
+
+    expect(writtenValue(turtle, `${CHECKUP}patientCost`)).toBe('12.50');
+    expect(writtenValue(turtle, `${CHECKUP}supplementStartDate`)).toBe('2026-01-15');
+    expect(writtenValue(turtle, `${CHECKUP}supplementIsActive`)).toBe('true');
+  });
+
+  it('leaves a string-declared property a plain literal', () => {
+    // RDF 1.1 makes a plain literal xsd:string already. Writing the long form
+    // would rewrite every existing string-valued bucket on its next merge for
+    // no semantic gain, so the test pins the SHORT form.
+    const { bucket } = podWithMixedDatatypes();
+    const turtle = fs.readFileSync(bucket, 'utf-8');
+
+    expect(writtenDatatype(turtle, `${CHECKUP}supplementName`)).toBe(`${XSD}string`);
+    expect(turtle).toContain('checkup:supplementName "Synthetic Kelp Blend"');
+    expect(turtle).not.toContain('"Synthetic Kelp Blend"^^xsd:string');
+  });
+
+  it('validates with nothing to report', () => {
+    const { bucket } = podWithMixedDatatypes();
+    const r = cli(['--json', 'validate', bucket]);
+    expect(r.status, r.output).toBe(0);
+
+    const [report] = JSON.parse(r.output);
+    expect(report.shapesFired).toContain('SupplementSummaryShape');
+    // Not `valid: true`, which was already true before the fix: these were
+    // Info-severity results and Info does not fail a file. The count is the
+    // assertion that moved, from 5 to 0.
+    expect(report.results).toEqual([]);
+  });
+
+  it('survives the round trip through pod query', () => {
+    const { podDir } = podWithMixedDatatypes();
+    const r = cli(['--json', 'pod', 'query', podDir, '--supplements']);
+    expect(r.status, r.output).toBe(0);
+
+    const record = JSON.parse(r.output).dataTypes.supplements.records[0];
+    expect(record.properties[`checkup:supplementIsActive`]).toBe('true');
+    expect(record.properties[`checkup:supplementStartDate`]).toBe('2026-01-15');
+    expect(record.properties[`checkup:patientCost`]).toBe('12.50');
+  });
+
+  it('types a JSON boolean and a JSON number the same as their string forms', () => {
+    // The payload is JSON, so a caller may well send `true` and `12.5` rather
+    // than "true" and "12.5". Both reach the writer as strings, and both must
+    // land typed.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'typed-lit-json-'));
+    roots.push(root);
+    const podDir = path.join(root, 'pod');
+    expect(cli(['pod', 'init', podDir]).status).toBe(0);
+
+    const add = cli([
+      '--json', 'pod', 'add-record', podDir,
+      '--type', 'checkup:SupplementSummary',
+      '--json', '{"checkup:supplementName":"Synthetic Beet Powder","checkup:supplementIsActive":true,"checkup:patientCost":12.5}',
+    ]);
+    expect(add.status, add.output).toBe(0);
+
+    const turtle = fs.readFileSync(path.join(podDir, 'wellness', 'supplements.ttl'), 'utf-8');
+    expect(writtenDatatype(turtle, `${CHECKUP}supplementIsActive`)).toBe(`${XSD}boolean`);
+    expect(writtenDatatype(turtle, `${CHECKUP}patientCost`)).toBe(`${XSD}decimal`);
+  });
+
+  it('refuses a value that cannot be its declared datatype, and writes nothing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'typed-lit-bad-'));
+    roots.push(root);
+    const podDir = path.join(root, 'pod');
+    expect(cli(['pod', 'init', podDir]).status).toBe(0);
+
+    const add = cli([
+      'pod', 'add-record', podDir,
+      '--type', 'checkup:SupplementSummary',
+      '--json', '{"checkup:supplementName":"Synthetic Beet Powder","checkup:supplementIsActive":"maybe"}',
+    ]);
+    expect(add.status).toBe(1);
+    expect(add.output).toContain('xsd:boolean');
+    expect(add.output).toContain('checkup:supplementIsActive');
+    // Refusal means refusal: the bucket must not exist holding a half-written
+    // record. Coercing "maybe" to a boolean, or falling back to an untyped
+    // literal, would both leave a file here.
+    expect(fs.existsSync(path.join(podDir, 'wellness', 'supplements.ttl'))).toBe(false);
+  });
+
+  it('refuses an impossible date as well as an impossible boolean', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'typed-lit-date-'));
+    roots.push(root);
+    const podDir = path.join(root, 'pod');
+    expect(cli(['pod', 'init', podDir]).status).toBe(0);
+
+    const add = cli([
+      'pod', 'add-record', podDir,
+      '--type', 'checkup:SupplementSummary',
+      '--json', '{"checkup:supplementName":"Synthetic Beet Powder","checkup:supplementStartDate":"2026-02-30"}',
+    ]);
+    expect(add.status).toBe(1);
+    expect(add.output).toContain('xsd:date');
+  });
+});
+
+describe('the declaration map read from the bundled shapes', () => {
+  it('reads the checkup supplement datatypes off the shapes, not off a local table', () => {
+    expect(declaredDatatype(`${CHECKUP}supplementIsActive`)).toBe(`${XSD}boolean`);
+    expect(declaredDatatype(`${CHECKUP}supplementStartDate`)).toBe(`${XSD}date`);
+    expect(declaredDatatype(`${CHECKUP}patientCost`)).toBe(`${XSD}decimal`);
+    expect(declaredDatatype(`${CHECKUP}supplementName`)).toBe(`${XSD}string`);
+  });
+
+  it('declares nothing for a property no shape constrains', () => {
+    expect(declaredDatatype('https://ns.cascadeprotocol.org/checkup/v1#notAProperty')).toBeUndefined();
+    expect(typedLiteralForPredicate(
+      'https://ns.cascadeprotocol.org/checkup/v1#notAProperty', 'anything',
+    ).datatype.value).toBe(`${XSD}string`);
+  });
+
+  it('is non-empty, so an all-undefined map cannot pass as "nothing is declared"', () => {
+    expect(shapeDeclaredDatatypes().size).toBeGreaterThan(100);
+  });
+
+  it('has a lexical-form check for every datatype the shapes declare', () => {
+    // The tripwire for the next vocabulary sync. A datatype with no check is
+    // refused at runtime rather than written unchecked, so without this test the
+    // first sign of a new one would be a user's write failing.
+    const declared = [...new Set(shapeDeclaredDatatypes().values())].sort();
+    const checked = new Set(checkedDatatypes());
+    expect(declared.filter((d) => !checked.has(d))).toEqual([]);
+  });
+
+  it('declares no property with two different datatypes', () => {
+    // Such a property is omitted from the map (the writer would have to pick one
+    // and the other shape would reject the pick), so it would silently go back
+    // to being written untyped. Zero today; this makes a change visible.
+    expect(ambiguouslyDeclaredProperties()).toEqual([]);
+  });
+
+  it('rejects each declared datatype with a value that cannot be it', () => {
+    const cases: Array<[string, string]> = [
+      [`${XSD}boolean`, 'maybe'],
+      [`${XSD}decimal`, '12.5.1'],
+      [`${XSD}integer`, '3.5'],
+      [`${XSD}date`, '15/01/2026'],
+      [`${XSD}dateTime`, '2026-01-15'],
+    ];
+    for (const [datatype, bad] of cases) {
+      const predicate = [...shapeDeclaredDatatypes()].find(([, d]) => d === datatype)?.[0];
+      expect(predicate, `no bundled property is declared ${datatype}`).toBeDefined();
+      expect(() => typedLiteralForPredicate(predicate!, bad)).toThrow(DatatypeMismatchError);
+    }
+  });
+});

--- a/tests/pod-supplement-summary-routing.test.ts
+++ b/tests/pod-supplement-summary-routing.test.ts
@@ -1,0 +1,215 @@
+/**
+ * A supplement a person records by hand must have somewhere to go.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * `DATA_TYPES` registered `clinical:Supplement` and nothing else, so
+ *
+ *     cascade pod add-record <pod> --type checkup:SupplementSummary --json '{...}'
+ *
+ * failed outright with
+ *
+ *     No known bucket for type checkup:SupplementSummary.
+ *
+ * and there was no way to add a supplement by hand at all. The checkup
+ * vocabulary's `SupplementSummary` is the patient-facing spelling: it is the one
+ * that carries `checkup:regulatoryStatus`, the classification that separates a
+ * dietary supplement or an OTC product from an FDA-approved medication, and it
+ * is what a person entering their own supplement has to say. Its SHACL shape has
+ * shipped in this package the whole time; only the route was missing.
+ *
+ * This is the same defect the family-history routing tests were written for: a
+ * ratified class with a bundled shape and no bucket. The difference is where it
+ * surfaced. Family history fell THROUGH to the FHIR passthrough bucket, so the
+ * import "succeeded" and the records were merely misfiled. `add-record` has no
+ * passthrough fallback, so this one is a hard refusal on the write path.
+ *
+ * WHAT THESE WOULD DO IF THE FIX WERE ABSENT
+ *   - `registers checkup:SupplementSummary` FAILS: the bucket's rdfTypes hold
+ *     only `clinical:Supplement`.
+ *   - `add-record writes one` FAILS: exit code 1 and the "No known bucket"
+ *     message, with `wellness/supplements.ttl` never created.
+ *   - `pod query --supplements returns it` and `pod query --all` FAIL: nothing
+ *     was ever written.
+ *   - `pod info counts it` FAILS for the same reason.
+ *
+ * The supplement names are obviously synthetic.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DATA_TYPES } from '../src/lib/pod-data-types.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+const CHECKUP = 'https://ns.cascadeprotocol.org/checkup/v1#';
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
+
+const roots: string[] = [];
+
+function cli(args: string[]): { output: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 180000 });
+  return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+function cliWithEnv(
+  args: string[],
+  env: Record<string, string>,
+): { output: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8', timeout: 180000, env: { ...process.env, ...env },
+  });
+  return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+/** A pod holding one hand-entered supplement summary. */
+function podWithSupplement(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'supp-route-'));
+  roots.push(root);
+  const podDir = path.join(root, 'pod');
+
+  const init = cli(['pod', 'init', podDir]);
+  expect(init.status, init.output).toBe(0);
+
+  const add = cli([
+    '--json', 'pod', 'add-record', podDir,
+    '--type', 'checkup:SupplementSummary',
+    '--json', JSON.stringify({
+      'checkup:supplementName': 'Synthetic Kelp Blend',
+      'checkup:regulatoryStatus': 'dietarySupplement',
+      'checkup:supplementForm': 'capsule',
+      'checkup:reasonForUse': 'general wellness',
+    }),
+  ]);
+  expect(add.status, add.output).toBe(0);
+  return podDir;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing. Run `npm run build` before `npm test`.');
+  }
+});
+
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+describe('the supplements routing bucket', () => {
+  it('registers checkup:SupplementSummary against wellness/supplements.ttl', () => {
+    const bucket = DATA_TYPES.supplements;
+    expect(bucket).toBeDefined();
+    expect(bucket.rdfTypes).toContain(`${CHECKUP}SupplementSummary`);
+    expect(bucket.directory).toBe('wellness');
+    expect(bucket.filename).toBe('supplements.ttl');
+  });
+
+  it('still registers the importer spelling in the SAME bucket', () => {
+    // Both vocabularies name a supplement, and a reader asking "what supplements
+    // are there" must not have to know which one the writer used. Two buckets
+    // would answer that question twice and agree by luck.
+    expect(DATA_TYPES.supplements.rdfTypes).toContain(`${CLINICAL}Supplement`);
+  });
+
+  it('claims the type exclusively, so no other bucket also routes it', () => {
+    // Two buckets claiming one type makes routing depend on object key order,
+    // which is a different defect wearing the same symptom.
+    const claimants = Object.entries(DATA_TYPES)
+      .filter(([, info]) => info.rdfTypes.includes(`${CHECKUP}SupplementSummary`))
+      .map(([key]) => key);
+    expect(claimants).toEqual(['supplements']);
+  });
+});
+
+describe('cascade pod add-record --type checkup:SupplementSummary', () => {
+  it('writes the record to wellness/supplements.ttl', () => {
+    const podDir = podWithSupplement();
+    const file = path.join(podDir, 'wellness', 'supplements.ttl');
+
+    expect(fs.existsSync(file), 'wellness/supplements.ttl was never created').toBe(true);
+    const turtle = fs.readFileSync(file, 'utf-8');
+    // The type AND the content: a file with the right type and the wrong values
+    // would satisfy the first assertion alone.
+    expect(turtle).toContain('checkup:SupplementSummary');
+    expect(turtle).toContain('Synthetic Kelp Blend');
+    expect(turtle).toContain('dietarySupplement');
+  });
+
+  it('reports the bucket it chose', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'supp-route-msg-'));
+    roots.push(root);
+    const podDir = path.join(root, 'pod');
+    expect(cli(['pod', 'init', podDir]).status).toBe(0);
+
+    // Through CASCADE_RECORD_JSON, so the documented `--json '<propsJson>'`
+    // surface does not also set the global JSON flag and the human-readable
+    // report (which is where the destination file is named) is what comes back.
+    const add = cliWithEnv(
+      ['pod', 'add-record', podDir, '--type', 'checkup:SupplementSummary'],
+      { CASCADE_RECORD_JSON: '{"checkup:supplementName":"Synthetic Beet Powder","checkup:regulatoryStatus":"dietarySupplement"}' },
+    );
+    expect(add.status, add.output).toBe(0);
+    expect(add.output).toContain('wellness/supplements.ttl');
+  });
+
+  it('reaches it through pod query --supplements', () => {
+    const podDir = podWithSupplement();
+    const r = cli(['--json', 'pod', 'query', podDir, '--supplements']);
+    expect(r.status, r.output).toBe(0);
+
+    const parsed = JSON.parse(r.output);
+    const bucket = parsed.dataTypes.supplements;
+    expect(bucket.count).toBe(1);
+    expect(bucket.records[0].type).toBe('checkup:SupplementSummary');
+    expect(bucket.records[0].properties['checkup:supplementName']).toBe('Synthetic Kelp Blend');
+  });
+
+  it('reaches it through pod query --all', () => {
+    const podDir = podWithSupplement();
+    const r = cli(['--json', 'pod', 'query', podDir, '--all']);
+    expect(r.status, r.output).toBe(0);
+    expect(JSON.stringify(JSON.parse(r.output))).toContain('Synthetic Kelp Blend');
+  });
+
+  it('counts the bucket in pod info', () => {
+    const podDir = podWithSupplement();
+    const r = cli(['pod', 'info', podDir]);
+    expect(r.status, r.output).toBe(0);
+    expect(r.output).toMatch(/supplements\.ttl\s+1 record/);
+  });
+
+  it('validates against the bundled checkup shapes with nothing to report', () => {
+    const podDir = podWithSupplement();
+    const r = cli(['--json', 'validate', path.join(podDir, 'wellness', 'supplements.ttl')]);
+    expect(r.status, r.output).toBe(0);
+
+    const [report] = JSON.parse(r.output);
+    expect(report.valid).toBe(true);
+    // The shape must actually have FIRED. A record no shape selects also
+    // produces zero results, and "nothing checked it" is not "it is correct".
+    expect(report.shapesFired).toContain('SupplementSummaryShape');
+    expect(report.coverage.unshapedSubjects).toEqual([]);
+    expect(report.results).toEqual([]);
+  });
+
+  it('still refuses a type no bucket routes', () => {
+    // The fix registers ONE class. A route map that started accepting anything
+    // would pass every assertion above and quietly file unknown records.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'supp-route-neg-'));
+    roots.push(root);
+    const podDir = path.join(root, 'pod');
+    expect(cli(['pod', 'init', podDir]).status).toBe(0);
+
+    const add = cli([
+      'pod', 'add-record', podDir,
+      '--type', 'checkup:IntakeFormData',
+      '--json', '{"checkup:supplementName":"Synthetic Kelp Blend"}',
+    ]);
+    expect(add.status).toBe(1);
+    expect(add.output).toContain('No known bucket');
+  });
+});

--- a/tests/reconciler-derived-reference-conflicts.test.ts
+++ b/tests/reconciler-derived-reference-conflicts.test.ts
@@ -1,0 +1,348 @@
+/**
+ * A DERIVED reference edge must not be read as evidence that two copies of one
+ * record are two different records.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * `clinical:parsedIndicationReference` and `clinical:linkedCondition` are not
+ * stated by any source. `liftTrappedLiterals` derives them at the END of an
+ * import, from a reason the converter captured or from the UUIDs packed into a
+ * `clinical:linkedConditionIds` literal. Reconciliation runs BEFORE that pass,
+ * so the two copies of one record it compares were caught at different stages
+ * of one pipeline:
+ *
+ *   - the copy read back out of the POD is post-lift and carries the derived
+ *     edge pointing at a real subject, or carries nothing because the reason
+ *     matched no condition and the pass dropped it;
+ *   - the copy from the BATCH is pre-lift and carries an opaque
+ *     `urn:cascade:parsed-indication:` placeholder holding the reason's codes,
+ *     or nothing at all on `clinical:linkedCondition` because the pass has not
+ *     run yet.
+ *
+ * Compared as written those never agree, so the content fingerprint declared
+ * them materially different records that the identity layer had put on one IRI:
+ * a false identity collision, a split onto a second IRI, and an unresolved
+ * conflict labelled "differs on clinical:parsedIndicationReference" for two
+ * records identical in everything a source ever said, source record id
+ * included.
+ *
+ * MEASURED AGAINST THE PRE-FIX BUILD
+ *   - re-importing the reason-code bundle once: 3 identity collisions, 3
+ *     unresolved conflicts, and the pod grew from 6 records to 9. A third
+ *     import grew it again.
+ *   - re-importing the linked-conditions fixture once: 1 identity collision and
+ *     the pod grew from 2 records to 3.
+ *
+ * THE FIX, AND WHY IT IS NOT "IGNORE THE PREDICATE"
+ * -------------------------------------------------
+ * Both sides are put through the SAME derivation and what is compared is the
+ * edge set the lift will actually write. Simply dropping these predicates from
+ * the fingerprint would remove the false conflicts and the true ones together:
+ * two records whose parsed indications genuinely point at different conditions
+ * would compare equal and one would be discarded as a duplicate. So both
+ * directions are pinned below, and the "still conflicts" half is the one that
+ * fails if the fix is ever loosened into an ignore-list.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parseTurtle,
+  splitIdentityCollisions,
+  recordContentFingerprint,
+  buildDerivedReferenceValues,
+} from '../src/lib/reconciler.js';
+import {
+  DERIVED_REFERENCE_PREDICATES,
+  parsedIndicationPlaceholder,
+} from '../src/lib/literal-lifting.js';
+import { Parser } from 'n3';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(REPO, 'dist', 'index.js');
+const REASONCODE_BUNDLE = path.join(REPO, 'test-fixtures', 'graph-meaning-m1-reasoncode-bundle.json');
+const LINKED_FIXTURE = path.join(REPO, 'test-fixtures', 'derived-reference-linked-conditions.ttl');
+
+const CLIN = 'https://ns.cascadeprotocol.org/clinical/v1#';
+const PARSED_INDICATION = `${CLIN}parsedIndicationReference`;
+const LINKED_CONDITION = `${CLIN}linkedCondition`;
+
+const roots: string[] = [];
+
+function cli(args: string[]): { output: string; status: number } {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf-8', timeout: 300000 });
+  return { output: `${r.stdout ?? ''}${r.stderr ?? ''}`, status: r.status ?? 1 };
+}
+
+/** Init a pod, drop `fixture` into an input directory, and return both paths. */
+function podWithInput(fixture: string, basename: string): { podDir: string; inputs: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'derived-ref-'));
+  roots.push(root);
+  const podDir = path.join(root, 'pod');
+  const inputs = path.join(root, 'inputs');
+  fs.mkdirSync(inputs);
+  fs.copyFileSync(fixture, path.join(inputs, basename));
+
+  expect(cli(['pod', 'init', podDir]).status).toBe(0);
+  return { podDir, inputs };
+}
+
+/** Total records the pod holds, across every registered bucket. */
+function recordCount(podDir: string): number {
+  const r = cli(['--json', 'pod', 'query', podDir, '--all']);
+  expect(r.status, r.output).toBe(0);
+  const parsed = JSON.parse(r.output) as { dataTypes: Record<string, { count: number }> };
+  return Object.values(parsed.dataTypes).reduce((n, b) => n + b.count, 0);
+}
+
+function unresolvedConflicts(podDir: string): number {
+  const r = cli(['pod', 'conflicts', podDir, '--format', 'json']);
+  return (JSON.parse(r.output) as unknown[]).length;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error('dist/index.js is missing. Run `npm run build` before `npm test`.');
+  }
+});
+
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Direction 1: a content-identical restatement no longer conflicts
+// ---------------------------------------------------------------------------
+
+describe('re-importing one unchanged file whose records carry a parsed indication', () => {
+  it('raises no identity collision and does not grow the pod', () => {
+    const { podDir, inputs } = podWithInput(REASONCODE_BUNDLE, 'bundle.json');
+
+    const first = cli(['pod', 'import', podDir, inputs, '--reconcile-existing']);
+    expect(first.status, first.output).toBe(0);
+    const afterFirst = recordCount(podDir);
+    expect(afterFirst).toBe(6);
+
+    const second = cli(['pod', 'import', podDir, inputs, '--reconcile-existing']);
+    expect(second.status, second.output).toBe(0);
+    expect(second.output).not.toContain('identity collision');
+    expect(recordCount(podDir)).toBe(afterFirst);
+    expect(unresolvedConflicts(podDir)).toBe(0);
+  });
+
+  it('stays flat over a third import, so the growth is not merely deferred', () => {
+    // Each false split minted a NEW iri that the next import collided with in
+    // turn, so a fix that only survived one re-import would still grow without
+    // bound. Three imports is the shortest run that shows the difference.
+    const { podDir, inputs } = podWithInput(REASONCODE_BUNDLE, 'bundle.json');
+    for (let i = 0; i < 3; i++) {
+      expect(cli(['pod', 'import', podDir, inputs, '--reconcile-existing']).status).toBe(0);
+    }
+    expect(recordCount(podDir)).toBe(6);
+    expect(unresolvedConflicts(podDir)).toBe(0);
+  });
+
+  it('keeps the derived edge itself: suppressing the conflict must not drop the edge', () => {
+    const { podDir, inputs } = podWithInput(REASONCODE_BUNDLE, 'bundle.json');
+    expect(cli(['pod', 'import', podDir, inputs, '--reconcile-existing']).status).toBe(0);
+    expect(cli(['pod', 'import', podDir, inputs, '--reconcile-existing']).status).toBe(0);
+
+    const medications = fs.readFileSync(path.join(podDir, 'clinical', 'medications.ttl'), 'utf-8');
+    const quads = new Parser({ format: 'Turtle' }).parse(medications);
+    // One lisinopril -> hypertension parsed indication, exactly one copy of it.
+    expect(quads.filter((q) => q.predicate.value === PARSED_INDICATION)).toHaveLength(1);
+    // And no placeholder ever reached disk.
+    expect(medications).not.toContain('urn:cascade:parsed-indication:');
+  });
+});
+
+describe('re-importing one unchanged file whose records carry linked-condition ids', () => {
+  it('raises no identity collision and does not grow the pod', () => {
+    const { podDir, inputs } = podWithInput(LINKED_FIXTURE, 'linked.ttl');
+
+    expect(cli(['pod', 'import', podDir, inputs, '--reconcile-existing']).status).toBe(0);
+    expect(recordCount(podDir)).toBe(2);
+
+    const second = cli(['pod', 'import', podDir, inputs, '--reconcile-existing']);
+    expect(second.status, second.output).toBe(0);
+    expect(second.output).not.toContain('identity collision');
+    expect(recordCount(podDir)).toBe(2);
+    expect(unresolvedConflicts(podDir)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direction 2: a genuine disagreement still conflicts
+// ---------------------------------------------------------------------------
+
+const HYPERLIPIDEMIA = 'urn:uuid:cccccccc-0000-4000-8000-000000000001';
+const DIABETES = 'urn:uuid:cccccccc-0000-4000-8000-000000000002';
+const MED = 'urn:uuid:dddddddd-0000-4000-8000-000000000001';
+
+const CONDITIONS = `
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+
+<${HYPERLIPIDEMIA}> a health:ConditionRecord ;
+    health:conditionName "Hyperlipidemia" ;
+    health:snomedCode <http://snomed.info/sct/55822004> .
+
+<${DIABETES}> a health:ConditionRecord ;
+    health:conditionName "Type 2 diabetes mellitus" ;
+    health:snomedCode <http://snomed.info/sct/44054006> .
+`;
+
+/** One medication stating the given parsed-indication object, verbatim. */
+function medicationStating(object: string): string {
+  return `${CONDITIONS}
+<${MED}> a clinical:Medication ;
+    clinical:drugName "simvastatin" ;
+    clinical:sourceRecordId "med-1" ;
+    clinical:parsedIndicationReference <${object}> .
+`;
+}
+
+/** Reconcile two spellings of ONE iri and report which predicates disagreed. */
+async function collisionOver(podTurtle: string, batchTurtle: string): Promise<string[] | null> {
+  const podRecords = await parseTurtle(podTurtle, 'pod', true);
+  const batchRecords = await parseTurtle(batchTurtle, 'batch', false);
+  const allQuads = new Parser({ format: 'Turtle' }).parse(`${podTurtle}\n${batchTurtle}`);
+
+  const derived = buildDerivedReferenceValues(allQuads);
+  const split = splitIdentityCollisions([...podRecords, ...batchRecords], undefined, derived);
+
+  const collision = split.collisions.find((c) => c.mintedUri === MED);
+  return collision ? collision.differingPredicates : null;
+}
+
+describe('two records whose parsed indications genuinely differ', () => {
+  it('still collide, and the conflict still names the derived predicate', async () => {
+    const differing = await collisionOver(
+      medicationStating(HYPERLIPIDEMIA),
+      medicationStating(DIABETES),
+    );
+    expect(differing).not.toBeNull();
+    expect(differing).toContain(PARSED_INDICATION);
+  });
+
+  it('still collide when one side states it and the other only implies it', async () => {
+    // The half that an ignore-list fix would break: the batch copy carries a
+    // placeholder for DIABETES, which re-derives to a different condition than
+    // the hyperlipidemia the pod copy states. Re-derivation must resolve it, and
+    // then still find the two unequal.
+    const placeholder = parsedIndicationPlaceholder(
+      ['http://snomed.info/sct/44054006'], 'Type 2 diabetes mellitus',
+    );
+    const differing = await collisionOver(
+      medicationStating(HYPERLIPIDEMIA),
+      medicationStating(placeholder),
+    );
+    expect(differing).not.toBeNull();
+    expect(differing).toContain(PARSED_INDICATION);
+  });
+
+  it('do NOT collide when the placeholder re-derives to the condition the pod already states', async () => {
+    // The same comparison with the codes agreeing. This is the pair that used to
+    // conflict, and it is the control for the two assertions above: without it,
+    // a fingerprint that simply always disagreed would pass them both.
+    const placeholder = parsedIndicationPlaceholder(
+      ['http://snomed.info/sct/55822004'], 'Hyperlipidemia',
+    );
+    const differing = await collisionOver(
+      medicationStating(HYPERLIPIDEMIA),
+      medicationStating(placeholder),
+    );
+    expect(differing).toBeNull();
+  });
+});
+
+describe('two records whose linked conditions genuinely differ', () => {
+  const linkedTo = (uuid: string) => `${CONDITIONS}
+<${MED}> a clinical:Medication ;
+    clinical:drugName "simvastatin" ;
+    clinical:sourceRecordId "med-1" ;
+    clinical:linkedConditionIds "${uuid}" .
+`;
+
+  it('still collide', async () => {
+    const differing = await collisionOver(
+      linkedTo('cccccccc-0000-4000-8000-000000000001'),
+      linkedTo('cccccccc-0000-4000-8000-000000000002'),
+    );
+    expect(differing).not.toBeNull();
+    // The deriving literal differs too, and BOTH are reported: the derived edge
+    // is not silently dropped from the explanation.
+    expect(differing).toContain(LINKED_CONDITION);
+  });
+
+  it('do NOT collide when one side has already had the edge derived onto it', async () => {
+    const stated = `${CONDITIONS}
+<${MED}> a clinical:Medication ;
+    clinical:drugName "simvastatin" ;
+    clinical:sourceRecordId "med-1" ;
+    clinical:linkedConditionIds "cccccccc-0000-4000-8000-000000000001" ;
+    clinical:linkedCondition <${HYPERLIPIDEMIA}> .
+`;
+    const differing = await collisionOver(
+      stated,
+      linkedTo('cccccccc-0000-4000-8000-000000000001'),
+    );
+    expect(differing).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The chokepoint itself
+// ---------------------------------------------------------------------------
+
+describe('the derived-reference predicate set', () => {
+  it('holds both predicates the lift derives, and nothing it merely reads', () => {
+    expect([...DERIVED_REFERENCE_PREDICATES].sort()).toEqual([LINKED_CONDITION, PARSED_INDICATION]);
+    // A STATED reference is the source's own claim and must keep counting as
+    // content. Putting it here would hide a real disagreement about what a
+    // record says.
+    expect(DERIVED_REFERENCE_PREDICATES.has(`${CLIN}indicationReference`)).toBe(false);
+  });
+
+  it('re-derives every predicate in the set, so adding one without wiring it fails here', async () => {
+    // The tripwire for the next derived edge family. A predicate listed in the
+    // set but not handled by `buildDerivedReferenceValues` returns [] for every
+    // record, which silently turns the set entry into an ignore-list entry: the
+    // false conflicts go away and the true ones go with them.
+    const implying = `${CONDITIONS}
+<${MED}> a clinical:Medication ;
+    clinical:drugName "simvastatin" ;
+    clinical:linkedConditionIds "cccccccc-0000-4000-8000-000000000001" ;
+    clinical:parsedIndicationReference <${DIABETES}> .
+`;
+    const records = await parseTurtle(implying, 'batch', false);
+    const quads = new Parser({ format: 'Turtle' }).parse(implying);
+    const derived = buildDerivedReferenceValues(quads);
+    const record = records.find((r) => r.uri === MED)!;
+
+    for (const predicate of DERIVED_REFERENCE_PREDICATES) {
+      expect(derived(record, predicate), `${predicate} re-derived to nothing`).not.toEqual([]);
+    }
+  });
+
+  it('leaves the fingerprint sensitive to everything else', async () => {
+    // The derived predicates are re-derived, not excused. A difference in
+    // ordinary content must still change the fingerprint, or the fix would have
+    // quietly widened into "records with indications never collide".
+    const a = (await parseTurtle(medicationStating(HYPERLIPIDEMIA), 'a', false))
+      .find((r) => r.uri === MED)!;
+    const b = (await parseTurtle(
+      medicationStating(HYPERLIPIDEMIA).replace('"simvastatin"', '"lovastatin"'), 'b', false,
+    )).find((r) => r.uri === MED)!;
+
+    const quads = new Parser({ format: 'Turtle' }).parse(medicationStating(HYPERLIPIDEMIA));
+    const derived = buildDerivedReferenceValues(quads);
+    expect(recordContentFingerprint(a, undefined, undefined, derived))
+      .not.toBe(recordContentFingerprint(b, undefined, undefined, derived));
+  });
+});


### PR DESCRIPTION
Three defects on the same theme: a value that means one thing being written or compared as something else.

## 1. `checkup:SupplementSummary` had no bucket

`pod add-record --type checkup:SupplementSummary` failed outright:

```
No known bucket for type checkup:SupplementSummary.
```

The data-type map registered `clinical:Supplement` and nothing else, so there was no way to record a supplement by hand at all. `checkup:SupplementSummary` is the patient-facing spelling, and the one carrying `checkup:regulatoryStatus`, the classification that separates a dietary supplement or an OTC product from an FDA-approved medication. Its SHACL shape has shipped in this package the whole time; only the route was missing.

Same class of defect as the family-history bucket, with one difference in where it surfaced. Family history fell THROUGH to the FHIR passthrough bucket, so imports "succeeded" and the records were merely misfiled. `add-record` has no passthrough fallback, so this was a hard refusal on the write path.

It now routes to the SAME `wellness/supplements.ttl` the importer spelling uses, so "show me the supplements" stays one read and a reader does not have to know which vocabulary the writer happened to use. Verified end to end with the real CLI: `pod init`, `pod add-record`, `pod query --supplements`, `pod query --all`, `pod info`, `cascade validate` (`SupplementSummaryShape` fires, nothing reported).

## 2. `pod add-record` wrote every value untyped

Values arrive as strings, because JSON and a shell both hand one over, and every one was written as a plain literal:

```turtle
checkup:supplementIsActive "true" ;
checkup:supplementStartDate "2026-01-15" ;
checkup:patientCost "12.50" ;
```

against a vocabulary declaring `xsd:boolean`, `xsd:date` and `xsd:decimal`. Measured on the pre-fix build, one five-property supplement produced five `sh:datatype` violations from `cascade validate` on a file that still reported PASS, because the checkup shapes raise datatype at Info. Beyond the report, the pod held dates that sort lexically by luck and decimals nothing could sum, and it disagreed with itself: the same properties written by an IMPORT arrived correctly typed.

The literal is now built at one chokepoint (`src/lib/shape-datatypes.ts`) from the `sh:datatype` the BUNDLED SHAPES declare, so:

- the writer and the validator cannot disagree about what a property is;
- no hand-maintained datatype table exists here to drift from the vocabulary on the next shapes sync;
- a property no shape declares stays a plain string literal, and `xsd:string` stays the short form, since RDF 1.1 makes a plain literal `xsd:string` already;
- lexical values are preserved exactly, so `"12.50"` does not become `12.5` and a date is not shifted through a timezone;
- a value that cannot be its declared datatype (`maybe` for a boolean, `2026-02-30` for a date) is REFUSED and nothing is written, rather than coerced or silently written untyped. Same stance the command already takes on an unwritable IRI: the input is the only place either is still fixable.

Two invariants are pinned as tripwires for the next vocabulary sync: every datatype the shapes declare has a lexical-form check, and no property is declared with two different datatypes (zero today).

## 3. Derived reference edges raised spurious reconcile conflicts

`clinical:parsedIndicationReference` and `clinical:linkedCondition` are stated by no source. The literal-lifting pass derives them at the END of an import, from a reason the converter captured or from the UUIDs packed into a `clinical:linkedConditionIds` literal. Reconciliation runs BEFORE that pass, so the two copies of one record it compares were caught at different stages of one pipeline:

- the copy read back out of the POD is post-lift, carrying the derived edge pointing at a real subject, or carrying nothing because the reason matched no condition and the pass dropped it;
- the copy from the BATCH is pre-lift, carrying an opaque `urn:cascade:parsed-indication:` placeholder holding the reason's codes, or nothing at all.

Compared as written, those never agree, so the content fingerprint declared them materially different records the identity layer had put on one IRI: a false identity collision, a split onto a second IRI, and an unresolved conflict labelled `differs on clinical:parsedIndicationReference` for two records identical in everything a source ever said, source record id included.

Measured on the reason-code fixture at the parent commit: **3 false conflicts, and a pod that grew from 6 records to 9** on the second import of ONE unchanged file, growing again on the third (each false split mints a new IRI the next import collides with in turn). A record carrying linked-condition ids reproduced the same defect on `clinical:linkedCondition`.

Both sides are now put through the SAME derivation, and what is compared is the edge set the lift will actually write.

**This is deliberately not an ignore-list.** Dropping the predicates from the fingerprint would remove the false conflicts and the true ones with them: two records whose parsed indications genuinely point at different conditions would compare equal and one would be discarded as a duplicate. Both directions are pinned by tests, and the "still conflicts" half is the one that fails if the fix is ever loosened.

**Chokepoint, not a special case.** The derivation is the lift's own (`buildDerivedReferenceResolver`), exported rather than reimplemented, because a second copy would drift and drift here is indistinguishable from the defect. `DERIVED_REFERENCE_PREDICATES` is the set the next derived edge family joins, and a test fails if a predicate is added to it without a re-derivation to match.

## Verification

`npm run build` clean. Full suite: **154 files, 2447 tests, 2447 passed, 0 failed, 0 skipped, 0 todo** (up from 2411, all 36 new). The reconciliation corpus and `tests/pathology-reconciliation-baseline.json` are unchanged, and all 177 corpus tests pass as before: that corpus carries no reason-code or linked-condition-id derived edges, so no verdict there moves.

Each fix has a load-bearing line whose removal was verified RED against a built tree and the full suite:

| Fix | Mutation | Result |
|---|---|---|
| Supplement route | drop `checkup:SupplementSummary` from the supplements bucket | 16 tests RED across 2 files |
| Typed literals | `typedLiteralForPredicate` returns an untyped literal | 3 tests RED |
| Derived references | drop the derived-predicate skip in `recordContentFingerprint` | 6 tests RED |

Version bumped to 0.20.0 with a CHANGELOG entry. Not tagged or published; release timing is the maintainer's. No new dependencies. All fixtures are synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
