### PR TITLE
docs: add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+CLI for validating, converting, querying and managing Cascade Protocol health data Pods. Ships as `@the-cascade-protocol/cli`.
+
+## Start here
+
+- `CLAUDE.md` -- architecture, the importer registry, the URI derivation algorithm, deployment discipline.
+- `CONTRIBUTING.md` -- setup, what must be green, PR conventions, how to add an importer.
+- `README.md` -- user-facing command reference.
+
+`CLAUDE.md` and this file describe the same repository. `CLAUDE.md` is loaded automatically by Claude Code; this file exists so any coding agent finds the same instructions.
+
+## Protocol context
+
+<https://cascadeprotocol.org/llms.txt> is the protocol index: install, quick start, data types, MCP server, security model, vocabulary versions, deployment sequence. About 95 lines, meant to be read in full.
+
+Do **not** load `llms-full.txt` from that site. It is roughly 1.3 MB, larger than most working contexts, and as of 2026-08-20 its ontology section is known to be incomplete. Read the TTL files in [`spec`](https://github.com/the-cascade-protocol/spec) instead.
+
+## Ground rules
+
+- **Never hand-edit `src/shapes/`.** Those files are copies from `spec`. Run `sh scripts/sync-shapes-from-spec.sh` and update `VOCAB_VERSIONS`. Vocabulary is authored in `spec` and nowhere else.
+- **To add a `--from <format>` importer, append to `src/lib/import-registry.ts`.** Do not edit `src/commands/convert.ts`; help text, validation and auto-detection derive from the registry.
+- **`deterministicUuid()` is a locked-in spec.** Changing it changes record identity in every SDK port at once. Coordinate before touching it.
+- **Build before you test.** Some suites spawn the built `dist/` output, so an unbuilt change is not under test and the suite can report green against code it never ran.
+- **`conformance` must be a sibling checkout**, at `../conformance`. Suites resolve fixtures through it, and without it they fail rather than skip.
+
+## What must be green
+
+```bash
+npm ci                # never npm install, never a symlinked node_modules
+npm run build
+npm test
+```
+
+Requires Node 22 and Apache Jena `riot` on `PATH` (five conformance suites canonicalize Turtle through it).
+
+Green is not the same as complete. CI ratchets the skip count and fails in both directions: a rise means a suite stopped running, a fall means a gap closed and the baseline must be lowered in the same change. If your run's skip count differs from CI's, find out why before claiming a pass.
+
+## Conventions
+
+- Commits: `feat(cli):`, `fix(cli):`, `chore(shapes): sync from spec`.
+- Update `CHANGELOG.md` and bump `package.json` on any user-visible change.
+- Branch from `main`; open a PR rather than pushing to it.
+- Report what you could not verify (a suite you could not run, a dependency you lacked) in the PR body rather than only in a commit message.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to cascade-cli
+
+`cascade-cli` is the reference implementation of the Cascade Protocol: it validates, converts, queries and manages local health data Pods, and it ships as `@the-cascade-protocol/cli`. Contributions here are typically a new `--from <format>` importer, a converter fix, a new command, or a shapes sync from `spec`.
+
+## Before you start
+
+- All open issues: <https://github.com/search?q=org%3Athe-cascade-protocol+is%3Aissue+is%3Aopen>
+- Good first issues: <https://github.com/search?q=org%3Athe-cascade-protocol+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>
+
+Open an issue before starting anything larger than a bug fix, so the approach can be agreed before the code exists.
+
+## Development setup
+
+**`conformance` must be cloned as a sibling directory**, not inside this one. Several suites resolve fixtures at `../../conformance/fixtures/`, and CI reproduces that layout exactly.
+
+```
+<parent>/
+  cascade-cli/
+  conformance/
+```
+
+```bash
+git clone https://github.com/the-cascade-protocol/cascade-cli.git
+git clone https://github.com/the-cascade-protocol/conformance.git
+cd cascade-cli
+
+npm ci          # not npm install, and never a symlinked node_modules
+npm run build
+```
+
+Two further requirements:
+
+- **Node 22.** The package declares `>=18`, but CI runs 22 and that is what the suite is measured against.
+- **Apache Jena `riot` on `PATH`.** Five `*-conformance` suites canonicalize Turtle through `riot` via `execFileSync` for byte-equal comparison. Without it those suites fail rather than skip.
+
+Install the hooks once: `sh scripts/install-hooks.sh`. The pre-commit hook blocks commits that change `src/shapes/` without updating `VOCAB_VERSIONS`.
+
+## What must be green before review
+
+```bash
+npm ci
+npm run build
+npm test
+```
+
+`npm test` runs the full vitest suite. Two things to know about reading its output:
+
+- **Green is not the same as complete.** A subset of suites is guarded by `describe.skipIf` and vanishes rather than fails when its inputs are absent, so a passing run can hide a suite that stopped executing. CI ratchets the skip count and fails in **both** directions: growth means something stopped running, and a decrease means a gap closed and the baseline must be lowered in the same change.
+- **Build before you test.** Some tests spawn the built `dist/` output rather than the sources, so a change that is not built is not under test, and the suite can report green against code you did not run.
+
+## Commit messages
+
+```
+feat(cli): <description>       # new command or behavior
+fix(cli): <description>        # bug fix
+chore(shapes): sync from spec  # shapes-only update from spec
+```
+
+## Opening a pull request
+
+1. Branch from `main`.
+2. Build, then run the full suite, and confirm the skip count did not move.
+3. Update `CHANGELOG.md` and bump the version in `package.json` (patch for a shapes-only sync, minor for new CLI behavior).
+4. Push and open a PR. `.github/PULL_REQUEST_TEMPLATE.md` fills in with the checklist; keep the items and tick them.
+5. State in the PR body which suites you ran and on what Node version. If you could not run a suite (no `riot`, no sibling `conformance`), say so rather than leaving it implied.
+
+### Adding a new `--from <format>` importer
+
+1. Create `src/lib/<format>-converter/` with the converter logic.
+2. Author a `registry-entry.ts` there exporting a `FormatImporter` const: `format`, `description`, `supportedOutputs`, `detect()`, `convert()`. Add `cliOptions` and `postProcess` only if you write sidecar files.
+3. Append the import and the const to the `importers` array in `src/lib/import-registry.ts`. **Do not edit `src/commands/convert.ts`.** `--help`, format validation and content auto-detection all follow from registry inspection.
+4. Adapt your converter's result to the unified `ImportResult` in `src/lib/import-types.ts`, populating `vocabularyGaps` and `importedIdentifiers`.
+
+CLI flags in `cliOptions` must be globally unique across importers; the dispatcher errors at startup on a collision. A genuinely shared flag belongs as a top-level option in `convert.ts` instead.
+
+## Vocabulary changes
+
+**Vocabulary is never authored here.** `src/shapes/*.ttl` and `src/shapes/*.shapes.ttl` are copies from [`spec`](https://github.com/the-cascade-protocol/spec). To update them:
+
+```bash
+sh scripts/sync-shapes-from-spec.sh
+git diff src/shapes/          # review what moved
+```
+
+Then update `VOCAB_VERSIONS` to the versions now embedded, and verify `cascade validate` passes against the current conformance fixtures.
+
+If your change needs a new class or property that does not exist yet, it starts in `spec`. Read [`spec/CONTRIBUTING.md`](https://github.com/the-cascade-protocol/spec/blob/main/CONTRIBUTING.md) for the full seven-step propagation sequence; this repository is step 4 of it.
+
+`deterministicUuid()` in `src/lib/fhir-converter/types.ts` is the canonical Cascade URI derivation algorithm. It is deliberately not RFC 4122 v5. **Do not change it without coordinating every SDK port**, because the same input must derive the same URI in all of them. Contract tests live in `tests/uri-generation.test.ts`.
+
+## Protocol context
+
+<https://cascadeprotocol.org/llms.txt> is the protocol index: install, quick start, data types, MCP server, security model, vocabulary versions, deployment sequence. About 95 lines, meant to be read in full.
+
+Do not load `llms-full.txt` from that site. It is roughly 1.3 MB, larger than most working contexts, and as of 2026-08-20 its ontology section is known to be incomplete. Read the TTL files in `spec` instead.
+
+## Questions?
+
+Open an issue on this repository, or a [discussion on `spec`](https://github.com/the-cascade-protocol/spec/discussions) for questions about the protocol itself rather than the tool.


### PR DESCRIPTION
Part of the contributor onboarding kit: every public protocol repository gains a `CONTRIBUTING.md` and an `AGENTS.md`, consistent in structure, so the curated public issue set has conventions to point at.

`AGENTS.md` is a peer of `CLAUDE.md` rather than a replacement, so a contributor's choice of coding agent is not assumed. Every `AGENTS.md` in the org shares the same five sections in the same order: Start here, Protocol context, Ground rules, What must be green, Conventions. Every `CONTRIBUTING.md` shares the same backbone: Before you start, Development setup, What must be green before review, Commit messages, Opening a pull request, Vocabulary changes, Protocol context, Questions.

No file points a reader at `llms-full.txt` as a thing to load. All point at the ~95-line `llms.txt` index.

Docs only. No code, config or workflow changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)