### PR TITLE
fix(tests): build before testing, and name missing prerequisites once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.20.2] - 2026-08-20
+
+### Fixed
+
+**A fresh clone reported hundreds of test failures that had nothing to do with the code.**
+`npm ci && npm test` on a clean checkout produced 313 failing tests across 65 files, because the
+suite has prerequisites that CI satisfies as separate workflow steps and a developer does not:
+a built `dist/`, which 25 of those files spawn instead of the sources, and a sibling `conformance`
+checkout, which the other 40 read fixtures from. Nothing in the output named either one, so the
+repository read as broken.
+
+`npm test` now runs the build first via a `pretest` hook, which removes the `dist/` class of
+failure outright. The remaining prerequisites are checked once, before the first test, and report
+everything that is missing in a single message naming the exact command to clone or install
+it (`tests/setup/preflight.ts`). Missing prerequisites fail rather than skip, so this cannot turn
+into the false green the CI skip ratchet already guards against from the other direction.
+
+**Fixture paths did not resolve from a git worktree.** All 42 fixture-backed suites hardcoded
+`path.resolve(__dirname, '../../conformance/...')`, which from a worktree points inside the
+worktrees directory rather than at the sibling checkout, so working in a worktree meant symlinking
+the fixtures into place by hand. Resolution now goes through one helper
+(`tests/helpers/conformance.ts`) that falls back to the main checkout's sibling when it is run from
+a worktree. `CASCADE_CONFORMANCE_DIR` was previously honored by 5 of the 42 suites; it now
+overrides all of them.
+
+No shipped CLI behavior changes; `dist/` output is byte-identical.
+
+---
+
 ## [0.20.1] - 2026-08-20
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Open an issue before starting anything larger than a bug fix, so the approach ca
 
 ## Development setup
 
-**`conformance` must be cloned as a sibling directory**, not inside this one. Several suites resolve fixtures at `../../conformance/fixtures/`, and CI reproduces that layout exactly.
+**`conformance` must be cloned as a sibling directory**, not inside this one. Several suites read fixtures from it, and CI reproduces that layout exactly.
 
 ```
 <parent>/
@@ -25,8 +25,19 @@ git clone https://github.com/the-cascade-protocol/conformance.git
 cd cascade-cli
 
 npm ci          # not npm install, and never a symlinked node_modules
-npm run build
 ```
+
+`npm test` builds first, so `npm run build` is no longer a separate step you have to
+remember. If a prerequisite is missing the suite stops before the first test and names
+what to clone or install, rather than failing several hundred times.
+
+Fixtures are resolved in `tests/helpers/conformance.ts`, in this order:
+
+1. `CASCADE_CONFORMANCE_DIR`, if set, for a checkout parked anywhere else.
+2. A sibling of your checkout.
+3. A sibling of the **main** checkout, when you are working in a git worktree. A
+   worktree has no sibling `conformance` of its own, so this is what lets a worktree
+   find fixtures you cloned as documented, without symlinking them into place.
 
 Two further requirements:
 
@@ -39,14 +50,13 @@ Install the hooks once: `sh scripts/install-hooks.sh`. The pre-commit hook block
 
 ```bash
 npm ci
-npm run build
 npm test
 ```
 
 `npm test` runs the full vitest suite. Two things to know about reading its output:
 
 - **Green is not the same as complete.** A subset of suites is guarded by `describe.skipIf` and vanishes rather than fails when its inputs are absent, so a passing run can hide a suite that stopped executing. CI ratchets the skip count and fails in **both** directions: growth means something stopped running, and a decrease means a gap closed and the baseline must be lowered in the same change.
-- **Build before you test.** Some tests spawn the built `dist/` output rather than the sources, so a change that is not built is not under test, and the suite can report green against code you did not run.
+- **`dist/` is what several suites actually run.** Some tests spawn the built output rather than the sources, so a change that is not built is not under test. `npm test` builds first for you; `npx vitest run` does not, and the preflight check will stop you if `dist/` is missing.
 
 ## Commit messages
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"
@@ -13,6 +13,7 @@
     "build": "tsc && npm run copy-shapes && npm run copy-data",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
+    "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/",

--- a/tests/ccda-converter.test.ts
+++ b/tests/ccda-converter.test.ts
@@ -27,12 +27,13 @@ import { fileURLToPath } from 'node:url';
 import { Parser } from 'n3';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
 import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+import { conformancePath } from './helpers/conformance.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Fixtures live in the conformance repo, two levels up from cascade-cli/tests/
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/ccda');
+const FIXTURES_DIR = conformancePath('fixtures/ccda');
 
 // This repo's own synthetic fixtures (co-located, committed here).
 const LOCAL_FIXTURES_DIR = path.resolve(__dirname, '../test-fixtures');

--- a/tests/ccda-p51-integration.test.ts
+++ b/tests/ccda-p51-integration.test.ts
@@ -19,17 +19,14 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { collectNarrativeBlocks } from '../src/lib/ccda-converter/narrative-extractor.js';
 import { parseCcdaXml } from '../src/lib/ccda-converter/parser.js';
 import { detectVendor } from '../src/lib/ccda-converter/vendor/detect.js';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/ccda');
+const FIXTURES_DIR = conformancePath('fixtures/ccda');
 
 function readFixture(name: string): string {
   return fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf-8');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,11 +3,12 @@ import { execSync } from 'child_process';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
 import { createRequire } from 'module';
+import { conformancePath } from './helpers/conformance.js';
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json') as { version: string };
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
-const REFERENCE_POD = resolve(__dirname, '../../conformance/reference-patient-pod');
+const REFERENCE_POD = conformancePath('reference-patient-pod');
 const skipIfNoPod = !existsSync(REFERENCE_POD);
 
 function runCli(args: string): string {
@@ -94,13 +95,13 @@ describe('cascade CLI', () => {
     });
 
     it.skipIf(skipIfNoPod)('should validate a valid Turtle file', () => {
-      const podPath = resolve(__dirname, '../../conformance/reference-patient-pod/clinical/medications.ttl');
+      const podPath = conformancePath('reference-patient-pod/clinical/medications.ttl');
       const output = runCli(`validate ${podPath}`);
       expect(output).toContain('PASS');
     });
 
     it.skipIf(skipIfNoPod)('should output JSON when --json flag is used', () => {
-      const podPath = resolve(__dirname, '../../conformance/reference-patient-pod/clinical/medications.ttl');
+      const podPath = conformancePath('reference-patient-pod/clinical/medications.ttl');
       const output = runCli(`--json validate ${podPath}`);
       const parsed = JSON.parse(output);
       expect(parsed).toBeInstanceOf(Array);
@@ -109,7 +110,7 @@ describe('cascade CLI', () => {
     });
 
     it.skipIf(skipIfNoPod)('should validate a directory of Turtle files', () => {
-      const podPath = resolve(__dirname, '../../conformance/reference-patient-pod/clinical');
+      const podPath = conformancePath('reference-patient-pod/clinical');
       const output = runCli(`validate ${podPath}`);
       expect(output).toContain('PASS');
       expect(output).toContain('Validation Summary');

--- a/tests/clinical-fhir-identity-conformance.test.ts
+++ b/tests/clinical-fhir-identity-conformance.test.ts
@@ -57,12 +57,13 @@ import { Parser } from 'n3';
 
 import { fhirImporter } from '../src/lib/fhir-converter/registry-entry.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const FIXTURES_DIR = process.env.CASCADE_CONFORMANCE_DIR
   ? path.resolve(process.env.CASCADE_CONFORMANCE_DIR, 'fixtures/clinical-fhir')
-  : path.resolve(__dirname, '../../conformance/fixtures/clinical-fhir');
+  : conformancePath('fixtures/clinical-fhir');
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 

--- a/tests/clinvar-conformance.test.ts
+++ b/tests/clinvar-conformance.test.ts
@@ -27,27 +27,15 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { clinvarImporter } from '../src/lib/clinvar-converter/registry-entry.js';
 import type {
   ImportContext,
   VocabularyGap,
 } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const DEFAULT_FIXTURES_DIR = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/clinvar',
-);
-const FIXTURES_DIR = process.env.CASCADE_CONFORMANCE_DIR
-  ? path.resolve(
-      process.env.CASCADE_CONFORMANCE_DIR,
-      'fixtures/genomics/clinvar',
-    )
-  : DEFAULT_FIXTURES_DIR;
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 
 const VCVS = [
   'VCV000007105-CFTR-deltaF508',

--- a/tests/clinvar-detect.test.ts
+++ b/tests/clinvar-detect.test.ts
@@ -13,11 +13,12 @@ import { clinvarImporter } from '../src/lib/clinvar-converter/registry-entry.js'
 import { getImporter, listFormats, autoDetect } from '../src/lib/import-registry.js';
 import { parseClinvarXml } from '../src/lib/clinvar-converter/xml-parser.js';
 import { collectVariationArchives } from '../src/lib/clinvar-converter/index.js';
+import { conformancePath } from './helpers/conformance.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/clinvar');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 const NON_GENOMICS_FHIR = path.resolve(__dirname, '../test-fixtures/fhir-bundle-example.json');
 
 const ALL_VCVS = [

--- a/tests/clinvar-e2e.test.ts
+++ b/tests/clinvar-e2e.test.ts
@@ -8,14 +8,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { getImporter, listFormats } from '../src/lib/import-registry.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/clinvar');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/clinvar-rcv-interpretation.test.ts
+++ b/tests/clinvar-rcv-interpretation.test.ts
@@ -5,15 +5,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertClinvarXml } from '../src/lib/clinvar-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/clinvar');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/clinvar-scv-submitter-assertion.test.ts
+++ b/tests/clinvar-scv-submitter-assertion.test.ts
@@ -5,15 +5,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertClinvarXml } from '../src/lib/clinvar-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/clinvar');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/clinvar-simple-allele.test.ts
+++ b/tests/clinvar-simple-allele.test.ts
@@ -5,15 +5,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertClinvarXml } from '../src/lib/clinvar-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/clinvar');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/clinvar-vocabulary-gaps.test.ts
+++ b/tests/clinvar-vocabulary-gaps.test.ts
@@ -11,14 +11,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertClinvarXml } from '../src/lib/clinvar-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/clinvar');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/clinvar');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-conformance.test.ts
+++ b/tests/fhir-genomics-conformance.test.ts
@@ -26,27 +26,15 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { fhirGenomicsImporter } from '../src/lib/fhir-genomics-converter/registry-entry.js';
 import type {
   ImportContext,
   VocabularyGap,
 } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const DEFAULT_FIXTURES_DIR = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/fhir-genomics-ig',
-);
-const FIXTURES_DIR = process.env.CASCADE_CONFORMANCE_DIR
-  ? path.resolve(
-      process.env.CASCADE_CONFORMANCE_DIR,
-      'fixtures/genomics/fhir-genomics-ig',
-    )
-  : DEFAULT_FIXTURES_DIR;
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const BUNDLES = [
   'Bundle-bundle-CG-IG-HLA-FullBundle-01',

--- a/tests/fhir-genomics-detect.test.ts
+++ b/tests/fhir-genomics-detect.test.ts
@@ -11,11 +11,12 @@ import { fileURLToPath } from 'node:url';
 import { detectFhirGenomics } from '../src/lib/fhir-genomics-converter/detect.js';
 import { fhirGenomicsImporter } from '../src/lib/fhir-genomics-converter/registry-entry.js';
 import { getImporter, listFormats, autoDetect } from '../src/lib/import-registry.js';
+import { conformancePath } from './helpers/conformance.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 const NON_GENOMICS_FHIR = path.resolve(__dirname, '../test-fixtures/fhir-bundle-example.json');
 
 const ALL_BUNDLES = [

--- a/tests/fhir-genomics-diagnostic-implication.test.ts
+++ b/tests/fhir-genomics-diagnostic-implication.test.ts
@@ -5,15 +5,13 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import { parseDiagnosticImplication } from '../src/lib/fhir-genomics-converter/observation-diagnostic-implication.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-diagnostic-report.test.ts
+++ b/tests/fhir-genomics-diagnostic-report.test.ts
@@ -5,14 +5,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-e2e.test.ts
+++ b/tests/fhir-genomics-e2e.test.ts
@@ -15,7 +15,6 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { fhirGenomicsImporter } from '../src/lib/fhir-genomics-converter/registry-entry.js';
 import {
@@ -24,10 +23,9 @@ import {
   autoDetect,
 } from '../src/lib/import-registry.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-genotype.test.ts
+++ b/tests/fhir-genomics-genotype.test.ts
@@ -5,14 +5,12 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-haplotype.test.ts
+++ b/tests/fhir-genomics-haplotype.test.ts
@@ -5,15 +5,13 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import { parseHaplotypeObservation } from '../src/lib/fhir-genomics-converter/observation-haplotype.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-service-request.test.ts
+++ b/tests/fhir-genomics-service-request.test.ts
@@ -5,15 +5,13 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import { parseServiceRequest } from '../src/lib/fhir-genomics-converter/service-request.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/fhir-genomics-variant.test.ts
+++ b/tests/fhir-genomics-variant.test.ts
@@ -5,15 +5,13 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { parseVariantObservation } from '../src/lib/fhir-genomics-converter/observation-variant.js';
 import { convertGenomicsBundle } from '../src/lib/fhir-genomics-converter/index.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/fhir-genomics-ig');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/fhir-genomics-ig');
 
 const baseCtx: ImportContext = {
   inputPath: '<test>',

--- a/tests/helpers/conformance.ts
+++ b/tests/helpers/conformance.ts
@@ -1,0 +1,74 @@
+/**
+ * Single resolver for the `conformance` fixture checkout.
+ *
+ * Fixtures live in a separate repository (the-cascade-protocol/conformance)
+ * that is expected to sit beside this one, and CI reproduces that layout.
+ * Resolution order:
+ *
+ *   1. `CASCADE_CONFORMANCE_DIR`, for a checkout parked anywhere else — a
+ *      conformance worktree on a feature branch, say, when the oracle for a
+ *      fixture is not on `main` yet.
+ *   2. A sibling of this checkout.
+ *   3. A sibling of the *main* checkout, when this is a git worktree.
+ *
+ * Step 3 is the one worth explaining. A worktree under `.claude/worktrees/`
+ * has no sibling `conformance` of its own, so resolving only against the
+ * worktree root looks for fixtures inside `.claude/worktrees/` and misses a
+ * checkout that was cloned exactly as documented. Every suite went through
+ * `path.resolve(__dirname, '../../conformance/...')` before this helper
+ * existed, which is why working in a worktree used to mean symlinking the
+ * fixtures into place by hand.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Root of this checkout — the worktree's own root when run from a worktree. */
+export const REPO_ROOT = path.resolve(HELPERS_DIR, '../..');
+
+/**
+ * Root of the main checkout when `root` is a git worktree, else undefined.
+ * A worktree's `.git` is a file holding `gitdir: <main>/.git/worktrees/<name>`.
+ */
+function mainCheckoutOf(root: string): string | undefined {
+  const dotGit = path.join(root, '.git');
+  let pointer: string;
+  try {
+    if (!fs.statSync(dotGit).isFile()) return undefined;
+    pointer = fs.readFileSync(dotGit, 'utf-8');
+  } catch {
+    return undefined;
+  }
+  const match = /^gitdir:\s*(.+)$/m.exec(pointer);
+  if (!match) return undefined;
+  const gitDir = path.resolve(root, match[1].trim());
+  const marker = `${path.sep}.git${path.sep}worktrees${path.sep}`;
+  const cut = gitDir.lastIndexOf(marker);
+  return cut === -1 ? undefined : gitDir.slice(0, cut);
+}
+
+/** Every location searched for the fixtures, in order, for error messages. */
+export const CONFORMANCE_CANDIDATES: readonly string[] = (() => {
+  const found = [path.resolve(REPO_ROOT, '../conformance')];
+  const main = mainCheckoutOf(REPO_ROOT);
+  if (main) found.push(path.resolve(main, '../conformance'));
+  return found;
+})();
+
+/** Root of the conformance checkout. May not exist; see `conformanceAvailable`. */
+export const CONFORMANCE_ROOT: string = process.env.CASCADE_CONFORMANCE_DIR
+  ? path.resolve(process.env.CASCADE_CONFORMANCE_DIR)
+  : (CONFORMANCE_CANDIDATES.find((c) => fs.existsSync(c)) ??
+    CONFORMANCE_CANDIDATES[0]);
+
+/** Absolute path to something inside the conformance checkout. */
+export function conformancePath(...segments: string[]): string {
+  return path.resolve(CONFORMANCE_ROOT, ...segments);
+}
+
+export function conformanceAvailable(): boolean {
+  return fs.existsSync(CONFORMANCE_ROOT);
+}

--- a/tests/narrative-extractor.test.ts
+++ b/tests/narrative-extractor.test.ts
@@ -9,7 +9,6 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 
 import { extractNarrativeText, collectNarrativeBlocks } from '../src/lib/ccda-converter/narrative-extractor.js';
@@ -19,11 +18,9 @@ import {
   EPIC_STATUS_CODES,
 } from '../src/lib/ccda-converter/vendor-normalizer.js';
 import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/ccda');
+const FIXTURES_DIR = conformancePath('fixtures/ccda');
 
 function readFixture(name: string): string {
   return fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf-8');

--- a/tests/phenopacket-biosamples.test.ts
+++ b/tests/phenopacket-biosamples.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import {
@@ -15,11 +14,9 @@ import {
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { GENOMICS_NS } from '../src/lib/phenopacket-converter/types.js';
 import { NS } from '../src/lib/fhir-converter/types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-conformance.test.ts
+++ b/tests/phenopacket-conformance.test.ts
@@ -31,27 +31,15 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { phenopacketImporter } from '../src/lib/phenopacket-converter/registry-entry.js';
 import type {
   ImportContext,
   VocabularyGap,
 } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const DEFAULT_FIXTURES_DIR = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/phenopackets',
-);
-const FIXTURES_DIR = process.env.CASCADE_CONFORMANCE_DIR
-  ? path.resolve(
-      process.env.CASCADE_CONFORMANCE_DIR,
-      'fixtures/genomics/phenopackets',
-    )
-  : DEFAULT_FIXTURES_DIR;
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 /** Phenopacket fixtures that round-trip through the importer. */
 const FIXTURES = [

--- a/tests/phenopacket-detect.test.ts
+++ b/tests/phenopacket-detect.test.ts
@@ -14,11 +14,12 @@ import {
 } from '../src/lib/phenopacket-converter/detect.js';
 import { phenopacketImporter } from '../src/lib/phenopacket-converter/registry-entry.js';
 import { getImporter, listFormats, autoDetect } from '../src/lib/import-registry.js';
+import { conformancePath } from './helpers/conformance.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 const NON_GENOMICS_FHIR = path.resolve(__dirname, '../test-fixtures/fhir-bundle-example.json');
 
 /**

--- a/tests/phenopacket-e2e.test.ts
+++ b/tests/phenopacket-e2e.test.ts
@@ -12,16 +12,13 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { phenopacketImporter } from '../src/lib/phenopacket-converter/registry-entry.js';
 import { autoDetect } from '../src/lib/import-registry.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-gap-audit.test.ts
+++ b/tests/phenopacket-gap-audit.test.ts
@@ -9,7 +9,6 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { phenopacketImporter } from '../src/lib/phenopacket-converter/registry-entry.js';
@@ -17,11 +16,9 @@ import {
   auditPhenopacketTopLevel,
   auditCohortWrapper,
 } from '../src/lib/phenopacket-converter/gap-audit.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-interpretations.test.ts
+++ b/tests/phenopacket-interpretations.test.ts
@@ -7,18 +7,15 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { parseInterpretations } from '../src/lib/phenopacket-converter/interpretations.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { GENOMICS_NS } from '../src/lib/phenopacket-converter/types.js';
 import { NS } from '../src/lib/fhir-converter/types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-medical-actions.test.ts
+++ b/tests/phenopacket-medical-actions.test.ts
@@ -6,16 +6,13 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { parseMedicalActions } from '../src/lib/phenopacket-converter/medical-actions.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 const CHECKUP_NS = 'https://ns.cascadeprotocol.org/checkup/v1#';
 
 const ctx: ImportContext = {

--- a/tests/phenopacket-pedigree.test.ts
+++ b/tests/phenopacket-pedigree.test.ts
@@ -9,18 +9,15 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { parsePedigree } from '../src/lib/phenopacket-converter/pedigree.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { GENOMICS_NS } from '../src/lib/phenopacket-converter/types.js';
 import { NS } from '../src/lib/fhir-converter/types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-phenotypic-features.test.ts
+++ b/tests/phenopacket-phenotypic-features.test.ts
@@ -6,17 +6,14 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { parsePhenotypicFeatures } from '../src/lib/phenopacket-converter/phenotypic-features.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { GENOMICS_NS } from '../src/lib/phenopacket-converter/types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-subject.test.ts
+++ b/tests/phenopacket-subject.test.ts
@@ -5,17 +5,14 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { parseSubject } from '../src/lib/phenopacket-converter/subject.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { NS } from '../src/lib/fhir-converter/types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/phenopacket-variation-descriptor.test.ts
+++ b/tests/phenopacket-variation-descriptor.test.ts
@@ -14,17 +14,14 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { ImportContext } from '../src/lib/import-types.js';
 import { parseVariationDescriptor } from '../src/lib/phenopacket-converter/variation-descriptor.js';
 import { convertPhenopacket } from '../src/lib/phenopacket-converter/index.js';
 import { GENOMICS_NS } from '../src/lib/phenopacket-converter/types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.resolve(__dirname, '../../conformance/fixtures/genomics/phenopackets');
+const FIXTURES_DIR = conformancePath('fixtures/genomics/phenopackets');
 
 const ctx: ImportContext = {
   inputPath: '<test>',

--- a/tests/pod.test.ts
+++ b/tests/pod.test.ts
@@ -15,7 +15,7 @@ import { resolve } from 'path';
 import { existsSync } from 'fs';
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
-const REFERENCE_POD = resolve(__dirname, '../../conformance/reference-patient-pod');
+const REFERENCE_POD = conformancePath('reference-patient-pod');
 const skipIfNoPod = !existsSync(REFERENCE_POD);
 
 function runCli(args: string): string {
@@ -41,6 +41,7 @@ import {
   extractLabelFromProps,
   selectKeyProperties,
 } from '../src/commands/pod/helpers.js';
+import { conformancePath } from './helpers/conformance.js';
 
 describe('Pod helpers', () => {
   describe('DATA_TYPES registry', () => {

--- a/tests/setup/preflight.ts
+++ b/tests/setup/preflight.ts
@@ -1,0 +1,105 @@
+/**
+ * Fails the run once, with everything that is missing, instead of letting the
+ * suite fail hundreds of times for reasons that have nothing to do with the
+ * code under test.
+ *
+ * The suite has three prerequisites beyond `npm ci`: a current `dist/`, a
+ * `conformance` fixture checkout, and Apache Jena's `riot` on PATH. CI
+ * satisfies all three as separate workflow steps, so CI never sees what a
+ * fresh clone sees. Without this check that state reads as a broken repo:
+ * ~313 failures across 65 files, none of which name a prerequisite.
+ *
+ * Missing prerequisites fail rather than skip. This suite ratchets its skip
+ * count in CI precisely so that a suite which stops running cannot pass as
+ * green, and quietly skipping the fixture-backed suites here would hand a
+ * contributor the same false green from the other direction.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import {
+  CONFORMANCE_CANDIDATES,
+  CONFORMANCE_ROOT,
+  REPO_ROOT,
+  conformanceAvailable,
+} from '../helpers/conformance.js';
+
+interface MissingPrerequisite {
+  what: string;
+  detail: string[];
+}
+
+function checkBuild(): MissingPrerequisite | undefined {
+  const entry = path.join(REPO_ROOT, 'dist', 'index.js');
+  const shapes = path.join(REPO_ROOT, 'dist', 'shapes');
+  if (fs.existsSync(entry) && fs.existsSync(shapes)) return undefined;
+  return {
+    what: 'dist/ is missing or incomplete',
+    detail: [
+      'Some suites spawn the built CLI (`node dist/index.js`) rather than the sources.',
+      'Fix: npm run build',
+      '`npm test` does this for you; running `vitest` directly does not.',
+    ],
+  };
+}
+
+function checkConformance(): MissingPrerequisite | undefined {
+  if (conformanceAvailable()) return undefined;
+  const searched = process.env.CASCADE_CONFORMANCE_DIR
+    ? [`CASCADE_CONFORMANCE_DIR=${CONFORMANCE_ROOT}`]
+    : CONFORMANCE_CANDIDATES.map((c) => `${c}`);
+  const parent = path.dirname(CONFORMANCE_CANDIDATES[0]);
+  return {
+    what: 'the `conformance` fixture checkout was not found',
+    detail: [
+      'Searched:',
+      ...searched.map((s) => `  ${s}`),
+      'Fix: clone it beside this repository —',
+      `  git clone https://github.com/the-cascade-protocol/conformance.git ${path.join(parent, 'conformance')}`,
+      'Or: set CASCADE_CONFORMANCE_DIR to an existing checkout.',
+    ],
+  };
+}
+
+function checkRiot(): MissingPrerequisite | undefined {
+  const probe = spawnSync('riot', ['--version'], { stdio: 'ignore' });
+  if (!probe.error) return undefined;
+  return {
+    what: 'Apache Jena `riot` is not on PATH',
+    detail: [
+      'The five *-conformance suites canonicalize Turtle through `riot` for',
+      'byte-equal comparison, and fail rather than skip without it.',
+      'Fix: brew install jena',
+      '  or download Apache Jena and add its bin/ directory to PATH.',
+    ],
+  };
+}
+
+export function setup(): void {
+  const missing = [checkBuild(), checkConformance(), checkRiot()].filter(
+    (m): m is MissingPrerequisite => m !== undefined,
+  );
+  if (missing.length === 0) return;
+
+  const lines = [
+    '',
+    `Cannot run the test suite: ${missing.length} prerequisite${missing.length === 1 ? ' is' : 's are'} missing.`,
+    '',
+  ];
+  for (const item of missing) {
+    lines.push(`  • ${item.what}`);
+    for (const line of item.detail) lines.push(`      ${line}`);
+    lines.push('');
+  }
+  lines.push('See CONTRIBUTING.md → Development setup for the full layout.');
+  lines.push('');
+
+  // Drop the stack. It would point at whichever check ran last rather than at
+  // anything the reader can act on, and a frame naming `riot` under a message
+  // about `conformance` is worse than no frame at all.
+  const failure = new Error(lines.join('\n'));
+  failure.stack = failure.message;
+  throw failure;
+}

--- a/tests/validate-coverage-reference-pod.test.ts
+++ b/tests/validate-coverage-reference-pod.test.ts
@@ -47,9 +47,10 @@ import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { loadShapes, validateFile, findTurtleFiles } from '../src/lib/shacl-validator.js';
+import { conformancePath } from './helpers/conformance.js';
 
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
-const REFERENCE_POD = resolve(__dirname, '../../conformance/reference-patient-pod');
+const REFERENCE_POD = conformancePath('reference-patient-pod');
 const skipIfNoPod = !existsSync(REFERENCE_POD);
 
 const CASCADE_NS = 'https://ns.cascadeprotocol.org/';

--- a/tests/vcf-conformance.test.ts
+++ b/tests/vcf-conformance.test.ts
@@ -33,27 +33,18 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { vcfImporter } from '../src/lib/vcf-converter/registry-entry.js';
 import type {
   ImportContext,
   VocabularyGap,
 } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const DEFAULT_FIXTURES_DIR = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vcf',
-);
 // No realpath canonicalization needed: derived IRIs no longer depend on the
 // path the fixture is read through, so any path that reaches the same bytes
 // produces the same graph.
-const FIXTURES_DIR = process.env.CASCADE_CONFORMANCE_DIR
-  ? path.resolve(process.env.CASCADE_CONFORMANCE_DIR, 'fixtures/genomics/vcf')
-  : DEFAULT_FIXTURES_DIR;
+const FIXTURES_DIR = conformancePath('fixtures/genomics/vcf');
 
 const FIXTURES = [
   {

--- a/tests/vcf-detect.test.ts
+++ b/tests/vcf-detect.test.ts
@@ -5,21 +5,14 @@
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
-import path from 'node:path';
 import zlib from 'node:zlib';
-import { fileURLToPath } from 'node:url';
 
 import { detectVcf, isGzipped, inflateGzip } from '../src/lib/vcf-converter/detect.js';
 import { vcfImporter } from '../src/lib/vcf-converter/registry-entry.js';
 import { getImporter, listFormats, autoDetect } from '../src/lib/import-registry.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const VCF_GZ_FIXTURE = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vcf/sample-clinvar.input.vcf.gz',
-);
+const VCF_GZ_FIXTURE = conformancePath('fixtures/genomics/vcf/sample-clinvar.input.vcf.gz');
 
 describe('detectVcf', () => {
   it('returns true for a plain VCFv4.1 header', () => {

--- a/tests/vcf-e2e.test.ts
+++ b/tests/vcf-e2e.test.ts
@@ -17,7 +17,6 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { Parser as N3Parser } from 'n3';
 
 import { convertVcf } from '../src/lib/vcf-converter/index.js';
@@ -25,14 +24,9 @@ import { vcfImporter } from '../src/lib/vcf-converter/registry-entry.js';
 import { GENOMICS_NS } from '../src/lib/fhir-genomics-converter/types.js';
 import { NS } from '../src/lib/fhir-converter/types.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const VCF_GZ_FIXTURE = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vcf/sample-clinvar.input.vcf.gz',
-);
+const VCF_GZ_FIXTURE = conformancePath('fixtures/genomics/vcf/sample-clinvar.input.vcf.gz');
 
 const CTX: ImportContext = {
   inputPath: VCF_GZ_FIXTURE,

--- a/tests/vcf-header.test.ts
+++ b/tests/vcf-header.test.ts
@@ -4,19 +4,12 @@
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { parseHeaderLines, classifySource } from '../src/lib/vcf-converter/header.js';
 import { inflateGzip } from '../src/lib/vcf-converter/detect.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const VCF_GZ_FIXTURE = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vcf/sample-clinvar.input.vcf.gz',
-);
+const VCF_GZ_FIXTURE = conformancePath('fixtures/genomics/vcf/sample-clinvar.input.vcf.gz');
 
 describe('parseHeaderLines', () => {
   it('parses a minimal v4.1 header with reference + source', () => {

--- a/tests/vrs-conformance.test.ts
+++ b/tests/vrs-conformance.test.ts
@@ -31,7 +31,6 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { vrsImporter } from '../src/lib/vrs-converter/registry-entry.js';
 import {
@@ -42,20 +41,9 @@ import type {
   ImportContext,
   VocabularyGap,
 } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const DEFAULT_FIXTURES_DIR = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vrs',
-);
-const FIXTURES_DIR = process.env.CASCADE_CONFORMANCE_DIR
-  ? path.resolve(
-      process.env.CASCADE_CONFORMANCE_DIR,
-      'fixtures/genomics/vrs',
-    )
-  : DEFAULT_FIXTURES_DIR;
+const FIXTURES_DIR = conformancePath('fixtures/genomics/vrs');
 
 const FIXTURE_ID = 'example-allele-BRCA2-deletion';
 

--- a/tests/vrs-detect.test.ts
+++ b/tests/vrs-detect.test.ts
@@ -5,20 +5,13 @@
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { detectVrs } from '../src/lib/vrs-converter/detect.js';
 import { vrsImporter } from '../src/lib/vrs-converter/registry-entry.js';
 import { getImporter, listFormats, autoDetect } from '../src/lib/import-registry.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const VRS_FIXTURE = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vrs/example-allele-BRCA2-deletion.input.json',
-);
+const VRS_FIXTURE = conformancePath('fixtures/genomics/vrs/example-allele-BRCA2-deletion.input.json');
 
 describe('detectVrs', () => {
   it('returns true for the corpus BRCA2 Allele fixture', () => {

--- a/tests/vrs-e2e.test.ts
+++ b/tests/vrs-e2e.test.ts
@@ -8,22 +8,15 @@
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { Parser as N3Parser } from 'n3';
 
 import { vrsImporter } from '../src/lib/vrs-converter/registry-entry.js';
 import { computeSimpleVrsDigest } from '../src/lib/vrs-converter/allele.js';
 import { GENOMICS_NS } from '../src/lib/fhir-genomics-converter/types.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const VRS_FIXTURE = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vrs/example-allele-BRCA2-deletion.input.json',
-);
+const VRS_FIXTURE = conformancePath('fixtures/genomics/vrs/example-allele-BRCA2-deletion.input.json');
 
 const STRICT_CTX: ImportContext = {
   inputPath: VRS_FIXTURE,

--- a/tests/vrs-hash.test.ts
+++ b/tests/vrs-hash.test.ts
@@ -17,7 +17,6 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import {
   ingestVrsAllele,
@@ -26,14 +25,9 @@ import {
   looksLikeVrsAllele,
 } from '../src/lib/vrs-converter/allele.js';
 import type { ImportContext } from '../src/lib/import-types.js';
+import { conformancePath } from './helpers/conformance.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const VRS_FIXTURE = path.resolve(
-  __dirname,
-  '../../conformance/fixtures/genomics/vrs/example-allele-BRCA2-deletion.input.json',
-);
+const VRS_FIXTURE = conformancePath('fixtures/genomics/vrs/example-allele-BRCA2-deletion.input.json');
 
 const STRICT_CTX: ImportContext = {
   inputPath: '<test>',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     // Exclude git worktrees (used for parallel agent development) from test discovery
     exclude: ['**/node_modules/**', '**/.claude/worktrees/**'],
+    // Report missing prerequisites once, up front, rather than as several
+    // hundred unrelated-looking failures. See tests/setup/preflight.ts.
+    globalSetup: ['./tests/setup/preflight.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Fixes #63.

`npm ci && npm test` on a clean checkout of `main` reports **313 failing tests across 65 files**, and nothing in that output names a cause. The issue quotes 304/47; the numbers have grown since it was filed, but the shape is the same.

The failures split cleanly by prerequisite:

| Cause | Failing files |
|---|---|
| `dist/` not built — the file spawns `node dist/index.js` | 25 |
| sibling `conformance` checkout absent — fixture `ENOENT` | 40 |

CI satisfies both as separate workflow steps (it checks the repo into a subdirectory so `conformance` can be cloned beside it), so CI never sees what a fresh clone sees.

### What changed

**`dist/` — removed as a failure class.** A `pretest` hook runs the build, which takes about two seconds. There is nothing left to document.

**`conformance` — one message instead of forty.** Prerequisites are now checked once, before the first test, in `tests/setup/preflight.ts`. A missing one stops the run and names the exact command:

```
Cannot run the test suite: 1 prerequisite is missing.

  • the `conformance` fixture checkout was not found
      Searched:
        /path/to/conformance
      Fix: clone it beside this repository —
        git clone https://github.com/the-cascade-protocol/conformance.git /path/to/conformance
      Or: set CASCADE_CONFORMANCE_DIR to an existing checkout.
```

Everything missing is reported together, so a bare machine gets one list rather than discovering prerequisites serially.

**Apache Jena `riot` is checked too.** It is a third prerequisite of the same kind, not mentioned in the issue: five `*-conformance` suites shell out to `riot` via `execFileSync` and fail with `spawnSync riot ENOENT` rather than skipping. CI installs it as its own step. `CONTRIBUTING.md` documents it; the suite now enforces it.

**Missing prerequisites fail rather than skip.** This suite already ratchets its skip count in CI so that a suite which stops running cannot pass as green. Skipping the fixture-backed suites locally would reintroduce exactly that false green from the other side.

**Fixture paths now resolve from a git worktree.** All 42 fixture-backed suites hardcoded `path.resolve(__dirname, '../../conformance/...')`, which from a worktree points inside the worktrees directory rather than at the sibling checkout — so working in a worktree meant symlinking the fixtures into place by hand. Resolution now goes through one helper (`tests/helpers/conformance.ts`) that falls back to the main checkout's sibling when it runs from a worktree. `CASCADE_CONFORMANCE_DIR` was honored by 5 of the 42 suites; it now overrides all of them.

### Verification

On a fresh clone in a directory with no sibling `conformance`, at the exact commit in this PR:

| | Test Files | Tests | Exit |
|---|---|---|---|
| `main`, before | 65 failed, 86 passed | 313 failed, 1656 passed | 1 |
| this branch, before cloning `conformance` | — | — | 1, with the message above |
| this branch, after following that message | **154 passed** | **2447 passed** | 0 |

Also run green from a `.claude/worktrees/` worktree (154 files, 2447 tests) with no fixture symlink in place, which did not work before.

Resolution order is verified against a synthetic layout for all three paths: `CASCADE_CONFORMANCE_DIR`, sibling-of-checkout, and sibling-of-main-checkout-from-a-worktree.

Node 22.22.3, macOS. `dist/` output is byte-identical; no shipped CLI behavior changes.

### Note on #64

I could not reproduce #64 at `main` (`91c160e`) with vitest 1.6.1: a run from `.claude/worktrees/<name>/` discovers all 154 test files. vitest matches `exclude` globs against paths relative to the config root, so `**/.claude/worktrees/**` does not match the worktree's own tests when the worktree is itself the root. Left alone here rather than changed on speculation.

---

## Checklist

- [x] If shapes updated: ran `scripts/sync-shapes-from-spec.sh` (did not hand-edit TTL files) — n/a, no shapes changed
- [x] `cascade validate` passes against conformance fixtures — full suite green, 2447 tests
- [x] `VOCAB_VERSIONS` updated (if shapes changed) — n/a
- [x] CHANGELOG.md updated
- [x] `package.json` version bumped — 0.20.1 → 0.20.2