### PR TITLE
Gate the vendored shapes against the spec they came from

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,3 +108,53 @@ jobs:
             echo "::error::Only ${skipped} tests skipped, expected ${EXPECTED_SKIPPED_TESTS}. Good news: lower EXPECTED_SKIPPED_TESTS here in the same change that closed the gap."
             exit 1
           fi
+
+  # Drift between this repository's vendored `src/shapes/` and the `spec` those
+  # files were copied from was, until 2026-08-20, checked by nothing at all. A
+  # correction to `genomics.shapes.ttl` sat unshipped here for roughly three
+  # weeks, and the copy in the published package told two conformant SHACL
+  # validators different things about the same star allele.
+  #
+  # This job is deliberately its own job rather than a step of `test`: it needs a
+  # second repository checked out, and a red here means "spec moved and this
+  # repository has not caught up", which is a different fact from a failing test
+  # and should read as one.
+  #
+  # `spec` is checked out at the default branch on purpose. Pinning a commit here
+  # would make the job deterministic and useless: it would go green against a
+  # `spec` that had moved on, which is precisely the failure being fixed. If this
+  # job is red on a PR that did not touch shapes, the correct response is to run
+  # the sync, not to relax the gate.
+  vendored-shapes:
+    name: Vendored shapes match spec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cascade-cli
+        uses: actions/checkout@v4
+        with:
+          path: cascade-cli
+
+      - name: Checkout spec
+        uses: actions/checkout@v4
+        with:
+          repository: the-cascade-protocol/spec
+          path: spec
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: cascade-cli/package-lock.json
+
+      # The checker parses both copies of every file, so it needs n3. Nothing
+      # else is built or run here.
+      - name: Install dependencies
+        working-directory: cascade-cli
+        run: npm ci
+
+      # Exit 2 (cannot check) is as fatal as exit 1 (drift). A checker that
+      # cannot see spec must not report "no drift".
+      - name: Check vendored shapes against spec
+        working-directory: cascade-cli
+        run: node scripts/check-shapes-drift.mjs --spec ../spec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Do **not** load `llms-full.txt` from that site. It is roughly 1.3 MB, larger tha
 ## Ground rules
 
 - **Never hand-edit `src/shapes/`.** Those files are copies from `spec`. Run `sh scripts/sync-shapes-from-spec.sh` and update `VOCAB_VERSIONS`. Vocabulary is authored in `spec` and nowhere else.
+- **`npm run check:shapes-drift` decides whether the copy is current.** It walks `spec/ontologies/` itself rather than asking the sync script what it copied, and CI runs it against `spec` `main` on every PR. Exit 1 is drift, exit 2 is "could not check" and is equally fatal.
 - **To add a `--from <format>` importer, append to `src/lib/import-registry.ts`.** Do not edit `src/commands/convert.ts`; help text, validation and auto-detection derive from the registry.
 - **`deterministicUuid()` is a locked-in spec.** Changing it changes record identity in every SDK port at once. Coordinate before touching it.
 - **Build before you test.** Some suites spawn the built `dist/` output, so an unbuilt change is not under test and the suite can report green against code it never ran.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.20.3] - 2026-08-20
+
+### Added
+
+**A gate that fails when the vendored `src/shapes/` no longer matches the `spec` it was copied
+from.** `src/shapes/` is a vendored copy of every ontology and shapes file authored in
+[`spec`](https://github.com/the-cascade-protocol/spec), and until now nothing checked that the copy
+was current. The existing `tests/shapes-sync.test.ts` checks the bundle is internally consistent,
+which is a different question and stays green while the whole bundle is uniformly stale. That gap
+is what let the `genomics:hasComponent` correction released in 0.20.1 sit unshipped for roughly
+three weeks: the published package told a validator performing no entailment and one performing
+RDFS entailment different things about the same star allele.
+
+`scripts/check-shapes-drift.mjs` (`npm run check:shapes-drift`) compares each vendored file against
+a `spec` checkout **it walks itself**. It shares no vocabulary list and no code path with
+`scripts/sync-shapes-from-spec.sh`, deliberately: a checker that asks the generator what the
+generator produced can only confirm the generator is self-consistent. It asserts that every `.ttl`
+published under `spec/ontologies/` is bundled here, that every bundled file has an upstream, that
+each pair is byte-identical, that both copies parse, and that `VOCAB_VERSIONS` agrees with
+`spec/VOCAB_VERSIONS` and with the `owl:versionInfo` each bundled ontology declares. It fails rather
+than passes when it cannot check, and refuses to report success from a walk that found implausibly
+little.
+
+CI runs it against `spec` `main` on every pull request as the `vendored-shapes` job, so drift fails
+the build instead of being found by accident.
+
+No vocabulary changed in this release: all 20 vendored files are byte-identical to `spec` at
+core 3.6 / health 2.7 / clinical 1.15 / coverage 1.4 / checkup 3.3 / pots 1.4.
+
+---
+
 ## [0.20.2] - 2026-08-20
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,32 @@ sh scripts/sync-shapes-from-spec.sh
 - [ ] Update CHANGELOG.md
 - [ ] Bump version in `package.json` (patch for shapes-only; minor for new CLI behavior)
 - [ ] Install hooks if you haven't: `sh scripts/install-hooks.sh`
+- [ ] Confirm the copy is now current: `npm run check:shapes-drift`
 
 The pre-commit hook will block commits that change `src/shapes/` without updating `VOCAB_VERSIONS`.
 
+### Checking the vendored copy is current
+
+```sh
+npm run check:shapes-drift                        # spec resolved at ../spec
+CASCADE_SPEC_DIR=/path/to/spec npm run check:shapes-drift
+```
+
+`scripts/check-shapes-drift.mjs` compares every file in `src/shapes/` against a `spec` checkout it
+walks itself. It deliberately shares no vocabulary list and no code path with
+`sync-shapes-from-spec.sh`: a checker that asks the generator what the generator copied can only
+confirm the generator is self-consistent, which is how the sync script's two lists fell out of step
+and `src/shapes/health.ttl` went un-synced entirely.
+
+Exit 1 is drift. Exit 2 is "could not check" — no `spec` checkout, or a walk that turned up
+implausibly little — and is a failure in the same way, never a pass. CI runs it against `spec`
+`main` on every pull request (`vendored-shapes` job).
+
 ### Current vocabulary versions
 
-Check `VOCAB_VERSIONS` at the repo root. Compare against `spec/VOCAB_VERSIONS` to see what's behind.
+Check `VOCAB_VERSIONS` at the repo root. `npm run check:shapes-drift` compares it against
+`spec/VOCAB_VERSIONS` row by row, and against the `owl:versionInfo` each bundled ontology actually
+declares.
 
 ## Commit Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,17 @@ git diff src/shapes/          # review what moved
 
 Then update `VOCAB_VERSIONS` to the versions now embedded, and verify `cascade validate` passes against the current conformance fixtures.
 
+To check whether the vendored copy is already current:
+
+```bash
+npm run check:shapes-drift                       # spec resolved at ../spec
+CASCADE_SPEC_DIR=/path/to/spec npm run check:shapes-drift
+```
+
+It compares `src/shapes/` against a `spec` checkout it walks itself, and CI runs it against `spec` `main` on every pull request, so drift fails the build instead of shipping. Exit 1 means drift; exit 2 means it could not check (no `spec` checkout, or a walk that turned up implausibly little) and is treated as a failure too, because a checker that cannot see `spec` must not report that nothing has moved.
+
+A `spec` clone is optional for the rest of the suite and required for this check. If you do not have one, say so in the PR body and let CI run it.
+
 If your change needs a new class or property that does not exist yet, it starts in `spec`. Read [`spec/CONTRIBUTING.md`](https://github.com/the-cascade-protocol/spec/blob/main/CONTRIBUTING.md) for the full seven-step propagation sequence; this repository is step 4 of it.
 
 `deterministicUuid()` in `src/lib/fhir-converter/types.ts` is the canonical Cascade URI derivation algorithm. It is deliberately not RFC 4122 v5. **Do not change it without coordinating every SDK port**, because the same input must derive the same URI in all of them. Contract tests live in `tests/uri-generation.test.ts`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"
@@ -16,6 +16,7 @@
     "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "check:shapes-drift": "node scripts/check-shapes-drift.mjs",
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "prepublishOnly": "npm run build"

--- a/scripts/2026-07-23-split-fhir-bundle.mjs
+++ b/scripts/2026-07-23-split-fhir-bundle.mjs
@@ -5,10 +5,10 @@
  * be exercised through the multi-file import path.
  *
  * `cascade pod import` resolves cross-record reference edges ONCE per import
- * invocation (root backlog 2.11, slice R5). A single Bundle resolves everything
- * in-batch; an Apple Health export is one resource per file, so the same edges
- * must resolve across files. This splitter turns a Bundle into that layout, which
- * lets a test assert the two layouts are equivalent (root backlog 3.22).
+ * invocation. A single Bundle resolves everything in-batch; an Apple Health
+ * export is one resource per file, so the same edges must resolve across files.
+ * This splitter turns a Bundle into that layout, which lets a test assert the
+ * two layouts are equivalent.
  *
  * The split is byte-deterministic: entries are emitted in bundle order, each file
  * is named `<ResourceType>-<id>.json`, and each holds the bare resource

--- a/scripts/check-shapes-drift.mjs
+++ b/scripts/check-shapes-drift.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/**
+ * check-shapes-drift.mjs — fail when `src/shapes/` no longer matches `spec`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `src/shapes/` is a vendored copy of every ontology and shapes file authored in
+ * `spec`, placed here by `scripts/sync-shapes-from-spec.sh`. Until this script
+ * existed nothing checked that the copy was current. `tests/shapes-sync.test.ts`
+ * checks the bundle is internally consistent — every shape has its ontology,
+ * every `sh:targetClass` resolves — which is a different question and stays
+ * green while the whole bundle is uniformly stale.
+ *
+ * The cost of that gap was not staleness, it was ambiguity. `genomics.shapes.ttl`
+ * spent roughly three weeks behind `spec` carrying `sh:class genomics:Variant` on
+ * `genomics:hasComponent`. SHACL resolves `sh:class` over instances in the DATA
+ * graph, so a component typed `genomics:CopyNumberVariant` (a subclass of
+ * `genomics:Variant`) was rejected by a validator performing no entailment and
+ * accepted by one that does. `spec` had already replaced that with an enumerated
+ * `sh:or` per `validation/index.md` rule S3, and the correction never reached
+ * anyone installing the package. Two conformant validators disagreeing about the
+ * same star allele is the worst answer a specification can give.
+ *
+ * THE INDEPENDENCE RULE, WHICH IS THE WHOLE POINT
+ * -----------------------------------------------
+ * This script discovers what `spec` publishes by WALKING `spec/ontologies/`. It
+ * does not read, source, import or otherwise consult
+ * `scripts/sync-shapes-from-spec.sh`, and it shares no vocabulary list with it.
+ *
+ * That is deliberate and it is not stylistic. A checker that asks the generator
+ * what the generator believes it produced can only ever confirm the generator is
+ * self-consistent. The reference case is a sibling repository's documentation
+ * generator: its self-report was green while five of six ratified ontologies
+ * were missing from its output, and it exited 0. The
+ * same shape produced this repository's own earlier bug — the sync script kept
+ * one list for shapes and another for ontologies, the second never grew, and
+ * `src/shapes/health.ttl` had never been synced at all.
+ *
+ * So the two lists here are discovered, not declared:
+ *   - what `spec` publishes  -> readdir over `spec/ontologies/<vocab>/<version>/`
+ *   - what this repo vendors -> readdir over `src/shapes/`
+ * and drift is any disagreement between them, in either direction.
+ *
+ * WHAT IT ASSERTS
+ * ---------------
+ *   1. Every `.ttl` published under `spec/ontologies/` is vendored here, unless
+ *      its vocabulary is in NOT_VENDORED below, which is an exact pinned set.
+ *   2. Every `.ttl` vendored here comes from a file `spec` still publishes.
+ *   3. Each pair is byte-identical. Byte equality is the assertion because it
+ *      holds today for all 20 files: the sync is a plain `cp`, nothing rewrites
+ *      a header, so there is no by-design difference to exempt. If one is ever
+ *      introduced, weaken THIS assertion to a graph comparison for THAT file and
+ *      say why, rather than adding a general escape hatch.
+ *   4. Both copies parse as Turtle. A file that differs is reported as drift; a
+ *      file that does not parse is reported separately, because a bundle the
+ *      validator cannot load fails differently from one that is merely stale.
+ *   5. `VOCAB_VERSIONS` here matches `spec/VOCAB_VERSIONS` row for row, and each
+ *      row's version is the `owl:versionInfo` the vendored ontology actually
+ *      declares. A version bumped in `spec` with no sync fails at (3); a row
+ *      edited here with no sync fails at (5).
+ *
+ * NOT FINDING ANYTHING IS NOT A PASS
+ * ----------------------------------
+ * The floors below fail the run if the walk turns up implausibly little. A
+ * mis-rooted or symlink-blocked walk otherwise reports "0 files differ", which
+ * reads exactly like success. That is how the generator above shipped.
+ *
+ * EXIT CODES
+ * ----------
+ *   0  vendored copy matches spec
+ *   1  drift found (this is the gate firing)
+ *   2  cannot check — no spec checkout, unreadable input, or a vacuous walk.
+ *      Never conflated with 0.
+ *
+ * USAGE
+ * -----
+ *   node scripts/check-shapes-drift.mjs [--spec <dir>]
+ *   CASCADE_SPEC_DIR=/path/to/spec node scripts/check-shapes-drift.mjs
+ *
+ * Resolution order: --spec, then CASCADE_SPEC_DIR, then the sibling `../spec`.
+ * From a git worktree the sibling will not resolve; pass --spec or the env var.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const VENDORED_DIR = path.join(REPO, 'src', 'shapes');
+
+/**
+ * Vocabularies published by `spec` that this repository deliberately does not
+ * bundle, with the reason. Pinned as an exact set, not a pattern: a new
+ * vocabulary appearing in `spec` should surface here as a decision someone makes
+ * once, not be waved through by a rule that happens to match its name.
+ *
+ * `diabetes` publishes `diabetes.ttl` and no `diabetes.shapes.ttl`. Bundling an
+ * ontology with no shapes would break the pairing invariant that
+ * `tests/shapes-sync.test.ts` asserts, so it stays out until `spec` ships shapes
+ * for it. Until then `cascade validate` cannot constrain diabetes data at all:
+ * with neither the ontology nor shapes bundled, a diabetes-typed record is
+ * checked by nothing and reports conforming.
+ */
+const NOT_VENDORED = new Map([
+  ['diabetes', 'spec publishes diabetes.ttl and no diabetes.shapes.ttl; bundling an ontology with no shapes would break the pairing invariant'],
+]);
+
+/**
+ * Floors, set below the counts measured on 2026-08-20 (11 vocabulary
+ * directories, 21 spec files, 20 vendored files) so ordinary vocabulary growth
+ * never touches them. They exist to make an empty walk fail loudly.
+ */
+const MIN_SPEC_VOCAB_DIRS = 8;
+const MIN_SPEC_FILES = 16;
+const MIN_VENDORED_FILES = 16;
+
+const OWL_ONTOLOGY = 'http://www.w3.org/2002/07/owl#Ontology';
+const OWL_VERSION_INFO = 'http://www.w3.org/2002/07/owl#versionInfo';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+function fail(message) {
+  console.error(`\nCANNOT CHECK: ${message}`);
+  console.error('Refusing to report "no drift" from a check that did not run.');
+  process.exit(2);
+}
+
+function resolveSpecDir(argv) {
+  const flagIndex = argv.indexOf('--spec');
+  if (flagIndex !== -1) {
+    const value = argv[flagIndex + 1];
+    if (!value) fail('--spec was given with no directory after it.');
+    return path.resolve(value);
+  }
+  if (process.env.CASCADE_SPEC_DIR) return path.resolve(process.env.CASCADE_SPEC_DIR);
+  return path.resolve(REPO, '..', 'spec');
+}
+
+/**
+ * `statSync` and not `withFileTypes`/`lstat`: the spec checkout is frequently
+ * reached through a symlink (a sibling link, a worktree parent), and a Dirent
+ * for a symlinked directory answers `isDirectory()` false. A walk that skips
+ * symlinked entries finds nothing and exits 0, which is the exact silent-empty
+ * failure this script exists to prevent.
+ */
+function isDirectory(p) {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Independent walk of what `spec` publishes: every `*.ttl` two levels under
+ * `ontologies/`, i.e. `ontologies/<vocab>/<version>/<file>.ttl`.
+ *
+ * Returns Map<basename, {vocab, version, absPath}> plus the directory count, so
+ * a caller can tell "found nothing" from "found everything and it all matched".
+ */
+function walkSpecOntologies(specRoot) {
+  const ontologies = path.join(specRoot, 'ontologies');
+  if (!isDirectory(ontologies)) fail(`${ontologies} is not a directory.`);
+
+  const files = new Map();
+  const vocabDirs = [];
+  const collisions = [];
+
+  for (const vocab of fs.readdirSync(ontologies).sort()) {
+    const vocabPath = path.join(ontologies, vocab);
+    if (!isDirectory(vocabPath)) continue;
+    vocabDirs.push(vocab);
+
+    for (const version of fs.readdirSync(vocabPath).sort()) {
+      const versionPath = path.join(vocabPath, version);
+      if (!isDirectory(versionPath)) continue;
+
+      for (const file of fs.readdirSync(versionPath).sort()) {
+        if (!file.endsWith('.ttl')) continue;
+        const entry = { vocab, version, absPath: path.join(versionPath, file) };
+        const existing = files.get(file);
+        if (existing) {
+          // Two version directories publishing the same basename would make
+          // "the vendored copy" ambiguous, and `src/shapes/` is flat so only one
+          // could ever land. Report it rather than letting sort order decide.
+          collisions.push(
+            `${file}: ${existing.vocab}/${existing.version} and ${vocab}/${version}`,
+          );
+          continue;
+        }
+        files.set(file, entry);
+      }
+    }
+  }
+
+  return { files, vocabDirs, collisions };
+}
+
+function walkVendored(dir) {
+  if (!isDirectory(dir)) fail(`${dir} is not a directory.`);
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.ttl'))
+    .sort();
+}
+
+function parseVersionsFile(file) {
+  const rows = new Map();
+  for (const line of fs.readFileSync(file, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [key, value] = trimmed.split('=');
+    if (key && value) rows.set(key.trim(), value.trim());
+  }
+  return rows;
+}
+
+/** Parse errors are returned, not thrown: an unparseable file is a finding. */
+function parseTurtle(absPath) {
+  try {
+    return { quads: new Parser().parse(fs.readFileSync(absPath, 'utf-8')), error: null };
+  } catch (e) {
+    return { quads: null, error: e.message };
+  }
+}
+
+/**
+ * Diagnostic only — the byte comparison above has already decided the verdict.
+ * This exists so a failure message can say whether someone changed a rule or
+ * only a comment. Blank node labels are collapsed rather than matched up, so
+ * this is a heuristic and is reported as one; SHACL property shapes are almost
+ * entirely blank nodes and true isomorphism checking is not worth carrying here.
+ */
+function characterizeDifference(specQuads, vendoredQuads) {
+  const collapse = (quads) =>
+    quads
+      .map((q) =>
+        [q.subject, q.predicate, q.object, q.graph]
+          .map((t) => (t.termType === 'BlankNode' ? '_:b' : `${t.termType}:${t.value}`))
+          .join(' '),
+      )
+      .sort()
+      .join('\n');
+
+  if (specQuads.length !== vendoredQuads.length) {
+    return `${vendoredQuads.length} triples vendored against ${specQuads.length} in spec`;
+  }
+  if (collapse(specQuads) !== collapse(vendoredQuads)) {
+    return `${specQuads.length} triples on both sides, but their content differs`;
+  }
+  return 'comments or formatting only, by a blank-node-collapsing comparison';
+}
+
+function firstDifferingLine(specPath, vendoredPath) {
+  const a = fs.readFileSync(specPath, 'utf-8').split('\n');
+  const b = fs.readFileSync(vendoredPath, 'utf-8').split('\n');
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    if (a[i] !== b[i]) {
+      return `line ${i + 1}\n        spec:     ${JSON.stringify(a[i] ?? '<end of file>')}\n        vendored: ${JSON.stringify(b[i] ?? '<end of file>')}`;
+    }
+  }
+  return 'no differing line (trailing bytes only)';
+}
+
+function main() {
+  const specRoot = resolveSpecDir(process.argv.slice(2));
+  if (!isDirectory(specRoot)) {
+    fail(
+      `no spec checkout at ${specRoot}.\n` +
+        '  Clone https://github.com/the-cascade-protocol/spec as a sibling of this\n' +
+        '  repository, or pass --spec <dir>, or set CASCADE_SPEC_DIR.',
+    );
+  }
+
+  console.log(`spec:     ${specRoot}`);
+  console.log(`vendored: ${VENDORED_DIR}`);
+
+  const { files: specFiles, vocabDirs, collisions } = walkSpecOntologies(specRoot);
+  const vendoredFiles = walkVendored(VENDORED_DIR);
+
+  console.log(
+    `walked ${vocabDirs.length} vocabulary directories, ${specFiles.size} spec files, ` +
+      `${vendoredFiles.length} vendored files`,
+  );
+
+  if (vocabDirs.length < MIN_SPEC_VOCAB_DIRS) {
+    fail(
+      `only ${vocabDirs.length} vocabulary directories under ${specRoot}/ontologies, ` +
+        `expected at least ${MIN_SPEC_VOCAB_DIRS}. The walk found too little to be believed.`,
+    );
+  }
+  if (specFiles.size < MIN_SPEC_FILES) {
+    fail(
+      `only ${specFiles.size} .ttl files under ${specRoot}/ontologies, expected at least ` +
+        `${MIN_SPEC_FILES}. The walk found too little to be believed.`,
+    );
+  }
+  if (vendoredFiles.length < MIN_VENDORED_FILES) {
+    fail(
+      `only ${vendoredFiles.length} .ttl files in ${VENDORED_DIR}, expected at least ` +
+        `${MIN_VENDORED_FILES}.`,
+    );
+  }
+
+  const problems = [];
+
+  for (const c of collisions) {
+    problems.push(`AMBIGUOUS  ${c}\n    Two spec version directories publish the same file name.`);
+  }
+
+  // (1) published by spec, absent here.
+  for (const [name, entry] of [...specFiles].sort()) {
+    if (vendoredFiles.includes(name)) continue;
+    const reason = NOT_VENDORED.get(entry.vocab);
+    if (reason) continue;
+    problems.push(
+      `MISSING    src/shapes/${name}\n` +
+        `    spec publishes ontologies/${entry.vocab}/${entry.version}/${name} and this\n` +
+        `    repository does not bundle it. If that is deliberate, add ${entry.vocab} to\n` +
+        `    NOT_VENDORED in this script with the reason.`,
+    );
+  }
+
+  // (1b) exempted, but the exemption has gone stale.
+  for (const [vocab, reason] of NOT_VENDORED) {
+    const stillUnpublished = ![...specFiles.values()].some((e) => e.vocab === vocab);
+    const nowVendored = [...specFiles]
+      .filter(([, e]) => e.vocab === vocab)
+      .some(([name]) => vendoredFiles.includes(name));
+    if (stillUnpublished) {
+      problems.push(
+        `STALE      NOT_VENDORED lists ${vocab}, which spec no longer publishes.\n` +
+          `    Remove the entry. (${reason})`,
+      );
+    } else if (nowVendored) {
+      problems.push(
+        `STALE      NOT_VENDORED lists ${vocab}, but it IS bundled now.\n` +
+          `    Remove the entry so the files are actually compared. (${reason})`,
+      );
+    }
+  }
+
+  // (2) bundled here, not published by spec.
+  for (const name of vendoredFiles) {
+    if (specFiles.has(name)) continue;
+    problems.push(
+      `ORPHAN     src/shapes/${name}\n` +
+        `    No file of this name is published under spec/ontologies/. Vocabulary is\n` +
+        `    authored in spec and nowhere else, so this file has no upstream.`,
+    );
+  }
+
+  // (3)(4) byte comparison, and both sides parse.
+  let compared = 0;
+  for (const name of vendoredFiles) {
+    const entry = specFiles.get(name);
+    if (!entry) continue;
+    const vendoredPath = path.join(VENDORED_DIR, name);
+
+    const vendoredParse = parseTurtle(vendoredPath);
+    if (vendoredParse.error) {
+      problems.push(`UNPARSEABLE src/shapes/${name}\n    ${vendoredParse.error}`);
+      continue;
+    }
+    const specParse = parseTurtle(entry.absPath);
+    if (specParse.error) {
+      problems.push(
+        `UNPARSEABLE spec/ontologies/${entry.vocab}/${entry.version}/${name}\n    ${specParse.error}`,
+      );
+      continue;
+    }
+
+    compared++;
+    const same = fs.readFileSync(entry.absPath).equals(fs.readFileSync(vendoredPath));
+    if (!same) {
+      problems.push(
+        `DRIFTED    src/shapes/${name}\n` +
+          `    against spec/ontologies/${entry.vocab}/${entry.version}/${name}\n` +
+          `    difference: ${characterizeDifference(specParse.quads, vendoredParse.quads)}\n` +
+          `    first at ${firstDifferingLine(entry.absPath, vendoredPath)}`,
+      );
+    }
+  }
+
+  // A run that compared nothing must not report success.
+  if (compared < MIN_VENDORED_FILES) {
+    fail(
+      `only ${compared} file pairs were actually compared, expected at least ` +
+        `${MIN_VENDORED_FILES}. Every assertion above would pass vacuously.`,
+    );
+  }
+
+  // (5) VOCAB_VERSIONS, in both directions, against the bundled ontology.
+  const specVersionsFile = path.join(specRoot, 'VOCAB_VERSIONS');
+  const localVersionsFile = path.join(REPO, 'VOCAB_VERSIONS');
+  if (!fs.existsSync(specVersionsFile)) fail(`${specVersionsFile} does not exist.`);
+  const specVersions = parseVersionsFile(specVersionsFile);
+  const localVersions = parseVersionsFile(localVersionsFile);
+  if (specVersions.size === 0) fail(`${specVersionsFile} declares no vocabulary rows.`);
+
+  for (const [vocab, specVersion] of [...specVersions].sort()) {
+    const localVersion = localVersions.get(vocab);
+    if (localVersion === undefined) {
+      problems.push(
+        `VERSION    VOCAB_VERSIONS has no row for ${vocab}; spec declares ${vocab}=${specVersion}.`,
+      );
+      continue;
+    }
+    if (localVersion !== specVersion) {
+      problems.push(
+        `VERSION    VOCAB_VERSIONS says ${vocab}=${localVersion}; spec says ${vocab}=${specVersion}.`,
+      );
+    }
+  }
+  for (const vocab of [...localVersions.keys()].sort()) {
+    if (!specVersions.has(vocab)) {
+      problems.push(
+        `VERSION    VOCAB_VERSIONS declares ${vocab}, which spec/VOCAB_VERSIONS does not.`,
+      );
+    }
+  }
+
+  // The row has to be the version the bundled file declares, not just the
+  // version spec agrees with — otherwise both files could say 2.7 while the
+  // ontology on disk here is still 2.6.
+  for (const [vocab, version] of [...localVersions].sort()) {
+    const bundled = path.join(VENDORED_DIR, `${vocab}.ttl`);
+    if (!fs.existsSync(bundled)) {
+      problems.push(`VERSION    VOCAB_VERSIONS declares ${vocab} but src/shapes/${vocab}.ttl is absent.`);
+      continue;
+    }
+    const parsed = parseTurtle(bundled);
+    if (parsed.error) continue; // already reported as UNPARSEABLE
+    const ontologyNodes = parsed.quads
+      .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === OWL_ONTOLOGY)
+      .map((q) => q.subject.value);
+    const declared = parsed.quads
+      .filter(
+        (q) => q.predicate.value === OWL_VERSION_INFO && ontologyNodes.includes(q.subject.value),
+      )
+      .map((q) => q.object.value);
+    if (!declared.includes(version)) {
+      problems.push(
+        `VERSION    VOCAB_VERSIONS says ${vocab}=${version}, but src/shapes/${vocab}.ttl\n` +
+          `    declares owl:versionInfo ${declared.length ? declared.join(', ') : '<none>'}.`,
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error(`\n${problems.length} problem(s):\n`);
+    for (const p of problems) console.error(`  ${p}\n`);
+    console.error('The vendored shapes are not the shapes spec publishes.');
+    console.error('Re-sync:  sh scripts/sync-shapes-from-spec.sh');
+    console.error('then update VOCAB_VERSIONS and CHANGELOG.md in the same change.');
+    process.exit(1);
+  }
+
+  console.log(
+    `\nOK: ${compared} files byte-identical to spec, ${localVersions.size} VOCAB_VERSIONS rows agree ` +
+      'with spec and with the bundled ontologies.',
+  );
+}
+
+main();

--- a/tests/no-internal-references.test.ts
+++ b/tests/no-internal-references.test.ts
@@ -35,7 +35,11 @@ function scan(dir: string): string[] {
 }
 
 describe('public repo carries no internal tracker references', () => {
-  for (const dir of ['src', 'tests', 'docs']) {
+  // `scripts/` is scanned for the same reason as the three above even though it
+  // is not in package.json `files`: it is public the moment it is pushed, and it
+  // was carrying two references when this line was added. Scanning only what
+  // ships confuses "not published to npm" with "not published".
+  for (const dir of ['src', 'tests', 'docs', 'scripts', '.github']) {
     it(`${dir}/ is free of them`, () => {
       expect(scan(dir)).toEqual([]);
     });


### PR DESCRIPTION
## What this changes

`src/shapes/` is a vendored copy of every ontology and shapes file authored in [`spec`](https://github.com/the-cascade-protocol/spec), placed here by `scripts/sync-shapes-from-spec.sh`. Nothing checked that the copy was current. `tests/shapes-sync.test.ts` checks the bundle is internally consistent, which is a different question and stays green while the whole bundle is uniformly stale.

This adds `scripts/check-shapes-drift.mjs` (`npm run check:shapes-drift`) and runs it in CI as a new `vendored-shapes` job.

The cost of the gap was not staleness, it was ambiguity. The `genomics:hasComponent` correction released in 0.20.1 sat unshipped here for roughly three weeks, and during that time the published package carried `sh:class genomics:Variant` on a property whose acceptable values include `genomics:CopyNumberVariant`, a subclass. SHACL resolves `sh:class` over instances in the data graph, so the same star allele was valid or invalid depending on whose validator you asked.

## The independence rule

The checker walks `spec/ontologies/` itself. It shares no vocabulary list and no code path with `sync-shapes-from-spec.sh`, deliberately: a checker that asks the generator what the generator copied can only confirm the generator is self-consistent. That is the failure mode that produced this repository's earlier bug, where the sync script kept one list for shapes and another for ontologies, the second never grew, and `src/shapes/health.ttl` had never been synced at all.

Demonstrated rather than asserted. Given a `spec` tree publishing a vocabulary the sync script's lists do not name, the two tools disagree:

```
$ node scripts/check-shapes-drift.mjs --spec <spec + one new vocabulary>
walked 12 vocabulary directories, 23 spec files, 20 vendored files

2 problem(s):

  MISSING    src/shapes/nutrition.shapes.ttl
    spec publishes ontologies/nutrition/v1-draft/nutrition.shapes.ttl and this
    repository does not bundle it.
  MISSING    src/shapes/nutrition.ttl
    ...
EXIT=1

$ SPEC_ROOT=<same tree> sh scripts/sync-shapes-from-spec.sh --dry-run
...
Done. Next steps:
  1. Review diffs: git diff src/shapes/
EXIT=0
```

## What it asserts

For every `.ttl` published under `spec/ontologies/` and every `.ttl` in `src/shapes/`, discovered by walking both:

1. Everything `spec` publishes is bundled here, unless its vocabulary is in an exact pinned `NOT_VENDORED` set (today: `diabetes`, which publishes an ontology and no shapes file). A stale exemption is itself a failure.
2. Everything bundled here has an upstream in `spec`.
3. Each pair is byte-identical. Byte equality is the assertion because it holds today for all 20 files; the sync is a plain `cp` and nothing rewrites a header, so there is no by-design difference to exempt.
4. Both copies parse as Turtle.
5. `VOCAB_VERSIONS` matches `spec/VOCAB_VERSIONS` row for row, and each row is the `owl:versionInfo` the bundled ontology actually declares.

Exit 1 is drift. **Exit 2 is "could not check"** — no `spec` checkout, or a walk that turned up implausibly little — and CI treats it as fatal. A checker that cannot see `spec` must not report that nothing has moved.

## Observed RED before being trusted

Every case below was run against this branch, then reverted, and the working tree confirmed clean.

**1. The historical regression, restored verbatim** (`sh:or` enumeration reverted to `sh:class genomics:Variant`):

```
1 problem(s):

  DRIFTED    src/shapes/genomics.shapes.ttl
    against spec/ontologies/genomics/v1-draft/genomics.shapes.ttl
    difference: 695 triples vendored against 701 in spec
    first at line 485
        spec:     "        sh:or ("
        vendored: "        sh:class genomics:Variant ;"
EXIT=1
```

**2. A comment appended to `core.shapes.ttl`** — still drift, and reported as such rather than waved through:

```
  DRIFTED    src/shapes/core.shapes.ttl
    difference: comments or formatting only, by a blank-node-collapsing comparison
    first at line 933
        spec:     "<end of file>"
        vendored: "# a stray comment nobody synced"
EXIT=1
```

**3. A vendored file deleted** (`pots.shapes.ttl`): `MISSING src/shapes/pots.shapes.ttl`, EXIT=1.

**4. `VOCAB_VERSIONS` bumped to `health=2.8` with no sync**: two problems, EXIT=1 — one against `spec/VOCAB_VERSIONS`, one against the `owl:versionInfo` in the bundled `health.ttl`.

**5. A vocabulary published by `spec` that the sync script's lists do not name**: the transcript above, EXIT=1.

**6. Cannot-check paths**, both EXIT=2, neither reported as a pass:

```
$ node scripts/check-shapes-drift.mjs --spec /nowhere/spec
CANNOT CHECK: no spec checkout at /nowhere/spec.
Refusing to report "no drift" from a check that did not run.

$ node scripts/check-shapes-drift.mjs --spec <a tree with one vocabulary>
walked 1 vocabulary directories, 1 spec files, 20 vendored files
CANNOT CHECK: only 1 vocabulary directories ... The walk found too little to be believed.
```

**GREEN, on this branch, against `spec` at `5a56ab4`:**

```
walked 11 vocabulary directories, 21 spec files, 20 vendored files

OK: 20 files byte-identical to spec, 6 VOCAB_VERSIONS rows agree with spec and with the bundled ontologies.
EXIT=0
```

## The `genomics:hasComponent` fix, checked against two validators

The fix itself shipped in 0.20.1; what had never been confirmed is that it removes the ambiguity rather than only changing version numbers. Data graph: `CYP2D6*5`, the whole-gene deletion star allele, whose only constituent is a `genomics:CopyNumberVariant`. The entailed graph is the same data under RDFS materialization (`riot --rdfs=src/shapes/genomics.ttl`), which is what a validator operating under the RDFS entailment regime sees; materialization does give the component `rdf:type genomics:Variant`, so the two regimes genuinely differ on this input.

**rdf-validate-shacl 0.5.x** (the validator this package ships):

```
  sh:class genomics:Variant (before) | no entailment  | REJECTED  <- 1 result(s) on genomics:hasComponent
  sh:class genomics:Variant (before) | RDFS entailment | ACCEPTED
  sh:or enumeration    (after)       | no entailment  | ACCEPTED
  sh:or enumeration    (after)       | RDFS entailment | ACCEPTED
```

**Apache Jena SHACL 5.6.0** (an independent implementation), same four runs:

```
  sh:class genomics:Variant (before) | no entailment  | REJECTED  <- 2 line(s) naming genomics:hasComponent
  sh:class genomics:Variant (before) | RDFS entailment | ACCEPTED
  sh:or enumeration    (after)       | no entailment  | ACCEPTED
  sh:or enumeration    (after)       | RDFS entailment | ACCEPTED
```

Two independent implementations, same verdict: before the fix the answer depended on the entailment regime, and after it does not. (`before` here is the file at `HEAD` with only the constraint reverted, so its `sh:message` is the current one; the constraint component is what differs.)

## Two internal tracker references were shipped in `scripts/`

`tests/no-internal-references.test.ts` scanned `src`, `tests` and `docs`. It did not scan `scripts/`, which is just as public, and two references were sitting in `scripts/2026-07-23-split-fhir-bundle.mjs`. The comments are rewritten to say the same thing substantively, and the scan now covers `scripts/` and `.github/` as well. Both new directories were observed failing on a planted reference before the fix was trusted:

```
  × scripts/ is free of them   -> expected [ 'scripts/install-hooks.sh' ] to deeply equal []
  × .github/ is free of them   -> expected [ '.github/workflows/tests.yml' ] to deeply equal []
  Tests  2 failed | 5 passed (7)
```

## In CI

The `vendored-shapes` job passed on this branch against a fresh `spec` clone, and did real work rather than passing vacuously:

```
spec:     /home/runner/work/cascade-cli/cascade-cli/spec
vendored: /home/runner/work/cascade-cli/cascade-cli/cascade-cli/src/shapes
walked 11 vocabulary directories, 21 spec files, 20 vendored files
```

Same counts as the local run, from an independent checkout.

**And observed RED in CI, not only locally.** The same regression was pushed to this branch as a temporary commit, the job was watched failing, and the commit was reverted. Run [32444321157](https://github.com/the-cascade-protocol/cascade-cli/actions/runs/32444321157), job step 6:

```
spec:     /home/runner/work/cascade-cli/cascade-cli/spec
vendored: /home/runner/work/cascade-cli/cascade-cli/cascade-cli/src/shapes
walked 11 vocabulary directories, 21 spec files, 20 vendored files

1 problem(s):

  DRIFTED    src/shapes/genomics.shapes.ttl
    against spec/ontologies/genomics/v1-draft/genomics.shapes.ttl
    difference: 695 triples vendored against 701 in spec
    first at line 485
        spec:     "        sh:or ("
        vendored: "        sh:class genomics:Variant ;"

The vendored shapes are not the shapes spec publishes.
Re-sync:  sh scripts/sync-shapes-from-spec.sh
then update VOCAB_VERSIONS and CHANGELOG.md in the same change.
##[error]Process completed with exit code 1.
```

Steps 1 through 5 (checkout `cascade-cli`, checkout `spec`, set up Node, `npm ci`) all succeeded and only step 6 failed, so this is the gate firing and not an environment error. The branch was then reset to the good commit and CI returned green.

## A note on the CI job

`spec` is checked out at its default branch, not a pinned commit, on purpose. A pin would make the job deterministic and useless: it would stay green against a `spec` that had moved on, which is the exact failure this closes. The consequence is that merging a vocabulary change in `spec` turns this job red here until the sync runs. That is the intended ordering, and the failure message names the files and the command.

## Checked and not changed

`scripts/sync-shapes-from-spec.sh` does **not** silently continue past a missing source file. Measured against a `spec` tree with `health.shapes.ttl` removed: it prints `MISSING:`, then `FAILED: 1 expected file(s) not found`, and exits 1.

## Version

Released as 0.20.3. This branch was written against 0.20.1 and rebased onto #80 after that merged and took 0.20.2; the CHANGELOG conflict was resolved by keeping both sections.

## Test plan

- `npm ci && npm test` — **154 files / 2449 tests passed, 0 skipped**, Node v22.22.3, Apache Jena `riot` 5.6.0 on `PATH`, sibling `conformance` checkout present. Measured after rebasing onto #80, and separately before it; both green with the same counts. The 2 tests above the 2447 measured on `main` are the new `scripts/` and `.github/` scan directories.
- `npm run check:shapes-drift` — green, output above.
- Run from a git worktree; `spec` resolved through a symlinked sibling, which is why the walk uses `statSync` and not `Dirent.isDirectory()` (a `Dirent` for a symlinked directory answers false, and a walk that skips it finds nothing and exits 0).
