### PR TITLE
fix(deps): bump adm-zip past CVE-2026-39244, drop unused pdfjs-dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.20.4] - 2026-08-21
+
+### Security
+
+**`adm-zip` is bumped past CVE-2026-39244, which was reachable from `cascade convert`.**
+`package.json` declared `^0.5.16`, and the advisory (GHSA-xpcp-8h2w-3j85, CVSS 7.5) covers every
+version below 0.6.0: `zipEntry.js` allocated `Buffer.alloc(_centralHeader.size)` from the ZIP
+central directory's *declared* uncompressed size, with no bounds check and no comparison against
+the actual compressed size, before validating the CRC. A ~120-byte archive could declare ~4GB and
+get it.
+
+This was not merely present in the dependency tree. `cascade convert` accepts a `.zip`
+(`src/commands/convert.ts`), reads it into a Buffer, and the C/CDA converter calls `new AdmZip(...)`
+then `entry.getData()` on each `.xml` entry (`src/lib/ccda-converter/index.ts`), and `getData()` is
+one of the methods the advisory names. The IHE XDM adapter exists precisely so a user can hand the
+tool a ZIP a hospital portal gave them, so untrusted input reaches that allocation by design.
+
+Note that `^0.5.16` could never have resolved to the fix on its own: a caret range on a `0.x`
+version pins the minor, so no lockfile refresh would have produced it.
+
+`tests/adm-zip-declared-size.test.ts` pins the behaviour. It asserts on **allocation**, not on
+whether the archive is rejected, because the obvious assertion is worthless here: a crafted archive
+throws `CRC32 checksum failed` on the vulnerable version too. The difference is that 0.5.16 requested
+67,108,864 bytes from a 121-byte file on the way to that outcome, exactly as the advisory describes
+(the allocation happens *before* CRC validation, so the payload cannot be rejected early). Both
+allocation tests were observed RED on 0.5.16 and GREEN on 0.6.0 before being trusted.
+
+Two things were found while writing that test and are worth recording, since both would have
+produced a tripwire that passed while the defect was live. The crafted entry must be named `*.xml`,
+or the converter never calls `getData()` on it and the convert-path test is vacuous. And the
+measurement must spy on `Buffer.alloc` rather than sample `process.memoryUsage()`, because when the
+allocation is followed by a throw the orphaned buffer can be collected before the "after" sample,
+which made the convert-path case measure ~0 on a version that demonstrably allocated 64 MB.
+
+### Removed
+
+**`pdfjs-dist` is dropped from `dependencies`.** It was referenced by no source file and appeared
+nowhere in the built `dist/`, while carrying a HIGH advisory ("PDF.js: Arbitrary JavaScript execution
+upon opening a malicious PDF") into every install of the package. There is no PDF path in the CLI
+today; when one is built, the dependency comes back with the code that uses it.
+
+**`@types/adm-zip` is dropped from `devDependencies`.** `adm-zip` 0.6.0 bundles its own
+`types.d.ts`, where 0.5.16 shipped none, so the separate stub package is now redundant. Verified by
+typechecking with it removed.
+
+Together these take `npm audit --omit=dev` from 15 advisories to 13, and remove both of the two
+DIRECT high-severity ones. The remainder are transitive and tracked separately.
+
+---
+
 ## [0.20.3] - 2026-08-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.17.0",
+  "version": "0.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-cascade-protocol/cli",
-      "version": "0.17.0",
+      "version": "0.20.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmod/vcf": "^7.0.2",
@@ -14,19 +14,17 @@
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
         "@the-cascade-protocol/agent": "^1.1.3",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "commander": "^13.0.0",
         "did-resolver": "^5.0.1",
         "fast-xml-parser": "^5.5.9",
         "n3": "^1.17.0",
-        "pdfjs-dist": "^5.7.284",
         "rdf-validate-shacl": "^0.5.0"
       },
       "bin": {
         "cascade": "dist/index.js"
       },
       "devDependencies": {
-        "@types/adm-zip": "^0.5.5",
         "@types/n3": "^1.16.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
@@ -786,256 +784,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/@napi-rs/canvas": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
-      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
-      "license": "MIT",
-      "optional": true,
-      "workspaces": [
-        "e2e/*"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-x64": "0.1.100",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
-      }
-    },
-    "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
-      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
-      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
-      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
-      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
-      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
-      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
-      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
-      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
-      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
-      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
-      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
     },
     "node_modules/@noble/curves": {
       "version": "2.2.0",
@@ -1949,16 +1697,6 @@
         "@zazuko/prefixes": "^2.3.0"
       }
     },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
-      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2375,12 +2113,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {
@@ -5678,18 +5416,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=22.13.0 || >=24"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"
@@ -59,16 +59,14 @@
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@the-cascade-protocol/agent": "^1.1.3",
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "commander": "^13.0.0",
     "did-resolver": "^5.0.1",
     "fast-xml-parser": "^5.5.9",
     "n3": "^1.17.0",
-    "pdfjs-dist": "^5.7.284",
     "rdf-validate-shacl": "^0.5.0"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.5",
     "@types/n3": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/tests/adm-zip-declared-size.test.ts
+++ b/tests/adm-zip-declared-size.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression pin for CVE-2026-39244 (GHSA-xpcp-8h2w-3j85, adm-zip < 0.6.0).
+ *
+ * A ZIP central directory declares the uncompressed size of each entry.
+ * adm-zip below 0.6.0 allocated that declared size before validating anything
+ * about it, so a ~120-byte archive claiming ~4GB got ~4GB. `cascade convert`
+ * accepts a `.zip` from the filesystem and hands it to `convertCcda`, which is
+ * how untrusted input reaches that allocation.
+ *
+ * WHAT THIS FILE ASSERTS, AND WHY IT IS NOT THE OBVIOUS ASSERTION
+ *
+ * The obvious test -- "a crafted archive is rejected" -- passes on the
+ * VULNERABLE version and is therefore worthless as a tripwire. Measured on
+ * adm-zip 0.5.16, the crafted archive below throws `ADM-ZIP: CRC32 checksum
+ * failed` exactly as it does on 0.6.0. The difference is not the outcome, it is
+ * that 0.5.16 allocated 64 MB from a 121-byte file on the way to that outcome.
+ * The CVE text says so directly: the allocation occurs BEFORE CRC validation,
+ * so the payload cannot be rejected early.
+ *
+ * So these tests assert on ALLOCATION: they spy on `Buffer.alloc` and record the
+ * largest single request made while the archive is read. Observed while writing
+ * them, with the entry named `CCD.xml` so the convert path actually reaches it:
+ *   adm-zip 0.5.16 -> peak request 67,108,864 bytes from a 121-byte file (RED)
+ *   adm-zip 0.6.0  -> peak request well under the threshold          (GREEN)
+ *
+ * DECLARED_SIZE is 64 MB rather than the ~4GB the advisory describes so that a
+ * RED run degrades a CI box instead of killing it. 64 MB against a 121-byte
+ * archive is already a ratio over 500,000:1, which is far outside anything a
+ * real archive produces and well clear of measurement noise.
+ */
+
+import { describe, it, expect } from 'vitest';
+import AdmZip from 'adm-zip';
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+
+const DECLARED_SIZE = 64 * 1024 * 1024;
+
+/** Offset of the uncompressed-size field within a central directory header. */
+const CD_SIGNATURE = 0x02014b50;
+const CD_UNCOMPRESSED_SIZE_OFFSET = 24;
+
+/**
+ * A structurally valid STORED archive whose central directory lies about how
+ * large the entry expands to. Built with adm-zip itself so that everything
+ * except the one patched field is genuinely well-formed.
+ */
+function craftOversizedDeclaration(): { archive: Buffer; realSize: number } {
+  const zip = new AdmZip();
+  zip.addFile('CCD.xml', Buffer.from('hello'), '', 0);
+  const archive = zip.toBuffer();
+
+  let cd = -1;
+  for (let i = 0; i + 4 <= archive.length; i++) {
+    if (archive.readUInt32LE(i) === CD_SIGNATURE) {
+      cd = i;
+      break;
+    }
+  }
+  if (cd < 0) throw new Error('no central directory in the generated archive');
+
+  const realSize = archive.readUInt32LE(cd + CD_UNCOMPRESSED_SIZE_OFFSET);
+  archive.writeUInt32LE(DECLARED_SIZE, cd + CD_UNCOMPRESSED_SIZE_OFFSET);
+  return { archive, realSize };
+}
+
+/**
+ * Largest single `Buffer.alloc` request made during `fn`, in bytes.
+ *
+ * This spies on the allocation rather than sampling `process.memoryUsage()`
+ * before and after. Sampling was tried first and is NOT reliable here: when the
+ * allocation is followed by a throw, the orphaned buffer can be collected
+ * before the "after" sample is taken, so the convert-path case measured ~0 on
+ * adm-zip 0.5.16 even though the 64 MB allocation demonstrably happened. The
+ * spy answers the question the CVE actually poses -- did anything ask for the
+ * declared size -- and is independent of when the collector runs.
+ */
+async function largestAllocationDuring(fn: () => unknown | Promise<unknown>): Promise<number> {
+  const realAlloc = Buffer.alloc;
+  let peak = 0;
+  (Buffer as { alloc: typeof Buffer.alloc }).alloc = ((size: number, ...rest: unknown[]) => {
+    if (typeof size === 'number' && size > peak) peak = size;
+    return (realAlloc as (...a: unknown[]) => Buffer)(size, ...rest);
+  }) as typeof Buffer.alloc;
+  try {
+    await fn();
+  } catch {
+    // Throwing is fine and expected. This measures the cost of getting there.
+  } finally {
+    (Buffer as { alloc: typeof Buffer.alloc }).alloc = realAlloc;
+  }
+  return peak;
+}
+
+describe('adm-zip declared uncompressed size (CVE-2026-39244)', () => {
+  it('crafts an archive whose declaration is wildly larger than its contents', () => {
+    const { archive, realSize } = craftOversizedDeclaration();
+    expect(realSize).toBe(5);
+    // The entry MUST end in .xml: convertCcda only calls getData() on .xml
+    // entries, so a differently-named entry makes the convert-path test below
+    // vacuous. Observed: with a .txt entry that test passes on adm-zip 0.5.16.
+    expect(new AdmZip(archive).getEntries()[0].entryName).toMatch(/\.xml$/);
+    expect(archive.length).toBeLessThan(1024);
+    // The amplification the advisory is about.
+    expect(DECLARED_SIZE / archive.length).toBeGreaterThan(100_000);
+  });
+
+  it('does not allocate the declared size when reading an entry directly', async () => {
+    const { archive } = craftOversizedDeclaration();
+    const peak = await largestAllocationDuring(() =>
+      new AdmZip(archive).getEntries()[0].getData(),
+    );
+    // 0.5.16 allocated the full 64 MB here. Anything approaching the declared
+    // size means the pre-allocation is back.
+    expect(peak).toBeLessThan(DECLARED_SIZE / 8);
+  });
+
+  it('does not allocate the declared size through the C/CDA convert path', async () => {
+    const { archive } = craftOversizedDeclaration();
+    // This is the reachable path: `cascade convert foo.zip` -> readFileSync ->
+    // convertCcda(Buffer). The converter catches zip errors and falls back to
+    // treating the bytes as raw XML, which means it swallows the symptom; the
+    // allocation is what has to not happen.
+    const peak = await largestAllocationDuring(() => convertCcda(archive));
+    expect(peak).toBeLessThan(DECLARED_SIZE / 8);
+  });
+
+  it('still reads a legitimate archive correctly', async () => {
+    const zip = new AdmZip();
+    zip.addFile('note.txt', Buffer.from('hello'), '', 0);
+    const entry = new AdmZip(zip.toBuffer()).getEntries()[0];
+    expect(entry.getData().toString('utf-8')).toBe('hello');
+  });
+});


### PR DESCRIPTION
## What

- `adm-zip` `^0.5.16` → `^0.6.0` (CVE-2026-39244 / GHSA-xpcp-8h2w-3j85, CVSS 7.5 HIGH)
- `pdfjs-dist` removed from `dependencies` (unused, carried a HIGH advisory)
- `@types/adm-zip` removed from `devDependencies` (0.6.0 bundles its own types)
- New `tests/adm-zip-declared-size.test.ts`
- Version `0.20.4`

## Why the adm-zip bump is not routine hygiene

The advisory is reachable from untrusted input, not merely present in the tree.

`cascade convert` accepts a `.zip` (`src/commands/convert.ts`), reads it to a Buffer, and the C/CDA converter calls `new AdmZip(...)` then `entry.getData()` on each `.xml` entry (`src/lib/ccda-converter/index.ts`). `getData()` is one of the methods the advisory names. The IHE XDM adapter exists so a user can hand the tool a ZIP a hospital portal gave them.

Below 0.6.0, `zipEntry.js` allocated `Buffer.alloc(_centralHeader.size)` from the *declared* uncompressed size in the central directory, with no bounds check and before CRC validation.

Also worth noting: `^0.5.16` could never have resolved to the fix. A caret range on a `0.x` version pins the minor, so no lockfile refresh would have produced it.

## The test asserts on allocation, deliberately

The obvious assertion (*"a crafted archive is rejected"*) **passes on the vulnerable version** and is worthless as a tripwire. Measured: the crafted archive throws `CRC32 checksum failed` on 0.5.16 exactly as on 0.6.0. The difference is that 0.5.16 requested **67,108,864 bytes from a 121-byte archive** on the way there, which is what the advisory means by the allocation happening before CRC validation.

So the tests spy on `Buffer.alloc` and assert on the largest request. Observed before being trusted:

| | peak `Buffer.alloc` request |
|---|---|
| adm-zip 0.5.16 | 67,108,864 bytes (**RED**) |
| adm-zip 0.6.0 | under threshold (**GREEN**) |

Two traps found while writing it, both of which would have produced a tripwire that passed while the defect was live:

1. The crafted entry must be named `*.xml`, or the converter never calls `getData()` and the convert-path test is vacuous. Observed passing on 0.5.16 with a `.txt` entry.
2. Measurement must spy on `Buffer.alloc`, not sample `process.memoryUsage()`. When the allocation is followed by a throw, the orphaned buffer can be collected before the "after" sample, which made the convert-path case measure ~0 on a version that demonstrably allocated 64 MB.

`DECLARED_SIZE` is 64 MB rather than the ~4GB the advisory describes so a RED run degrades a CI box instead of killing it. Against a 121-byte archive that is still over 500,000:1.

## Verification

- Full suite: **155 files / 2453 tests / 0 skipped** locally
- `npm audit --omit=dev`: **15 → 13** advisories; both DIRECT high-severity entries resolved
- `tsc --noEmit` clean with `@types/adm-zip` removed (0.6.0's bundled types suffice; 0.5.16 shipped none, so this drop is only valid at 0.6.0)

Remaining production advisories are transitive and tracked separately.