### PR TITLE
feat(cli): differential field-coverage chokepoint for FHIR import

### DIFF
--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -1,0 +1,317 @@
+/**
+ * cascade sources coverage <pod-dir>
+ *
+ * What a pod's retained raw sources say that the pod's records do not.
+ *
+ * This is the runtime twin of the conformance gate in
+ * `tests/fhir-field-coverage.test.ts`: the same differential computation
+ * (convert, convert again without one element, compare), pointed at a real
+ * pod's `sources/` rather than at fixtures. Fixtures prove the converters
+ * behave as the manifests say; this verb answers the question a person actually
+ * has, which is "what did MY import leave behind".
+ *
+ * THE OUTPUT IS PHI-FREE BY CONSTRUCTION
+ * --------------------------------------
+ * Element paths and counts. `Encounter.reasonCode: 41` says forty-one
+ * encounters stated a reason and none of them reached the pod; it does not say
+ * what any reason was. Nothing read out of the sources is ever printed, which is
+ * what makes the report shareable: a design partner can send the SHAPE of what
+ * their EHR populates without sending a value out of their pod. That is the
+ * corpus-growth path — a new path in someone's report becomes a synthetic
+ * fixture here.
+ *
+ * NOTHING REPORTED HERE IS LOST
+ * -----------------------------
+ * The raw bundles are retained. Every field below is recoverable by re-import
+ * once the converter emits it; no new pull from the EHR is needed. The summary
+ * line says so, because a number without that sentence reads as data destroyed.
+ *
+ * Exit codes (docs/exit-codes.md):
+ *   0 — the sources were read and the report below is of their actual contents
+ *   1 — usage error (no such directory, or the pod retains no sources/)
+ *   2 — the pod, or a file inside it, could NOT be read
+ *
+ * NOTE ON COVERAGE BY THE READ-HONESTY BATTERY: `tests/pod-read-conformance.test.ts`
+ * enumerates the subcommands of `pod`, so this top-level verb inherits nothing
+ * from it. The three exit codes are honoured here by hand, and the gap is worth
+ * closing rather than working around.
+ */
+
+import type { Command } from 'commander';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+  printResult,
+  printError,
+  printErrorDetail,
+  printVerbose,
+  printWarning,
+  type OutputOptions,
+} from '../lib/output.js';
+import {
+  openPod,
+  resolvePodDir,
+  isDirectory,
+  PodReadLedger,
+  PodUnreadableError,
+  unreadableFilesMessage,
+  type PodReader,
+} from '../lib/pod-read.js';
+import {
+  CoverageAccumulator,
+  coverageDisclosure,
+  type CoverageReport,
+} from '../lib/fhir-converter/field-coverage/analyze.js';
+
+/** The pod-relative directory a pod retains its raw imported sources in. */
+const SOURCES_DIR = 'sources';
+
+/** Extensions the scan attempts to parse as FHIR JSON. */
+const JSON_EXTENSIONS = new Set(['.json', '.ndjson']);
+
+async function listSourceFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const walk = async (current: string): Promise<void> => {
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (JSON_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) out.push(full);
+    }
+  };
+  await walk(dir);
+  out.sort();
+  return out;
+}
+
+/**
+ * Every FHIR resource one source document holds.
+ *
+ * Accepts a Bundle, a bare resource, or NDJSON (one resource per line), because
+ * all three are shapes a retained pull actually takes.
+ */
+function resourcesIn(text: string): unknown[] {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return [];
+  const fromValue = (value: unknown): unknown[] => {
+    const obj = value as { resourceType?: string; entry?: Array<{ resource?: unknown }> };
+    if (obj?.resourceType === 'Bundle' && Array.isArray(obj.entry)) {
+      return obj.entry.map((e) => e?.resource).filter((r): r is object => Boolean(r));
+    }
+    return obj?.resourceType ? [value] : [];
+  };
+  try {
+    return fromValue(JSON.parse(trimmed));
+  } catch {
+    // NDJSON: one JSON document per line.
+    const out: unknown[] = [];
+    for (const line of trimmed.split('\n')) {
+      const l = line.trim();
+      if (!l) continue;
+      try {
+        out.push(...fromValue(JSON.parse(l)));
+      } catch {
+        return [];
+      }
+    }
+    return out;
+  }
+}
+
+/** A stable key for de-duplicating the same resource across overlapping pulls. */
+function dedupeKey(resource: unknown, file: string, ordinal: number): string {
+  const r = resource as { resourceType?: string; id?: string };
+  // Without an id there is nothing to deduplicate ON, so the resource is kept as
+  // its own: collapsing id-less resources by content would hide exactly the
+  // repetition this report is meant to count.
+  return r?.id ? `${r.resourceType}/${r.id}` : `${file}#${ordinal}`;
+}
+
+interface ScanResult {
+  report: CoverageReport;
+  filesRead: number;
+  resourcesSeen: number;
+  resourcesUnique: number;
+  unparseableFiles: string[];
+}
+
+async function scanSources(reader: PodReader, sourcesDir: string, ledger: PodReadLedger): Promise<ScanResult> {
+  const files = await listSourceFiles(sourcesDir);
+  const accumulator = new CoverageAccumulator();
+  const seen = new Set<string>();
+  const unparseableFiles: string[] = [];
+  let filesRead = 0;
+  let resourcesSeen = 0;
+
+  for (const file of files) {
+    ledger.attempt();
+    const text = reader.readText(file);
+    if (!text.ok) {
+      ledger.record(text.failure);
+      continue;
+    }
+    filesRead++;
+    const resources = resourcesIn(text.value);
+    if (resources.length === 0) {
+      // Not a fatal read failure: `sources/` legitimately holds JSON that is not
+      // FHIR (a pull's own metadata, for one). Named, not silently skipped.
+      unparseableFiles.push(reader.relativePath(file));
+      continue;
+    }
+    for (let i = 0; i < resources.length; i++) {
+      resourcesSeen++;
+      const key = dedupeKey(resources[i], reader.relativePath(file), i);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      accumulator.add(resources[i]);
+    }
+  }
+
+  return {
+    report: accumulator.report(),
+    filesRead,
+    resourcesSeen,
+    resourcesUnique: seen.size,
+    unparseableFiles,
+  };
+}
+
+function statusLabel(status: string, backlog: string | undefined): string {
+  if (status === 'pending') return `pending ${backlog ?? ''}`.trim();
+  return status;
+}
+
+function renderText(podDir: string, scan: ScanResult): string {
+  const { report } = scan;
+  const lines: string[] = [];
+  lines.push(`Field coverage of retained sources: ${podDir}`);
+  lines.push('');
+  lines.push(
+    `  Files read:        ${scan.filesRead}` +
+      (scan.unparseableFiles.length ? ` (${scan.unparseableFiles.length} not FHIR JSON)` : ''),
+  );
+  lines.push(`  Resources:         ${scan.resourcesUnique} unique of ${scan.resourcesSeen} read`);
+  lines.push(
+    `  Populated fields:  ${report.totals.populatedFields} — ` +
+      `imported ${report.totals.emittedFields}, not imported ${report.totals.droppedFields}`,
+  );
+  lines.push(
+    `  Not imported:      ${report.totals.acknowledged} acknowledged, ` +
+      `${report.totals.pending} pending a fix, ${report.totals.unaccounted} unaccounted`,
+  );
+  if (report.resourcesTypeExcluded > 0) {
+    lines.push(`  Excluded types:    ${report.resourcesTypeExcluded} resources`);
+  }
+  lines.push('');
+  lines.push(`  ${coverageDisclosure(report)}`);
+
+  for (const [resourceType, summary] of Object.entries(report.byType)) {
+    if (summary.droppedPaths.length === 0) continue;
+    lines.push('');
+    lines.push(`${resourceType} (${summary.resourcesScanned} resources)`);
+    for (const tally of summary.droppedPaths) {
+      lines.push(
+        `  ${String(tally.count).padStart(6)}  ${tally.path.padEnd(52)}  ${statusLabel(tally.status, tally.backlog)}`,
+      );
+    }
+    if (summary.untestablePaths.length > 0) {
+      lines.push(`          not measurable: ${summary.untestablePaths.join(', ')}`);
+    }
+  }
+
+  if (report.totals.unaccounted > 0) {
+    lines.push('');
+    lines.push(
+      '  Paths marked "unaccounted" are populated, not imported, and on no converter\'s drop manifest.',
+    );
+    lines.push(
+      '  They are the report worth sending back: each one becomes a fixture and a manifest entry.',
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function registerSourcesCommand(program: Command): void {
+  const sources = program
+    .command('sources')
+    .description('Inspect the raw source documents a pod retained at import');
+
+  sources
+    .command('coverage')
+    .description('Report which populated source fields the import did not carry into the pod')
+    .argument('<pod-dir>', 'Path to the Cascade Pod')
+    .action(async (podDir: string) => {
+      const globalOpts = program.opts() as OutputOptions;
+      const absDir = resolvePodDir(podDir);
+
+      if (!(await isDirectory(absDir))) {
+        printError(`Pod directory not found: ${absDir}`, globalOpts);
+        process.exitCode = 1;
+        return;
+      }
+
+      const sourcesDir = path.join(absDir, SOURCES_DIR);
+      if (!(await isDirectory(sourcesDir))) {
+        printError(
+          `This pod retains no ${SOURCES_DIR}/ directory, so there is nothing to compare its records against. ` +
+            'Coverage is measured against the raw documents an import kept, not against the records it wrote.',
+          globalOpts,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      printVerbose(`Scanning retained sources in: ${sourcesDir}`, globalOpts);
+
+      // Open the pod ONCE. `sources/` is inside the encrypted set, so a sealed
+      // pod this invocation cannot unlock stops here rather than reporting a
+      // pod full of retained bundles as one holding none.
+      let reader: PodReader;
+      try {
+        reader = await openPod(absDir);
+      } catch (err: unknown) {
+        if (err instanceof PodUnreadableError) {
+          printErrorDetail(
+            err.message,
+            { pod: podDir, encrypted: true, readable: false, reason: err.reason },
+            globalOpts,
+          );
+        } else {
+          printError(err instanceof Error ? err.message : String(err), globalOpts);
+        }
+        process.exitCode = 2;
+        return;
+      }
+
+      const ledger = new PodReadLedger();
+      const scan = await scanSources(reader, sourcesDir, ledger);
+
+      if (ledger.hasFatal) {
+        printError(unreadableFilesMessage(absDir, ledger.fatal, ledger.attempted), globalOpts);
+        process.exitCode = 2;
+        return;
+      }
+      for (const file of scan.unparseableFiles) {
+        printWarning(`Not FHIR JSON, so not measured: ${file}`, globalOpts);
+      }
+
+      if (globalOpts.json) {
+        printResult(
+          {
+            pod: absDir,
+            filesRead: scan.filesRead,
+            resourcesRead: scan.resourcesSeen,
+            resourcesUnique: scan.resourcesUnique,
+            notFhirJson: scan.unparseableFiles,
+            disclosure: coverageDisclosure(scan.report),
+            ...scan.report,
+          },
+          globalOpts,
+        );
+      } else {
+        printResult(renderText(absDir, scan), globalOpts);
+      }
+    });
+}

--- a/src/lib/fhir-converter/field-coverage/analyze.ts
+++ b/src/lib/fhir-converter/field-coverage/analyze.ts
@@ -1,0 +1,342 @@
+/**
+ * The differential coverage computation, shared by the conformance test and by
+ * `cascade sources coverage`.
+ *
+ * ONE experiment, run per populated element path:
+ *
+ *   1. Convert the resource.
+ *   2. Convert a copy with exactly that element deleted.
+ *   3. Compare the two outputs.
+ *
+ * Identical output means the element reached nothing: not a triple, not an IRI,
+ * not a warning-free difference of any kind. That is a DROP, whatever the
+ * converter's source code appears to do with the field.
+ *
+ * WHAT "IDENTICAL" MEANS, AND WHY THE SUBJECT IRI IS PART OF IT
+ * ------------------------------------------------------------
+ * Records are compared as a multiset of predicate + object, not as raw quads,
+ * because on the content-keyed types (Condition, AllergyIntolerance, lab
+ * Observation, Immunization, Patient) deleting a field can re-mint the subject
+ * IRI and shift every quad's subject with it. Comparing raw quads would then
+ * report "everything changed" for a field that changed nothing else.
+ *
+ * The subject SET is compared separately and a change in it counts as EMITTED,
+ * because a field that moves the IRI is a field that participates in identity:
+ * it decides which records merge, which is a stronger form of reaching the pod
+ * than a triple is. This is the join with `clinical-identity.test.ts`, which
+ * holds the next link — that every serialized field is in the identity key or
+ * excluded in writing. Source -> serialized is proven here; serialized ->
+ * identity is proven there; a field cannot silently skip a layer.
+ */
+
+import type { Quad } from 'n3';
+
+import { convertFhirResourceToQuads } from '../fhir-to-cascade.js';
+import { EXCLUDED_TYPES } from '../converters-passthrough.js';
+import { childFieldPaths, enumerateFieldPaths, topLevelFieldPaths, withoutPath } from './paths.js';
+import type { FieldCoverageVerdict, FieldDropEntry } from './types.js';
+import { lookupFieldDrop } from './manifests/index.js';
+
+/**
+ * A conversion's content, independent of which subject IRI carries it.
+ *
+ * Object terms are compared with their term type, datatype and language, so a
+ * literal "5" and a reference to `.../5` are two different outputs, and an
+ * `xsd:dateTime` is not equal to the same characters as a plain string.
+ */
+function contentSignature(quads: readonly Quad[]): string {
+  const triples = quads.map((q) => {
+    const o = q.object;
+    const datatype = 'datatype' in o && o.datatype ? o.datatype.value : '';
+    const language = 'language' in o && o.language ? o.language : '';
+    return [q.predicate.value, o.termType, o.value, datatype, language].join('\u0000');
+  });
+  triples.sort();
+  return triples.join('\u0001');
+}
+
+/** The set of subject IRIs a conversion minted. */
+function subjectSignature(quads: readonly Quad[]): string {
+  return [...new Set(quads.map((q) => q.subject.value))].sort().join('\u0001');
+}
+
+interface Conversion {
+  content: string;
+  subjects: string;
+}
+
+function convertOnce(resource: unknown): Conversion | undefined {
+  const result = convertFhirResourceToQuads(structuredClone(resource));
+  if (!result) return undefined;
+  return { content: contentSignature(result._quads), subjects: subjectSignature(result._quads) };
+}
+
+/** What the analysis found for one resource. */
+export interface ResourceCoverage {
+  resourceType: string;
+  /** Populated element paths whose deletion changes the converted output. */
+  emitted: string[];
+  /** Populated element paths whose deletion changes nothing. */
+  dropped: string[];
+  /**
+   * Paths that could not be tested (the deletion did not resolve, or conversion
+   * returned nothing). Never silently folded into `dropped`: an untestable path
+   * reported as a drop is a live field described as lost.
+   */
+  untestable: string[];
+  /** True for a resource type excluded wholesale (see EXCLUDED_TYPES). */
+  typeExcluded: boolean;
+}
+
+/**
+ * Run the differential over the populated elements of one resource.
+ *
+ * The walk descends only into elements that PROVED emitted: a dropped element
+ * takes its whole subtree with it (see `paths.ts` on why that is sound), so one
+ * omission is reported once, at the level a person would name it.
+ *
+ * Cost is one conversion per visited path plus one baseline. Conversions are
+ * pure and local, so this is fast enough to run over a whole pod's retained
+ * sources, and no result is cached across resources: emission can depend on a
+ * VALUE (a coding system that maps, a status that is recognised), so collapsing
+ * two resources of the same shape into one measurement would report a field as
+ * kept on records where it was not.
+ */
+export function analyzeResourceCoverage(resource: unknown): ResourceCoverage {
+  const resourceType =
+    typeof (resource as { resourceType?: unknown })?.resourceType === 'string'
+      ? (resource as { resourceType: string }).resourceType
+      : 'Unknown';
+
+  if (EXCLUDED_TYPES.has(resourceType)) {
+    return { resourceType, emitted: [], dropped: [], untestable: [], typeExcluded: true };
+  }
+
+  const baseline = convertOnce(resource);
+  if (!baseline) {
+    return {
+      resourceType,
+      emitted: [],
+      dropped: [],
+      untestable: enumerateFieldPaths(resource),
+      typeExcluded: false,
+    };
+  }
+
+  const emitted: string[] = [];
+  const dropped: string[] = [];
+  const untestable: string[] = [];
+
+  const queue = [...topLevelFieldPaths(resource)];
+  while (queue.length > 0) {
+    const path = queue.shift()!;
+    const reduced = withoutPath(resource, path);
+    if (reduced === undefined) {
+      untestable.push(path);
+      continue;
+    }
+    const after = convertOnce(reduced);
+    if (!after) {
+      untestable.push(path);
+      continue;
+    }
+    if (after.content === baseline.content && after.subjects === baseline.subjects) {
+      // Dropped: the subtree below it is dropped with it, and saying so once is
+      // the whole difference between a manifest and a transcript.
+      dropped.push(path);
+      continue;
+    }
+    emitted.push(path);
+    queue.push(...childFieldPaths(resource, path));
+  }
+
+  return { resourceType, emitted, dropped, untestable, typeExcluded: false };
+}
+
+/** Per-path verdicts with the manifest entry that covers each drop, if any. */
+export function verdicts(coverage: ResourceCoverage): FieldCoverageVerdict[] {
+  const out: FieldCoverageVerdict[] = [];
+  for (const path of coverage.emitted) {
+    out.push({ path, emitted: true, entry: lookupFieldDrop(coverage.resourceType, path) });
+  }
+  for (const path of coverage.dropped) {
+    out.push({ path, emitted: false, entry: lookupFieldDrop(coverage.resourceType, path) });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Corpus aggregation — the runtime twin
+// ---------------------------------------------------------------------------
+
+/** One dropped element path, with how often it was populated and its status. */
+export interface DroppedPathTally {
+  path: string;
+  /** How many resources of this type populated the path but did not emit it. */
+  count: number;
+  status: 'acknowledged' | 'pending' | 'unaccounted';
+  backlog?: string;
+  reason?: string;
+}
+
+/** What a corpus scan found, per resource type. Paths and counts only. */
+export interface TypeCoverageSummary {
+  resourcesScanned: number;
+  populatedFields: number;
+  emittedFields: number;
+  droppedFields: number;
+  droppedPaths: DroppedPathTally[];
+  untestablePaths: string[];
+}
+
+/** The whole-corpus report. Contains no values from the source, by construction. */
+export interface CoverageReport {
+  resourcesScanned: number;
+  /** Resources whose whole type is excluded from conversion (EXCLUDED_TYPES). */
+  resourcesTypeExcluded: number;
+  totals: {
+    populatedFields: number;
+    emittedFields: number;
+    droppedFields: number;
+    acknowledged: number;
+    pending: number;
+    unaccounted: number;
+  };
+  byType: Record<string, TypeCoverageSummary>;
+}
+
+function statusOf(entry: FieldDropEntry | undefined): DroppedPathTally['status'] {
+  if (!entry) return 'unaccounted';
+  return entry.disposition;
+}
+
+/**
+ * Accumulates coverage across many resources into a report of PATHS AND COUNTS.
+ *
+ * Nothing from the source's content enters this structure: element paths are
+ * schema, counts are arithmetic. That is what makes the report shareable — a
+ * design partner can send the shape of what their EHR populates without sending
+ * a single value out of their pod.
+ */
+export class CoverageAccumulator {
+  private scanned = 0;
+  private typeExcluded = 0;
+  private readonly types = new Map<
+    string,
+    {
+      resources: number;
+      populated: number;
+      emitted: number;
+      dropped: number;
+      paths: Map<string, { count: number; entry?: FieldDropEntry }>;
+      untestable: Set<string>;
+    }
+  >();
+
+  add(resource: unknown): void {
+    const coverage = analyzeResourceCoverage(resource);
+    this.scanned++;
+    if (coverage.typeExcluded) {
+      this.typeExcluded++;
+      return;
+    }
+    let bucket = this.types.get(coverage.resourceType);
+    if (!bucket) {
+      bucket = {
+        resources: 0,
+        populated: 0,
+        emitted: 0,
+        dropped: 0,
+        paths: new Map(),
+        untestable: new Set(),
+      };
+      this.types.set(coverage.resourceType, bucket);
+    }
+    bucket.resources++;
+    bucket.populated += coverage.emitted.length + coverage.dropped.length;
+    bucket.emitted += coverage.emitted.length;
+    bucket.dropped += coverage.dropped.length;
+    for (const path of coverage.dropped) {
+      const existing = bucket.paths.get(path);
+      if (existing) existing.count++;
+      else bucket.paths.set(path, { count: 1, entry: lookupFieldDrop(coverage.resourceType, path) });
+    }
+    for (const path of coverage.untestable) bucket.untestable.add(path);
+  }
+
+  report(): CoverageReport {
+    const byType: Record<string, TypeCoverageSummary> = {};
+    const totals = {
+      populatedFields: 0,
+      emittedFields: 0,
+      droppedFields: 0,
+      acknowledged: 0,
+      pending: 0,
+      unaccounted: 0,
+    };
+
+    for (const [resourceType, bucket] of [...this.types.entries()].sort((a, b) =>
+      a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0,
+    )) {
+      const droppedPaths: DroppedPathTally[] = [...bucket.paths.entries()]
+        .map(([path, { count, entry }]) => ({
+          path,
+          count,
+          status: statusOf(entry),
+          backlog: entry?.backlog,
+          reason: entry?.reason,
+        }))
+        .sort((a, b) => b.count - a.count || (a.path < b.path ? -1 : 1));
+
+      for (const tally of droppedPaths) totals[tally.status] += tally.count;
+
+      totals.populatedFields += bucket.populated;
+      totals.emittedFields += bucket.emitted;
+      totals.droppedFields += bucket.dropped;
+
+      byType[resourceType] = {
+        resourcesScanned: bucket.resources,
+        populatedFields: bucket.populated,
+        emittedFields: bucket.emitted,
+        droppedFields: bucket.dropped,
+        droppedPaths,
+        untestablePaths: [...bucket.untestable].sort(),
+      };
+    }
+
+    return {
+      resourcesScanned: this.scanned,
+      resourcesTypeExcluded: this.typeExcluded,
+      totals,
+      byType,
+    };
+  }
+}
+
+/** Convenience: a report over an iterable of resources. */
+export function analyzeCorpus(resources: Iterable<unknown>): CoverageReport {
+  const acc = new CoverageAccumulator();
+  for (const resource of resources) acc.add(resource);
+  return acc.report();
+}
+
+/**
+ * The one-line disclosure the import manifest carries.
+ *
+ * Deliberately states where the unimported data still IS. Nothing is lost when
+ * the raw bundle is retained: every field below is recoverable by re-import once
+ * the converter widens, and a user who is told a number but not that fact reads
+ * it as data destroyed.
+ */
+export function coverageDisclosure(report: CoverageReport): string {
+  const { droppedFields, unaccounted } = report.totals;
+  if (droppedFields === 0) return 'Every populated source field was imported.';
+  const unaccountedNote =
+    unaccounted > 0 ? ` ${unaccounted} of them are not on any converter's drop manifest.` : '';
+  return (
+    `${droppedFields} populated field${droppedFields === 1 ? '' : 's'} across ` +
+    `${report.resourcesScanned} resource${report.resourcesScanned === 1 ? '' : 's'} ` +
+    `${droppedFields === 1 ? 'was' : 'were'} not imported; the raw source is retained under sources/ ` +
+    `and a re-import recovers them once the converter emits them.${unaccountedNote}`
+  );
+}

--- a/src/lib/fhir-converter/field-coverage/manifests/allergyintolerance.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/allergyintolerance.ts
@@ -1,0 +1,92 @@
+import type { FieldDropManifest } from '../types.js';
+
+/** What `convertAllergyIntolerance` does not emit. */
+export const ALLERGY_INTOLERANCE_DROPS: FieldDropManifest = {
+  resourceType: 'AllergyIntolerance',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/allergyintolerance.json.',
+  drops: {
+    'AllergyIntolerance.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'AllergyIntolerance.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The allergy record identifier in the issuing system, and the join key for the same allergy arriving over two transports.',
+    },
+    'AllergyIntolerance.clinicalStatus.text': {
+      disposition: 'acknowledged',
+      reason:
+        'The coded clinical status is what is read, and it is emitted. The text is not consulted at all, so an allergy stating its status ONLY as text still arrives without one — mapping free text onto a status code set would be a guess, and the vendor output this was measured against always states the coding.',
+    },
+    'AllergyIntolerance.verificationStatus': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'confirmed, unconfirmed, refuted or entered-in-error. A refuted allergy presented as confirmed narrows treatment for no reason.',
+    },
+    'AllergyIntolerance.type': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Allergy versus intolerance — an immune reaction and a side effect are different clinical facts with different consequences.',
+    },
+    'AllergyIntolerance.criticality': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only when no reaction severity is stated; with a reaction severity present that value wins. The mapping is deliberate (low/high/unable-to-assess to mild/severe/moderate) and stated once.',
+    },
+    'AllergyIntolerance.patient': {
+      disposition: 'acknowledged',
+      reason: "A pod holds one person's records, so the patient link is the pod itself.",
+    },
+    'AllergyIntolerance.recordedDate': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'When the allergy was recorded. health:onsetDate is emitted only from onsetDateTime, which allergy records rarely carry, so most allergies land in the pod with no date at all.',
+    },
+    'AllergyIntolerance.lastOccurrence': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'When the patient last reacted. It is how a reader judges whether an allergy is current.',
+    },
+    'AllergyIntolerance.code.coding': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The coded allergen (SNOMED or RxNorm). Only the display text is emitted, so allergy checking against a coded medication list cannot be done in the pod.',
+    },
+    'AllergyIntolerance.recorder.reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Practitioner resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName.',
+    },
+    'AllergyIntolerance.reaction[0].substance': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The specific substance that produced the reaction, which can be narrower than the allergy code (a single drug within a class).',
+    },
+    'AllergyIntolerance.reaction[0].severity': {
+      disposition: 'acknowledged',
+      reason:
+        'Redundant alternative in this shape: health:allergySeverity is taken from the reaction severity when stated and mapped from criticality otherwise, and here both express the same level. Deleting either alone leaves the value unchanged.',
+    },
+    'AllergyIntolerance.reaction[0].onset': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason: 'When the reaction happened, which is what dates an allergy record in practice.',
+    },
+    'AllergyIntolerance.reaction[0].description': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The free-text account of what happened. health:reaction carries the coded manifestations only, which is the difference between "anaphylaxis" and what a reader can act on.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/condition.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/condition.ts
@@ -1,0 +1,56 @@
+import type { FieldDropManifest } from '../types.js';
+
+/** What `convertCondition` does not emit. */
+export const CONDITION_DROPS: FieldDropManifest = {
+  resourceType: 'Condition',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/condition.json; matches the field census taken over 46 Epic R4 Conditions.',
+  drops: {
+    'Condition.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'Condition.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        "The problem's identifier in the issuing system, and the join key for the same problem arriving over two transports.",
+    },
+    'Condition.clinicalStatus': {
+      disposition: 'acknowledged',
+      reason:
+        "Redundant with the converter's default: health:status is emitted from the stated clinical status, but an ABSENT clinicalStatus is emitted as 'active'. Deleting a stated 'active' therefore changes nothing, while a stated 'resolved' does move the output. The defaulting is the part worth knowing: a source that says nothing is reported as active.",
+    },
+    'Condition.verificationStatus.text': {
+      disposition: 'acknowledged',
+      reason:
+        'The coded verification status is what is read, and it is emitted. The text is not consulted, so a problem stating confirmed-or-refuted ONLY as text still arrives without it; mapping free text onto that code set would be a guess.',
+    },
+    'Condition.severity': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason: 'Mild, moderate or severe. It changes what the same diagnosis means.',
+    },
+    'Condition.subject': {
+      disposition: 'acknowledged',
+      reason: "A pod holds one person's records, so the subject link is the pod itself.",
+    },
+    'Condition.recordedDate': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'When the problem was written down, as distinct from when it began. A problem list entry with no onset has nothing to place it in time without this.',
+    },
+    'Condition.recorder.reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Practitioner resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName.',
+    },
+    'Condition.category[0].text': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only when the category states no coding. With a coding present the code is emitted as health:conditionCategory and the text restates it.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/coverage.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/coverage.ts
@@ -1,0 +1,66 @@
+import type { FieldDropManifest } from '../types.js';
+
+/** What `convertCoverage` does not emit. */
+export const COVERAGE_DROPS: FieldDropManifest = {
+  resourceType: 'Coverage',
+  provenance: 'Differential run over test-fixtures/field-coverage/coverage.json.',
+  drops: {
+    'Coverage.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'Coverage.identifier': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only as a fallback for coverage:memberId when the resource states no subscriberId. With a subscriberId present that value is the member id.',
+    },
+    'Coverage.status': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'active, cancelled or draft. A cancelled policy that reads as active is a plan a person may believe still covers them.',
+    },
+    'Coverage.subscriber': {
+      disposition: 'acknowledged',
+      reason:
+        "A pod holds one person's records. Who the policy holder is relative to that person is carried by coverage:subscriberRelationship, which is emitted.",
+    },
+    'Coverage.beneficiary': {
+      disposition: 'acknowledged',
+      reason: "A pod holds one person's records, so the beneficiary link is the pod itself.",
+    },
+    'Coverage.order': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Which policy pays first. With two plans in a pod and no order, nothing says which is primary.',
+    },
+    'Coverage.network': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The network the plan pays in-network rates for, which is what decides whether a given clinic is covered.',
+    },
+    'Coverage.type.text': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only when the type states no coding. With a coding present the code is emitted as coverage:coverageType and the text restates it.',
+    },
+    'Coverage.relationship.coding': {
+      disposition: 'acknowledged',
+      reason:
+        "Redundant with the converter's default: coverage:subscriberRelationship takes the coded value, and an absent relationship defaults to 'self'. Deleting a stated 'self' therefore changes nothing, while any other stated relationship does move the output.",
+    },
+    'Coverage.relationship.text': {
+      disposition: 'acknowledged',
+      reason:
+        'The coded relationship is what is read; the text restates it and is not consulted.',
+    },
+    'Coverage.payor[0].reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Organization resources are not imported as records, so the reference would dangle. The display is emitted as coverage:providerName.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/diagnosticreport.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/diagnosticreport.ts
@@ -1,0 +1,69 @@
+import type { FieldDropManifest } from '../types.js';
+
+/**
+ * What `convertLaboratoryReport` does not emit.
+ *
+ * `presentedForm` is the report as the lab rendered it. The pod describes
+ * reports whose content it cannot show.
+ */
+export const DIAGNOSTIC_REPORT_DROPS: FieldDropManifest = {
+  resourceType: 'DiagnosticReport',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/diagnosticreport.json; matches the field census taken over 62 Epic R4 DiagnosticReports.',
+  drops: {
+    'DiagnosticReport.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'DiagnosticReport.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The accession number. The cross-transport join key for a report, and the reason one report pulled twice cannot be recognised as one report.',
+    },
+    'DiagnosticReport.subject': {
+      disposition: 'acknowledged',
+      reason: "A pod holds one person's records, so the subject link is the pod itself.",
+    },
+    'DiagnosticReport.resultsInterpreter': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The clinician who signed the interpretation, which is a different person from the performing laboratory that clinical:providerName currently carries.',
+    },
+    'DiagnosticReport.specimen': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason: 'What was sampled. Same gap as Observation.specimen, one level up.',
+    },
+    'DiagnosticReport.conclusion': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The narrative interpretation of the panel — the sentence a clinician wrote about what the numbers mean.',
+    },
+    'DiagnosticReport.conclusionCode': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The coded finding the report concludes. It is the machine-readable half of the conclusion and the part a query can act on.',
+    },
+    'DiagnosticReport.presentedForm': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The rendered report itself (usually a PDF). Keeping it needs a blob-storage decision rather than a converter line, which is why this is sequenced separately from the other drops here.',
+    },
+    'DiagnosticReport.category[0].text': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only when the category states no coding. With a coding present the code is emitted as clinical:reportCategory and the text restates it.',
+    },
+    'DiagnosticReport.performer[0].reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Practitioner and Organization resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/documentreference.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/documentreference.ts
@@ -1,0 +1,89 @@
+import type { FieldDropManifest } from '../types.js';
+
+/**
+ * What `convertClinicalDocument` does not emit.
+ *
+ * `docStatus` is emitted now, so an amended note is no longer byte-identical to
+ * a final one. `status` still is not: a superseded or retracted document reads
+ * as a live one.
+ */
+export const DOCUMENT_REFERENCE_DROPS: FieldDropManifest = {
+  resourceType: 'DocumentReference',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/documentreference.json; matches the field census taken over 57 Epic R4 DocumentReferences.',
+  drops: {
+    'DocumentReference.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'DocumentReference.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The document\'s own identifier in the issuing system, and the key that would let the same note arriving over two transports be recognised as one note.',
+    },
+    'DocumentReference.status': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'current, superseded and entered-in-error import identically, so a retracted document reads as a live one.',
+    },
+    'DocumentReference.category': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The class of document (clinical note, imaging report, discharge summary). It is what a document list is grouped by.',
+    },
+    'DocumentReference.subject': {
+      disposition: 'acknowledged',
+      reason:
+        "A pod holds one person's records, so the subject link is the pod itself.",
+    },
+    'DocumentReference.author': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Who wrote the note. The provenance recovery pass reads performer/requester/recorder/asserter/serviceProvider and DocumentReference states none of them, so the author is lost on every document.',
+    },
+    'DocumentReference.authenticator': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Who attested the note. Distinct from the author on any note signed by a supervising clinician.',
+    },
+    'DocumentReference.custodian': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The organization holding the document, which is this record\'s source EHR. provenance.ts does not read `custodian`, so a bundle whose only organization signal is this field derives no source label.',
+    },
+    'DocumentReference.description': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The one-line description of the document, which is where a source commonly states what an amendment changed.',
+    },
+    'DocumentReference.type.coding': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The LOINC document-type code. Only the display text reaches the pod, so documents cannot be selected by code.',
+    },
+    'DocumentReference.context.period': {
+      disposition: 'acknowledged',
+      reason:
+        'The service period the document covers. The document date is emitted and the encounter edge carries the visit interval, so this restates facts already in the graph.',
+    },
+    'DocumentReference.context.facilityType': {
+      disposition: 'acknowledged',
+      reason:
+        'The care setting. Duplicated by the linked encounter\'s own type, which is where a reader looks for it.',
+    },
+    'DocumentReference.content[0].format': {
+      disposition: 'acknowledged',
+      reason:
+        'An IHE format code describing how to render the attachment. clinical:contentType is emitted and is what a reader needs to open it.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/encounter.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/encounter.ts
@@ -1,0 +1,133 @@
+import type { FieldDropManifest } from '../types.js';
+
+/**
+ * What `convertEncounter` does not emit.
+ *
+ * Seeded from the differential run over `test-fixtures/field-coverage/encounter.json`,
+ * which reproduces the shape measured across 54 Epic R4 Encounters.
+ *
+ * The clinic and the role-correct provider now survive. What still does not: the
+ * reason, the contact serial number, the admission detail, every type coding
+ * past the first, and every participant except the one that wins the role
+ * ranking — including that participant's own specialty.
+ */
+export const ENCOUNTER_DROPS: FieldDropManifest = {
+  resourceType: 'Encounter',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/encounter.json; matches the field census taken over a 54-encounter Epic R4 pull.',
+  drops: {
+    'Encounter.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient. Cascade states its own provenance and keys records on sourceRecordId.",
+    },
+    'Encounter.identifier': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'The visit contact serial number. Read for identity minting and never written as a fact, which is why the same visit arriving over FHIR and over C-CDA cannot be recognised as one visit: the join key sits on one side of the pair only.',
+    },
+    'Encounter.serviceType': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason: 'The specialty the visit was booked under. No clinical: term carries it yet.',
+    },
+    'Encounter.subject': {
+      disposition: 'acknowledged',
+      reason:
+        "A pod holds one person's records, so the subject link is the pod itself. A reference to a Patient resource the pod does not hold would dangle.",
+    },
+    'Encounter.length': {
+      disposition: 'acknowledged',
+      reason:
+        'Duration is derivable from the emitted encounterStart and encounterEnd. Storing it as a second fact invites the two to disagree.',
+    },
+    'Encounter.reasonCode': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Why the visit happened, which is the single most orienting fact on a visit card. Needs vocabulary: check US Core and IPS Encounter before authoring a clinical: term.',
+    },
+    'Encounter.hospitalization': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Admit source and discharge disposition. Present on inpatient encounters only, and the part of an admission a reader most wants. Needs vocabulary.',
+    },
+    'Encounter.location[1]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Only the first named location becomes clinical:facilityName. An encounter that moves between units states each of them, and every location after the first reaches nothing.',
+    },
+    'Encounter.location[0].status': {
+      disposition: 'acknowledged',
+      reason:
+        "Whether the patient was planned for, present at, or finished with that location. It describes movement WITHIN a stay, which needs vocabulary Cascade does not have; the encounter's own status is emitted.",
+    },
+    'Encounter.location[0].period': {
+      disposition: 'acknowledged',
+      reason:
+        "The interval the patient spent at that location. Same reasoning as location[0].status: intra-stay movement needs vocabulary, and the encounter's own period is emitted.",
+    },
+    'Encounter.class.system': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'clinical:encounterClass is emitted as a bare code, so a vendor category id and a v3-ActCode arrive indistinguishable. The system is what makes the code readable.',
+    },
+    'Encounter.class.display': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'The human label for the class ("Appointment", "Hospital Encounter"). Emitting the code without it leaves a bare id on screen.',
+    },
+    'Encounter.type[0].coding': {
+      disposition: 'acknowledged',
+      reason:
+        'Only a SNOMED coding on the first type is emitted (as clinical:snomedCode). A vendor-local code identifies a row in the issuing EHR and means nothing outside it, so it is not carried.',
+    },
+    'Encounter.type[1]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Only type[0] is read. An encounter routinely states several types (setting, service, admission kind) and all but the first are lost.',
+    },
+    'Encounter.type[2]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Same gap as type[1], and this slot is where a SNOMED-coded type commonly sits: the converter looks for SNOMED in type[0] only.',
+    },
+    'Encounter.type[3]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Same gap as type[1]. Epic routinely states four types on one encounter and three of them reach nothing.',
+    },
+    'Encounter.participant[0]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Provider selection now ranks participants by declared role, so this generic-role participant reaches nothing once a treating role is present. Exactly ONE participant becomes clinical:providerName; the rest of the care team, roles included, is still dropped.',
+    },
+    'Encounter.participant[1].extension': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'The specialty extension on the participant who WAS selected. The name reaches the pod and the specialty beside it does not, so "who treated me" arrives without "as what".',
+    },
+    'Encounter.participant[2]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Same gap as participant[0]. A visit with four participants keeps one name and loses three, roles and all.',
+    },
+    'Encounter.participant[3]': {
+      disposition: 'pending',
+      backlog: '3.254',
+      reason:
+        'Same gap as participant[0]. A participant losing the ranking is a participant the pod never mentions.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/immunization.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/immunization.ts
@@ -1,0 +1,84 @@
+import type { FieldDropManifest } from '../types.js';
+
+/** What `convertImmunization` does not emit. */
+export const IMMUNIZATION_DROPS: FieldDropManifest = {
+  resourceType: 'Immunization',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/immunization.json; matches the field census taken over the Epic R4 immunization set.',
+  drops: {
+    'Immunization.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'Immunization.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The registry or EHR identifier for the dose, and the join key for the same dose arriving from a state registry and from a clinic.',
+    },
+    'Immunization.status': {
+      disposition: 'acknowledged',
+      reason:
+        "Redundant with the converter's default: health:status is emitted, but an ABSENT status is emitted as 'completed', so deleting a 'completed' status changes nothing. A source stating not-done or entered-in-error does move the output — and a source stating nothing is reported as completed, which is the defaulting this entry exists to make visible.",
+    },
+    'Immunization.patient': {
+      disposition: 'acknowledged',
+      reason: "A pod holds one person's records, so the patient link is the pod itself.",
+    },
+    'Immunization.primarySource': {
+      disposition: 'acknowledged',
+      reason:
+        'Whether the record came from the administering source or from a report of it. Cascade records provenance on its own axes (cascade:dataProvenance, clinical:sourceEHR).',
+    },
+    'Immunization.expirationDate': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The lot expiry. The lot number is emitted, so the pod can say which lot was given but not whether it was in date — the pair is only useful together.',
+    },
+    'Immunization.protocolApplied': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Dose number within the series. Whether a two-dose series was completed is the question an immunization record is most often asked.',
+    },
+    'Immunization.location.reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Location resources are not imported as records, so the reference would dangle. The display is emitted as health:administeringLocation.',
+    },
+    'Immunization.manufacturer.reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Organization resources are not imported as records, so the reference would dangle. The display is emitted as health:manufacturer.',
+    },
+    'Immunization.site.coding': {
+      disposition: 'acknowledged',
+      reason:
+        'health:site carries the stated text, which is what a reader needs. The coded body site would need a coded-value term no consumer reads today.',
+    },
+    'Immunization.route.coding': {
+      disposition: 'acknowledged',
+      reason:
+        'health:route carries the stated text. Same reasoning as site.coding.',
+    },
+    'Immunization.doseQuantity.system': {
+      disposition: 'acknowledged',
+      reason:
+        'Names the code system for doseQuantity.code. Carrying it while the code itself is not stored would state a system for nothing.',
+    },
+    'Immunization.doseQuantity.code': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The UCUM unit code for the dose. health:doseQuantity carries value and display unit only, so doses cannot be compared without parsing prose.',
+    },
+    'Immunization.performer[0].function': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Whether the performer administered the dose or ordered it. health:administeringProvider is filled from performer[0] regardless, which is the same role-blind selection Encounter.participant has.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/index.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/index.ts
@@ -1,0 +1,53 @@
+/**
+ * The drop-manifest registry: every converter's written record of the fields it
+ * does not emit.
+ *
+ * A resource type with NO manifest here is not "clean" — it is unexamined, and
+ * the conformance test says so rather than passing it. Adding a type means
+ * authoring its fixture and its manifest together.
+ */
+
+import type { FieldDropEntry, FieldDropManifest } from '../types.js';
+
+import { ALLERGY_INTOLERANCE_DROPS } from './allergyintolerance.js';
+import { CONDITION_DROPS } from './condition.js';
+import { COVERAGE_DROPS } from './coverage.js';
+import { DIAGNOSTIC_REPORT_DROPS } from './diagnosticreport.js';
+import { DOCUMENT_REFERENCE_DROPS } from './documentreference.js';
+import { ENCOUNTER_DROPS } from './encounter.js';
+import { IMMUNIZATION_DROPS } from './immunization.js';
+import { MEDICATION_REQUEST_DROPS } from './medicationrequest.js';
+import { OBSERVATION_DROPS } from './observation.js';
+import { PATIENT_DROPS } from './patient.js';
+
+export const FIELD_DROP_MANIFESTS: readonly FieldDropManifest[] = [
+  ALLERGY_INTOLERANCE_DROPS,
+  CONDITION_DROPS,
+  COVERAGE_DROPS,
+  DIAGNOSTIC_REPORT_DROPS,
+  DOCUMENT_REFERENCE_DROPS,
+  ENCOUNTER_DROPS,
+  IMMUNIZATION_DROPS,
+  MEDICATION_REQUEST_DROPS,
+  OBSERVATION_DROPS,
+  PATIENT_DROPS,
+];
+
+const BY_TYPE = new Map<string, FieldDropManifest>(
+  FIELD_DROP_MANIFESTS.map((m) => [m.resourceType, m]),
+);
+
+/** The manifest for a resource type, or `undefined` if the type has none yet. */
+export function manifestFor(resourceType: string): FieldDropManifest | undefined {
+  return BY_TYPE.get(resourceType);
+}
+
+/** The drop entry covering one element path, if the converter declared one. */
+export function lookupFieldDrop(resourceType: string, path: string): FieldDropEntry | undefined {
+  return BY_TYPE.get(resourceType)?.drops[path];
+}
+
+/** Every resource type that has a drop manifest. */
+export function manifestedTypes(): string[] {
+  return [...BY_TYPE.keys()].sort();
+}

--- a/src/lib/fhir-converter/field-coverage/manifests/medicationrequest.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/medicationrequest.ts
@@ -1,0 +1,72 @@
+import type { FieldDropManifest } from '../types.js';
+
+/**
+ * What `convertMedicationStatement` does not emit for a MedicationRequest.
+ *
+ * The converter serves both MedicationStatement and MedicationRequest; the paths
+ * here are the ones a prescription carries.
+ */
+export const MEDICATION_REQUEST_DROPS: FieldDropManifest = {
+  resourceType: 'MedicationRequest',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/medicationrequest.json; matches the field census taken over 25 Epic R4 MedicationRequests.',
+  drops: {
+    'MedicationRequest.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'MedicationRequest.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The prescription number in the issuing system, and the key that would let one prescription arriving over two transports be recognised as one.',
+    },
+    'MedicationRequest.intent': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'order versus plan versus proposal. A drug a clinician considered and a drug a patient was actually prescribed import identically, and clinical:clinicalIntent is set from the RESOURCE TYPE rather than from this field.',
+    },
+    'MedicationRequest.category': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'inpatient, outpatient or community. It is how a medication list separates what a patient takes at home from what was given during an admission.',
+    },
+    'MedicationRequest.recorder': {
+      disposition: 'acknowledged',
+      reason:
+        'Redundant alternative: the provenance pass reads the first populated of performer, requester, recorder, asserter and serviceProvider. With a requester present, the recorder adds nothing.',
+    },
+    'MedicationRequest.dispenseRequest': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Quantity, refills and the validity period of the prescription. An earlier corpus-wide value match reported this as retained; the differential shows the values matched other records and the field reaches nothing.',
+    },
+    'MedicationRequest.requester.reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Practitioner resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName.',
+    },
+    'MedicationRequest.dosageInstruction[0].patientInstruction': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The instruction written for the patient rather than for the pharmacy, which is the phrasing a person actually follows.',
+    },
+    'MedicationRequest.dosageInstruction[0].doseAndRate': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The numeric dose. clinical:dosage carries the free-text sig, so dose comparisons run on prose. Dose is deliberately excluded from the medication identity key precisely so a dose CHANGE raises a conflict, and a dose nobody stored cannot.',
+    },
+    'MedicationRequest.dosageInstruction[1]': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Only the first Dosage element is read. A tapering or step-up regimen keeps its first step and loses the rest.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/observation.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/observation.ts
@@ -1,0 +1,89 @@
+import type { FieldDropManifest } from '../types.js';
+
+/**
+ * What `convertObservationLab` does not emit.
+ *
+ * `status` used to head this list: `amended` and `final` produced byte-identical
+ * records, so a corrected result was indistinguishable from an original one. It
+ * is emitted now, and the entry is gone rather than annotated — a manifest that
+ * kept a fixed item as history would be describing a loss that no longer
+ * happens.
+ */
+export const OBSERVATION_DROPS: FieldDropManifest = {
+  resourceType: 'Observation',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/observation-lab.json; matches the field census taken over 659 Epic R4 Observations.',
+  drops: {
+    'Observation.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'Observation.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The lab\'s own order/filler number. The same cross-transport join key Encounter.identifier is: without it, one result arriving twice cannot be recognised as one result.',
+    },
+    'Observation.subject': {
+      disposition: 'acknowledged',
+      reason:
+        "A pod holds one person's records, so the subject link is the pod itself. A reference to a Patient resource the pod does not hold would dangle.",
+    },
+    'Observation.issued': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only as a fallback for health:performedDate when the resource states no effective time. When both are present the effective instant is the clinically meaningful one and wins.',
+    },
+    'Observation.note': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The free text where a lab explains a flagged value ("specimen hemolyzed", "confirmed on repeat"). Reading a number without it can mean reading it wrongly.',
+    },
+    'Observation.specimen': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'What was sampled. It is already part of the lab identity key, so it decides which results merge while never appearing as a fact a reader can see.',
+    },
+    'Observation.valueQuantity.system': {
+      disposition: 'acknowledged',
+      reason:
+        'Names the code system for valueQuantity.code. Carrying it while the code itself is not stored would state a system for nothing.',
+    },
+    'Observation.valueQuantity.code': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The UCUM unit code. health:resultUnit carries the display unit, which is what a person reads and what a machine cannot safely compare ("mg/dL" typed three ways is three units).',
+    },
+    'Observation.interpretation[0].text': {
+      disposition: 'acknowledged',
+      reason:
+        'Redundant alternative: the coded interpretation is emitted as health:interpretation and the text restates it.',
+    },
+    'Observation.referenceRange[0].text': {
+      disposition: 'acknowledged',
+      reason:
+        'Read only when the range states neither low nor high. With both present the numeric bounds are emitted and the text repeats them.',
+    },
+    'Observation.referenceRange[0].type': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Which meaning the range has (normal range, therapeutic target, critical). A treatment target read as a normal range says the opposite of what it means.',
+    },
+    'Observation.referenceRange[1]': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Only referenceRange[0] is read. A result carrying population-specific ranges keeps whichever the server happened to list first.',
+    },
+    'Observation.performer[0].reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Practitioner and Organization resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName by the provenance pass.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/manifests/patient.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/patient.ts
@@ -1,0 +1,83 @@
+import type { FieldDropManifest } from '../types.js';
+
+/**
+ * What `convertPatient` does not emit.
+ *
+ * The entry worth reading first is `Patient.name`: the FHIR path stores the
+ * profile's date of birth, sex, address and marital status and never the
+ * person's name.
+ */
+export const PATIENT_DROPS: FieldDropManifest = {
+  resourceType: 'Patient',
+  provenance:
+    'Differential run over test-fixtures/field-coverage/patient.json.',
+  drops: {
+    'Patient.meta': {
+      disposition: 'acknowledged',
+      reason:
+        "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient.",
+    },
+    'Patient.identifier': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'The medical record number and every other identifier the EHR itself uses to tell two patients apart. It is already an input to the profile identity key, so it decides which profiles merge while never appearing as a fact.',
+    },
+    'Patient.active': {
+      disposition: 'acknowledged',
+      reason:
+        "Whether the record is active in the source system. That is the source's own bookkeeping about its chart, not a fact about the person.",
+    },
+    'Patient.name': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        "The person's name. The FHIR path emits date of birth, computed age, sex, address and marital status and no name at all, so a profile imported from FHIR is nameless while the C-CDA path fills it in.",
+    },
+    'Patient.telecom': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Phone numbers and email. The address is emitted, so the profile carries where a person lives but no way to reach them.',
+    },
+    'Patient.deceasedBoolean': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Whether the source states the person has died. It is in the identity key already, so it can split a profile while never being visible in one.',
+    },
+    'Patient.communication': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        'Preferred language and whether an interpreter is needed — a care-delivery fact, not a demographic nicety.',
+    },
+    'Patient.generalPractitioner': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        "The person's own clinician. Every record in the pod can name the clinician who performed it while the profile cannot name the one who follows them.",
+    },
+    'Patient.managingOrganization': {
+      disposition: 'pending',
+      backlog: '3.256',
+      reason:
+        "The organization holding the chart. deriveBundleOrigin does not read this field, so a bundle whose only organization signal is here derives no source label and every record falls back to the endpoint host or to unknown.",
+    },
+    'Patient.maritalStatus.coding': {
+      disposition: 'acknowledged',
+      reason:
+        'Redundant alternative: cascade:maritalStatus is mapped from the coding when present and from the text otherwise, and both spellings map to the same value.',
+    },
+    'Patient.maritalStatus.text': {
+      disposition: 'acknowledged',
+      reason:
+        'Redundant alternative: see maritalStatus.coding. Either alone produces the same cascade:maritalStatus.',
+    },
+    'Patient.address[0].use': {
+      disposition: 'acknowledged',
+      reason:
+        'home, work or temporary. Only one address is flattened onto the profile and Cascade has no term to qualify which kind it is.',
+    },
+  },
+};

--- a/src/lib/fhir-converter/field-coverage/paths.ts
+++ b/src/lib/fhir-converter/field-coverage/paths.ts
@@ -1,0 +1,232 @@
+/**
+ * Element-path navigation for the FHIR field-coverage chokepoint.
+ *
+ * A "path" here is one populated element of a FHIR resource, written the way the
+ * FHIR spec writes element paths, with array indices made explicit:
+ *
+ *   Encounter.status
+ *   Encounter.class.display
+ *   Encounter.type[1]
+ *   Encounter.participant[0].individual
+ *
+ * WHY PATHS AND DELETION RATHER THAN A READ-LIST
+ * ----------------------------------------------
+ * The obvious way to ask "does the converter keep this field?" is to read the
+ * converter: collect every `resource.<field>` it mentions. That was tried and it
+ * was wrong in both directions. Reading a field is not emitting it —
+ * `convertEncounter` reads `resource.identifier` to mint identity and never
+ * writes it as a fact, so a read-list calls it kept while the pod contains none.
+ * Matching source VALUES against the whole pod is wrong in the other direction:
+ * an unrelated record containing the same string reports a false hit.
+ *
+ * The only question that answers itself is the differential one: convert the
+ * resource, convert it again with exactly one element deleted, and compare the
+ * output. This module owns the two halves of that experiment that are not about
+ * RDF: which elements to try, and how to remove one.
+ *
+ * ENUMERATION IS LAZY, AND THAT IS THE POINT
+ * ------------------------------------------
+ * Paths are handed out one level at a time ({@link topLevelFieldPaths}, then
+ * {@link childFieldPaths}) rather than as one flat list, so the analysis can
+ * STOP DESCENDING at a path it has already proven is dropped. Enumerating
+ * `identifier`, `identifier[0]`, `identifier[0].system` and
+ * `identifier[0].value` as four separate drops describes one omission four
+ * times, and a manifest full of that is a manifest nobody reads.
+ *
+ * Pruning is sound rather than merely tidy: if any descendant of an element
+ * reached the output, deleting the element would have removed that descendant
+ * too and the parent would have measured as EMITTED. A dropped parent therefore
+ * guarantees dropped descendants.
+ *
+ * DEPTH IS BOUNDED ON PURPOSE
+ * ---------------------------
+ * Descent goes two NAMED steps below the resource root (array indices do not
+ * count as steps), which is what the measured loss classes need: whole fields
+ * (`Encounter.reasonCode`), one level of qualifier (`Encounter.class.display`),
+ * array tails (`Encounter.type[1]`), and per-element qualifiers
+ * (`Encounter.participant[0].type`). Deeper elements are covered transitively:
+ * an emitted `content[0].attachment` carries its own `url`.
+ */
+
+/** How many NAMED key steps below the resource root to descend. */
+export const MAX_KEY_DEPTH = 2;
+
+/**
+ * Elements never enumerated. `resourceType` is the dispatch key: deleting it
+ * does not test a field, it tests what happens when the converter is handed
+ * something that is not a resource.
+ */
+const NEVER_ENUMERATED = new Set(['resourceType']);
+
+/** Whether a value counts as populated, i.e. whether the source actually said it. */
+export function isPopulated(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'object') return Object.keys(value as object).length > 0;
+  return true;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+interface PathSegment {
+  key?: string;
+  index?: number;
+}
+
+/**
+ * Split `Encounter.participant[0].type` into its navigable segments, dropping
+ * the leading resource type. Returns `undefined` for a path that is not written
+ * in this grammar, so a hand-edited manifest entry with a typo is a reported
+ * error rather than a silently unmatched rule.
+ */
+export function parseFieldPath(path: string): PathSegment[] | undefined {
+  const firstDot = path.indexOf('.');
+  if (firstDot < 0) return undefined;
+  const rest = path.slice(firstDot + 1);
+  const segments: PathSegment[] = [];
+  const token = /([A-Za-z_][A-Za-z0-9_-]*)|\[(\d+)\]/y;
+  let cursor = 0;
+  while (cursor < rest.length) {
+    if (rest[cursor] === '.') {
+      cursor++;
+      continue;
+    }
+    token.lastIndex = cursor;
+    const match = token.exec(rest);
+    if (!match) return undefined;
+    if (match[1] !== undefined) segments.push({ key: match[1] });
+    else segments.push({ index: Number(match[2]) });
+    cursor = token.lastIndex;
+  }
+  return segments.length > 0 ? segments : undefined;
+}
+
+/** How many NAMED steps a path takes below the resource root. */
+export function namedDepth(path: string): number {
+  const segments = parseFieldPath(path);
+  if (!segments) return Number.POSITIVE_INFINITY;
+  return segments.filter((s) => s.key !== undefined).length;
+}
+
+/** The value a path points at, or `undefined` if it does not resolve. */
+export function valueAtPath(resource: unknown, path: string): unknown {
+  const segments = parseFieldPath(path);
+  if (!segments) return undefined;
+  let cursor: unknown = resource;
+  for (const seg of segments) {
+    if (seg.key !== undefined) {
+      if (!isPlainObject(cursor)) return undefined;
+      cursor = cursor[seg.key];
+    } else {
+      if (!Array.isArray(cursor)) return undefined;
+      cursor = cursor[seg.index!];
+    }
+    if (cursor === undefined || cursor === null) return undefined;
+  }
+  return cursor;
+}
+
+/** The resource's own type, used as the root of every path it produces. */
+export function pathRoot(resource: unknown): string {
+  return isPlainObject(resource) && typeof resource.resourceType === 'string'
+    ? resource.resourceType
+    : 'Resource';
+}
+
+/** Every populated top-level element of a resource, in document order. */
+export function topLevelFieldPaths(resource: unknown): string[] {
+  if (!isPlainObject(resource)) return [];
+  const root = pathRoot(resource);
+  const paths: string[] = [];
+  for (const [key, value] of Object.entries(resource)) {
+    if (NEVER_ENUMERATED.has(key)) continue;
+    if (!isPopulated(value)) continue;
+    paths.push(`${root}.${key}`);
+  }
+  return paths;
+}
+
+/**
+ * The populated elements one level below `path`, or an empty list at the depth
+ * bound. Array indices and object keys are both one level; only object keys
+ * count against the bound.
+ */
+export function childFieldPaths(resource: unknown, path: string): string[] {
+  if (namedDepth(path) >= MAX_KEY_DEPTH) return [];
+  const value = valueAtPath(resource, path);
+  if (Array.isArray(value)) {
+    const paths: string[] = [];
+    for (let i = 0; i < value.length; i++) {
+      if (isPopulated(value[i])) paths.push(`${path}[${i}]`);
+    }
+    return paths;
+  }
+  if (isPlainObject(value)) {
+    const paths: string[] = [];
+    for (const [key, child] of Object.entries(value)) {
+      if (isPopulated(child)) paths.push(`${path}.${key}`);
+    }
+    return paths;
+  }
+  return [];
+}
+
+/**
+ * Every populated path a full walk would visit, WITHOUT pruning.
+ *
+ * Only for the degenerate case where a resource cannot be converted at all and
+ * every path is therefore untestable. The analysis proper walks lazily.
+ */
+export function enumerateFieldPaths(resource: unknown): string[] {
+  const out: string[] = [];
+  const visit = (path: string): void => {
+    out.push(path);
+    for (const child of childFieldPaths(resource, path)) visit(child);
+  };
+  for (const path of topLevelFieldPaths(resource)) visit(path);
+  return out;
+}
+
+/**
+ * A deep copy of `resource` with exactly one element removed.
+ *
+ * A named element is deleted; an array element is SPLICED OUT rather than set to
+ * `undefined`, because a hole in an array is not a shape any FHIR server emits
+ * and a converter reading `type[1]` of a two-element array with a hole would be
+ * answering a question nobody asked.
+ *
+ * Returns `undefined` when the path does not resolve, which the callers treat as
+ * an error rather than as "no difference": a path that cannot be deleted cannot
+ * be tested, and reporting it as unchanged would mark a live field as dropped.
+ */
+export function withoutPath<T>(resource: T, path: string): T | undefined {
+  const segments = parseFieldPath(path);
+  if (!segments) return undefined;
+  const copy = structuredClone(resource) as unknown;
+
+  let cursor: unknown = copy;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    if (seg.key !== undefined) {
+      if (!isPlainObject(cursor)) return undefined;
+      cursor = cursor[seg.key];
+    } else {
+      if (!Array.isArray(cursor)) return undefined;
+      cursor = cursor[seg.index!];
+    }
+    if (cursor === undefined || cursor === null) return undefined;
+  }
+
+  const last = segments[segments.length - 1];
+  if (last.key !== undefined) {
+    if (!isPlainObject(cursor) || !(last.key in cursor)) return undefined;
+    delete cursor[last.key];
+  } else {
+    if (!Array.isArray(cursor) || last.index! >= cursor.length) return undefined;
+    cursor.splice(last.index!, 1);
+  }
+  return copy as T;
+}

--- a/src/lib/fhir-converter/field-coverage/types.ts
+++ b/src/lib/fhir-converter/field-coverage/types.ts
@@ -1,0 +1,65 @@
+/**
+ * The drop-manifest vocabulary: what it means for a converter to NOT emit a
+ * field the source populated.
+ *
+ * This is the field-level analogue of `EXCLUDED_TYPES` / `EXCLUDED_REASONS` in
+ * `converters-passthrough.ts`. That pair made type-level exclusion explicit and
+ * reasoned; below the type level, omissions were silent, and silence is the
+ * actual defect class: a field a converter never reads, a field it reads for
+ * identity and never writes as a fact, and an array whose tail is dropped all
+ * look identical from outside — nothing says so anywhere.
+ *
+ * Two dispositions, and the difference between them is a commitment, not a
+ * mood:
+ *
+ *   `acknowledged`  A permanent decision. The reason is the argument for it and
+ *                   is expected to still read as correct in a year.
+ *   `pending`       A known gap with a fix owed. Carries the backlog id that
+ *                   tracks it, so the entry cannot outlive the promise: closing
+ *                   the backlog item means the converter emits the field, and
+ *                   the differential test then FAILS on the stale entry until it
+ *                   is deleted.
+ *
+ * Manifests are data, deliberately. A converter fix flips an entry by deleting a
+ * line in a manifest file — no test edit, no change to the converters, so two
+ * sequenced pieces of work do not collide in the same source file.
+ */
+
+/** Whether a drop is a decision or a debt. */
+export type FieldDropDisposition = 'acknowledged' | 'pending';
+
+/** One element path a converter does not emit, and why. */
+export interface FieldDropEntry {
+  disposition: FieldDropDisposition;
+  /**
+   * Why the field is not emitted. A sentence a reader can disagree with, not a
+   * restatement of the path.
+   */
+  reason: string;
+  /**
+   * The root-backlog id tracking the fix. Required on `pending`, absent on
+   * `acknowledged` — an untracked gap is how a gap becomes permanent by
+   * accident.
+   */
+  backlog?: string;
+}
+
+/** Every drop one converter takes, keyed by full element path. */
+export interface FieldDropManifest {
+  /** The FHIR resource type these paths belong to. */
+  resourceType: string;
+  /**
+   * Where the seed list came from, so a reader knows whether an entry was
+   * measured or assumed.
+   */
+  provenance: string;
+  drops: Record<string, FieldDropEntry>;
+}
+
+/** How one populated element fared: emitted, or dropped with a disposition. */
+export interface FieldCoverageVerdict {
+  path: string;
+  emitted: boolean;
+  /** The manifest entry covering this path, when the path is not emitted. */
+  entry?: FieldDropEntry;
+}

--- a/src/lib/fhir-converter/import-manifest.ts
+++ b/src/lib/fhir-converter/import-manifest.ts
@@ -8,11 +8,38 @@
 
 import type { BatchConversionResult } from './types.js';
 import { EXCLUDED_REASONS } from './converters-passthrough.js';
+import { analyzeCorpus, coverageDisclosure, type CoverageReport } from './field-coverage/analyze.js';
 
 export interface ManifestEntry {
   count: number;
   strategy: 'mapped' | 'passthrough' | 'passthrough-minimal' | 'excluded';
   reason?: string;
+}
+
+/**
+ * What the import did NOT carry across, at the field level.
+ *
+ * The manifest already said which resource TYPES were mapped, passed through or
+ * excluded. Below the type, omissions were silent: a mapped Encounter counted as
+ * a success in this document while the clinic, the reason and the care team it
+ * stated reached nothing. This block closes that, in the same terms the
+ * `cascade sources coverage` verb reports — element paths and counts, no values
+ * — and states where the unimported data still is, since the source document is
+ * retained and a re-import recovers it.
+ */
+export interface FieldCoverageDisclosure {
+  /** One sentence a person can act on. */
+  summary: string;
+  populatedFields: number;
+  importedFields: number;
+  notImportedFields: number;
+  /** Of the not-imported fields, how many each disposition accounts for. */
+  acknowledged: number;
+  pending: number;
+  /** Not imported and on no converter's drop manifest. */
+  unaccounted: number;
+  /** Per type, the dropped element paths and how many resources populated each. */
+  byType: CoverageReport['byType'];
 }
 
 export interface ImportManifest {
@@ -26,6 +53,29 @@ export interface ImportManifest {
     excluded: number;
   };
   byType: Record<string, ManifestEntry>;
+  /** Absent when the caller did not supply the source resources to measure. */
+  fieldCoverage?: FieldCoverageDisclosure;
+}
+
+/**
+ * Measure what the converters did not emit, over the resources actually imported.
+ *
+ * Separate from {@link buildImportManifest} so the cost is the caller's choice:
+ * it runs one conversion per populated element path, which is the price of an
+ * answer that is measured rather than assumed.
+ */
+export function buildFieldCoverageDisclosure(resources: Iterable<unknown>): FieldCoverageDisclosure {
+  const report = analyzeCorpus(resources);
+  return {
+    summary: coverageDisclosure(report),
+    populatedFields: report.totals.populatedFields,
+    importedFields: report.totals.emittedFields,
+    notImportedFields: report.totals.droppedFields,
+    acknowledged: report.totals.acknowledged,
+    pending: report.totals.pending,
+    unaccounted: report.totals.unaccounted,
+    byType: report.byType,
+  };
 }
 
 /**
@@ -40,12 +90,18 @@ export interface ImportManifest {
  * @param sourceFile    The source FHIR file path
  * @param sourceSystem  The --source-system CLI argument
  * @param excludedTypes Map of resource types that were excluded with their counts
+ * @param fieldCoverage Optional field-level disclosure from
+ *                      {@link buildFieldCoverageDisclosure}. Omitted rather than
+ *                      faked when the caller has no source resources to measure:
+ *                      an absent block means "not measured", and a zero would
+ *                      mean "measured, nothing lost".
  */
 export function buildImportManifest(
   result: BatchConversionResult,
   sourceFile: string,
   sourceSystem: string,
   excludedTypes: Record<string, number>,
+  fieldCoverage?: FieldCoverageDisclosure,
 ): ImportManifest {
   const byType: Record<string, ManifestEntry> = {};
   let fullyMapped = 0;
@@ -91,5 +147,6 @@ export function buildImportManifest(
       excluded,
     },
     byType,
+    ...(fieldCoverage ? { fieldCoverage } : {}),
   };
 }

--- a/src/lib/fhir-converter/registry-entry.ts
+++ b/src/lib/fhir-converter/registry-entry.ts
@@ -21,7 +21,11 @@ import type {
 } from '../import-types.js';
 import { convert as legacyConvert, detectFormat } from './index.js';
 import type { BatchConversionResult, InputFormat } from './types.js';
-import { buildImportManifest } from './import-manifest.js';
+import {
+  buildFieldCoverageDisclosure,
+  buildImportManifest,
+  type FieldCoverageDisclosure,
+} from './import-manifest.js';
 import { EXCLUDED_TYPES } from './converters-passthrough.js';
 
 function adapt(r: BatchConversionResult): ImportResult {
@@ -79,8 +83,14 @@ export const fhirImporter: FormatImporter = {
     const manifestOpt = ctx.options['manifest'];
     if (manifestOpt === undefined || !result.success) return;
 
-    // Count excluded resource types from the original FHIR Bundle.
+    // Count excluded resource types from the original FHIR Bundle, and measure
+    // what the converters did NOT emit from the resources they did convert.
+    //
+    // Both need the SOURCE, which is why they are here rather than in the
+    // manifest builder: the manifest builder sees only what came out, and "what
+    // came out" is precisely the side of the comparison that cannot show a loss.
     const excludedCounts: Record<string, number> = {};
+    let fieldCoverage: FieldCoverageDisclosure | undefined;
     try {
       const inputStr = Buffer.isBuffer(input) ? input.toString('utf-8') : input;
       const parsed = JSON.parse(inputStr);
@@ -93,8 +103,11 @@ export const fhirImporter: FormatImporter = {
           excludedCounts[res.resourceType] = (excludedCounts[res.resourceType] ?? 0) + 1;
         }
       }
+      fieldCoverage = buildFieldCoverageDisclosure(resources);
     } catch {
-      // JSON already validated upstream by the converter; ignore.
+      // JSON already validated upstream by the converter; ignore. `fieldCoverage`
+      // stays undefined, which the manifest reports as "not measured" rather
+      // than as "nothing lost".
     }
 
     // buildImportManifest expects the legacy BatchConversionResult shape;
@@ -121,6 +134,7 @@ export const fhirImporter: FormatImporter = {
       ctx.inputPath,
       ctx.sourceSystem ?? '',
       excludedCounts,
+      fieldCoverage,
     );
 
     let manifestPath: string;

--- a/src/program.ts
+++ b/src/program.ts
@@ -15,6 +15,7 @@ import { registerValidateCommand } from './commands/validate.js';
 import { registerConvertCommand } from './commands/convert.js';
 import { registerReconcileCommand } from './commands/reconcile.js';
 import { registerPodCommand } from './commands/pod/index.js';
+import { registerSourcesCommand } from './commands/sources.js';
 import { registerConformanceCommand } from './commands/conformance.js';
 import { registerServeCommand } from './commands/serve.js';
 import { registerCapabilitiesCommand } from './commands/capabilities.js';
@@ -37,6 +38,7 @@ export function buildProgram(): Command {
   registerConvertCommand(program);
   registerReconcileCommand(program);
   registerPodCommand(program);
+  registerSourcesCommand(program);
   registerConformanceCommand(program);
   registerServeCommand(program);
   registerCapabilitiesCommand(program);
@@ -57,6 +59,7 @@ Examples:
   cascade pod extract ./my-pod
   cascade pod doctor ./my-pod
   cascade pod doctor ./my-pod --write
+  cascade sources coverage ./my-pod
   cascade agent
   cascade agent serve
   cascade capabilities

--- a/test-fixtures/field-coverage/FIXTURES.md
+++ b/test-fixtures/field-coverage/FIXTURES.md
@@ -1,0 +1,80 @@
+# Field-coverage fixture corpus: provenance and licensing
+
+These fixtures drive `tests/fhir-field-coverage.test.ts`, the differential gate
+that requires every populated FHIR element to either reach the converted output
+or sit on a converter's drop manifest with a written reason.
+
+## What these fixtures are, and what they are not
+
+**Every fixture is hand-authored and every value in it is invented.** No fixture
+is an export, a redaction, or a transformation of any real person's record. The
+names, identifiers, dates, addresses, phone numbers, lot numbers, member ids and
+free-text notes are fabrications chosen to look like the real thing.
+
+What IS copied from reality is the **shape**: which elements a production EHR
+populates, how deeply they nest, and which of them repeat. An Epic R4 pull states
+four `Encounter.type` codings and four typed `participant` entries where the FHIR
+spec only permits them, and a fixture that states one of each would prove the
+converter handles a case that does not occur. The shapes here are modelled on
+observed Epic R4 output; vendor-specific identifier systems appear as
+`urn:oid:1.2.840.114350.1.13.999.*`, where `999` is a placeholder in place of any
+real organization's assigning-authority arc, and vendor extension URLs use
+`vendor.example`.
+
+References are deliberately **relative** (`Practitioner/fc-practitioner-attender`)
+rather than absolute. The provenance pass derives a record's source EHR from the
+first absolute reference host it finds anywhere in a resource, so an absolute URL
+would make unrelated deletions change the output and the differential would
+report fields as kept that are not.
+
+## Per-fixture provenance
+
+| Fixture | Resource | Origin | Terminologies used | License notes |
+|---|---|---|---|---|
+| `allergyintolerance.json` | AllergyIntolerance | Hand-authored | SNOMED CT (International), HL7 terminology | SNOMED via GPS, see below |
+| `condition.json` | Condition | Hand-authored | SNOMED CT (International), ICD-10-CM, HL7 terminology | ICD-10-CM is US public domain |
+| `coverage.json` | Coverage | Hand-authored | HL7 terminology only | No licensed content |
+| `diagnosticreport.json` | DiagnosticReport | Hand-authored | LOINC, SNOMED CT (International), HL7 v2 table | LOINC redistributable with attribution |
+| `documentreference.json` | DocumentReference | Hand-authored | LOINC, IHE format codes | LOINC redistributable with attribution |
+| `encounter.json` | Encounter | Hand-authored | SNOMED CT (International), HL7 v3 ParticipationType, HL7 admit-source / discharge-disposition | SNOMED via GPS, see below |
+| `immunization.json` | Immunization | Hand-authored | CVX, HL7 v3 ActSite / RouteOfAdministration, UCUM | CVX is US public domain |
+| `medicationrequest.json` | MedicationRequest | Hand-authored | RxNorm, HL7 terminology, UCUM | RxNorm is US public domain |
+| `observation-lab.json` | Observation (lab) | Hand-authored | LOINC, HL7 ObservationInterpretation, UCUM | LOINC redistributable with attribution |
+| `patient.json` | Patient | Hand-authored | HL7 v3 MaritalStatus, BCP 47 | No licensed content |
+
+**No CPT code appears in any fixture, and none may be added.** The `Procedure`
+converter can emit `clinical:cptCode`, so a Procedure fixture added later must
+exercise that path with a SNOMED procedure code only.
+
+Every SNOMED CT concept used here is from the **International Edition**, drawn
+from the small set that appears verbatim in HL7's own published FHIR examples,
+with the description copied exactly:
+
+| Code | Description as written | Used in |
+|---|---|---|
+| 185349003 | Encounter for check up | `encounter.json` |
+| 195967001 | Asthma | `condition.json` |
+| 227493005 | Cashew nuts | `allergyintolerance.json` |
+| 39579001 | Anaphylactic reaction | `allergyintolerance.json` |
+| 271737000 | Anemia | `diagnosticreport.json` |
+
+No US Edition (or any other national extension) concept is used, which keeps this
+corpus distributable outside the United States along with the rest of this
+repository.
+
+## Attribution
+
+This material includes SNOMED Clinical Terms (SNOMED CT) identifiers and
+descriptions from the SNOMED International Global Patient Set, used under the
+Creative Commons Attribution-NoDerivatives 4.0 International License. SNOMED and
+SNOMED CT are registered trademarks of SNOMED International.
+
+## Adding a fixture
+
+1. Add the resource here, all values invented, references relative.
+2. Add a row to the table above, and to the SNOMED table if it uses SNOMED.
+3. Add a drop manifest for its resource type under
+   `src/lib/fhir-converter/field-coverage/manifests/` — the gate fails a fixture
+   whose type has no manifest, and fails a manifest whose type has no fixture.
+4. Run the gate. It will name every populated element that reaches nothing; each
+   one needs an entry with a reason, or a converter that emits it.

--- a/test-fixtures/field-coverage/allergyintolerance.json
+++ b/test-fixtures/field-coverage/allergyintolerance.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "AllergyIntolerance",
+  "id": "fc-allergy-cashew-1",
+  "meta": {
+    "versionId": "2",
+    "lastUpdated": "2023-08-11T14:05:31Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.3.688884.102",
+      "value": "90100000005"
+    }
+  ],
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+        "code": "active",
+        "display": "Active"
+      }
+    ],
+    "text": "Active"
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+        "code": "confirmed",
+        "display": "Confirmed"
+      }
+    ],
+    "text": "Confirmed"
+  },
+  "type": "allergy",
+  "category": ["food"],
+  "criticality": "high",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "227493005",
+        "display": "Cashew nuts"
+      }
+    ],
+    "text": "Cashew nut (tree nut)"
+  },
+  "patient": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "recordedDate": "2023-08-11T13:58:00Z",
+  "recorder": {
+    "reference": "Practitioner/fc-practitioner-pcp",
+    "display": "Tobias Lund, MD"
+  },
+  "lastOccurrence": "2023-08-10",
+  "reaction": [
+    {
+      "substance": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "227493005",
+            "display": "Cashew nuts"
+          }
+        ],
+        "text": "Cashew nuts"
+      },
+      "manifestation": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "39579001",
+              "display": "Anaphylactic reaction"
+            }
+          ],
+          "text": "Anaphylactic reaction"
+        }
+      ],
+      "severity": "severe",
+      "onset": "2023-08-10T19:40:00Z",
+      "description": "Lip swelling and wheeze within 20 minutes of ingestion; treated in urgent care."
+    }
+  ],
+  "note": [
+    {
+      "text": "Carries epinephrine auto-injector."
+    }
+  ]
+}

--- a/test-fixtures/field-coverage/condition.json
+++ b/test-fixtures/field-coverage/condition.json
@@ -1,0 +1,82 @@
+{
+  "resourceType": "Condition",
+  "id": "fc-condition-asthma-1",
+  "meta": {
+    "versionId": "3",
+    "lastUpdated": "2025-04-01T16:41:55Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.3.688884.101",
+      "value": "80100000003"
+    }
+  ],
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+        "code": "active",
+        "display": "Active"
+      }
+    ],
+    "text": "Active"
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+        "code": "confirmed",
+        "display": "Confirmed"
+      }
+    ],
+    "text": "Confirmed"
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "problem-list-item",
+          "display": "Problem List Item"
+        }
+      ],
+      "text": "Problem List Item"
+    }
+  ],
+  "severity": {
+    "text": "Moderate"
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "195967001",
+        "display": "Asthma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "J45.909",
+        "display": "Unspecified asthma, uncomplicated"
+      }
+    ],
+    "text": "Asthma, mild intermittent"
+  },
+  "subject": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "encounter": {
+    "reference": "Encounter/fc-encounter-derm-1"
+  },
+  "onsetDateTime": "2011-09-03T00:00:00Z",
+  "recordedDate": "2019-02-18T21:08:00Z",
+  "recorder": {
+    "reference": "Practitioner/fc-practitioner-pcp",
+    "display": "Tobias Lund, MD"
+  },
+  "note": [
+    {
+      "text": "Well controlled on as-needed inhaler; no exacerbation since 2022."
+    }
+  ]
+}

--- a/test-fixtures/field-coverage/coverage.json
+++ b/test-fixtures/field-coverage/coverage.json
@@ -1,0 +1,81 @@
+{
+  "resourceType": "Coverage",
+  "id": "fc-coverage-ppo-1",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2025-01-02T08:15:44Z"
+  },
+  "identifier": [
+    {
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.3.688884.103",
+      "value": "COV-4471002"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "PPO",
+        "display": "preferred provider organization policy"
+      }
+    ],
+    "text": "Preferred Provider Organization"
+  },
+  "subscriber": {
+    "reference": "Patient/fc-patient-1",
+    "display": "Rowan Sample"
+  },
+  "subscriberId": "MEM-88213400",
+  "beneficiary": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "relationship": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
+        "code": "self",
+        "display": "Self"
+      }
+    ],
+    "text": "Self"
+  },
+  "period": {
+    "start": "2025-01-01",
+    "end": "2025-12-31"
+  },
+  "payor": [
+    {
+      "reference": "Organization/fc-organization-payer",
+      "display": "Cascade Mutual Health"
+    }
+  ],
+  "class": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "group"
+          }
+        ]
+      },
+      "value": "GRP-77120",
+      "name": "Northgate Employer Group"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "plan"
+          }
+        ]
+      },
+      "value": "PLN-3300",
+      "name": "Cascade Mutual PPO Silver"
+    }
+  ],
+  "order": 1,
+  "network": "Cascade Preferred Network"
+}

--- a/test-fixtures/field-coverage/diagnosticreport.json
+++ b/test-fixtures/field-coverage/diagnosticreport.json
@@ -1,0 +1,89 @@
+{
+  "resourceType": "DiagnosticReport",
+  "id": "fc-diagnosticreport-cbc-1",
+  "meta": {
+    "versionId": "2",
+    "lastUpdated": "2025-03-12T18:05:03Z"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.2.798268",
+      "value": "50100000004"
+    }
+  ],
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+          "code": "HM",
+          "display": "Hematology"
+        }
+      ],
+      "text": "Hematology"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "58410-2",
+        "display": "CBC panel - Blood by Automated count"
+      }
+    ],
+    "text": "CBC with Differential"
+  },
+  "subject": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "encounter": {
+    "reference": "Encounter/fc-encounter-derm-1"
+  },
+  "effectiveDateTime": "2025-03-12T15:22:00Z",
+  "issued": "2025-03-12T17:41:00Z",
+  "performer": [
+    {
+      "reference": "Organization/fc-organization-lab",
+      "display": "Northgate Reference Laboratory"
+    }
+  ],
+  "resultsInterpreter": [
+    {
+      "reference": "Practitioner/fc-practitioner-pathologist",
+      "display": "Ines Vargas, MD"
+    }
+  ],
+  "specimen": [
+    {
+      "reference": "Specimen/fc-specimen-blood-1"
+    }
+  ],
+  "result": [
+    {
+      "reference": "Observation/fc-observation-hgb-1"
+    }
+  ],
+  "conclusion": "Mild normocytic anemia. Recommend repeat CBC in 8 weeks.",
+  "conclusionCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "271737000",
+          "display": "Anemia"
+        }
+      ],
+      "text": "Anemia"
+    }
+  ],
+  "presentedForm": [
+    {
+      "contentType": "application/pdf",
+      "url": "Binary/fc-binary-cbc-report-1",
+      "title": "CBC with Differential - final report",
+      "creation": "2025-03-12T17:41:00Z"
+    }
+  ]
+}

--- a/test-fixtures/field-coverage/documentreference.json
+++ b/test-fixtures/field-coverage/documentreference.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "fc-documentreference-progress-1",
+  "meta": {
+    "versionId": "4",
+    "lastUpdated": "2025-04-03T02:10:52Z"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.8.688883.5",
+      "value": "40100000012"
+    }
+  ],
+  "status": "current",
+  "docStatus": "amended",
+  "type": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "11506-3",
+        "display": "Progress note"
+      }
+    ],
+    "text": "Progress Notes"
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "47039-3",
+          "display": "Hospital Admission history and physical note"
+        }
+      ],
+      "text": "Clinical Notes"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "date": "2025-04-01T18:22:00Z",
+  "author": [
+    {
+      "reference": "Practitioner/fc-practitioner-attender",
+      "display": "Amara Okoye, MD"
+    },
+    {
+      "reference": "Practitioner/fc-practitioner-resident",
+      "display": "Noor Habib, MD"
+    }
+  ],
+  "authenticator": {
+    "reference": "Practitioner/fc-practitioner-attender",
+    "display": "Amara Okoye, MD"
+  },
+  "custodian": {
+    "reference": "Organization/fc-organization-1",
+    "display": "Northgate Health Network"
+  },
+  "description": "Dermatology progress note, amended 2025-04-02 to correct laterality.",
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/html",
+        "url": "Binary/fc-binary-progress-1",
+        "title": "Progress Notes",
+        "creation": "2025-04-01T18:22:00Z"
+      },
+      "format": {
+        "system": "http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem",
+        "code": "urn:ihe:iti:xds:2017:mimeTypeSufficient",
+        "display": "mimeType Sufficient"
+      }
+    }
+  ],
+  "context": {
+    "encounter": [
+      {
+        "reference": "Encounter/fc-encounter-derm-1"
+      }
+    ],
+    "period": {
+      "start": "2025-04-01T16:00:00Z",
+      "end": "2025-04-01T16:40:00Z"
+    },
+    "facilityType": {
+      "text": "Outpatient clinic"
+    }
+  }
+}

--- a/test-fixtures/field-coverage/encounter.json
+++ b/test-fixtures/field-coverage/encounter.json
@@ -1,0 +1,216 @@
+{
+  "resourceType": "Encounter",
+  "id": "fc-encounter-derm-1",
+  "meta": {
+    "versionId": "3",
+    "lastUpdated": "2025-04-01T21:12:44Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.8",
+      "value": "20100000001"
+    }
+  ],
+  "status": "finished",
+  "class": {
+    "system": "urn:oid:1.2.840.114350.1.72.1.7.1",
+    "code": "5",
+    "display": "Appointment"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "urn:oid:1.2.840.114350.1.13.999.2.7.10.698084.30",
+          "code": "101",
+          "display": "Ambulatory office visit"
+        }
+      ],
+      "text": "Office Visit"
+    },
+    {
+      "text": "Outpatient"
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "185349003",
+          "display": "Encounter for check up"
+        }
+      ],
+      "text": "Encounter for check up"
+    },
+    {
+      "text": "Elective"
+    }
+  ],
+  "serviceType": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.840.114350.1.13.999.2.7.10.698084.18",
+        "code": "42",
+        "display": "Dermatology"
+      }
+    ],
+    "text": "Dermatology"
+  },
+  "subject": {
+    "reference": "Patient/fc-patient-1",
+    "display": "Rowan Sample"
+  },
+  "participant": [
+    {
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "urn:oid:1.2.840.114350.1.72.1.30.5",
+              "code": "6",
+              "display": "Participation"
+            }
+          ],
+          "text": "Participation"
+        }
+      ],
+      "period": {
+        "start": "2025-04-01T16:00:00Z",
+        "end": "2025-04-01T16:40:00Z"
+      },
+      "individual": {
+        "reference": "Practitioner/fc-practitioner-referrer",
+        "display": "Lucia Marsh, MD"
+      }
+    },
+    {
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+              "code": "ATND",
+              "display": "attender"
+            }
+          ],
+          "text": "attender"
+        }
+      ],
+      "extension": [
+        {
+          "url": "https://vendor.example/fhir/StructureDefinition/participant-specialty",
+          "valueCodeableConcept": {
+            "text": "Dermatology"
+          }
+        }
+      ],
+      "individual": {
+        "reference": "Practitioner/fc-practitioner-attender",
+        "display": "Amara Okoye, MD"
+      }
+    },
+    {
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "urn:oid:1.2.840.114350.1.72.1.30.5",
+              "code": "11",
+              "display": "losAuthorizingPhysician"
+            }
+          ],
+          "text": "losAuthorizingPhysician"
+        }
+      ],
+      "individual": {
+        "reference": "Practitioner/fc-practitioner-authorizing",
+        "display": "Devin Hollis, MD"
+      }
+    },
+    {
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+              "code": "REF",
+              "display": "referrer"
+            }
+          ],
+          "text": "referrer"
+        }
+      ],
+      "individual": {
+        "reference": "Practitioner/fc-practitioner-referrer",
+        "display": "Lucia Marsh, MD"
+      }
+    }
+  ],
+  "period": {
+    "start": "2025-04-01T16:00:00Z",
+    "end": "2025-04-01T16:40:00Z"
+  },
+  "length": {
+    "value": 40,
+    "unit": "min",
+    "system": "http://unitsofmeasure.org",
+    "code": "min"
+  },
+  "reasonCode": [
+    {
+      "text": "Derm Problem"
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "185349003",
+          "display": "Encounter for check up"
+        }
+      ],
+      "text": "Annual skin check"
+    }
+  ],
+  "hospitalization": {
+    "admitSource": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/admit-source",
+          "code": "outp",
+          "display": "From outpatient department"
+        }
+      ],
+      "text": "From outpatient department"
+    },
+    "dischargeDisposition": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/discharge-disposition",
+          "code": "home",
+          "display": "Home"
+        }
+      ],
+      "text": "Home"
+    }
+  },
+  "location": [
+    {
+      "location": {
+        "reference": "Location/fc-location-derm",
+        "display": "NORTHGATE DERMATOLOGY"
+      },
+      "status": "completed",
+      "period": {
+        "start": "2025-04-01T16:00:00Z",
+        "end": "2025-04-01T16:40:00Z"
+      }
+    },
+    {
+      "location": {
+        "reference": "Location/fc-location-campus",
+        "display": "NORTHGATE MEDICAL CAMPUS"
+      },
+      "status": "completed"
+    }
+  ]
+}

--- a/test-fixtures/field-coverage/immunization.json
+++ b/test-fixtures/field-coverage/immunization.json
@@ -1,0 +1,99 @@
+{
+  "resourceType": "Immunization",
+  "id": "fc-immunization-influenza-1",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2024-10-08T19:31:07Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.2.768076",
+      "value": "70100000009"
+    }
+  ],
+  "status": "completed",
+  "vaccineCode": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/cvx",
+        "code": "150",
+        "display": "Influenza, injectable, quadrivalent, preservative free"
+      }
+    ],
+    "text": "Influenza Vaccine Quadrivalent PF"
+  },
+  "patient": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "encounter": {
+    "reference": "Encounter/fc-encounter-derm-1"
+  },
+  "occurrenceDateTime": "2024-10-08T17:12:00Z",
+  "primarySource": true,
+  "location": {
+    "reference": "Location/fc-location-derm",
+    "display": "NORTHGATE DERMATOLOGY"
+  },
+  "manufacturer": {
+    "reference": "Organization/fc-organization-manufacturer",
+    "display": "Meridian Biologics"
+  },
+  "lotNumber": "LOT-2024-4471",
+  "expirationDate": "2025-06-30",
+  "site": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActSite",
+        "code": "LA",
+        "display": "left arm"
+      }
+    ],
+    "text": "Left Deltoid"
+  },
+  "route": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-RouteOfAdministration",
+        "code": "IM",
+        "display": "Injection, intramuscular"
+      }
+    ],
+    "text": "Intramuscular"
+  },
+  "doseQuantity": {
+    "value": 0.5,
+    "unit": "mL",
+    "system": "http://unitsofmeasure.org",
+    "code": "mL"
+  },
+  "performer": [
+    {
+      "function": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+            "code": "AP",
+            "display": "Administering Provider"
+          }
+        ],
+        "text": "Administering Provider"
+      },
+      "actor": {
+        "reference": "Practitioner/fc-practitioner-nurse",
+        "display": "Priya Raman, RN"
+      }
+    }
+  ],
+  "note": [
+    {
+      "text": "Observed 15 minutes post-administration with no reaction."
+    }
+  ],
+  "protocolApplied": [
+    {
+      "doseNumberPositiveInt": 1,
+      "seriesDosesPositiveInt": 1
+    }
+  ]
+}

--- a/test-fixtures/field-coverage/medicationrequest.json
+++ b/test-fixtures/field-coverage/medicationrequest.json
@@ -1,0 +1,119 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "fc-medicationrequest-cetirizine-1",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2025-04-01T16:44:19Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.2.798802",
+      "value": "60100000021"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+          "code": "outpatient",
+          "display": "Outpatient"
+        }
+      ],
+      "text": "Outpatient"
+    }
+  ],
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "1014676",
+        "display": "cetirizine hydrochloride 10 MG Oral Tablet"
+      }
+    ],
+    "text": "CETIRIZINE HCL 10 MG PO TABS"
+  },
+  "subject": {
+    "reference": "Patient/fc-patient-1"
+  },
+  "encounter": {
+    "reference": "Encounter/fc-encounter-derm-1"
+  },
+  "authoredOn": "2025-04-01T16:38:00Z",
+  "requester": {
+    "reference": "Practitioner/fc-practitioner-attender",
+    "display": "Amara Okoye, MD"
+  },
+  "recorder": {
+    "reference": "Practitioner/fc-practitioner-resident",
+    "display": "Noor Habib, MD"
+  },
+  "reasonCode": [
+    {
+      "text": "Seasonal allergic rhinitis"
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient advised to take at bedtime; may cause drowsiness."
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "text": "Take 1 tablet (10 mg total) by mouth daily.",
+      "patientInstruction": "Take one tablet at bedtime.",
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.999.2.7.4.698288.330",
+            "code": "15",
+            "display": "Oral"
+          }
+        ],
+        "text": "Oral"
+      },
+      "doseAndRate": [
+        {
+          "doseQuantity": {
+            "value": 10,
+            "unit": "mg",
+            "system": "http://unitsofmeasure.org",
+            "code": "mg"
+          }
+        }
+      ]
+    },
+    {
+      "text": "If symptoms persist after 14 days, increase to 1 tablet twice daily.",
+      "sequence": 2,
+      "timing": {
+        "repeat": {
+          "frequency": 2,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "validityPeriod": {
+      "start": "2025-04-01",
+      "end": "2026-04-01"
+    },
+    "numberOfRepeatsAllowed": 3,
+    "quantity": {
+      "value": 30,
+      "unit": "tablet"
+    }
+  }
+}

--- a/test-fixtures/field-coverage/observation-lab.json
+++ b/test-fixtures/field-coverage/observation-lab.json
@@ -1,0 +1,130 @@
+{
+  "resourceType": "Observation",
+  "id": "fc-observation-hgb-1",
+  "meta": {
+    "versionId": "2",
+    "lastUpdated": "2025-03-12T18:04:11Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.2.798268",
+      "value": "30100000007"
+    }
+  ],
+  "status": "amended",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "laboratory",
+          "display": "Laboratory"
+        }
+      ],
+      "text": "Laboratory"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "718-7",
+        "display": "Hemoglobin [Mass/volume] in Blood"
+      }
+    ],
+    "text": "Hemoglobin"
+  },
+  "subject": {
+    "reference": "Patient/fc-patient-1",
+    "display": "Rowan Sample"
+  },
+  "encounter": {
+    "reference": "Encounter/fc-encounter-derm-1"
+  },
+  "effectiveDateTime": "2025-03-12T15:22:00Z",
+  "issued": "2025-03-12T17:41:00Z",
+  "performer": [
+    {
+      "reference": "Practitioner/fc-practitioner-pathologist",
+      "display": "Ines Vargas, MD"
+    }
+  ],
+  "valueQuantity": {
+    "value": 11.4,
+    "unit": "g/dL",
+    "system": "http://unitsofmeasure.org",
+    "code": "g/dL"
+  },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+          "code": "L",
+          "display": "Low"
+        }
+      ],
+      "text": "Low"
+    }
+  ],
+  "note": [
+    {
+      "text": "Specimen slightly hemolyzed; result confirmed on repeat draw."
+    },
+    {
+      "text": "Corrected from 11.9 g/dL reported 2025-03-12 16:05."
+    }
+  ],
+  "specimen": {
+    "reference": "Specimen/fc-specimen-blood-1",
+    "display": "Blood specimen"
+  },
+  "referenceRange": [
+    {
+      "low": {
+        "value": 12,
+        "unit": "g/dL",
+        "system": "http://unitsofmeasure.org",
+        "code": "g/dL"
+      },
+      "high": {
+        "value": 15.5,
+        "unit": "g/dL",
+        "system": "http://unitsofmeasure.org",
+        "code": "g/dL"
+      },
+      "text": "12.0 - 15.5 g/dL",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning",
+            "code": "normal",
+            "display": "Normal Range"
+          }
+        ],
+        "text": "Normal Range"
+      }
+    },
+    {
+      "low": {
+        "value": 13.5,
+        "unit": "g/dL",
+        "system": "http://unitsofmeasure.org",
+        "code": "g/dL"
+      },
+      "high": {
+        "value": 17.5,
+        "unit": "g/dL",
+        "system": "http://unitsofmeasure.org",
+        "code": "g/dL"
+      },
+      "text": "13.5 - 17.5 g/dL",
+      "appliesTo": [
+        {
+          "text": "Adult male reference population"
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/field-coverage/patient.json
+++ b/test-fixtures/field-coverage/patient.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "Patient",
+  "id": "fc-patient-1",
+  "meta": {
+    "versionId": "7",
+    "lastUpdated": "2025-04-01T16:00:02Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "text": "MRN"
+      },
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.5.737384.14",
+      "value": "MRN-9100042"
+    },
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.840.114350.1.13.999.2.7.3.688884.100",
+      "value": "E9100042"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "text": "Rowan Alexis Sample",
+      "family": "Sample",
+      "given": ["Rowan", "Alexis"]
+    },
+    {
+      "use": "usual",
+      "text": "Ro Sample",
+      "family": "Sample",
+      "given": ["Ro"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "555-0100",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "555-0142",
+      "use": "mobile"
+    },
+    {
+      "system": "email",
+      "value": "rowan.sample@example.org",
+      "use": "home"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1978-06-14",
+  "deceasedBoolean": false,
+  "address": [
+    {
+      "use": "home",
+      "line": ["4120 Northgate Way", "Apt 7"],
+      "city": "Springfield",
+      "state": "WA",
+      "postalCode": "99999",
+      "country": "US"
+    }
+  ],
+  "maritalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+        "code": "M",
+        "display": "Married"
+      }
+    ],
+    "text": "Married"
+  },
+  "communication": [
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "en",
+            "display": "English"
+          }
+        ],
+        "text": "English"
+      },
+      "preferred": true
+    }
+  ],
+  "generalPractitioner": [
+    {
+      "reference": "Practitioner/fc-practitioner-pcp",
+      "display": "Tobias Lund, MD"
+    },
+    {
+      "reference": "Organization/fc-organization-1",
+      "display": "Northgate Health Network"
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/fc-organization-1",
+    "display": "Northgate Health Network"
+  }
+}

--- a/tests/fhir-field-coverage.test.ts
+++ b/tests/fhir-field-coverage.test.ts
@@ -1,0 +1,324 @@
+/**
+ * The field-coverage chokepoint: no FHIR field is dropped in silence.
+ *
+ * THE DEFECT CLASS THIS EXISTS FOR
+ * --------------------------------
+ * A converter that never reads a field, a converter that reads a field only to
+ * mint identity and never writes it, and a converter that reads the first
+ * element of an array and ignores the rest all produce the same thing from
+ * outside: a pod that is quietly thinner than its source. Measured on one real
+ * Epic R4 pull, that came to a visit record holding seven bookkeeping facts
+ * while the source stated the clinic, the reason, four typed participants, the
+ * contact serial number and four type codings — and, twice, an AMENDED result
+ * imported byte-identical to a final one.
+ *
+ * No single omission was the bug. The bug was that omissions were silent. So
+ * this gate does not check for any particular field: it requires that EVERY
+ * populated element either reaches the converted output or sits on that
+ * converter's drop manifest with a written reason.
+ *
+ * WHY DIFFERENTIAL, AND WHY NOT THE TWO OBVIOUS ALTERNATIVES
+ * ----------------------------------------------------------
+ * Both were tried on the real corpus and both gave wrong answers.
+ *
+ *   Grep the converter for `resource.<field>`: wrong in both directions.
+ *   `convertEncounter` reads `resource.identifier` for identity and never emits
+ *   it, so the read-list called it kept while the pod contained none.
+ *
+ *   Match source VALUES against the pod: wrong in the other direction. Matching
+ *   against the whole corpus reports a hit whenever any unrelated record
+ *   contains the same string, so encounter reason texts collided with condition
+ *   names and retention was overstated.
+ *
+ * Deleting one element and re-converting asks the question that answers itself.
+ * If the output does not move, the element reached nothing.
+ *
+ * WHAT COUNTS AS REACHING THE OUTPUT
+ * ----------------------------------
+ * Predicate + object multiset, plus the SET OF SUBJECT IRIs. A field that only
+ * moves the IRI still counts as emitted, because on the content-keyed types it
+ * decides which records merge — a stronger effect than a triple. That is the
+ * seam with `clinical-identity.test.ts`: source -> serialized is proven here,
+ * serialized -> identity key is proven there, and a field cannot silently skip a
+ * layer.
+ *
+ * THE ONE THING THE DIFFERENTIAL CANNOT SEE
+ * -----------------------------------------
+ * It deletes ONE element at a time, so two elements that express the same value
+ * (a `text` beside a coding `display`, or a stated status equal to the
+ * converter's default) each measure as dropped: with either one gone the other
+ * still produces the same output. Those are recorded as `acknowledged` entries
+ * whose reason names the redundancy, rather than silently excluded — the
+ * defaulting cases in particular are worth stating, since they are how an
+ * ABSENT status becomes a confident "completed" in the pod.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { analyzeResourceCoverage } from '../src/lib/fhir-converter/field-coverage/analyze.js';
+import {
+  FIELD_DROP_MANIFESTS,
+  manifestFor,
+  manifestedTypes,
+} from '../src/lib/fhir-converter/field-coverage/manifests/index.js';
+import {
+  childFieldPaths,
+  enumerateFieldPaths,
+  topLevelFieldPaths,
+  withoutPath,
+} from '../src/lib/fhir-converter/field-coverage/paths.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.resolve(HERE, '..', 'test-fixtures', 'field-coverage');
+
+interface Fixture {
+  file: string;
+  resource: Record<string, unknown>;
+  resourceType: string;
+}
+
+function loadFixtures(): Fixture[] {
+  return fs
+    .readdirSync(FIXTURE_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((file) => {
+      const resource = JSON.parse(
+        fs.readFileSync(path.join(FIXTURE_DIR, file), 'utf-8'),
+      ) as Record<string, unknown>;
+      return { file, resource, resourceType: String(resource.resourceType) };
+    });
+}
+
+const FIXTURES = loadFixtures();
+
+/**
+ * The coverage of every fixture, measured once. Each measurement runs one
+ * conversion per visited path, so doing it per assertion would multiply a real
+ * cost for no extra proof.
+ */
+const COVERAGE = FIXTURES.map((fixture) => ({
+  fixture,
+  coverage: analyzeResourceCoverage(fixture.resource),
+}));
+
+/** Every path any fixture proved dropped, as `Type|path`. */
+const DROPPED_SOMEWHERE = new Set(
+  COVERAGE.flatMap(({ fixture, coverage }) =>
+    coverage.dropped.map((p) => `${fixture.resourceType}|${p}`),
+  ),
+);
+
+/** Every path any fixture proved emitted, as `Type|path`. */
+const EMITTED_SOMEWHERE = new Set(
+  COVERAGE.flatMap(({ fixture, coverage }) =>
+    coverage.emitted.map((p) => `${fixture.resourceType}|${p}`),
+  ),
+);
+
+/** Every path any fixture populated at all, as `Type|path`. */
+const POPULATED_SOMEWHERE = new Set(
+  FIXTURES.flatMap((fixture) =>
+    enumerateFieldPaths(fixture.resource).map((p) => `${fixture.resourceType}|${p}`),
+  ),
+);
+
+describe('FHIR field coverage: the corpus and the manifests describe the same converters', () => {
+  it('every fixture is a resource type that has a drop manifest', () => {
+    const orphans = FIXTURES.filter((f) => !manifestFor(f.resourceType)).map(
+      (f) => `${f.file} (${f.resourceType})`,
+    );
+    expect(
+      orphans,
+      'A fixture without a manifest cannot be checked: every dropped path would fail with nowhere to record it.',
+    ).toEqual([]);
+  });
+
+  it('every manifested resource type has at least one fixture', () => {
+    const covered = new Set(FIXTURES.map((f) => f.resourceType));
+    const unexercised = manifestedTypes().filter((t) => !covered.has(t));
+    expect(
+      unexercised,
+      'A manifest with no fixture is unfalsifiable: nothing can ever prove one of its entries stale.',
+    ).toEqual([]);
+  });
+
+  it('every manifest entry is well formed', () => {
+    const problems: string[] = [];
+    for (const manifest of FIELD_DROP_MANIFESTS) {
+      for (const [entryPath, entry] of Object.entries(manifest.drops)) {
+        if (!entryPath.startsWith(`${manifest.resourceType}.`)) {
+          problems.push(`${entryPath}: path does not start with ${manifest.resourceType}.`);
+        }
+        if (entry.disposition === 'pending' && !entry.backlog) {
+          problems.push(`${entryPath}: pending without a backlog id — an untracked gap becomes permanent by accident.`);
+        }
+        if (entry.disposition === 'acknowledged' && entry.backlog) {
+          problems.push(`${entryPath}: acknowledged with a backlog id — decide whether it is a decision or a debt.`);
+        }
+        if (entry.reason.trim().length < 40) {
+          problems.push(`${entryPath}: reason is too short to be an argument.`);
+        }
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+});
+
+describe.each(COVERAGE)('$fixture.file', ({ fixture, coverage }) => {
+  it('every populated element is either emitted or on the drop manifest', () => {
+    const manifest = manifestFor(fixture.resourceType);
+    const undeclared = coverage.dropped.filter((p) => !manifest?.drops[p]);
+    expect(
+      undeclared,
+      `${fixture.resourceType}: these populated elements reach nothing in the converted output and no drop ` +
+        `manifest accounts for them. Either emit them, or add an entry to ` +
+        `src/lib/fhir-converter/field-coverage/manifests/ saying why they are not emitted.`,
+    ).toEqual([]);
+  });
+
+  it('no element is untestable', () => {
+    expect(
+      coverage.untestable,
+      'An element that could not be deleted was not measured. Reporting it as either kept or dropped would be a guess.',
+    ).toEqual([]);
+  });
+
+  it('the fixture exercises both outcomes', () => {
+    // A fixture that emits everything, or drops everything, is not measuring the
+    // converter — it is measuring itself.
+    expect(coverage.emitted.length).toBeGreaterThan(0);
+    expect(coverage.dropped.length + coverage.emitted.length).toBeGreaterThan(10);
+  });
+});
+
+describe('drop manifests stay honest', () => {
+  it('no manifest entry describes a drop that no longer happens at that level', () => {
+    // Two ways an entry goes stale, and the message says which, because the two
+    // read very differently to whoever has to act on it:
+    //
+    //   EMITTED — the converter now carries the field. This is what a fix looks
+    //   like from here, and finishing the fix means deleting the entry.
+    //
+    //   COVERED BY A DROPPED ANCESTOR — the field is still lost, but the loss is
+    //   now reported one level up, because the walk stops descending at a drop.
+    //   Wave 1 produced exactly this: role-aware provider selection moved the
+    //   drop from `participant[0].type` to the whole of `participant[0]`.
+    //
+    // Both mean delete, and calling the second one "emitted" would tell a reader
+    // their data is safe when it is not.
+    const stale: string[] = [];
+    for (const manifest of FIELD_DROP_MANIFESTS) {
+      for (const entryPath of Object.keys(manifest.drops)) {
+        const key = `${manifest.resourceType}|${entryPath}`;
+        if (!POPULATED_SOMEWHERE.has(key)) continue;
+        if (DROPPED_SOMEWHERE.has(key)) continue;
+        stale.push(
+          `${entryPath} — ${EMITTED_SOMEWHERE.has(key) ? 'EMITTED now' : 'still dropped, but covered by a dropped ancestor'}`,
+        );
+      }
+    }
+    expect(
+      stale,
+      'These manifest entries no longer describe a drop measured at their own path. Delete them.',
+    ).toEqual([]);
+  });
+
+  it('no manifest entry names a path no fixture populates', () => {
+    const unexercised: string[] = [];
+    for (const manifest of FIELD_DROP_MANIFESTS) {
+      for (const entryPath of Object.keys(manifest.drops)) {
+        if (!POPULATED_SOMEWHERE.has(`${manifest.resourceType}|${entryPath}`)) {
+          unexercised.push(entryPath);
+        }
+      }
+    }
+    expect(
+      unexercised,
+      'An entry no fixture populates can never be proven stale, so it would outlive the omission it describes. ' +
+        'Either populate the path in the fixture or delete the entry.',
+    ).toEqual([]);
+  });
+
+  it('every pending entry carries a backlog id and every acknowledged one carries none', () => {
+    // Restated here as a corpus-wide count so the numbers appear in the run,
+    // and so a manifest added later without either property is visible.
+    const pending = FIELD_DROP_MANIFESTS.flatMap((m) =>
+      Object.values(m.drops).filter((e) => e.disposition === 'pending'),
+    );
+    const acknowledged = FIELD_DROP_MANIFESTS.flatMap((m) =>
+      Object.values(m.drops).filter((e) => e.disposition === 'acknowledged'),
+    );
+    expect(pending.every((e) => typeof e.backlog === 'string' && e.backlog.length > 0)).toBe(true);
+    expect(acknowledged.every((e) => e.backlog === undefined)).toBe(true);
+    expect(pending.length + acknowledged.length).toBe(
+      FIELD_DROP_MANIFESTS.reduce((n, m) => n + Object.keys(m.drops).length, 0),
+    );
+  });
+});
+
+describe('the measurement itself', () => {
+  /**
+   * The differential is only as good as its deletion step. If `withoutPath` ever
+   * stopped removing anything, every path would measure as emitted, every drop
+   * would disappear, and the whole suite above would pass while proving nothing.
+   * These pin the mechanism rather than the converters.
+   */
+  it('deleting a path removes exactly that path', () => {
+    const encounter = FIXTURES.find((f) => f.resourceType === 'Encounter')!.resource;
+    const reduced = withoutPath(encounter, 'Encounter.type[1]');
+    expect(reduced).toBeDefined();
+    expect((encounter.type as unknown[]).length).toBe(4);
+    expect(((reduced as Record<string, unknown>).type as unknown[]).length).toBe(3);
+    // Spliced out, not blanked: index 1 is now what index 2 was.
+    expect(((reduced as Record<string, unknown>).type as unknown[])[1]).toEqual(
+      (encounter.type as unknown[])[2],
+    );
+    // And the original is untouched, so one measurement cannot poison the next.
+    expect((encounter.type as unknown[]).length).toBe(4);
+  });
+
+  it('a path that does not resolve is reported, never treated as unchanged', () => {
+    const encounter = FIXTURES.find((f) => f.resourceType === 'Encounter')!.resource;
+    expect(withoutPath(encounter, 'Encounter.noSuchField')).toBeUndefined();
+    expect(withoutPath(encounter, 'Encounter.type[99]')).toBeUndefined();
+    expect(withoutPath(encounter, 'not a path')).toBeUndefined();
+  });
+
+  it('enumeration reaches array tails and one level of qualifier', () => {
+    const encounter = FIXTURES.find((f) => f.resourceType === 'Encounter')!.resource;
+    const top = topLevelFieldPaths(encounter);
+    expect(top).toContain('Encounter.type');
+    expect(top).toContain('Encounter.participant');
+    expect(childFieldPaths(encounter, 'Encounter.type')).toEqual([
+      'Encounter.type[0]',
+      'Encounter.type[1]',
+      'Encounter.type[2]',
+      'Encounter.type[3]',
+    ]);
+    expect(childFieldPaths(encounter, 'Encounter.class')).toContain('Encounter.class.display');
+    expect(childFieldPaths(encounter, 'Encounter.participant[1]')).toContain(
+      'Encounter.participant[1].type',
+    );
+    // Bounded: nothing below two named steps.
+    expect(childFieldPaths(encounter, 'Encounter.participant[1].type')).toEqual([]);
+  });
+
+  it('the three known loss modes are each measured as a drop', () => {
+    // Not an assertion about which fields SHOULD be lost — the manifests hold
+    // that — but proof that the instrument detects all three shapes. If a wave
+    // lands that fixes one of these, its manifest entry goes stale and the test
+    // above fails first, which is the intended order.
+    const encounter = COVERAGE.find((c) => c.fixture.resourceType === 'Encounter')!.coverage;
+    // Never read.
+    expect(encounter.dropped).toContain('Encounter.reasonCode');
+    // Read for identity, never written as a fact.
+    expect(encounter.dropped).toContain('Encounter.identifier');
+    // Partial array: the head is emitted, the tail is not.
+    expect(encounter.emitted).toContain('Encounter.type[0]');
+    expect(encounter.dropped).toContain('Encounter.type[1]');
+  });
+});

--- a/tests/sources-coverage.test.ts
+++ b/tests/sources-coverage.test.ts
@@ -1,0 +1,227 @@
+/**
+ * `cascade sources coverage`: the field-coverage report a person can run on
+ * their own pod, and the same disclosure written into an import manifest.
+ *
+ * Three things are worth pinning here, and only one of them is the arithmetic.
+ *
+ * 1. THE REPORT CARRIES NO VALUES. It exists to be shared — a design partner
+ *    sends back the SHAPE of what their EHR populates so a synthetic fixture can
+ *    be authored for it — and that only works if paths and counts are all it
+ *    ever prints. The test asserts that no value from the source appears in the
+ *    output, so a future "helpful" example value fails here rather than in
+ *    somebody's inbox.
+ *
+ * 2. AN UNREADABLE POD IS NOT AN EMPTY ONE. `sources/` is inside a sealed pod's
+ *    encrypted set. A verb that read ciphertext, parsed nothing and reported
+ *    "no fields lost" would be making a confident claim about a health record it
+ *    could not open. Exit 2, per docs/exit-codes.md.
+ *
+ * 3. THE MANIFEST DISTINGUISHES "not measured" FROM "nothing lost". The
+ *    fieldCoverage block is absent when there was nothing to measure, never zero.
+ *
+ * The verb runs as a real subprocess: the exit code is part of what is under
+ * test, and it is set on `process.exitCode` inside an action handler.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildPassphraseManifest,
+  writeEncryptionManifest,
+  writeResource,
+} from '../src/lib/pod-encryption.js';
+import {
+  buildFieldCoverageDisclosure,
+  buildImportManifest,
+} from '../src/lib/fhir-converter/import-manifest.js';
+import type { BatchConversionResult } from '../src/lib/fhir-converter/types.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(HERE, '..', 'dist', 'index.js');
+const FIXTURE_DIR = path.resolve(HERE, '..', 'test-fixtures', 'field-coverage');
+
+const PASSPHRASE = 'sources-coverage-passphrase';
+
+function fixtures(): Record<string, unknown>[] {
+  return fs
+    .readdirSync(FIXTURE_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((f) => JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, f), 'utf-8')));
+}
+
+function bundleOf(resources: unknown[]): string {
+  return JSON.stringify({
+    resourceType: 'Bundle',
+    type: 'searchset',
+    entry: resources.map((resource) => ({ resource })),
+  });
+}
+
+let tmpRoot: string;
+let plainPod: string;
+let sealedPod: string;
+let podWithoutSources: string;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cascade-sources-coverage-'));
+  plainPod = path.join(tmpRoot, 'plain-pod');
+  sealedPod = path.join(tmpRoot, 'sealed-pod');
+  podWithoutSources = path.join(tmpRoot, 'no-sources-pod');
+
+  const all = fixtures();
+  // The same encounter twice across two overlapping pulls, plus a second one, so
+  // the de-duplication and the per-path counts are both exercised.
+  const encounter = all.find((r) => r.resourceType === 'Encounter')!;
+  const secondEncounter = structuredClone(encounter);
+  secondEncounter.id = 'fc-encounter-derm-2';
+
+  fs.mkdirSync(path.join(plainPod, 'sources'), { recursive: true });
+  fs.writeFileSync(path.join(plainPod, 'sources', 'bundle-1.json'), bundleOf(all));
+  fs.writeFileSync(
+    path.join(plainPod, 'sources', 'bundle-2.json'),
+    bundleOf([encounter, secondEncounter]),
+  );
+  // A JSON file in sources/ that is not FHIR: named in a warning, never fatal.
+  fs.writeFileSync(path.join(plainPod, 'sources', 'pull-metadata.json'), '{"pulledAt":"2025-04-02"}');
+
+  fs.mkdirSync(podWithoutSources, { recursive: true });
+
+  fs.mkdirSync(path.join(sealedPod, 'sources'), { recursive: true });
+  const dek = Buffer.alloc(32, 7);
+  // Cheap KDF parameters: this suite derives a KEK per invocation and the
+  // default cost is deliberately heavy. The pod records its own parameters, so
+  // every code path under test is unchanged.
+  writeEncryptionManifest(sealedPod, buildPassphraseManifest(dek, PASSPHRASE, { t: 1, m: 8192, p: 1 }));
+  writeResource(path.join(sealedPod, 'sources', 'bundle-1.json'), bundleOf(all), dek);
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function run(args: string[], env: Record<string, string> = {}) {
+  return spawnSync('node', [CLI, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, CASCADE_POD_PASSPHRASE: '', ...env },
+  });
+}
+
+describe('cascade sources coverage', () => {
+  it('reports paths and counts over the retained sources', () => {
+    const result = run(['sources', 'coverage', plainPod]);
+    expect(result.status).toBe(0);
+    // Deduplicated: the encounter appearing in both bundles is one resource.
+    expect(result.stdout).toContain('11 unique of 12 read');
+    expect(result.stdout).toMatch(/Encounter \(2 resources\)/);
+    expect(result.stdout).toMatch(/2 {2}Encounter\.identifier\s+pending 3\.254/);
+    expect(result.stdout).toMatch(/Encounter\.reasonCode\s+pending 3\.254/);
+    expect(result.stdout).toMatch(/Observation\.specimen\s+pending 3\.256/);
+    // The disclosure says where the data still is, not only that it is missing.
+    expect(result.stdout).toContain('retained under sources/');
+    // A non-FHIR JSON file is named, and does not fail the command.
+    expect(result.stderr).toContain('pull-metadata.json');
+  });
+
+  it('prints no value from the sources', () => {
+    const result = run(['sources', 'coverage', plainPod]);
+    expect(result.status).toBe(0);
+    // A sample drawn from every fixture: names, identifiers, free text, codes.
+    const values = [
+      'NORTHGATE DERMATOLOGY',
+      'Derm Problem',
+      '20100000001',
+      'Rowan',
+      'Sample',
+      '555-0100',
+      'MEM-88213400',
+      'LOT-2024-4471',
+      'Cashew',
+      'hemolyzed',
+      'CETIRIZINE',
+      'Amara Okoye',
+      'MRN-9100042',
+    ];
+    const leaked = values.filter((v) => result.stdout.includes(v));
+    expect(
+      leaked,
+      'The coverage report is meant to be shareable. Element paths and counts only — never a value.',
+    ).toEqual([]);
+  });
+
+  it('exits 2 rather than reporting an unreadable pod as a clean one', () => {
+    const result = run(['sources', 'coverage', sealedPod]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).not.toContain('not imported');
+  });
+
+  it('reads a sealed pod when given its passphrase', () => {
+    const result = run(['sources', 'coverage', sealedPod], { CASCADE_POD_PASSPHRASE: PASSPHRASE });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/Encounter \(1 resources\)/);
+  }, 60_000);
+
+  it('exits 1 when the directory is not a pod, or retains no sources', () => {
+    expect(run(['sources', 'coverage', path.join(tmpRoot, 'nope')]).status).toBe(1);
+    const noSources = run(['sources', 'coverage', podWithoutSources]);
+    expect(noSources.status).toBe(1);
+    expect(noSources.stderr).toContain('sources/');
+  });
+
+  it('answers as JSON with the same numbers', () => {
+    const result = run(['--json', 'sources', 'coverage', plainPod]);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      resourcesUnique: number;
+      totals: { droppedFields: number; unaccounted: number };
+      byType: Record<string, { droppedPaths: Array<{ path: string; count: number }> }>;
+    };
+    expect(parsed.resourcesUnique).toBe(11);
+    expect(parsed.totals.droppedFields).toBeGreaterThan(0);
+    // Every drop in this corpus is accounted for by a manifest; if that ever
+    // stops being true the conformance test fails too, and this is the same
+    // fact stated where a user would see it.
+    expect(parsed.totals.unaccounted).toBe(0);
+    expect(
+      parsed.byType.Encounter.droppedPaths.find((p) => p.path === 'Encounter.location[1]')?.count,
+    ).toBe(2);
+  });
+});
+
+describe('the import manifest discloses the same thing', () => {
+  const emptyResult: BatchConversionResult = {
+    success: true,
+    output: '',
+    format: 'turtle',
+    resourceCount: 1,
+    skippedCount: 0,
+    warnings: [],
+    errors: [],
+    results: [{ turtle: '', warnings: [], resourceType: 'Encounter', cascadeType: 'clinical:Encounter' }],
+  };
+
+  it('carries the field-level counts and a sentence saying where the data is', () => {
+    const disclosure = buildFieldCoverageDisclosure(fixtures());
+    const manifest = buildImportManifest(emptyResult, 'bundle.json', 'test', {}, disclosure);
+    expect(manifest.fieldCoverage).toBeDefined();
+    expect(manifest.fieldCoverage!.notImportedFields).toBeGreaterThan(0);
+    expect(manifest.fieldCoverage!.populatedFields).toBe(
+      manifest.fieldCoverage!.importedFields + manifest.fieldCoverage!.notImportedFields,
+    );
+    expect(manifest.fieldCoverage!.acknowledged + manifest.fieldCoverage!.pending +
+      manifest.fieldCoverage!.unaccounted).toBe(manifest.fieldCoverage!.notImportedFields);
+    expect(manifest.fieldCoverage!.summary).toContain('retained under sources/');
+    expect(manifest.fieldCoverage!.byType.Encounter.droppedPaths.length).toBeGreaterThan(0);
+  });
+
+  it('omits the block entirely when nothing was measured', () => {
+    const manifest = buildImportManifest(emptyResult, 'bundle.json', 'test', {});
+    expect(manifest.fieldCoverage).toBeUndefined();
+    expect('fieldCoverage' in manifest).toBe(false);
+  });
+});


### PR DESCRIPTION
Makes FHIR field loss impossible to take silently: every populated element of an imported resource must either reach the converted output or sit on its converter's drop manifest with a written reason.

**Rebased on #85.** The manifests were re-measured against it: nine entries no longer described a drop at their own path and were deleted, and seven newly visible drops were declared. No converter file is touched by this branch.

## How coverage is measured

Differential, per populated element path: convert the resource, convert a copy with exactly that element deleted, compare. Identical output means the element reached nothing.

Comparison is the predicate+object multiset plus the set of subject IRIs. A deletion that only moves the IRI counts as **emitted**, because such a field participates in identity and decides which records merge — the seam with `clinical-identity.test.ts`, which holds the serialized→identity-key half.

Two cheaper methods were tried first and are wrong in opposite directions: reading the converter for `resource.<field>` counts a field read for identity and never written as kept, and matching source values against a pod reports a hit whenever an unrelated record contains the same string.

Enumeration is pruned at drops (a dropped element takes its subtree, so one omission is reported once) and bounded at two named steps below the root, with array indices free.

## What is in the diff

| | |
|---|---|
| Drop manifests | 10 types, 127 entries: **59 acknowledged**, **68 pending** (each carrying the backlog id that tracks it) |
| Fixtures | 10 hand-authored synthetic resources + `FIXTURES.md` provenance manifest |
| Conformance test | `tests/fhir-field-coverage.test.ts`, 40 assertions |
| Verb test | `tests/sources-coverage.test.ts`, 8 assertions |
| New verb | `cascade sources coverage <pod-dir>` |
| Manifest | optional `fieldCoverage` block on the import manifest |

Per type (acknowledged / pending): AllergyIntolerance 6/9 · Condition 6/3 · Coverage 8/3 · DiagnosticReport 4/6 · DocumentReference 5/8 · Encounter 6/14 · Immunization 9/5 · MedicationRequest 3/7 · Observation 7/6 · Patient 5/7.

## What fails the gate

- a populated element that reaches nothing and is on no manifest — named by path
- a manifest entry that no longer describes a drop at its own path, saying which of the two reasons applies: the converter now **emits** it, or it is **still dropped but covered by a dropped ancestor** (calling the second one "emitted" would tell a reader their data is safe when it is not)
- a manifest entry no fixture populates (unfalsifiable)
- `pending` without a backlog id, `acknowledged` with one, or a reason too short to be an argument
- a fixture whose type has no manifest, or a manifest whose type has no fixture

The first two were observed RED before this branch was opened, and the second fired for real on the rebase.

## The verb

`cascade sources coverage <pod-dir>` runs the same computation over the raw documents a pod retained at import, and reports **element paths and counts only** — never a value, which is what makes the report shareable. A test asserts no fixture value appears in the output. A sealed pod that cannot be opened exits 2 rather than reporting a clean import.

Throughput: 600 resources / 17,940 populated fields in ~2s.

## Fixtures

Hand-authored, all values invented; shapes modelled on production R4 output (multiple type codings, four typed participants, two locations, nested attachments) because a one-of-each fixture proves the converter handles a case that does not occur. References are relative on purpose — an absolute reference host feeds provenance derivation and would make unrelated deletions look like emissions.

SNOMED CT concepts are International Edition only, five of them, each with its description copied verbatim, attributed in `FIXTURES.md` per the Global Patient Set terms. No CPT code appears anywhere, and `FIXTURES.md` says none may be added.

## Verification

- `npm run build` clean
- full suite: **158 files, 2531 tests, 0 failures, 0 skipped**
- `npm run lint`: no findings in the added files
- new verb exercised end to end on a synthetic pod, including the sealed-pod and no-`sources/` paths
