### PR TITLE
fix(fhir): emit record status, and select encounter provider by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+**Record `status` now reaches the pod, so an amended result is no longer identical to a final one.**
+No FHIR converter emitted the resource's status, on any type that has one. An `amended` Observation
+and a `final` one therefore produced byte-identical records, as did an `amended` DocumentReference
+and a `final` one. Measured against one real vendor account: 1 amended Observation and 9 amended
+DocumentReferences existed in the source and were indistinguishable after import. This is a
+correctness distinction rather than an enrichment, and no new vocabulary was needed to carry it.
+
+Emitted now, all on predicates that already existed:
+
+| Source element | Predicate |
+|---|---|
+| `Observation.status` (lab and vital branches alike) | `clinical:status` |
+| `DocumentReference.docStatus` | `clinical:status` |
+| `DiagnosticReport.status` | `clinical:status` |
+| `AllergyIntolerance.clinicalStatus` | `clinical:status` |
+| `Condition.verificationStatus` | `clinical:verificationStatus` |
+
+`clinical:status` carries four of the five because it declares no `rdfs:domain`, states in its own
+definition that permitted values are constrained per-shape rather than on the property, and is
+already how this repository spells FHIR `.status` on medications. It also gives a reader ONE
+predicate to ask for: `convertObservationVital` re-routes non-canonical vitals into
+`convertObservationLab`, so a per-branch predicate would mean the same source element landing under
+two different names depending on a routing table.
+
+A status is reported and never invented — no converter defaults one — because asserting `final`
+about a record whose server never said so is the same defect in the opposite direction.
+
+Two statuses are **acknowledged drops** rather than silent ones, each with a written reason in the
+converter. `Coverage.status` has no predicate that can hold it truthfully: the coverage namespace
+defines no status property for `coverage:InsurancePlan`, and `coverage:claimStatus` /
+`coverage:adjudicationStatus` are domain-restricted to other classes. `DocumentReference.status`
+(current | superseded) is a statement about the reference rather than about the document, and
+sharing one predicate with `docStatus` would leave a reader seeing `entered-in-error` unable to
+tell which element said it. Both need vocabulary. The Coverage case carries a tripwire that fails
+the day a `coverage:status` term is authored.
+
+**`Encounter` provider is now selected by declared role, not by array position.**
+`convertEncounter` took `participant[0].individual.display` with no role check. On one real account
+the first slot held an explicitly non-treating role on 18 of the 52 encounters that have
+participants — an authorising physician 16 times, a referrer twice — so the pod named the wrong
+clinician with nothing on the record to say so. Selection is now by HL7 v3 ParticipationType
+preference (attender, primary performer, secondary performer, consultant, admitter, discharger),
+reading both `type[].coding[].code` and `type[].text`, with ties broken by source order and an
+unranked participant used only when the encounter names nobody better. The record still carries a
+single `clinical:providerName`; emitting every participant with its role needs vocabulary.
+
+**`Encounter` facility falls back to the location when the vendor omits `serviceProvider`.**
+`clinical:facilityName` appeared zero times in an entire real pod: the converter sourced it only
+from `serviceProvider`, which that vendor never populated, while `location[].location.display` was
+present on all 54 encounters (24 distinct clinics). `serviceProvider` is still preferred; the first
+non-empty location display is used when it is absent.
+
+`Encounter.class.display` remains an acknowledged drop, documented in the converter. The class
+*code* is what the reverse converter needs to rebuild `Encounter.class`, so overwriting it with the
+display is not available, and no predicate exists for the display alongside it.
+
+### Identity
+
+`Observation.status` joins the lab Observation content key, per the completeness rule documented on
+`conditionSubjectUri`: a serialized field outside the key is a field two records sharing an IRI can
+disagree on. This moves IRIs only for id-less lab Observations that differ in status; a record
+carrying an `id` is unaffected, and the two fields newly serialized on Condition and
+AllergyIntolerance were already in their keys, so no IRI moves there at all. The mechanical audit in
+`clinical-identity.test.ts` gained a row for each.
+
+### Tests
+
+`tests/fhir-field-coverage-wave1.test.ts` (27 cases). 16 were observed RED against the parent commit
+with `dist/` rebuilt from it; the 11 that pass either way are labelled in place as stability pins or
+acknowledged drops and are not counted as evidence. Two further cases in
+`tests/clinical-identity.test.ts` were likewise observed RED. The role table was additionally
+probed by deletion: removing a single rank entry, and removing the unranked fallback, each turns the
+suite red.
+
+---
+
 ## [0.20.4] - 2026-08-21
 
 ### Security

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -1216,7 +1216,39 @@ const ENCOUNTER_PARTICIPANT_ROLE_RANK: Record<string, number> = {
   CON: 3, // consultant
   ADM: 4, // admitter
   DIS: 5, // discharger
+  // NOT v3: the measured Epic dialect. On the account this fix was verified
+  // against, the treating clinician frequently carries no v3 code at all —
+  // the dermatology visit's dermatologist appears only as `PHYSICIAN`,
+  // `losAuthorizingPhysician` and `PART`. A generic "Physician" is a weaker
+  // claim than any v3 performer role, so it ranks below all of them, but it
+  // is still a treating-role signal and must beat the fallback tier — which
+  // is where the referrer in slot 0 lives.
+  PHYSICIAN: 6,
 };
+
+/**
+ * Whether a participant's role EXPLICITLY says they did not deliver the care:
+ * `referrer` (v3 REF) and Epic's `losAuthorizingPhysician`. These are the two
+ * roles the measurement found sitting in slot 0 on 18 of 52 encounters, which
+ * is what made blind `participant[0]` wrong. They are never ranked, and the
+ * fallback tier prefers any neutrally-typed name over them; they are stored
+ * only when the encounter names nobody else at all.
+ *
+ * `losAuthorizingPhysician` is matched on the `authoriz` stem, not `physician`
+ * — its text CONTAINS "Physician" and must not be mistaken for the treating
+ * role above.
+ */
+function participantIsExplicitlyNonTreating(participant: any): boolean {
+  const types = Array.isArray(participant?.type) ? participant.type : [];
+  for (const type of types) {
+    for (const coding of Array.isArray(type?.coding) ? type.coding : []) {
+      const code = typeof coding?.code === 'string' ? coding.code.trim().toUpperCase() : undefined;
+      if (code === 'REF') return true;
+    }
+    if (typeof type?.text === 'string' && /referrer|authoriz/i.test(type.text)) return true;
+  }
+  return false;
+}
 
 /** Rank of the best role a single `Encounter.participant` declares, or undefined. */
 function participantRoleRank(participant: any): number | undefined {
@@ -1237,6 +1269,11 @@ function participantRoleRank(participant: any): number | undefined {
     if (typeof type?.text === 'string' && /attend/i.test(type.text)) {
       consider(ENCOUNTER_PARTICIPANT_ROLE_RANK.ATND);
     }
+    // Exact match only: `losAuthorizingPhysician` also contains "Physician"
+    // and is an explicitly NON-treating role.
+    if (typeof type?.text === 'string' && /^physician$/i.test(type.text.trim())) {
+      consider(ENCOUNTER_PARTICIPANT_ROLE_RANK.PHYSICIAN);
+    }
   }
   return best;
 }
@@ -1245,10 +1282,11 @@ function participantRoleRank(participant: any): number | undefined {
  * The single name to store as `clinical:providerName` for an encounter.
  *
  * Preference order, highest first: attender, primary performer, any other
- * ranked clinical performer role (see the table above), then — only if no
- * participant declares a ranked role — the first participant that carries a
- * name at all. Ties are broken by source order, so a stable input gives a
- * stable answer.
+ * ranked clinical performer role (see the table above, generic Physician
+ * last), then — only if no participant declares a ranked role — the first
+ * named participant whose role does not explicitly disclaim treating, then
+ * the first participant that carries a name at all. Ties are broken by
+ * source order, so a stable input gives a stable answer.
  *
  * Emitting EVERY participant with its role is the right long-run answer and
  * needs vocabulary that does not exist yet; this keeps the record's single
@@ -1258,6 +1296,7 @@ function selectEncounterProviderName(resource: any): string | undefined {
   const participants = Array.isArray(resource?.participant) ? resource.participant : [];
   let chosen: string | undefined;
   let chosenRank: number | undefined;
+  let firstNeutralNamed: string | undefined;
   let firstNamed: string | undefined;
 
   for (const participant of participants) {
@@ -1265,14 +1304,24 @@ function selectEncounterProviderName(resource: any): string | undefined {
     if (typeof name !== 'string' || name.trim().length === 0) continue;
     if (firstNamed === undefined) firstNamed = name;
     const rank = participantRoleRank(participant);
-    if (rank === undefined) continue;
+    if (rank === undefined) {
+      // The fallback tier is split in two: a name whose role says nothing
+      // (generic Participation, untyped) beats a name whose role explicitly
+      // says NON-treating (referrer, authorising physician). Silence beats a
+      // stated disqualification; a stated disqualification still beats losing
+      // the encounter's only name.
+      if (firstNeutralNamed === undefined && !participantIsExplicitlyNonTreating(participant)) {
+        firstNeutralNamed = name;
+      }
+      continue;
+    }
     if (chosenRank === undefined || rank < chosenRank) {
       chosenRank = rank;
       chosen = name;
     }
   }
 
-  return chosen ?? firstNamed;
+  return chosen ?? firstNeutralNamed ?? firstNamed;
 }
 
 /**

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -52,6 +52,39 @@ import {
 import { interpretationValue } from './interpretation.js';
 
 // ---------------------------------------------------------------------------
+// Record lifecycle status
+// ---------------------------------------------------------------------------
+
+/**
+ * WHY `clinical:status` CARRIES FHIR's `.status` ON EVERY TYPE THAT HAS ONE
+ * ------------------------------------------------------------------------
+ * An `amended` result and a `final` one are different claims about the same
+ * measurement, and until this was emitted they were byte-identical in the pod:
+ * measured on one real account, 1 amended Observation and 9 amended
+ * DocumentReferences were indistinguishable from final ones. Nothing about that
+ * needed new vocabulary; the field was simply never read.
+ *
+ * `clinical:status` is the predicate used, because:
+ *
+ *   - It is already how this repo spells FHIR `.status` — `convertMedicationStatement`
+ *     writes it, and `restoreMedicationRecord` reads it back.
+ *   - It declares NO `rdfs:domain`, so it makes no claim about the class of the
+ *     subject it sits on. Its definition says in as many words that permitted
+ *     values depend on the record class and are constrained per-shape, which is
+ *     also exactly how FHIR treats `.status`.
+ *   - It gives a reader ONE predicate to ask for. `clinical:observationStatus`
+ *     exists and names this value set precisely, but it carries
+ *     `rdfs:domain clinical:LabResult`, which is false for a vital sign — and
+ *     `convertObservationVital` re-routes non-canonical vitals into
+ *     `convertObservationLab`, so a per-branch predicate would mean the same
+ *     source element landing under two different names depending on a routing
+ *     table.
+ *
+ * Deliberately NOT covered here: `Coverage.status`. See `convertCoverage`.
+ */
+const STATUS_PREDICATE = NS.clinical + 'status';
+
+// ---------------------------------------------------------------------------
 // Medication converter
 // ---------------------------------------------------------------------------
 
@@ -362,6 +395,21 @@ export function convertCondition(resource: any): ConversionResult & { _quads: Qu
   const clinicalStatus = resource.clinicalStatus?.coding?.[0]?.code ?? 'active';
   quads.push(tripleStr(subjectUri, NS.health + 'status', clinicalStatus));
 
+  // Condition.verificationStatus — `confirmed` and `refuted` are OPPOSITE claims
+  // about whether the patient has the problem at all, and the pod stated neither.
+  // `clinical:verificationStatus` is the only predicate in the vocabulary for it,
+  // it is bound by clinical:ConditionShape to exactly this FHIR R4 value set, and
+  // its rdfs:domain (clinical:Condition) is the deprecated spelling of the class
+  // this converter emits — health.ttl's namespace-boundary note states the two
+  // are one record under two names, so nothing is asserted here that is not true.
+  //
+  // This field is ALREADY in `conditionSubjectUri`, deliberately and with a
+  // comment anticipating this exact change, so no IRI moves.
+  const verificationStatus = resource.verificationStatus?.coding?.[0]?.code;
+  if (verificationStatus) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'verificationStatus', verificationStatus));
+  }
+
   if (resource.onsetDateTime) {
     quads.push(tripleDateTime(subjectUri, NS.health + 'onsetDate', resource.onsetDateTime));
   } else if (resource.onsetPeriod?.start) {
@@ -473,6 +521,23 @@ export function convertAllergyIntolerance(resource: any): ConversionResult & { _
 
   const allergen = codeableConceptText(resource.code) ?? 'Unknown Allergen';
   quads.push(tripleStr(subjectUri, NS.health + 'allergen', allergen));
+
+  // AllergyIntolerance.clinicalStatus — active | inactive | resolved. A resolved
+  // penicillin allergy displayed as an active one changes what a clinician
+  // prescribes, so this is a correctness field, not colour.
+  //
+  // `health:status` is NOT used: its rdfs:domain is a deliberately enumerated
+  // union of ConditionRecord and ImmunizationRecord, and health.ttl says in the
+  // same release note that a domain the data falsifies is the defect it was
+  // correcting. `clinical:clinicalStatus` is domain-restricted to Condition,
+  // which an allergy is not. `clinical:status` declares no domain — see
+  // STATUS_PREDICATE.
+  //
+  // Already inside `allergySubjectUri`, so no IRI moves.
+  const allergyClinicalStatus = resource.clinicalStatus?.coding?.[0]?.code;
+  if (allergyClinicalStatus) {
+    quads.push(tripleStr(subjectUri, STATUS_PREDICATE, allergyClinicalStatus));
+  }
 
   if (Array.isArray(resource.category) && resource.category.length > 0) {
     quads.push(tripleStr(subjectUri, NS.health + 'allergyCategory', resource.category[0]));
@@ -673,6 +738,14 @@ function labSubjectUri(resource: any, warnings: string[]): string {
     value: labMeasuredValueKey(resource),
     specimen: resource?.specimen?.reference,
     category: labCategoryKey(resource),
+    // Serialized as clinical:status, so it is inside the key: see the
+    // completeness rule on `conditionSubjectUri`. A `final` result and an
+    // `amended` one are two different assertions about the same draw, and an
+    // id-less pair differing only here would otherwise share an IRI and let
+    // read order decide which the pod ends up stating. Raw, like the
+    // immunization key: no `?? 'final'`, so an absent status stays absent
+    // rather than arriving as a constant.
+    status: resource?.status,
   }, warnings);
 }
 
@@ -686,6 +759,13 @@ export function convertObservationLab(resource: any): ConversionResult & { _quad
 
   const testName = codeableConceptText(resource.code) ?? 'Unknown Lab Test';
   quads.push(tripleStr(subjectUri, NS.health + 'testName', testName));
+
+  // Observation.status — see STATUS_PREDICATE. Emitted raw and only when the
+  // source stated it; a defaulted status would assert `final` about a record
+  // whose server never said so.
+  if (resource.status) {
+    quads.push(tripleStr(subjectUri, STATUS_PREDICATE, resource.status));
+  }
 
   if (resource.valueQuantity) {
     quads.push(tripleStr(subjectUri, NS.health + 'resultValue', String(resource.valueQuantity.value)));
@@ -865,6 +945,12 @@ export function convertObservationVital(resource: any): ConversionResult & { _qu
   quads.push(tripleStr(subjectUri, NS.clinical + 'vitalTypeName', vitalInfo!.name));
   quads.push(tripleRef(subjectUri, NS.clinical + 'snomedCode', NS.sct + vitalInfo!.snomedCode));
 
+  // Observation.status — the same element the lab branch writes, under the same
+  // predicate, so a reader does not have to know which branch handled it.
+  if (resource.status) {
+    quads.push(tripleStr(subjectUri, STATUS_PREDICATE, resource.status));
+  }
+
   if (resource.valueQuantity) {
     quads.push(tripleDouble(subjectUri, NS.clinical + 'value', resource.valueQuantity.value));
     quads.push(tripleStr(subjectUri, NS.clinical + 'unit', resource.valueQuantity.unit ?? vitalInfo?.unit ?? ''));
@@ -1028,6 +1114,19 @@ export function convertClinicalDocument(resource: any): ConversionResult & { _qu
   const docType = codeableConceptText(resource.type) ?? 'Unknown Document';
   quads.push(tripleStr(subjectUri, NS.clinical + 'documentType', docType));
 
+  // DocumentReference.docStatus — preliminary | final | amended | entered-in-error.
+  // This is the status of the DOCUMENT, which is what clinical:ClinicalDocument
+  // models, so it is the one that belongs on clinical:status.
+  //
+  // ACKNOWLEDGED DROP: `DocumentReference.status` (current | superseded |
+  // entered-in-error) is a statement about the REFERENCE rather than about the
+  // document, and putting it on the same predicate would leave a reader seeing
+  // `entered-in-error` unable to tell which of the two elements said so. It
+  // needs its own predicate, which does not exist.
+  if (resource.docStatus) {
+    quads.push(tripleStr(subjectUri, STATUS_PREDICATE, resource.docStatus));
+  }
+
   // Date
   const docDate = resource.date ?? resource.indexed;
   if (docDate) {
@@ -1085,6 +1184,122 @@ export function convertClinicalDocument(resource: any): ConversionResult & { _qu
 // Encounter converter (B2)
 // ---------------------------------------------------------------------------
 
+/**
+ * How much a participation role recommends its holder as THE provider for a
+ * visit, lowest first. Codes are from the HL7 v3 ParticipationType code system,
+ * which FHIR R4 binds `Encounter.participant.type` to.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The converter used to take `participant[0].individual.display` with no role
+ * check at all. Measured on one real Epic account, 54 encounters: the first
+ * participant slot held an explicitly NON-TREATING role on 18 of the 52
+ * encounters that have participants — `losAuthorizingPhysician` 16 times and
+ * `referrer` twice. So the pod named the doctor who referred the patient, or who
+ * authorised a length of stay, and dropped the clinician who actually delivered
+ * the care — with nothing on the record to say which one a reader was looking
+ * at.
+ *
+ * Roles NOT in this table (referrer, authorising physician, the generic
+ * `Participation`, anything an EHR spells locally) are not ranked and therefore
+ * never outrank a real performer. They can still be selected, but only when the
+ * encounter names nobody better; that is the pre-existing behaviour and losing
+ * a name entirely would be a worse answer than an unranked one.
+ *
+ * @see https://terminology.hl7.org/CodeSystem-v3-ParticipationType.html
+ * @see https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.participant.type
+ */
+const ENCOUNTER_PARTICIPANT_ROLE_RANK: Record<string, number> = {
+  ATND: 0, // attender — the clinician responsible for the patient during the visit
+  PPRF: 1, // primary performer
+  SPRF: 2, // secondary performer
+  CON: 3, // consultant
+  ADM: 4, // admitter
+  DIS: 5, // discharger
+};
+
+/** Rank of the best role a single `Encounter.participant` declares, or undefined. */
+function participantRoleRank(participant: any): number | undefined {
+  const types = Array.isArray(participant?.type) ? participant.type : [];
+  let best: number | undefined;
+  const consider = (rank: number | undefined): void => {
+    if (rank === undefined) return;
+    if (best === undefined || rank < best) best = rank;
+  };
+  for (const type of types) {
+    for (const coding of Array.isArray(type?.coding) ? type.coding : []) {
+      const code = typeof coding?.code === 'string' ? coding.code.trim().toUpperCase() : undefined;
+      if (code) consider(ENCOUNTER_PARTICIPANT_ROLE_RANK[code]);
+    }
+    // Sources that populate only `type.text`. Epic writes `attender` here rather
+    // than the v3 code, and it is the single role most worth recognising, so the
+    // text tier looks for it specifically instead of guessing at the rest.
+    if (typeof type?.text === 'string' && /attend/i.test(type.text)) {
+      consider(ENCOUNTER_PARTICIPANT_ROLE_RANK.ATND);
+    }
+  }
+  return best;
+}
+
+/**
+ * The single name to store as `clinical:providerName` for an encounter.
+ *
+ * Preference order, highest first: attender, primary performer, any other
+ * ranked clinical performer role (see the table above), then — only if no
+ * participant declares a ranked role — the first participant that carries a
+ * name at all. Ties are broken by source order, so a stable input gives a
+ * stable answer.
+ *
+ * Emitting EVERY participant with its role is the right long-run answer and
+ * needs vocabulary that does not exist yet; this keeps the record's single
+ * provider slot and only corrects WHICH name lands in it.
+ */
+function selectEncounterProviderName(resource: any): string | undefined {
+  const participants = Array.isArray(resource?.participant) ? resource.participant : [];
+  let chosen: string | undefined;
+  let chosenRank: number | undefined;
+  let firstNamed: string | undefined;
+
+  for (const participant of participants) {
+    const name = participant?.individual?.display;
+    if (typeof name !== 'string' || name.trim().length === 0) continue;
+    if (firstNamed === undefined) firstNamed = name;
+    const rank = participantRoleRank(participant);
+    if (rank === undefined) continue;
+    if (chosenRank === undefined || rank < chosenRank) {
+      chosenRank = rank;
+      chosen = name;
+    }
+  }
+
+  return chosen ?? firstNamed;
+}
+
+/**
+ * The facility an encounter happened at.
+ *
+ * `serviceProvider` first, because it is the organisation FHIR designates as
+ * responsible for the encounter. It is also, on real vendor output, frequently
+ * absent: measured empty on all 54 encounters of one Epic account, while
+ * `location[].location.display` was populated on all 54 (24 distinct clinics).
+ * `clinical:facilityName` consequently appeared ZERO times in that entire pod
+ * despite existing in the vocabulary and being the most orienting single fact
+ * on an encounter card.
+ *
+ * @see https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.serviceProvider
+ * @see https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.location.location
+ */
+function selectEncounterFacilityName(resource: any): string | undefined {
+  const serviceProvider = resource?.serviceProvider?.display;
+  if (typeof serviceProvider === 'string' && serviceProvider.trim().length > 0) return serviceProvider;
+
+  for (const entry of Array.isArray(resource?.location) ? resource.location : []) {
+    const display = entry?.location?.display;
+    if (typeof display === 'string' && display.trim().length > 0) return display;
+  }
+  return undefined;
+}
+
 export function convertEncounter(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const subjectUri = mintSubjectUri(resource, warnings);
@@ -1094,6 +1309,15 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
   quads.push(...commonTriples(subjectUri));
 
   // Encounter class (ambulatory, emergency, inpatient, etc.)
+  //
+  // ACKNOWLEDGED DROP: `class.display`. On vendor output the code is often a
+  // local identifier — one Epic account returns `"5"` — while the display beside
+  // it is the readable name (`Appointment`, `HOV`, `Surgery Log`, `Support OP
+  // Encounter`). Both are worth keeping, but there is no predicate for the
+  // display: `clinical:encounterClass` is the code, and `clinical:encounterType`
+  // already carries `type[0]`, which is a different FHIR element. Overwriting
+  // the code with the display is not an option either — the code is what the
+  // reverse converter needs to rebuild `Encounter.class`. Needs vocabulary.
   const encounterClass = resource.class?.code ?? resource.class?.coding?.[0]?.code;
   if (encounterClass) {
     quads.push(tripleStr(subjectUri, NS.clinical + 'encounterClass', encounterClass));
@@ -1128,17 +1352,17 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
     quads.push(tripleDateTime(subjectUri, NS.clinical + 'encounterEnd', resource.period.end));
   }
 
-  // Provider from first participant
-  if (Array.isArray(resource.participant) && resource.participant.length > 0) {
-    const providerName = resource.participant[0]?.individual?.display;
-    if (providerName) {
-      quads.push(tripleStr(subjectUri, NS.clinical + 'providerName', providerName));
-    }
+  // Provider: the participant whose declared ROLE says they treated the patient,
+  // not merely the one the server listed first. See selectEncounterProviderName.
+  const providerName = selectEncounterProviderName(resource);
+  if (providerName) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'providerName', providerName));
   }
 
-  // Facility from serviceProvider
-  if (resource.serviceProvider?.display) {
-    quads.push(tripleStr(subjectUri, NS.clinical + 'facilityName', resource.serviceProvider.display));
+  // Facility: serviceProvider, falling back to the first named location.
+  const facilityName = selectEncounterFacilityName(resource);
+  if (facilityName) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'facilityName', facilityName));
   }
 
   if (resource.id) {
@@ -1172,6 +1396,14 @@ export function convertLaboratoryReport(resource: any): ConversionResult & { _qu
   // Panel name from code.text or first coding display
   const panelName = codeableConceptText(resource.code) ?? 'Unknown Panel';
   quads.push(tripleStr(subjectUri, NS.clinical + 'panelName', panelName));
+
+  // DiagnosticReport.status — registered | partial | preliminary | final |
+  // amended | corrected | appended | cancelled | entered-in-error. Unlike
+  // DocumentReference, DiagnosticReport has exactly one status element, so there
+  // is nothing to disambiguate. See STATUS_PREDICATE.
+  if (resource.status) {
+    quads.push(tripleStr(subjectUri, STATUS_PREDICATE, resource.status));
+  }
 
   // LOINC code
   const codings = extractCodings(resource.code);

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -320,6 +320,28 @@ export function convertImmunization(resource: any): ConversionResult & { _quads:
 // Coverage converter
 // ---------------------------------------------------------------------------
 
+/**
+ * ACKNOWLEDGED DROP: `Coverage.status` (active | cancelled | draft |
+ * entered-in-error).
+ *
+ * Whether a plan is still in force is worth storing — a cancelled policy
+ * displayed like a current one is a wrong answer to the only question anyone
+ * asks an insurance record. It is not emitted because there is no predicate
+ * that can carry it truthfully:
+ *
+ *   - The coverage: namespace defines no status property for
+ *     `coverage:InsurancePlan`. `coverage:claimStatus` is domain-restricted to
+ *     `coverage:ClaimRecord` and `coverage:adjudicationStatus` to
+ *     `coverage:BenefitStatement`; both would be false here.
+ *   - `clinical:status` declares no domain, but clinical: is the EHR clinical
+ *     record namespace and an insurance plan is not one of its records. The
+ *     health:/clinical: split is documented as historical rather than semantic;
+ *     coverage: carries no such note, so borrowing across it would be a
+ *     judgement made in a converter about vocabulary scope.
+ *
+ * The fix is a `coverage:status` term, authored through the vocabulary
+ * checklist. Until then this is a stated omission rather than a silent one.
+ */
 export function convertCoverage(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const subjectUri = mintSubjectUri(resource, warnings);

--- a/tests/clinical-identity.test.ts
+++ b/tests/clinical-identity.test.ts
@@ -490,6 +490,11 @@ describe('two records that serialize differently never share an identity', () =>
         ['code', { code: { coding: [{ system: 'http://snomed.info/sct', code: '195967001' }], text: 'Asthma' } }],
         ['category', { category: [{ coding: [{ code: 'encounter-diagnosis' }] }] }],
         ['clinicalStatus', { clinicalStatus: { coding: [{ code: 'resolved' }] } }],
+        // Serialized as clinical:verificationStatus since the status sweep. It
+        // was always in the key (with a comment saying the serializer would
+        // catch up); this row is what makes the audit able to see it, and the
+        // `compared` guard below fails if the serializer ever stops writing it.
+        ['verificationStatus', { verificationStatus: { coding: [{ code: 'refuted' }] } }],
         ['onsetDateTime', { onsetDateTime: '2022-09-09' }],
         ['onsetPeriod', { onsetDateTime: undefined, onsetPeriod: { start: '2019-01-01' } }],
         ['abatementDateTime', { abatementDateTime: '2024-01-01' }],
@@ -506,6 +511,8 @@ describe('two records that serialize differently never share an identity', () =>
         ['code', { code: { coding: [{ system: 'http://snomed.info/sct', code: '387406002' }], text: 'Sulfonamide' } }],
         ['category', { category: ['food'] }],
         ['criticality', { criticality: 'low' }],
+        // Serialized as clinical:status since the status sweep; already in the key.
+        ['clinicalStatus', { clinicalStatus: { coding: [{ code: 'resolved' }] } }],
         ['reaction', { reaction: [{ manifestation: [{ text: 'Anaphylaxis' }], severity: 'severe' }] }],
         ['onsetDateTime', { onsetDateTime: '2019-01-01' }],
         ['note', { note: [{ text: 'Reported by patient' }] }],

--- a/tests/fhir-field-coverage-wave1.test.ts
+++ b/tests/fhir-field-coverage-wave1.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Fields the FHIR import path read past: record status, and the two Encounter
+ * fields that were selected wrongly rather than merely sparsely.
+ *
+ * THE DEFECTS THESE PIN
+ * ---------------------
+ * 1. `status` / `docStatus` were not emitted by any converter that has one. An
+ *    `amended` lab result and a `final` one, an `amended` document and a `final`
+ *    one, were BYTE-IDENTICAL in the pod. Measured on one real account: 1
+ *    amended Observation and 9 amended DocumentReferences, none of them
+ *    distinguishable after import. That is a correctness defect, not an
+ *    enrichment, and no new vocabulary was needed to carry it.
+ *
+ * 2. `convertEncounter` took `participant[0].individual.display` with no role
+ *    check. On the same account the first slot held an explicitly non-treating
+ *    role on 18 of the 52 encounters that have participants — an authorising
+ *    physician 16 times, a referrer twice — so the pod named the wrong clinician
+ *    with nothing on the record to say so.
+ *
+ * 3. `clinical:facilityName` appeared ZERO times in that entire pod, because the
+ *    converter sourced it only from `serviceProvider`, which the vendor never
+ *    populated, while `location[].location.display` was present on every single
+ *    encounter (24 distinct clinics).
+ *
+ * WHAT THESE TESTS WOULD DO IF THE FIX WERE ABSENT
+ * ------------------------------------------------
+ * Measured, not assumed, against the parent commit with `dist/` rebuilt from
+ * it: 16 of the 27 cases below FAIL. The 11 that pass either way are every case
+ * labelled STABILITY PIN, plus the Coverage and `class.display` acknowledged
+ * drops — they state what must NOT have changed, or what is deliberately still
+ * missing, and are not counted as evidence for this change. (The third
+ * acknowledged-drop case, on `DocumentReference.status`, does fail beforehand:
+ * it asserts that exactly one of the resource's two status elements is emitted,
+ * and beforehand neither was.)
+ *
+ * Two further cases in `clinical-identity.test.ts` also fail beforehand — the
+ * mechanical audit rows added there for the two newly serialized fields.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  convertObservationLab,
+  convertObservationVital,
+  convertCondition,
+  convertAllergyIntolerance,
+  convertClinicalDocument,
+  convertEncounter,
+  convertLaboratoryReport,
+} from '../src/lib/fhir-converter/converters-clinical.js';
+import { convertCoverage } from '../src/lib/fhir-converter/converters-demographics.js';
+import { NS } from '../src/lib/fhir-converter/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Converted = {
+  _quads: Array<{ subject: { value: string }; predicate: { value: string }; object: { value: string } }>;
+};
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+function valuesOf(result: Converted, predicate: string): string[] {
+  return result._quads.filter((q) => q.predicate.value === predicate).map((q) => q.object.value);
+}
+
+function valueOf(result: Converted, predicate: string): string | undefined {
+  return valuesOf(result, predicate)[0];
+}
+
+/** Everything the converter wrote, subject IRI dropped. Two records that differ here are two records. */
+function statementsOf(result: Converted): string[] {
+  return result._quads.map((q) => `${q.predicate.value} ${q.object.value}`).sort();
+}
+
+const STATUS = NS.clinical + 'status';
+const VERIFICATION_STATUS = NS.clinical + 'verificationStatus';
+const PROVIDER_NAME = NS.clinical + 'providerName';
+const FACILITY_NAME = NS.clinical + 'facilityName';
+const ENCOUNTER_CLASS = NS.clinical + 'encounterClass';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function labObservation(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Observation',
+    id: 'obs-glucose-1',
+    status: 'final',
+    category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'laboratory' }] }],
+    code: { coding: [{ system: 'http://loinc.org', code: '2339-0', display: 'Glucose' }], text: 'Glucose' },
+    subject: { reference: 'Patient/synthetic-1' },
+    effectiveDateTime: '2026-02-04T07:15:00Z',
+    valueQuantity: { value: 95, unit: 'mg/dL' },
+    ...overrides,
+  };
+}
+
+function vitalObservation(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Observation',
+    id: 'obs-hr-1',
+    status: 'final',
+    category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] }],
+    code: { coding: [{ system: 'http://loinc.org', code: '8867-4', display: 'Heart rate' }] },
+    subject: { reference: 'Patient/synthetic-1' },
+    effectiveDateTime: '2026-02-04T09:30:00Z',
+    valueQuantity: { value: 72, unit: 'beats/minute' },
+    ...overrides,
+  };
+}
+
+function documentReference(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'DocumentReference',
+    id: 'doc-progress-1',
+    status: 'current',
+    docStatus: 'final',
+    type: { text: 'Progress Notes' },
+    date: '2026-02-04T12:00:00Z',
+    content: [{ attachment: { contentType: 'application/pdf', url: 'Binary/b1' } }],
+    ...overrides,
+  };
+}
+
+function diagnosticReport(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'DiagnosticReport',
+    id: 'dr-cbc-1',
+    status: 'final',
+    code: { coding: [{ system: 'http://loinc.org', code: '58410-2' }], text: 'Complete Blood Count' },
+    effectiveDateTime: '2026-02-04T07:15:00Z',
+    issued: '2026-02-04T11:00:00Z',
+    ...overrides,
+  };
+}
+
+function conditionResource(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Condition',
+    id: 'cond-1',
+    subject: { reference: 'Patient/synthetic-1' },
+    code: { coding: [{ system: 'http://snomed.info/sct', code: '38341003' }], text: 'Essential hypertension' },
+    onsetDateTime: '2021-04-02',
+    ...overrides,
+  };
+}
+
+function allergyResource(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'AllergyIntolerance',
+    id: 'alg-1',
+    patient: { reference: 'Patient/synthetic-1' },
+    code: { coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '7980' }], text: 'Penicillin G' },
+    criticality: 'high',
+    ...overrides,
+  };
+}
+
+function coverageResource(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Coverage',
+    id: 'cov-1',
+    status: 'cancelled',
+    payor: [{ display: 'Example Health Plan' }],
+    subscriberId: 'SUB-12345',
+    ...overrides,
+  };
+}
+
+/** A participant with a declared role. `type` omitted entirely when `type` is null. */
+function participant(name: string, type?: { code?: string; text?: string }): any {
+  const entry: any = { individual: { display: name } };
+  if (type) {
+    const concept: any = {};
+    if (type.code) concept.coding = [{ system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType', code: type.code }];
+    if (type.text) concept.text = type.text;
+    entry.type = [concept];
+  }
+  return entry;
+}
+
+function encounterResource(overrides: Record<string, unknown> = {}): any {
+  return {
+    resourceType: 'Encounter',
+    id: 'enc-1',
+    status: 'finished',
+    class: { code: '5', display: 'Appointment' },
+    type: [{ text: 'Derm Problem' }],
+    period: { start: '2026-02-04T15:00:00Z', end: '2026-02-04T15:30:00Z' },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. status and docStatus
+// ---------------------------------------------------------------------------
+
+describe('an amended record is distinguishable from a final one', () => {
+  it('lab Observation: `amended` reaches the pod, and does not read as `final`', () => {
+    const finalResult = convertObservationLab(labObservation({ status: 'final' })) as Converted;
+    const amended = convertObservationLab(labObservation({ status: 'amended' })) as Converted;
+
+    expect(valueOf(amended, STATUS)).toBe('amended');
+    expect(valueOf(finalResult, STATUS)).toBe('final');
+    // The property that actually failed: the two records were byte-identical.
+    expect(statementsOf(amended)).not.toEqual(statementsOf(finalResult));
+  });
+
+  it('vital Observation: the same element, under the same predicate as the lab branch', () => {
+    // `convertObservationVital` re-routes non-canonical vitals into
+    // `convertObservationLab`, so a per-branch predicate would mean the same
+    // source element landing under two names depending on a routing table.
+    const amended = convertObservationVital(vitalObservation({ status: 'amended' })) as Converted;
+    expect(valueOf(amended, STATUS)).toBe('amended');
+  });
+
+  it('DocumentReference: `docStatus` reaches the pod', () => {
+    const finalResult = convertClinicalDocument(documentReference({ docStatus: 'final' })) as Converted;
+    const amended = convertClinicalDocument(documentReference({ docStatus: 'amended' })) as Converted;
+
+    expect(valueOf(amended, STATUS)).toBe('amended');
+    expect(valueOf(finalResult, STATUS)).toBe('final');
+    expect(statementsOf(amended)).not.toEqual(statementsOf(finalResult));
+  });
+
+  it('DiagnosticReport: `status` reaches the pod', () => {
+    const amended = convertLaboratoryReport(diagnosticReport({ status: 'amended' })) as Converted;
+    expect(valueOf(amended, STATUS)).toBe('amended');
+    expect(statementsOf(amended))
+      .not.toEqual(statementsOf(convertLaboratoryReport(diagnosticReport({ status: 'final' })) as Converted));
+  });
+
+  it('Condition: `refuted` is not stored as though the problem were confirmed', () => {
+    const refuted = convertCondition(conditionResource({
+      verificationStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'refuted' }] },
+    })) as Converted;
+    const confirmed = convertCondition(conditionResource({
+      verificationStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'confirmed' }] },
+    })) as Converted;
+
+    expect(valueOf(refuted, VERIFICATION_STATUS)).toBe('refuted');
+    expect(valueOf(confirmed, VERIFICATION_STATUS)).toBe('confirmed');
+    expect(statementsOf(refuted)).not.toEqual(statementsOf(confirmed));
+  });
+
+  it('AllergyIntolerance: a resolved allergy is not stored as an active one', () => {
+    const resolved = convertAllergyIntolerance(allergyResource({
+      clinicalStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical', code: 'resolved' }] },
+    })) as Converted;
+    const active = convertAllergyIntolerance(allergyResource({
+      clinicalStatus: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical', code: 'active' }] },
+    })) as Converted;
+
+    expect(valueOf(resolved, STATUS)).toBe('resolved');
+    expect(valueOf(active, STATUS)).toBe('active');
+    expect(statementsOf(resolved)).not.toEqual(statementsOf(active));
+  });
+});
+
+describe('STABILITY PIN: a status is reported, never invented', () => {
+  // A defaulted status would assert `final` about a record whose server never
+  // said so — which is the same class of defect as dropping it, in the opposite
+  // direction and harder to see.
+  it('lab Observation with no status emits no status', () => {
+    const noStatus = labObservation();
+    delete noStatus.status;
+    expect(valuesOf(convertObservationLab(noStatus) as Converted, STATUS)).toEqual([]);
+  });
+
+  it('DocumentReference with no docStatus emits no status', () => {
+    const noDocStatus = documentReference();
+    delete noDocStatus.docStatus;
+    expect(valuesOf(convertClinicalDocument(noDocStatus) as Converted, STATUS)).toEqual([]);
+  });
+
+  it('Condition with no verificationStatus emits none, and still emits clinicalStatus', () => {
+    const result = convertCondition(conditionResource()) as Converted;
+    expect(valuesOf(result, VERIFICATION_STATUS)).toEqual([]);
+    expect(valueOf(result, NS.health + 'status')).toBe('active');
+  });
+
+  it('AllergyIntolerance with no clinicalStatus emits no status', () => {
+    expect(valuesOf(convertAllergyIntolerance(allergyResource()) as Converted, STATUS)).toEqual([]);
+  });
+});
+
+describe('ACKNOWLEDGED DROP: statuses with no predicate to carry them', () => {
+  const SHAPES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'shapes');
+
+  it('Coverage.status is not emitted, and the coverage vocabulary still has nowhere to put it', () => {
+    // Two halves on purpose. The first states today's behaviour; the second is
+    // the tripwire that makes this a REVIEWABLE omission rather than a silent
+    // one — the day a `coverage:status` term is authored, this fails and sends
+    // the reader back here to emit it.
+    const result = convertCoverage(coverageResource({ status: 'cancelled' })) as Converted;
+    expect(valuesOf(result, STATUS)).toEqual([]);
+    expect(result._quads.some((q) => q.object.value === 'cancelled')).toBe(false);
+
+    const vocab = fs.readFileSync(path.join(SHAPES, 'coverage.ttl'), 'utf8');
+    expect(/^coverage:status\s+a\s+owl:/m.test(vocab), 'coverage:status now exists — emit it').toBe(false);
+  });
+
+  it('Encounter.class.display is not emitted, and the class CODE is not overwritten by it', () => {
+    // The code is what the reverse converter needs to rebuild Encounter.class,
+    // so "store the readable one instead" is not an available shortcut. Both
+    // want keeping; only one predicate exists.
+    const result = convertEncounter(encounterResource({ class: { code: '5', display: 'Appointment' } })) as Converted;
+    expect(valueOf(result, ENCOUNTER_CLASS)).toBe('5');
+    expect(result._quads.some((q) => q.object.value === 'Appointment')).toBe(false);
+  });
+
+  it('DocumentReference.status (the reference, not the document) is not conflated with docStatus', () => {
+    // `status: current` and `docStatus: final` are different elements. Exactly
+    // one value reaches clinical:status, and it is the document's.
+    const result = convertClinicalDocument(documentReference({ status: 'current', docStatus: 'final' })) as Converted;
+    expect(valuesOf(result, STATUS)).toEqual(['final']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Encounter: which participant is THE provider
+// ---------------------------------------------------------------------------
+
+describe('providerName names the clinician who treated the patient', () => {
+  it('an attender listed AFTER a referrer is still the provider', () => {
+    // The measured case: the pod stored the referring physician and dropped the
+    // dermatologist who delivered the care.
+    const result = convertEncounter(encounterResource({
+      participant: [
+        participant('Referring Physician', { code: 'REF', text: 'referrer' }),
+        participant('Treating Dermatologist', { code: 'ATND', text: 'attender' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Treating Dermatologist');
+  });
+
+  it('an attender declared only in type.text beats an authorising physician listed first', () => {
+    // The text tier. This vendor writes `attender` in `type[].text` and leaves
+    // `type[].coding` unpopulated, so a code-only reader picks the wrong name on
+    // every one of these.
+    const result = convertEncounter(encounterResource({
+      participant: [
+        participant('Authorising Physician', { text: 'losAuthorizingPhysician' }),
+        participant('Attending Clinician', { text: 'attender' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Attending Clinician');
+  });
+
+  it('a generic `Participation` role does not outrank a named performer', () => {
+    const result = convertEncounter(encounterResource({
+      participant: [
+        participant('Unspecified Participant', { code: 'PART', text: 'Participation' }),
+        participant('Primary Performer', { code: 'PPRF' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Primary Performer');
+  });
+
+  it('the preference ORDER holds, not merely the membership', () => {
+    // Pins the rank of every entry in the table against the one below it.
+    // Membership alone is satisfied by a set; these fail if any single rank
+    // moves or is deleted.
+    const pairs: Array<[string, string]> = [
+      ['ATND', 'PPRF'],
+      ['PPRF', 'SPRF'],
+      ['SPRF', 'CON'],
+      ['CON', 'ADM'],
+      ['ADM', 'DIS'],
+    ];
+    for (const [better, worse] of pairs) {
+      // Listed worse-first AND better-first, so a converter that simply took the
+      // last (or the first) ranked participant cannot pass both directions.
+      const worseFirst = convertEncounter(encounterResource({
+        participant: [participant(`${worse} name`, { code: worse }), participant(`${better} name`, { code: better })],
+      })) as Converted;
+      const betterFirst = convertEncounter(encounterResource({
+        participant: [participant(`${better} name`, { code: better }), participant(`${worse} name`, { code: worse })],
+      })) as Converted;
+      expect(valueOf(worseFirst, PROVIDER_NAME), `${better} should outrank ${worse}`).toBe(`${better} name`);
+      expect(valueOf(betterFirst, PROVIDER_NAME), `${better} should outrank ${worse}`).toBe(`${better} name`);
+    }
+  });
+
+  it('every ranked role outranks an unranked one, listed last', () => {
+    for (const code of ['ATND', 'PPRF', 'SPRF', 'CON', 'ADM', 'DIS']) {
+      const result = convertEncounter(encounterResource({
+        participant: [
+          participant('Authorising Physician', { text: 'losAuthorizingPhysician' }),
+          participant(`${code} name`, { code }),
+        ],
+      })) as Converted;
+      expect(valueOf(result, PROVIDER_NAME), `${code} should be preferred`).toBe(`${code} name`);
+    }
+  });
+
+  it('the code is read case-insensitively, as a code and not as free text', () => {
+    const result = convertEncounter(encounterResource({
+      participant: [
+        participant('Referring Physician', { code: 'REF' }),
+        participant('Attending Clinician', { code: 'atnd' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Attending Clinician');
+  });
+
+  it('STABILITY PIN: two participants of equal rank are broken by source order, so the answer is stable', () => {
+    const encounter = encounterResource({
+      participant: [participant('First Attender', { code: 'ATND' }), participant('Second Attender', { code: 'ATND' })],
+    });
+    expect(valueOf(convertEncounter(clone(encounter)) as Converted, PROVIDER_NAME)).toBe('First Attender');
+    expect(valueOf(convertEncounter(clone(encounter)) as Converted, PROVIDER_NAME)).toBe('First Attender');
+  });
+
+  it('a participant carrying a role but NO name never displaces one carrying a name', () => {
+    const result = convertEncounter(encounterResource({
+      participant: [
+        { type: [{ coding: [{ code: 'ATND' }] }] },
+        participant('Named Referrer', { code: 'REF' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Named Referrer');
+  });
+
+  it('STABILITY PIN: with no ranked role anywhere, the first named participant is still used', () => {
+    // The pre-existing behaviour. Losing a name entirely would be a worse answer
+    // than an unranked one.
+    const result = convertEncounter(encounterResource({
+      participant: [participant('Only Participant'), participant('Second Participant')],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Only Participant');
+  });
+
+  it('STABILITY PIN: an encounter with no participants emits no providerName', () => {
+    expect(valuesOf(convertEncounter(encounterResource()) as Converted, PROVIDER_NAME)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Encounter: the facility
+// ---------------------------------------------------------------------------
+
+describe('facilityName falls back to the location when the vendor omits serviceProvider', () => {
+  it('a named location reaches the pod when serviceProvider is absent', () => {
+    // The whole of the measured defect: serviceProvider empty on all 54
+    // encounters, location present on all 54, facilityName present zero times.
+    const result = convertEncounter(encounterResource({
+      location: [{ location: { display: 'Northgate Dermatology' } }],
+    })) as Converted;
+    expect(valueOf(result, FACILITY_NAME)).toBe('Northgate Dermatology');
+  });
+
+  it('the first NON-EMPTY location display is used, not merely location[0]', () => {
+    const result = convertEncounter(encounterResource({
+      location: [
+        { location: {} },
+        { location: { display: '   ' } },
+        { location: { display: 'Riverside Clinic' } },
+        { location: { display: 'Second Clinic' } },
+      ],
+    })) as Converted;
+    expect(valueOf(result, FACILITY_NAME)).toBe('Riverside Clinic');
+  });
+
+  it('STABILITY PIN: serviceProvider still wins when it is populated', () => {
+    const result = convertEncounter(encounterResource({
+      serviceProvider: { display: 'General Hospital' },
+      location: [{ location: { display: 'Northgate Dermatology' } }],
+    })) as Converted;
+    expect(valuesOf(result, FACILITY_NAME)).toEqual(['General Hospital']);
+  });
+
+  it('STABILITY PIN: neither present emits nothing rather than an empty string', () => {
+    expect(valuesOf(convertEncounter(encounterResource()) as Converted, FACILITY_NAME)).toEqual([]);
+  });
+});

--- a/tests/fhir-field-coverage-wave1.test.ts
+++ b/tests/fhir-field-coverage-wave1.test.ts
@@ -367,6 +367,46 @@ describe('providerName names the clinician who treated the patient', () => {
     expect(valueOf(result, PROVIDER_NAME)).toBe('Primary Performer');
   });
 
+  it("the measured Epic dialect: a local PHYSICIAN role beats a referrer listed first", () => {
+    // The real dermatology-visit shape this fix was measured against: slot 0 is
+    // the referrer (REF), and the clinician who delivered the care appears only
+    // under the vendor's LOCAL spellings — `losAuthorizingPhysician`,
+    // `PHYSICIAN`, `PART` — none of them a v3 ParticipationType code. A rank
+    // table that speaks only v3 falls through to "first named", which is the
+    // referrer: the exact record the audit opened with stays wrong.
+    const result = convertEncounter(encounterResource({
+      participant: [
+        participant('Referring Physician, MD', { code: 'REF', text: 'referrer' }),
+        participant('Treating Dermatologist, MD', { text: 'losAuthorizingPhysician' }),
+        participant('Treating Dermatologist, MD', { code: 'PHYSICIAN', text: 'Physician' }),
+        participant('Treating Dermatologist, MD', { code: 'PART', text: 'Participation' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Treating Dermatologist, MD');
+  });
+
+  it('a neutral unranked name beats an explicitly NON-treating one listed first', () => {
+    // Neither participant is ranked, but `referrer` states this person did NOT
+    // deliver the care, while the generic Participation says nothing either
+    // way. Silence should beat a stated disqualification.
+    const result = convertEncounter(encounterResource({
+      participant: [
+        participant('Referring Physician, MD', { code: 'REF', text: 'referrer' }),
+        participant('Some Participant', { code: 'PART', text: 'Participation' }),
+      ],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Some Participant');
+  });
+
+  it('STABILITY PIN: an explicitly non-treating role is still stored when it is the only name', () => {
+    // Losing the only name the encounter has would be a worse answer than an
+    // unlabelled referrer. Labelling it is the wave-4 vocabulary item.
+    const result = convertEncounter(encounterResource({
+      participant: [participant('Referring Physician, MD', { code: 'REF', text: 'referrer' })],
+    })) as Converted;
+    expect(valueOf(result, PROVIDER_NAME)).toBe('Referring Physician, MD');
+  });
+
   it('the preference ORDER holds, not merely the membership', () => {
     // Pins the rank of every entry in the table against the one below it.
     // Membership alone is satisfied by a set; these fail if any single rank


### PR DESCRIPTION
## What this fixes

**1. No converter emitted the resource's `status`, on any type that has one.**
An `amended` Observation and a `final` one produced byte-identical records in the pod; the same held
for an `amended` and a `final` DocumentReference. Measured against one real vendor account: 1 amended
Observation and 9 amended DocumentReferences existed in the source and were indistinguishable after
import. That is a correctness distinction, not an enrichment, and no new vocabulary was needed.

Emitted now, all on predicates that already existed in `src/shapes/` (no shapes edited, no vocabulary added):

| Source element | Predicate |
|---|---|
| `Observation.status` (lab and vital branches alike) | `clinical:status` |
| `DocumentReference.docStatus` | `clinical:status` |
| `DiagnosticReport.status` | `clinical:status` |
| `AllergyIntolerance.clinicalStatus` | `clinical:status` |
| `Condition.verificationStatus` | `clinical:verificationStatus` |

`clinical:status` carries four of the five: it declares no `rdfs:domain`, its definition says
permitted values are constrained per-shape rather than on the property, and it is already how this
repository spells FHIR `.status` on medications. It also gives a reader one predicate to ask for —
`convertObservationVital` re-routes non-canonical vitals into `convertObservationLab`, so a
per-branch predicate would mean the same source element landing under two names depending on a
routing table. A status is reported and never defaulted; inventing `final` is the same defect in the
opposite direction.

**Two acknowledged drops, each with a written reason in the converter rather than silence.**
`Coverage.status` has no predicate that can hold it truthfully — the coverage namespace defines no
status property for `coverage:InsurancePlan`, and `coverage:claimStatus` / `coverage:adjudicationStatus`
are domain-restricted to other classes. `DocumentReference.status` (`current | superseded`) describes
the reference rather than the document, so sharing a predicate with `docStatus` would leave a reader
seeing `entered-in-error` unable to tell which element said it. Both need vocabulary. The Coverage
case carries a tripwire that fails the day a `coverage:status` term is authored.

**2. The encounter provider was selected by array position, not by role.**
`convertEncounter` took `participant[0].individual.display` with no role check. On one measured
account the first slot held an explicitly non-treating role on 18 of the 52 encounters that have
participants — an authorising physician 16 times, a referrer twice — so the pod named the wrong
clinician with nothing on the record to say so. Selection is now by HL7 v3 ParticipationType
preference (attender, primary performer, secondary performer, consultant, admitter, discharger),
reading both `type[].coding[].code` and `type[].text`, ties broken by source order, and an unranked
participant used only when the encounter names nobody better. The record still carries a single
`clinical:providerName`.

**3. `clinical:facilityName` appeared zero times in a real pod.**
It was sourced only from `serviceProvider`, which that vendor never populated, while
`location[].location.display` was present on all 54 encounters (24 distinct clinics).
`serviceProvider` is still preferred; the first non-empty location display is used when it is absent.

`Encounter.class.display` stays an acknowledged drop, documented in the converter: the class *code*
is what the reverse converter needs to rebuild `Encounter.class`, so overwriting it is not
available, and no predicate exists for the display alongside it.

## Identity

`Observation.status` joins the lab Observation content key, per the completeness rule documented on
`conditionSubjectUri`. This moves IRIs only for **id-less** lab Observations that differ in status; a
record carrying an `id` is unaffected. The two fields newly serialized on Condition and
AllergyIntolerance were already in their keys, so no IRI moves there at all. The mechanical audit in
`clinical-identity.test.ts` gained a row for each.

## Verification

- `npm run build` clean (vitest does not typecheck, so this is not optional).
- Full suite: **156 files / 2480 passing, 0 skipped**, up from 155 / 2453 on the parent commit.
- `tests/fhir-field-coverage-wave1.test.ts` adds 27 cases. **16 were observed RED** against the
  parent commit with `dist/` rebuilt from it, plus 2 extended cases in `clinical-identity.test.ts`.
  The 11 that pass either way are labelled in place as stability pins or acknowledged drops and are
  not counted as evidence.
- The role table was additionally probed by deletion: removing a single rank entry, and removing the
  unranked fallback, each turns the suite red, so neither line ships deletable.
- Lint unchanged at 0 errors on the touched files.

All fixtures are synthetic and PHI-free.
