### PR TITLE
feat(cli): encounter deduplication, and a re-conversion is not an identity collision

### DIFF
--- a/src/lib/ccda-converter/sections/encounters.ts
+++ b/src/lib/ccda-converter/sections/encounters.ts
@@ -146,7 +146,23 @@ export function buildEncounterRecord(
   const quads: Quad[] = [];
   quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Encounter')));
   quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
-  if (displayName) quads.push(makeQuad(subj, namedNode(NS.cascade + 'encounterType'), literal(displayName)));
+  // THE TYPE, IN THE CANONICAL SPELLING AND THE OLD ONE.
+  //
+  // `clinical:EncounterShape` constrains `clinical:encounterType` and says
+  // nothing about `cascade:encounterType`, and the FHIR path has always written
+  // the `clinical:` one. So an encounter's type was validated on one transport
+  // and invisible on the other, and a consumer reading either spelling saw half
+  // the encounters in a pod that holds both. `clinical:` is canonical because
+  // the shapes already say so.
+  //
+  // The `cascade:` spelling is dual-written for one release rather than
+  // migrated in place: readers exist (this repo's own C-CDA tests, and anything
+  // downstream that learned the old spelling), and retiring a predicate is a
+  // change with its own blast radius and its own measurement.
+  if (displayName) {
+    quads.push(makeQuad(subj, namedNode(NS.clinical + 'encounterType'), literal(displayName)));
+    quads.push(makeQuad(subj, namedNode(NS.cascade + 'encounterType'), literal(displayName)));
+  }
   // Kept, unchanged and untyped, because the reconciler reads
   // health:effectiveDate. Moving a record's date out from under a matcher in the
   // same change that gives it a second one is two changes wearing one commit.
@@ -173,7 +189,15 @@ export function buildEncounterRecord(
     if (q) quads.push(q);
   }
 
-  if (sourceId) quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
+  // THE VISIT'S IDENTIFIER, on both spellings, for the same reason as the type
+  // above. `clinical:sourceRecordId` is what
+  // clinical:EncounterShape constrains; `cascade:sourceRecordId` is what the
+  // reconciler's encounter matcher and the FHIR path's `Encounter.identifier`
+  // emission both key on, so it is also the cross-transport join key and stays.
+  if (sourceId) {
+    quads.push(makeQuad(subj, namedNode(NS.clinical + 'sourceRecordId'), literal(sourceId)));
+    quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));
+  }
 
   return { subject: uri, quads };
 }

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -1349,6 +1349,58 @@ function selectEncounterFacilityName(resource: any): string | undefined {
   return undefined;
 }
 
+/**
+ * Every business identifier an `Encounter` states, normalized to the ONE
+ * spelling both transports write.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `Encounter.identifier` is the visit's identifier in the health system — on
+ * Epic output, the contact serial number. The C-CDA export of the same visit
+ * states the same value as `<encounter><id root= extension=/>` and the C-CDA
+ * path has always written it into the pod. This converter read `identifier`
+ * only when `resource.id` was absent (for identity minting) and never wrote it
+ * as a fact, so on a pod holding both transports the join key sat on one side
+ * of every duplicate pair: measured 0 of 54 FHIR-derived encounter blocks
+ * carrying a serial number, against 48 of 52 C-CDA ones naming the same visits.
+ * That is why 177 encounter subjects described about 58 visits and nothing
+ * in-pod could tell.
+ *
+ * THE SPELLING IS `ccdaSourceId`'s, DELIBERATELY
+ * ----------------------------------------------
+ * `<system>:<value>`, with FHIR's `urn:oid:` URI prefix stripped so what remains
+ * is the bare OID the C-CDA `<id root>` carries. A value with no system renders
+ * as `:value`, which is exactly what `ccdaSourceId` produces for an
+ * extension-only `<id>` — a bare `value` would silently join with a
+ * differently-scoped identifier that happens to share it.
+ *
+ * The two derivations are separate functions in separate modules because the
+ * inputs are different shapes; `tests/encounter-identifier-join.test.ts` pins
+ * their OUTPUTS as equal on twin fixtures, so a change to either spelling fails
+ * rather than quietly unjoining the transports.
+ *
+ * @see https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.identifier
+ */
+function encounterIdentifierTokens(resource: any): string[] {
+  const identifiers = Array.isArray(resource?.identifier) ? resource.identifier : [];
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const identifier of identifiers) {
+    const value = typeof identifier?.value === 'string' ? identifier.value.trim() : '';
+    // An identifier with no value identifies nothing. Emitting `system:` for it
+    // would put a token in the join space that every other system-only
+    // identifier also matches.
+    if (!value) continue;
+    const rawSystem = typeof identifier?.system === 'string' ? identifier.system.trim() : '';
+    const system = rawSystem.startsWith('urn:oid:') ? rawSystem.slice('urn:oid:'.length) : rawSystem;
+    const token = `${system}:${value}`;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens;
+}
+
 export function convertEncounter(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const subjectUri = mintSubjectUri(resource, warnings);
@@ -1414,8 +1466,28 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
     quads.push(tripleStr(subjectUri, NS.clinical + 'facilityName', facilityName));
   }
 
+  // The FHIR SERVER's row id. Kept on its own predicate: `clinical:sourceRecordId`
+  // is `sh:maxCount 1` on clinical:EncounterShape, and it is the join key a
+  // `Reference.reference` string points at, which the visit identifier below is
+  // not.
   if (resource.id) {
     quads.push(tripleStr(subjectUri, NS.clinical + 'sourceRecordId', resource.id));
+  }
+
+  // The VISIT's identifier(s) in the health system, on the predicate the C-CDA
+  // path already writes them to, so one visit's two transports carry one join
+  // key. `cascade:sourceRecordId` is core v3's "original source system record
+  // identifier ... preserved for provenance", carries no shape constraint on
+  // Encounter, and is repeatable — all three of which `clinical:sourceRecordId`
+  // is not. See encounterIdentifierTokens.
+  //
+  // A FACT, NOT AN IDENTITY INPUT. `mintSubjectUri` above is unchanged and still
+  // keys on `resource.id`. Deciding that two subjects are one visit is the
+  // reconciler's judgement, made with both records in hand and recorded as
+  // cascade:mergedFrom lineage; the identity layer sees one record at a time and
+  // could only overwrite.
+  for (const token of encounterIdentifierTokens(resource)) {
+    quads.push(tripleStr(subjectUri, NS.cascade + 'sourceRecordId', token));
   }
 
   quads.push(tripleRef(subjectUri, NS.cascade + 'layerPromotionStatus', NS.cascade + 'FullyMapped'));

--- a/src/lib/fhir-converter/field-coverage/manifests/encounter.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/encounter.ts
@@ -6,9 +6,9 @@ import type { FieldDropManifest } from '../types.js';
  * Seeded from the differential run over `test-fixtures/field-coverage/encounter.json`,
  * which reproduces the shape measured across 54 Epic R4 Encounters.
  *
- * The clinic and the role-correct provider now survive. What still does not: the
- * reason, the contact serial number, the admission detail, every type coding
- * past the first, and every participant except the one that wins the role
+ * The clinic, the role-correct provider and the visit's contact serial number
+ * now survive. What still does not: the reason, the admission detail, every type
+ * coding past the first, and every participant except the one that wins the role
  * ranking — including that participant's own specialty.
  */
 export const ENCOUNTER_DROPS: FieldDropManifest = {
@@ -21,11 +21,10 @@ export const ENCOUNTER_DROPS: FieldDropManifest = {
       reason:
         "FHIR server bookkeeping (versionId, lastUpdated) about the resource's life on a server, not about the patient. Cascade states its own provenance and keys records on sourceRecordId.",
     },
-    'Encounter.identifier': {
-      disposition: 'pending',
-      backlog: '3.254',
+    'Encounter.identifier[0].use': {
+      disposition: 'acknowledged',
       reason:
-        'The visit contact serial number. Read for identity minting and never written as a fact, which is why the same visit arriving over FHIR and over C-CDA cannot be recognised as one visit: the join key sits on one side of the pair only.',
+        "Whether the health system calls this identifier usual, official or secondary. The identifier itself is emitted, scoped by its assigning system, which is everything the join between a FHIR encounter and its C-CDA twin needs; the use code qualifies the label a chart would print it under and identifies nothing on its own.",
     },
     'Encounter.serviceType': {
       disposition: 'pending',

--- a/src/lib/fhir-converter/reference-resolution.ts
+++ b/src/lib/fhir-converter/reference-resolution.ts
@@ -230,17 +230,39 @@ export interface ConvertedResourceRef {
 
 /**
  * Predicates that carry a record's source FHIR id (`resource.id`), the join key
- * a `Reference.reference` string points at. Every importer path persists one of
- * these on a record, so a resolution index can be rebuilt from serialized pod
- * quads without the conversion-time `ConvertedResourceRef[]` in hand.
+ * a `Reference.reference` string points at, MOST SPECIFIC FIRST. Every importer
+ * path persists one of these on a record, so a resolution index can be rebuilt
+ * from serialized pod quads without the conversion-time `ConvertedResourceRef[]`
+ * in hand.
+ *
+ * THE ORDER IS LOAD-BEARING, and it is a list rather than a set because of it.
+ * A record can persist TWO source ids that mean different things: since the
+ * encounter join key landed, a FHIR encounter states the FHIR server's row id on
+ * `clinical:sourceRecordId` and the VISIT's identifier (the contact serial
+ * number, which the C-CDA twin states too) on `cascade:sourceRecordId`. Only the
+ * first is what `Encounter/enc-1` points at. The selection here used to be
+ * first-quad-wins, so which of the two got indexed depended on the order the
+ * serializer happened to emit them in — an edge resolving or dangling by
+ * emission order is the identity-determinism failure shape one layer out.
+ *
+ * `cascade:sourceRecordId` ranks last because it is the only one of the five a
+ * record can carry ALONGSIDE a FHIR resource id. Ranking it last costs nothing
+ * for the C-CDA path, which writes no FHIR resource id at all and is therefore
+ * still indexed by it.
  */
-const SOURCE_ID_PREDICATES = new Set([
+const SOURCE_ID_PREDICATES: readonly string[] = [
+  NS.clinical + 'fhirResourceId',
   NS.health + 'sourceRecordId',
   NS.clinical + 'sourceRecordId',
   NS.coverage + 'sourceRecordId',
   NS.cascade + 'sourceRecordId',
-  NS.clinical + 'fhirResourceId',
-]);
+];
+
+/** Where a predicate sits in {@link SOURCE_ID_PREDICATES}, or undefined. */
+function sourceIdRank(predicate: string): number | undefined {
+  const rank = SOURCE_ID_PREDICATES.indexOf(predicate);
+  return rank < 0 ? undefined : rank;
+}
 
 /** Predicates that carry a record's source FHIR resourceType, when persisted. */
 const SOURCE_TYPE_PREDICATES = new Set([
@@ -276,22 +298,27 @@ export function buildResourceRefsFromQuads(quads: Quad[]): ConvertedResourceRef[
     if (q.predicate.value === NS.rdf + 'type') recordSubjects.add(q.subject.value);
   }
 
-  const ids = new Map<string, string>();
+  const ids = new Map<string, { id: string; rank: number }>();
   const types = new Map<string, string>();
   for (const q of quads) {
     const s = q.subject.value;
     if (!recordSubjects.has(s)) continue;
     if (q.object.termType !== 'Literal') continue;
     const p = q.predicate.value;
-    if (SOURCE_ID_PREDICATES.has(p)) {
-      if (!ids.has(s)) ids.set(s, q.object.value);
+    const rank = sourceIdRank(p);
+    if (rank !== undefined) {
+      // Best PREDICATE wins, not first quad. Within one predicate the first
+      // value still wins, which keeps a repeatable id single-valued here and
+      // independent of nothing but document order within that predicate.
+      const held = ids.get(s);
+      if (!held || rank < held.rank) ids.set(s, { id: q.object.value, rank });
     } else if (SOURCE_TYPE_PREDICATES.has(p)) {
       if (!types.has(s)) types.set(s, q.object.value);
     }
   }
 
   const refs: ConvertedResourceRef[] = [];
-  for (const [subject, id] of ids) {
+  for (const [subject, { id }] of ids) {
     refs.push({ resourceType: types.get(subject) ?? '', id, subject });
   }
   return refs;

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -204,6 +204,7 @@ type CascadeRecordType =
   | 'health:LabResultRecord'
   | 'health:ImmunizationRecord'
   | 'clinical:VitalSign'
+  | 'clinical:Encounter'
   | 'cascade:PatientProfile'
   | 'coverage:InsurancePlan';
 
@@ -214,6 +215,11 @@ const KNOWN_TYPES: Record<string, CascadeRecordType> = {
   [NS.health + 'LabResultRecord']:    'health:LabResultRecord',
   [NS.health + 'ImmunizationRecord']: 'health:ImmunizationRecord',
   [NS.clinical + 'VitalSign']:        'clinical:VitalSign',
+  // Encounters were PASSTHROUGH until the visit identifier existed on both
+  // transports: with no join key there was nothing for a matcher to key on, so
+  // a pod holding one Epic account's FHIR pull and that account's C-CDA export
+  // held 177 encounter subjects for about 58 visits and could not tell.
+  [NS.clinical + 'Encounter']:        'clinical:Encounter',
   [NS.cascade + 'PatientProfile']:    'cascade:PatientProfile',
   [NS.coverage + 'InsurancePlan']:    'coverage:InsurancePlan',
 };
@@ -814,6 +820,28 @@ export function recordContentFingerprint(
   ignored: ReadonlySet<string> = COLLISION_IGNORED_PREDICATES,
   derived?: DerivedReferenceValues,
 ): string {
+  // The separator, like the sort inside contentParts, is part of the IRI a split
+  // derives from this hash (see collisionSplitUri), so neither may change: a
+  // different byte string here re-mints every split subject a pod has written.
+  const parts = contentParts(r, resolveRef, ignored, derived);
+  return createHash('sha256').update(parts.join('\u0001'), 'utf8').digest('hex');
+}
+
+/**
+ * The sorted (predicate, value, datatype) statements the fingerprint hashes.
+ *
+ * Split out from {@link recordContentFingerprint} so that two records can be
+ * compared for CONTAINMENT and not only for equality, on exactly the statements
+ * the fingerprint would have compared. Two derivations of "what this record
+ * says" that could drift apart would make the containment test and the collision
+ * test disagree, which is the failure sharing one function avoids.
+ */
+function contentParts(
+  r: ParsedRecord,
+  resolveRef?: (raw: string) => string | null,
+  ignored: ReadonlySet<string> = COLLISION_IGNORED_PREDICATES,
+  derived?: DerivedReferenceValues,
+): string[] {
   const parts: string[] = [];
   for (const [pred, vals] of r.properties) {
     if (ignored.has(pred)) continue;
@@ -841,7 +869,7 @@ export function recordContentFingerprint(
     }
   }
   parts.sort();
-  return createHash('sha256').update(parts.join('\u0001'), 'utf8').digest('hex');
+  return parts;
 }
 
 /** `https://ns.cascadeprotocol.org/health/v1#resultValue` -> `health:resultValue`. */
@@ -940,6 +968,44 @@ function differingPredicates(
 }
 
 /**
+ * THE THIRD REASON two records share an IRI, and the one that is neither a
+ * re-import nor a collision.
+ *
+ * A near-duplicate merge writes the UNION of a group's facts onto the winner's
+ * subject. On the next import the winner's OWN source arrives again, converts to
+ * the same IRI, and carries only its own facts — strictly fewer than the pod now
+ * holds. Nothing disagrees: the pod's copy is that record plus what a sibling
+ * contributed. Splitting them would separate a survivor from its own source,
+ * grow the pod by one on the first re-sync, and raise a conflict describing a
+ * disagreement that does not exist.
+ *
+ * BOTH CLAUSES ARE LOAD-BEARING.
+ *
+ *   LINEAGE   the survivor must name THIS IRI in its own `cascade:mergedFrom`.
+ *             That is the pod stating it already absorbed a record minted here,
+ *             so the exemption can never reach a record that never merged.
+ *   SUBSET    the arriving copy must state nothing the survivor does not already
+ *             state, value for value, on exactly the statements the fingerprint
+ *             compares. A CONTRADICTION — a different clinic, a different result
+ *             — is the collision this mechanism exists for, and merge lineage
+ *             buys no exemption from it.
+ */
+function absorbedByMergeSurvivor(
+  survivor: ParsedRecord,
+  arriving: ParsedRecord,
+  uri: string,
+  resolveRef?: (raw: string) => string | null,
+  derived?: DerivedReferenceValues,
+): boolean {
+  const lineage = survivor.properties.get(NS.cascade + 'mergedFrom') ?? [];
+  if (!lineage.some((v) => v.value === uri)) return false;
+  const stated = new Set(contentParts(survivor, resolveRef, COLLISION_IGNORED_PREDICATES, derived));
+  return contentParts(arriving, resolveRef, COLLISION_IGNORED_PREDICATES, derived).every((part) =>
+    stated.has(part),
+  );
+}
+
+/**
  * Re-key every record whose minted IRI is shared by two or more materially
  * different records, so that no record is dropped for being a "duplicate" of
  * something it does not match.
@@ -988,7 +1054,18 @@ export function splitIdentityCollisions(
     }
 
     const rekeyed = new Map<ParsedRecord, string>();
-    for (const [uri, bucket] of byUri) {
+    for (const [uri, wholeBucket] of byUri) {
+      if (wholeBucket.length < 2) continue;
+      // A source this IRI's merge survivor has already absorbed is not a second
+      // claimant on it. Removed from the bucket rather than reconciled away, so
+      // the ordinary re-import pass-over keeps the survivor and drops the thin
+      // copy — see absorbedByMergeSurvivor.
+      const bucket = wholeBucket.filter(
+        (r) =>
+          !wholeBucket.some(
+            (other) => other !== r && absorbedByMergeSurvivor(other, r, uri, resolveRef, derived),
+          ),
+      );
       if (bucket.length < 2) continue;
       const distinct = [...new Set(bucket.map((r) => fingerprints.get(r)!))].sort();
       if (distinct.length < 2) continue;  // a re-import, not a collision
@@ -1355,6 +1432,91 @@ function matchVitalSigns(a: ParsedRecord, b: ParsedRecord): MatchResult {
   return { match: true, confidence: 0.85, matchedOn: `loinc:${code}+${at}` };
 }
 
+/**
+ * The predicate carrying a visit's identifier, on BOTH transports.
+ *
+ * The C-CDA path writes `<encounter><id root= extension=/>` here as
+ * `root:extension`; the FHIR path writes each `Encounter.identifier` entry here
+ * as `system:value` with `urn:oid:` stripped. On Epic output those are the same
+ * contact serial number written twice, which is what makes a cross-transport
+ * join possible at all.
+ *
+ * NOT `clinical:sourceRecordId`. On a FHIR encounter that predicate holds
+ * `Encounter.id`, the FHIR SERVER's row id, which names nothing outside that
+ * server and shares no key space with a visit identifier. Reading both would
+ * mix two id spaces in one comparison for no gain: the C-CDA path writes the
+ * visit identifier to BOTH predicates, so the cascade: one alone already sees
+ * every identifier either transport states.
+ */
+const ENCOUNTER_IDENTIFIER_PREDICATE = NS.cascade + 'sourceRecordId';
+
+/** Every visit identifier a record states, trimmed and de-duplicated. */
+function encounterIdentifiers(r: ParsedRecord): Set<string> {
+  const out = new Set<string>();
+  for (const v of r.properties.get(ENCOUNTER_IDENTIFIER_PREDICATE) ?? []) {
+    const value = v.value.trim();
+    if (value) out.add(value);
+  }
+  return out;
+}
+
+/**
+ * Do two encounter records denote one visit?
+ *
+ * ONE TIER, AND NO FALLBACK. Two encounters match when they state a visit
+ * identifier IN COMMON, and never otherwise. There is deliberately no
+ * type-and-date tier below it: "Office Visit on 2025-04-01" describes two
+ * genuinely separate visits as readily as one visit twice, and a pod's whole
+ * timeline hangs off `clinical:hasEncounter` edges that a wrong merge silently
+ * re-points. An encounter carrying NO identifier therefore never merges with
+ * anything — absence of a join key is not evidence of a match.
+ *
+ * The empty-set guard below is REDUNDANT with the intersection that follows
+ * (nothing intersects an empty set) and is kept for the same reason the `b === a`
+ * clause in the matching loop is: it states the rule directly, rather than
+ * leaving the most important property of this matcher to be inferred from a
+ * filter. `tests/reconciler-encounter-dedupe.test.ts` pins the behaviour either
+ * way.
+ *
+ * `matchedOn` names the SHARED identifier and picks it deterministically (the
+ * lexicographically smallest of the intersection), because `generateConflictId`
+ * builds a persisted conflict id out of this string: a constant there would give
+ * every encounter conflict in a pod one id, which is the defect the medication
+ * matcher's `partial-name` comment records paying for.
+ */
+function matchEncounters(a: ParsedRecord, b: ParsedRecord): MatchResult {
+  const noMatch: MatchResult = { match: false, confidence: 0, matchedOn: '' };
+  const idsA = encounterIdentifiers(a);
+  if (idsA.size === 0) return noMatch;
+  const shared = [...encounterIdentifiers(b)].filter((id) => idsA.has(id)).sort();
+  if (shared.length === 0) return noMatch;
+  // The source assigned this identifier to both records. That is the source
+  // stating they are one act, not a similarity score.
+  return { match: true, confidence: 1.0, matchedOn: `encounter-id:${shared[0]}` };
+}
+
+/**
+ * True when two records are ONE act the SOURCE ITSELF identified twice.
+ *
+ * This is the one thing allowed past {@link sameSourceStatement}, the guard that
+ * otherwise stops one organization's single export from being matched against
+ * itself. That guard exists because "a source does not restate the same record
+ * twice inside one export" — and for encounters that premise is measurably
+ * false: every clinical document in a C-CDA export re-declares the encounter it
+ * was written under, so one export carried 123 encounter blocks bearing 52
+ * identifiers, one of them five times.
+ *
+ * The exemption is narrow on purpose. It is not a similarity judgement the guard
+ * is being asked to trust; it is the source's own identifier, stated twice, on
+ * the one record type where restating an act inside one export is the norm
+ * rather than the exception. Everything else the guard suppresses stays
+ * suppressed.
+ */
+function sourceStatedOneAct(a: ParsedRecord, b: ParsedRecord): boolean {
+  if (a.type !== 'clinical:Encounter' || b.type !== 'clinical:Encounter') return false;
+  return matchEncounters(a, b).match;
+}
+
 function matchPatientProfiles(a: ParsedRecord, b: ParsedRecord): MatchResult {
   const dobA = getProp(a, NS.cascade + 'dateOfBirth');
   const dobB = getProp(b, NS.cascade + 'dateOfBirth');
@@ -1399,6 +1561,7 @@ function doRecordsMatch(a: ParsedRecord, b: ParsedRecord, tol: number, resolver?
     case 'health:LabResultRecord':    return matchLabs(a, b, tol);
     case 'health:ImmunizationRecord': return matchImmunizations(a, b);
     case 'clinical:VitalSign':        return matchVitalSigns(a, b);
+    case 'clinical:Encounter':        return matchEncounters(a, b);
     case 'cascade:PatientProfile':    return matchPatientProfiles(a, b);
     default:                          return { match: false, confidence: 0, matchedOn: '' };
   }
@@ -1572,6 +1735,37 @@ function classifyGroup(
     const nA = normalizeMedName(getProp(a, NS.clinical + 'drugName') ?? '', resolver);
     const nB = normalizeMedName(getProp(b, NS.clinical + 'drugName') ?? '', resolver);
     const mergeable = nA !== nB || onlyOneSide(doseA, doseB) || onlyOneSide(freqA, freqB);
+    return { matchType: mergeable ? 'near_duplicate' : 'exact_duplicate' };
+  }
+  if (a.type === 'clinical:Encounter') {
+    // The whole point of merging the two transports' copies of one visit is that
+    // each knows things the other does not: the C-CDA twin carries the document
+    // bookkeeping and often the only date, the FHIR twin carries the clinic, the
+    // class, the status and the provider. `exact_duplicate` resolves by trust
+    // priority and keeps the winner's properties ALONE, which would throw away
+    // whichever half lost — a merge that loses facts is not a merge.
+    //
+    // `near_duplicate` selects resolveGroup's `merge_values` strategy: the
+    // winner supplies every contested value and the losers fill in only the
+    // predicates the winner does not state. So a visit ends up with the union,
+    // and where both twins state one predicate at different fidelity the winner
+    // decides — the winner being the record with the most stated facts, since
+    // both transports of one account carry the same trust score and
+    // `resolveGroup` breaks that tie on completeness.
+    //
+    // NO CONFLICT ROW. Two transports disagreeing about an encounter's type text
+    // ("Office Visit" vs "Ambulatory office visit") is a vocabulary difference,
+    // not a clinical divergence to put in front of a person; the medication
+    // status and dose conflicts exist because those DO change what someone
+    // should do.
+    const contentPredicates = (r: ParsedRecord): Set<string> => {
+      const out = new Set<string>();
+      for (const p of r.properties.keys()) if (!COLLISION_IGNORED_PREDICATES.has(p)) out.add(p);
+      return out;
+    };
+    const pa = contentPredicates(a);
+    const pb = contentPredicates(b);
+    const mergeable = [...pa].some((p) => !pb.has(p)) || [...pb].some((p) => !pa.has(p));
     return { matchType: mergeable ? 'near_duplicate' : 'exact_duplicate' };
   }
   return { matchType: 'exact_duplicate' };
@@ -2368,7 +2562,12 @@ export async function runReconciliation(
         // it is the direct statement of the condition, it matches the
         // single-batch loop below, and it does not depend on a guard about
         // SOURCES happening to also exclude identity.
-        if (b === a || assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
+        if (b === a || assigned.has(b.uri) || sameCollision(a, b)) continue;
+        // The same-source guard, with its one exemption: a source that stated
+        // ONE identifier on two records is telling us they are one act, and
+        // suppressing that comparison leaves the duplicate in the pod. See
+        // sourceStatedOneAct.
+        if (sameSourceStatement(a, b) && !sourceStatedOneAct(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {
@@ -2422,7 +2621,12 @@ export async function runReconciliation(
 
       const candidates = typeIndex.get(a.type) ?? [];
       for (const b of candidates) {
-        if (b === a || assigned.has(b.uri) || sameSourceStatement(a, b) || sameCollision(a, b)) continue;
+        if (b === a || assigned.has(b.uri) || sameCollision(a, b)) continue;
+        // The same-source guard, with its one exemption: a source that stated
+        // ONE identifier on two records is telling us they are one act, and
+        // suppressing that comparison leaves the duplicate in the pod. See
+        // sourceStatedOneAct.
+        if (sameSourceStatement(a, b) && !sourceStatedOneAct(a, b)) continue;
         const { match, confidence, matchedOn: mo } = doRecordsMatch(a, b, labTol, resolver);
         const threshold = getMatchThreshold(a, b);
         if (match && confidence >= threshold) {

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -968,41 +968,210 @@ function differingPredicates(
 }
 
 /**
- * THE THIRD REASON two records share an IRI, and the one that is neither a
- * re-import nor a collision.
+ * Every predicate on which a record states the SOURCE's own id for itself.
  *
- * A near-duplicate merge writes the UNION of a group's facts onto the winner's
- * subject. On the next import the winner's OWN source arrives again, converts to
- * the same IRI, and carries only its own facts — strictly fewer than the pod now
- * holds. Nothing disagrees: the pod's copy is that record plus what a sibling
- * contributed. Splitting them would separate a survivor from its own source,
- * grow the pod by one on the first re-sync, and raise a conflict describing a
- * disagreement that does not exist.
- *
- * BOTH CLAUSES ARE LOAD-BEARING.
- *
- *   LINEAGE   the survivor must name THIS IRI in its own `cascade:mergedFrom`.
- *             That is the pod stating it already absorbed a record minted here,
- *             so the exemption can never reach a record that never merged.
- *   SUBSET    the arriving copy must state nothing the survivor does not already
- *             state, value for value, on exactly the statements the fingerprint
- *             compares. A CONTRADICTION — a different clinic, a different result
- *             — is the collision this mechanism exists for, and merge lineage
- *             buys no exemption from it.
+ * Not one predicate, because the importers disagree about which to use and a
+ * record routinely carries two that mean different things: a FHIR encounter
+ * states the server's row id on `clinical:sourceRecordId` and the visit's
+ * identifier on `cascade:sourceRecordId`. Agreement is therefore checked
+ * per-predicate, never by flattening them into one bag where a row id could be
+ * compared against a visit identifier.
  */
-function absorbedByMergeSurvivor(
-  survivor: ParsedRecord,
-  arriving: ParsedRecord,
-  uri: string,
+const SOURCE_RECORD_ID_PREDICATES: readonly string[] = [
+  NS.cascade + 'sourceRecordId',
+  NS.clinical + 'sourceRecordId',
+  NS.health + 'sourceRecordId',
+  NS.coverage + 'sourceRecordId',
+  NS.clinical + 'fhirResourceId',
+];
+
+/** The source ids a record states, keyed by the predicate it stated them on. */
+function sourceRecordIds(r: ParsedRecord): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  for (const pred of SOURCE_RECORD_ID_PREDICATES) {
+    const values = new Set(
+      (r.properties.get(pred) ?? []).map((v) => v.value.trim()).filter((v) => v.length > 0),
+    );
+    if (values.size > 0) out.set(pred, values);
+  }
+  return out;
+}
+
+/**
+ * Do two records that claim ONE IRI describe ONE source record?
+ *
+ * THE QUESTION THIS ANSWERS IS NOT "IS THE CONTENT THE SAME". It is deliberately
+ * blind to content, because the case it exists for is precisely two conversions
+ * of one record whose content DIFFERS — the newer one states more, and sometimes
+ * states a corrected value where the older converter chose wrongly.
+ *
+ * Three clauses, each doing work:
+ *
+ *   AGREEMENT      at least one source-id predicate is stated by both with the
+ *                  same value. That is the source's own answer to "is this that
+ *                  record?", the same evidence `ccdaRecordUri` and
+ *                  `mintSubjectUri` key identity on.
+ *   NO CONTRADICTION  no source-id predicate they BOTH state disagrees. A pair
+ *                  agreeing on a FHIR row id while disagreeing on the visit
+ *                  identifier is not one record, and the agreement clause alone
+ *                  would have admitted it.
+ *   SAME ORIGIN    the same organization said both. One id string claimed by two
+ *                  organizations is the cross-source collision the origin axis
+ *                  exists to catch — the C-CDA root-only-id case, where a shared
+ *                  assigning-authority OID is misused as a record id. When either
+ *                  origin is UNKNOWN (a record written before core v3.5, or one
+ *                  whose origin honestly landed on the `transport:` tier) the
+ *                  ingestion label decides instead, which suppresses MORE
+ *                  collapsing and leaves the split-and-conflict path in place.
+ *                  That is the recoverable direction, and it mirrors the cascade
+ *                  `sameSourceStatement` already documents.
+ *
+ * A pair stating no source id at all fails the first clause and stays a
+ * collision, which is right: content-hashed identity plus differing content is
+ * the case the whole mechanism was built for.
+ */
+function sameSourceRecord(a: ParsedRecord, b: ParsedRecord): boolean {
+  const idsA = sourceRecordIds(a);
+  const idsB = sourceRecordIds(b);
+  if (idsA.size === 0 || idsB.size === 0) return false;
+
+  let agreed = false;
+  for (const [pred, valuesA] of idsA) {
+    const valuesB = idsB.get(pred);
+    if (!valuesB) continue;
+    const shared = [...valuesA].some((v) => valuesB.has(v));
+    if (!shared) return false;  // both state this predicate and they disagree
+    agreed = true;
+  }
+  if (!agreed) return false;
+
+  if (isKnownOrigin(a.sourceIdentity) && isKnownOrigin(b.sourceIdentity)) {
+    return a.sourceIdentity === b.sourceIdentity;
+  }
+  return a.sourceSystem === b.sourceSystem;
+}
+
+/**
+ * Fold two conversions of ONE source record into one record, before the
+ * collision door ever sees them.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Converters get better. When they do, re-importing a pod's own retained source
+ * produces the SAME subject IRI — identity keys on the source's id, which has
+ * not changed — carrying DIFFERENT content. `splitIdentityCollisions` reads
+ * "same IRI, materially different" and reports a collision, which is the one
+ * thing it is not: there is one source record here, converted twice.
+ *
+ * Measured on a real pod re-imported through the enriched converters: 723
+ * identity-collision conflicts, and each of 54 encounters split into an old thin
+ * twin and a new rich one. Worse than the noise, the split defeated the fix: the
+ * thin twins carried no visit identifier — the field the new converter had just
+ * started emitting — so the encounter matcher could not rejoin them, and a
+ * re-import intended to collapse 177 subjects to 58 produced 112.
+ *
+ * WHICH COPY WINS, AND WHY IT IS NOT SYMMETRIC
+ * -------------------------------------------
+ * The INCOMING conversion is authoritative for every predicate it states. A
+ * converter is the authority on its own source record, so a value it changed is
+ * a CORRECTION and must land as one — wave 1's role-aware `providerName` fix is
+ * worthless if it arrives as a question for a person to answer.
+ *
+ * Predicates the incoming conversion does NOT state are kept from the pod's
+ * copy. That clause is not politeness: the pod's copy may be a merge survivor
+ * carrying facts that came from a DIFFERENT source record, and replacing it
+ * wholesale would un-merge every cross-transport union on every re-import.
+ * Keeping them is also what preserves the reconciler's own lineage
+ * (`cascade:mergedFrom`, `prov:wasDerivedFrom`) without naming a list of
+ * predicates that would drift from the ones the reconciler actually writes.
+ *
+ * WHAT IT DOES NOT TOUCH
+ * ----------------------
+ * Two DIFFERENT source records on one IRI, and any pair with no source id to
+ * agree on, are left exactly as they were, for `splitIdentityCollisions` to
+ * split and raise. This narrows what reaches that door; it does not soften it.
+ */
+export function collapseReconversions(
+  records: ParsedRecord[],
   resolveRef?: (raw: string) => string | null,
   derived?: DerivedReferenceValues,
-): boolean {
-  const lineage = survivor.properties.get(NS.cascade + 'mergedFrom') ?? [];
-  if (!lineage.some((v) => v.value === uri)) return false;
-  const stated = new Set(contentParts(survivor, resolveRef, COLLISION_IGNORED_PREDICATES, derived));
-  return contentParts(arriving, resolveRef, COLLISION_IGNORED_PREDICATES, derived).every((part) =>
-    stated.has(part),
-  );
+): { records: ParsedRecord[]; collapsed: number } {
+  const byUri = new Map<string, ParsedRecord[]>();
+  for (const r of records) {
+    const bucket = byUri.get(r.uri);
+    if (bucket) bucket.push(r);
+    else byUri.set(r.uri, [r]);
+  }
+
+  const replacement = new Map<ParsedRecord, ParsedRecord | null>();
+  let collapsed = 0;
+
+  for (const bucket of byUri.values()) {
+    if (bucket.length < 2) continue;
+    const incoming = bucket.filter((r) => !r.fromExistingPod);
+    const prior = bucket.filter((r) => r.fromExistingPod);
+    // Both sides are required. Two POD copies of one IRI is not a re-conversion
+    // — nothing arrived to be authoritative — and two fresh copies within one
+    // batch are the ordinary re-import the pass-over already handles.
+    if (incoming.length === 0 || prior.length === 0) continue;
+
+    // The incoming copies must agree with each other, or "the incoming
+    // conversion" names no single record and choosing one would decide a real
+    // collision by input order.
+    const incomingFingerprints = new Set(
+      incoming.map((r) => recordContentFingerprint(r, resolveRef, COLLISION_IGNORED_PREDICATES, derived)),
+    );
+    if (incomingFingerprints.size > 1) continue;
+
+    const winner = incoming[0];
+    if (!bucket.every((r) => r === winner || sameSourceRecord(winner, r))) continue;
+
+    const properties = new Map(winner.properties);
+    for (const other of bucket) {
+      if (other === winner) continue;
+      for (const [pred, vals] of other.properties) {
+        if (properties.has(pred)) continue;
+        properties.set(pred, vals);
+      }
+    }
+
+    // One exception to "the incoming copy's values win": a record-to-record edge
+    // the pod already holds RESOLVED and the fresh conversion still carries as a
+    // placeholder is the same statement in two spellings, and the resolved one
+    // is the copy whose target provably exists. Taking the placeholder instead
+    // would hand a resolved edge back to the resolution pass to re-resolve, and
+    // on the `pod reconcile` path — which has no resolution pass — would leave
+    // it a placeholder for good.
+    for (const [pred, vals] of properties) {
+      const priorValues = new Set(
+        prior.flatMap((r) => (r.properties.get(pred) ?? []).map((v) => v.value)),
+      );
+      if (priorValues.size === 0) continue;
+      let changed = false;
+      const spelled = vals.map((v) => {
+        const resolvedTo = normalizeEdgeValue(v.value, resolveRef);
+        if (resolvedTo !== undefined && resolvedTo !== v.value && priorValues.has(resolvedTo)) {
+          changed = true;
+          return { value: resolvedTo, datatype: v.datatype, isIri: true };
+        }
+        return v;
+      });
+      if (changed) properties.set(pred, spelled);
+    }
+
+    const merged: ParsedRecord = { ...winner, properties };
+    for (const r of bucket) replacement.set(r, r === winner ? merged : null);
+    collapsed += bucket.length - 1;
+  }
+
+  if (collapsed === 0) return { records, collapsed: 0 };
+  const out: ParsedRecord[] = [];
+  for (const r of records) {
+    if (!replacement.has(r)) { out.push(r); continue; }
+    const to = replacement.get(r);
+    if (to) out.push(to);
+  }
+  return { records: out, collapsed };
 }
 
 /**
@@ -1054,18 +1223,7 @@ export function splitIdentityCollisions(
     }
 
     const rekeyed = new Map<ParsedRecord, string>();
-    for (const [uri, wholeBucket] of byUri) {
-      if (wholeBucket.length < 2) continue;
-      // A source this IRI's merge survivor has already absorbed is not a second
-      // claimant on it. Removed from the bucket rather than reconciled away, so
-      // the ordinary re-import pass-over keeps the survivor and drops the thin
-      // copy — see absorbedByMergeSurvivor.
-      const bucket = wholeBucket.filter(
-        (r) =>
-          !wholeBucket.some(
-            (other) => other !== r && absorbedByMergeSurvivor(other, r, uri, resolveRef, derived),
-          ),
-      );
+    for (const [uri, bucket] of byUri) {
       if (bucket.length < 2) continue;
       const distinct = [...new Set(bucket.map((r) => fingerprints.get(r)!))].sort();
       if (distinct.length < 2) continue;  // a re-import, not a collision
@@ -2374,6 +2532,15 @@ export async function runReconciliation(
   // the same footing rather than on the pipeline stage each was caught at.
   const derivedReferenceValues = buildDerivedReferenceValues(allInputQuads, referenceResolver);
 
+  // Two conversions of ONE source record are folded together FIRST, so the
+  // collision door below only ever sees pairs that are genuinely two records.
+  // Without this every enrichment to a converter turns the next re-import of a
+  // pod's own retained sources into a wall of conflicts — measured at 723 on one
+  // real pod — and splits apart the very records the new fields were emitted to
+  // let the matchers join.
+  const reconverted = collapseReconversions(allRecords, referenceResolver, derivedReferenceValues);
+  allRecords = reconverted.records;
+
   const split = splitIdentityCollisions(allRecords, referenceResolver, derivedReferenceValues);
   allRecords = split.records;
   const identityCollisions = split.collisions;
@@ -2656,7 +2823,11 @@ export async function runReconciliation(
   // reported as a merge.
   const groupedRecords = new Set<ParsedRecord>();
   for (const g of groups) for (const r of g.records) groupedRecords.add(r);
-  const duplicateSubjectsDropped = allRecords.length - groupedRecords.size;
+  // Re-conversions folded before the collision door are counted here too: they
+  // ARE a second arrival of a subject the pod already held, and leaving them out
+  // would report a re-import of an entire pod as having dropped nothing.
+  const duplicateSubjectsDropped =
+    allRecords.length - groupedRecords.size + reconverted.collapsed;
 
   // Tier-0 classification, BEFORE resolution, because resolveGroup reads it.
   // The fingerprint is memoized: it is a SHA-256 over the record's whole property

--- a/test-fixtures/ccda-encounter-csn-twin.xml
+++ b/test-fixtures/ccda-encounter-csn-twin.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic C-CDA Encounters section holding ONE visit, written the way an Epic
+  document export writes it: the encounter's <id> is the contact serial number,
+  root = the assigning-authority OID and extension = the serial itself.
+
+  Its twin is the FHIR Encounter authored inline in
+  tests/encounter-identifier-join.test.ts, which states the SAME identifier as
+  `identifier[0] = {system: "urn:oid:<root>", value: "<extension>"}`. The pair
+  exists to prove one thing: both transports write that identifier into the pod
+  in the SAME normalized spelling, so the reconciler has a join key on both
+  sides of the pair rather than on one.
+
+  The OID is in the example-use `.999.` arc. No content is derived from a real
+  record and no real assigning authority is named.
+-->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <id root="2.16.840.1.113883.3.88.11.32.1" extension="ENC-CSN-TWIN-001"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Encounter CSN Twin Fixture</title>
+  <effectiveTime value="20260401120000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
+    <patientRole>
+      <id root="2.16.840.1.113883.4.1" extension="000-00-0000"/>
+      <patient>
+        <name use="L"><given>Jane</given><family>Doe</family></name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+        <birthTime value="19650101"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.3.88.11.32.1"/>
+        <name>Fixture Health</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+          <code code="46240-8" displayName="History of encounters" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Encounters</title>
+          <text>One visit, identified by its contact serial number.</text>
+
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="1.2.840.114350.1.13.999.2.7.3.698084.8" extension="20100000001"/>
+              <code code="99213" displayName="Office Visit" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+              <effectiveTime>
+                <low value="20250401090000-0700"/>
+                <high value="20250401094500-0700"/>
+              </effectiveTime>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/tests/encounter-identifier-join.test.ts
+++ b/tests/encounter-identifier-join.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The encounter join key: both transports write one visit's identifier the same
+ * way, or the two halves of a duplicate can never be recognised as one visit.
+ *
+ * WHAT WAS MISSING
+ * ----------------
+ * `convertEncounter` READ `resource.identifier` (for identity minting, and only
+ * when `resource.id` was absent) and never wrote it as a fact. The C-CDA path
+ * has always written the same visit's identifier — the Epic contact serial
+ * number, `<id root= extension=/>` — as `cascade:sourceRecordId`. So on a pod
+ * holding both transports the join key sat on ONE side of every duplicate pair:
+ * measured, 0 of 54 FHIR-derived encounter blocks carried a serial number while
+ * 48 of the 52 C-CDA ones named the very same visits.
+ *
+ * WHICH PREDICATE, AND WHY
+ * ------------------------
+ * `cascade:sourceRecordId`, core v3: "the original source system record
+ * identifier (e.g. C-CDA <id> element value) preserved for provenance". Two
+ * reasons, both from the shapes rather than from taste:
+ *
+ *   `clinical:sourceRecordId` is constrained `sh:maxCount 1` on
+ *   `clinical:EncounterShape` and already carries `Encounter.id`, the FHIR
+ *   SERVER's resource id. FHIR `Encounter.identifier` is 0..*, so a second
+ *   business identifier cannot go there without either evicting the resource id
+ *   or violating the shape.
+ *
+ *   `cascade:sourceRecordId` carries no shape constraint on Encounter, is
+ *   repeatable, and is ALREADY the predicate the C-CDA path writes this exact
+ *   value on. Emitting it there is join parity by construction rather than by a
+ *   matcher that has to know two spellings.
+ *
+ * IDENTITY IS UNTOUCHED. `mintSubjectUri` still keys on `resource.id` first;
+ * this change adds a FACT, never an identity input. Deduplication is the
+ * reconciler's judgement with a provenance trail, not the identity layer's
+ * silent overwrite — see `ccda-converter/record-identity.ts` for the doctrine.
+ *
+ * Every fixture here is synthetic. The identifier OID is in the example-use
+ * `.999.` arc.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import type { Quad } from 'n3';
+
+import { convertCcda } from '../src/lib/ccda-converter/index.js';
+import { convertEncounter } from '../src/lib/fhir-converter/converters-clinical.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, '../test-fixtures');
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
+
+/** The assigning authority and serial the two transports both state. */
+const CSN_OID = '1.2.840.114350.1.13.999.2.7.3.698084.8';
+const CSN_VALUE = '20100000001';
+const CSN = `${CSN_OID}:${CSN_VALUE}`;
+
+/** The FHIR twin of `test-fixtures/ccda-encounter-csn-twin.xml`. */
+function fhirTwin(): Record<string, unknown> {
+  return {
+    resourceType: 'Encounter',
+    id: 'eNcOuNtEr-twin-1',
+    identifier: [{ use: 'usual', system: `urn:oid:${CSN_OID}`, value: CSN_VALUE }],
+    status: 'finished',
+    class: { system: 'urn:oid:1.2.840.114350.1.72.1.7.1', code: '5', display: 'Appointment' },
+    type: [{ text: 'Office Visit' }],
+    period: { start: '2025-04-01T16:00:00Z', end: '2025-04-01T16:45:00Z' },
+  };
+}
+
+function valuesOf(quads: Quad[], predicate: string): string[] {
+  return quads.filter((q) => q.predicate.value === predicate).map((q) => q.object.value).sort();
+}
+
+/** Every `cascade:sourceRecordId` carried by a `clinical:Encounter` subject. */
+function encounterSourceIds(quads: Quad[], predicate = CASCADE + 'sourceRecordId'): string[] {
+  const encounters = new Set(
+    quads
+      .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === CLINICAL + 'Encounter')
+      .map((q) => q.subject.value),
+  );
+  return quads
+    .filter((q) => q.predicate.value === predicate && encounters.has(q.subject.value))
+    .map((q) => q.object.value)
+    .sort();
+}
+
+async function ccdaTwinQuads(): Promise<Quad[]> {
+  const xml = fs.readFileSync(path.join(FIXTURES, 'ccda-encounter-csn-twin.xml'), 'utf-8');
+  const result = await convertCcda(xml, {
+    sourceSystem: 'TestSystem',
+    importedAt: '2026-01-01T00:00:00Z',
+  });
+  expect(result.errors, `conversion errors: ${result.errors.join(', ')}`).toHaveLength(0);
+  return new Parser().parse(result.output);
+}
+
+describe('the encounter identifier is written by BOTH transports, in one spelling', () => {
+  it('the FHIR converter emits the identifier as system:value with urn:oid: stripped', () => {
+    const quads = convertEncounter(fhirTwin())._quads;
+    expect(valuesOf(quads, CASCADE + 'sourceRecordId')).toEqual([CSN]);
+  });
+
+  it('the two transports produce the SAME identifier string for the same visit', async () => {
+    // The join key, stated as an equality rather than as two separate format
+    // assertions: if either side changes its spelling, this fails even though
+    // both sides still "emit an identifier".
+    const fromFhir = encounterSourceIds(convertEncounter(fhirTwin())._quads);
+    const fromCcda = encounterSourceIds(await ccdaTwinQuads());
+    expect(fromCcda).not.toEqual([]);
+    expect(fromFhir).toEqual(fromCcda);
+  });
+
+  it('emits every identifier the resource states, not only the first', () => {
+    const resource = fhirTwin();
+    (resource.identifier as unknown[]).push({
+      system: 'urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.68',
+      value: 'AF-4471',
+    });
+    expect(valuesOf(convertEncounter(resource)._quads, CASCADE + 'sourceRecordId')).toEqual([
+      CSN,
+      '1.2.840.114350.1.13.999.2.7.3.698084.68:AF-4471',
+    ].sort());
+  });
+
+  it('states a system-less identifier the way the C-CDA path states an extension-only id', () => {
+    // `ccdaSourceId` renders `<id extension="X"/>` with no root as ":X". A FHIR
+    // identifier with a value and no system is the same statement, and rendering
+    // it as a bare "X" would make it collide with a differently-scoped id.
+    const resource = fhirTwin();
+    resource.identifier = [{ value: 'X-1' }];
+    expect(valuesOf(convertEncounter(resource)._quads, CASCADE + 'sourceRecordId')).toEqual([':X-1']);
+  });
+
+  it('writes nothing for an identifier that carries no value', () => {
+    const resource = fhirTwin();
+    resource.identifier = [{ system: `urn:oid:${CSN_OID}` }, { use: 'usual' }];
+    expect(valuesOf(convertEncounter(resource)._quads, CASCADE + 'sourceRecordId')).toEqual([]);
+  });
+
+  it('keeps the FHIR server resource id on its own predicate, unshared', () => {
+    // The two are different things: one identifies the visit in the health
+    // system, the other identifies the ROW on the FHIR server. Collapsing them
+    // onto one predicate would put a `sh:maxCount 1` shape in an impossible
+    // position and lose whichever value lost the race.
+    const quads = convertEncounter(fhirTwin())._quads;
+    expect(valuesOf(quads, CLINICAL + 'sourceRecordId')).toEqual(['eNcOuNtEr-twin-1']);
+  });
+
+  it('does not move the subject IRI: identity stays id-first', () => {
+    // Pinned against the IRI this resource minted BEFORE the identifier became a
+    // fact. An encounter IRI that moves is a duplicate visit on every pod that
+    // already holds the record, plus a dangling clinical:hasEncounter edge from
+    // everything that pointed at it.
+    const withIdentifier = convertEncounter(fhirTwin())._quads[0].subject.value;
+    const without = fhirTwin();
+    delete without.identifier;
+    const withoutIdentifier = convertEncounter(without)._quads[0].subject.value;
+    expect(withIdentifier).toBe(withoutIdentifier);
+  });
+});
+
+describe('3.208: the C-CDA encounter states its type and id in the canonical clinical: spellings', () => {
+  it('emits clinical:encounterType and clinical:sourceRecordId', async () => {
+    // `clinical:EncounterShape` constrains the `clinical:` spellings and says
+    // nothing about the `cascade:` ones, so an encounter's type and source id
+    // were validated on the FHIR transport and invisible on the C-CDA one.
+    const quads = await ccdaTwinQuads();
+    expect(encounterSourceIds(quads, CLINICAL + 'sourceRecordId')).toEqual([CSN]);
+    expect(valuesOf(quads, CLINICAL + 'encounterType')).toEqual(['Office Visit']);
+  });
+
+  it('keeps dual-writing the cascade: spellings this release', async () => {
+    // The readers are real and still on the old spelling: the pathology corpus
+    // harness's SOURCE_RECORD_ID list and the reconciler's source-id path.
+    // Retiring the dual write is its own change, with its own measurement.
+    const quads = await ccdaTwinQuads();
+    expect(encounterSourceIds(quads, CASCADE + 'sourceRecordId')).toEqual([CSN]);
+    expect(valuesOf(quads, CASCADE + 'encounterType')).toEqual(['Office Visit']);
+  });
+});

--- a/tests/fhir-field-coverage.test.ts
+++ b/tests/fhir-field-coverage.test.ts
@@ -315,8 +315,15 @@ describe('the measurement itself', () => {
     const encounter = COVERAGE.find((c) => c.fixture.resourceType === 'Encounter')!.coverage;
     // Never read.
     expect(encounter.dropped).toContain('Encounter.reasonCode');
-    // Read for identity, never written as a fact.
-    expect(encounter.dropped).toContain('Encounter.identifier');
+    // Read for identity, never written as a fact. `Encounter.identifier` was the
+    // exemplar of this mode and is now emitted (wave 2, the encounter join key),
+    // so the mode is pinned on the resource that still exhibits it: a
+    // DiagnosticReport's `identifier` reaches the identity seed and no triple.
+    const report = COVERAGE.find((c) => c.fixture.resourceType === 'DiagnosticReport')!.coverage;
+    expect(report.dropped).toContain('DiagnosticReport.identifier');
+    // And the exemplar's fix is pinned in the same place the gap was, so a
+    // regression that stops emitting it fails HERE as well as in the manifest.
+    expect(encounter.emitted).toContain('Encounter.identifier');
     // Partial array: the head is emitted, the tail is not.
     expect(encounter.emitted).toContain('Encounter.type[0]');
     expect(encounter.dropped).toContain('Encounter.type[1]');

--- a/tests/fhir-reference-resolution.test.ts
+++ b/tests/fhir-reference-resolution.test.ts
@@ -183,6 +183,48 @@ describe('buildResourceRefsFromQuads (R5 index reconstruction)', () => {
     expect(buildResourceRefsFromQuads(quads)).toEqual([]);
   });
 
+  it('indexes the FHIR resource id, not a business identifier, whatever the quad order', () => {
+    // A record can persist TWO kinds of source id, and only one of them is the
+    // join key a `Reference.reference` string points at. Since wave 2 a FHIR
+    // encounter states its visit identifier (the contact serial number) on
+    // `cascade:sourceRecordId` and the FHIR server's own resource id on
+    // `clinical:sourceRecordId`. First-quad-wins made the index depend on which
+    // one the serializer happened to write first, so `Encounter/enc-1` resolved
+    // or dangled according to emission order — the identity-determinism failure
+    // shape, one layer out. Priority is by PREDICATE, and both orders are
+    // asserted because one of them passed by luck before.
+    const businessIdFirst = [
+      makeQuad(namedNode(S1), namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Encounter')),
+      makeQuad(namedNode(S1), namedNode(NS.cascade + 'sourceRecordId'), literal('1.2.999:20100000001')),
+      makeQuad(namedNode(S1), namedNode(NS.clinical + 'sourceRecordId'), literal('enc-1')),
+      makeQuad(namedNode(S1), namedNode(NS.clinical + 'fhirResourceType'), literal('Encounter')),
+    ];
+    const resourceIdFirst = [
+      businessIdFirst[0],
+      businessIdFirst[2],
+      businessIdFirst[1],
+      businessIdFirst[3],
+    ];
+    expect(buildResourceRefsFromQuads(businessIdFirst)).toEqual([
+      { resourceType: 'Encounter', id: 'enc-1', subject: S1 },
+    ]);
+    expect(buildResourceRefsFromQuads(resourceIdFirst)).toEqual(
+      buildResourceRefsFromQuads(businessIdFirst),
+    );
+  });
+
+  it('still indexes a C-CDA record whose only source id is the cascade: one', () => {
+    // The C-CDA path writes no FHIR resource id at all, so demoting
+    // `cascade:sourceRecordId` must not make those records unindexable.
+    const quads = [
+      makeQuad(namedNode(S2), namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Encounter')),
+      makeQuad(namedNode(S2), namedNode(NS.cascade + 'sourceRecordId'), literal('1.2.999:20100000001')),
+    ];
+    expect(buildResourceRefsFromQuads(quads)).toEqual([
+      { resourceType: '', id: '1.2.999:20100000001', subject: S2 },
+    ]);
+  });
+
   it('feeds resolveReferenceEdges so a relative reference resolves by bare id', async () => {
     // Rebuild the index from a target record, then resolve a placeholder edge
     // that points at it with a typed relative reference.

--- a/tests/reconciler-encounter-dedupe.test.ts
+++ b/tests/reconciler-encounter-dedupe.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Encounter deduplication: one visit is one subject, whichever transport carried
+ * it and however many documents re-declared it.
+ *
+ * THE MEASURED DEFECT
+ * -------------------
+ * A pod holding one Epic account's SMART on FHIR pull AND that account's C-CDA
+ * document export held 177 `clinical:Encounter` subjects describing about 58
+ * real visits. 123 came from the C-CDA path carrying only 52 distinct visit
+ * identifiers (each clinical document re-declares the encounter it was written
+ * under), 54 came from the FHIR path, and 48 of the 52 C-CDA identifiers named
+ * the SAME visits as FHIR encounters. Neither half could recognise the other,
+ * because `clinical:Encounter` was not a reconcilable type at all: encounter
+ * quads went through the reconciler as passthrough, never compared with
+ * anything.
+ *
+ * THE JOIN KEY
+ * ------------
+ * The C-CDA `<encounter><id root= extension=/>` and the FHIR
+ * `Encounter.identifier[0]` are the same Epic contact serial number written
+ * twice, and both transports now state it on `cascade:sourceRecordId` in the
+ * same normalized `system:value` spelling. That is the ONLY key this matcher
+ * uses. An encounter that states no identifier never merges with anything:
+ * absence of a join key is not evidence of a match, and two undated, untyped
+ * visit stubs are not one visit because they are equally empty.
+ *
+ * All data below is synthetic and PHI-free. The identifier OIDs are in the
+ * example-use `.999.` arc, not any real Epic assigning authority.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+import { runReconciliation } from '../src/lib/reconciler.js';
+
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+const PROV = 'http://www.w3.org/ns/prov#';
+
+const HAS_ENCOUNTER = CLINICAL + 'hasEncounter';
+const ENCOUNTER_TYPE = CLINICAL + 'Encounter';
+const MERGED_FROM = CASCADE + 'mergedFrom';
+const WAS_DERIVED_FROM = PROV + 'wasDerivedFrom';
+
+const PREFIXES = `@prefix cascade: <${CASCADE}> .
+@prefix clinical: <${CLINICAL}> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
+@prefix prov: <${PROV}> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+`;
+
+/** The contact serial number both transports state for the same visit. */
+const CSN = '1.2.840.114350.1.13.999.2.7.3.698084.8:20100000001';
+const OTHER_CSN = '1.2.840.114350.1.13.999.2.7.3.698084.8:20100000002';
+
+/**
+ * A C-CDA-shaped encounter block: thin, dated, typed, and carrying the document
+ * bookkeeping the C-CDA path writes. `subject` varies because each document
+ * re-declaring one visit mints its own subject today.
+ */
+function ccdaEncounter(subject: string, sourceId?: string): string {
+  return `<${subject}> a clinical:Encounter ;
+  cascade:sourceSystem "providence-ccda" ;
+  cascade:sourceIdentity "org:providence" ;
+  cascade:dataProvenance cascade:EHRVerified ;
+  cascade:schemaVersion "1.0" ;
+  cascade:documentType "summarization" ;
+  cascade:encounterType "Office Visit" ;
+  clinical:encounterType "Office Visit" ;
+  clinical:encounterDate "2025-04-01"^^xsd:date ;
+  health:effectiveDate "2025-04-01"${sourceId ? ` ;\n  cascade:sourceRecordId "${sourceId}"` : ''} .
+`;
+}
+
+/** A FHIR-shaped encounter block: the rich one, with clinic, provider, class. */
+function fhirEncounter(subject: string, sourceId?: string): string {
+  return `<${subject}> a clinical:Encounter ;
+  cascade:sourceSystem "providence-fhir" ;
+  cascade:sourceIdentity "org:providence" ;
+  cascade:dataProvenance cascade:EHRVerified ;
+  cascade:schemaVersion "1.0" ;
+  clinical:fhirResourceType "Encounter" ;
+  clinical:sourceRecordId "eNcOuNtEr-1" ;
+  clinical:encounterClass "5" ;
+  clinical:encounterStatus "finished" ;
+  clinical:encounterType "Ambulatory office visit" ;
+  clinical:encounterStart "2025-04-01T16:00:00Z"^^xsd:dateTime ;
+  clinical:encounterEnd "2025-04-01T16:45:00Z"^^xsd:dateTime ;
+  clinical:providerName "Alex Rivera, MD" ;
+  clinical:facilityName "NORTHGATE DERMATOLOGY"${sourceId ? ` ;\n  cascade:sourceRecordId "${sourceId}"` : ''} .
+`;
+}
+
+function parse(ttl: string) {
+  return new Parser({ format: 'Turtle' }).parse(ttl);
+}
+
+/** Every subject typed `clinical:Encounter` in a reconciled output. */
+function encounterSubjects(ttl: string): string[] {
+  return parse(ttl)
+    .filter((q) => q.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' && q.object.value === ENCOUNTER_TYPE)
+    .map((q) => q.subject.value)
+    .sort();
+}
+
+function objectsOf(ttl: string, subject: string, predicate: string): string[] {
+  return parse(ttl)
+    .filter((q) => q.subject.value === subject && q.predicate.value === predicate)
+    .map((q) => q.object.value)
+    .sort();
+}
+
+function valuesOf(ttl: string, predicate: string): string[] {
+  return parse(ttl)
+    .filter((q) => q.predicate.value === predicate)
+    .map((q) => q.object.value)
+    .sort();
+}
+
+/** Every `clinical:hasEncounter` object that names no encounter subject. */
+function danglingEncounterEdges(ttl: string): string[] {
+  const subjects = new Set(encounterSubjects(ttl));
+  return valuesOf(ttl, HAS_ENCOUNTER).filter((o) => !subjects.has(o));
+}
+
+describe('reconciler: encounters converge on the identifier both transports state', () => {
+  it('merges the thin C-CDA twin and the rich FHIR twin of one visit into one subject', async () => {
+    const result = await runReconciliation([
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-ccda', CSN)}`, systemName: 'providence-ccda' },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}`, systemName: 'providence-fhir' },
+    ]);
+
+    const subjects = encounterSubjects(result.turtle);
+    expect(subjects).toHaveLength(1);
+
+    // The union of facts, not the winner's alone: the clinic came from the FHIR
+    // twin and the document type from the C-CDA one, and one visit knows both.
+    const survivor = subjects[0];
+    expect(objectsOf(result.turtle, survivor, CLINICAL + 'facilityName')).toEqual(['NORTHGATE DERMATOLOGY']);
+    expect(objectsOf(result.turtle, survivor, CLINICAL + 'providerName')).toEqual(['Alex Rivera, MD']);
+    expect(objectsOf(result.turtle, survivor, CASCADE + 'documentType')).toEqual(['summarization']);
+    expect(objectsOf(result.turtle, survivor, CASCADE + 'sourceRecordId')).toEqual([CSN]);
+  });
+
+  it('records the absorbed subjects as lineage rather than deleting them silently', async () => {
+    const result = await runReconciliation([
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-ccda', CSN)}`, systemName: 'providence-ccda' },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}`, systemName: 'providence-fhir' },
+    ]);
+
+    const survivor = encounterSubjects(result.turtle)[0];
+    const mergedFrom = objectsOf(result.turtle, survivor, MERGED_FROM);
+    const derivedFrom = objectsOf(result.turtle, survivor, WAS_DERIVED_FROM);
+    expect(mergedFrom).toEqual(['urn:uuid:enc-ccda', 'urn:uuid:enc-fhir']);
+    expect(derivedFrom).toEqual(['urn:uuid:enc-ccda', 'urn:uuid:enc-fhir']);
+  });
+
+  it('collapses a C-CDA identifier re-declared by three documents in ONE import', async () => {
+    // Same batch label AND same origin, which is exactly what the same-source
+    // guard normally suppresses. It is right to suppress a heuristic match
+    // there; this is not one. The source stated one identifier three times, so
+    // the source itself is saying these are one act.
+    const result = await runReconciliation([
+      {
+        content:
+          PREFIXES +
+          ccdaEncounter('urn:uuid:enc-doc-a', CSN) +
+          ccdaEncounter('urn:uuid:enc-doc-b', CSN) +
+          ccdaEncounter('urn:uuid:enc-doc-c', CSN),
+        systemName: 'providence-ccda',
+      },
+    ]);
+
+    expect(encounterSubjects(result.turtle)).toHaveLength(1);
+  });
+
+  it('never merges two encounters that state no identifier', async () => {
+    // Byte-identical apart from their subjects, and still two records. Absence
+    // of a join key is not a match, and there is no second tier to fall to.
+    const result = await runReconciliation([
+      {
+        content: PREFIXES + ccdaEncounter('urn:uuid:enc-anon-1') + ccdaEncounter('urn:uuid:enc-anon-2'),
+        systemName: 'providence-ccda',
+      },
+    ]);
+
+    expect(encounterSubjects(result.turtle).length).toBe(2);
+  });
+
+  it('never merges an identifier-less encounter into an identified one', async () => {
+    const result = await runReconciliation([
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-anon-1')}`, systemName: 'providence-ccda' },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}`, systemName: 'providence-fhir' },
+    ]);
+
+    expect(encounterSubjects(result.turtle).length).toBe(2);
+  });
+
+  it('keeps two visits with different identifiers apart', async () => {
+    const result = await runReconciliation([
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-ccda', CSN)}`, systemName: 'providence-ccda' },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', OTHER_CSN)}`, systemName: 'providence-fhir' },
+    ]);
+
+    expect(encounterSubjects(result.turtle).length).toBe(2);
+  });
+});
+
+describe('reconciler: every hasEncounter edge follows the merge', () => {
+  const LAB = `<urn:uuid:lab-0001> a health:LabResultRecord ;
+  cascade:sourceSystem "providence-ccda" ;
+  health:testCode <http://loinc.org/rdf#2339-0> ;
+  health:testName "Glucose" ;
+  health:resultValue "95" ;
+  health:performedDate "2025-04-01T09:15:00Z"^^xsd:dateTime ;
+  clinical:hasEncounter <urn:uuid:enc-ccda> .
+`;
+
+  const DOCUMENT = `<urn:uuid:doc-0001> a clinical:ClinicalDocument ;
+  cascade:sourceSystem "providence-fhir" ;
+  clinical:sourceEHR "Providence" ;
+  clinical:hasEncounter <urn:uuid:enc-fhir> .
+`;
+
+  it('rewrites edges from BOTH a reconciled record and a passthrough one', async () => {
+    const result = await runReconciliation([
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-ccda', CSN)}${LAB}`, systemName: 'providence-ccda' },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}${DOCUMENT}`, systemName: 'providence-fhir' },
+    ]);
+
+    const survivor = encounterSubjects(result.turtle)[0];
+    // The lab is a reconciled record; the clinical document is passthrough.
+    expect(objectsOf(result.turtle, 'urn:uuid:lab-0001', HAS_ENCOUNTER)).toEqual([survivor]);
+    expect(objectsOf(result.turtle, 'urn:uuid:doc-0001', HAS_ENCOUNTER)).toEqual([survivor]);
+    expect(danglingEncounterEdges(result.turtle)).toEqual([]);
+    expect(result.report.summary.edgeObjectsRewritten).toBeGreaterThan(0);
+  });
+
+  it('leaves no dangling edge when three documents re-declared one visit', async () => {
+    const edgesTo = (enc: string, n: number) =>
+      `<urn:uuid:note-${n}> a clinical:ClinicalDocument ;
+  clinical:sourceEHR "Providence" ;
+  clinical:hasEncounter <${enc}> .
+`;
+    const result = await runReconciliation([
+      {
+        content:
+          PREFIXES +
+          ccdaEncounter('urn:uuid:enc-doc-a', CSN) +
+          ccdaEncounter('urn:uuid:enc-doc-b', CSN) +
+          ccdaEncounter('urn:uuid:enc-doc-c', CSN) +
+          edgesTo('urn:uuid:enc-doc-a', 1) +
+          edgesTo('urn:uuid:enc-doc-b', 2) +
+          edgesTo('urn:uuid:enc-doc-c', 3),
+        systemName: 'providence-ccda',
+      },
+    ]);
+
+    const subjects = encounterSubjects(result.turtle);
+    expect(subjects).toHaveLength(1);
+    expect(new Set(valuesOf(result.turtle, HAS_ENCOUNTER))).toEqual(new Set(subjects));
+    expect(danglingEncounterEdges(result.turtle)).toEqual([]);
+  });
+});
+
+describe('reconciler: --reconcile-existing converges a pod that already holds duplicates', () => {
+  it('pulls the pod\'s two copies of one visit into the survivor of the new import', async () => {
+    // The pod holds today's shape: two subjects, one visit. The import brings a
+    // third document re-declaring the same visit. Only NEW records seed a group
+    // (pod content is reconciled by `pod reconcile`, not as a side effect of an
+    // unrelated import), so the seed is the new record and both pod copies are
+    // candidates it absorbs.
+    const pod =
+      PREFIXES +
+      ccdaEncounter('urn:uuid:enc-pod-a', CSN) +
+      fhirEncounter('urn:uuid:enc-pod-b', CSN) +
+      `<urn:uuid:note-1> a clinical:ClinicalDocument ;
+  clinical:sourceEHR "Providence" ;
+  clinical:hasEncounter <urn:uuid:enc-pod-a> .
+<urn:uuid:note-2> a clinical:ClinicalDocument ;
+  clinical:sourceEHR "Providence" ;
+  clinical:hasEncounter <urn:uuid:enc-pod-b> .
+`;
+
+    const result = await runReconciliation([
+      { content: pod, systemName: 'existing-pod', existingPod: true },
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-new', CSN)}`, systemName: 'providence-ccda-2' },
+    ]);
+
+    const subjects = encounterSubjects(result.turtle);
+    expect(subjects).toHaveLength(1);
+    expect(objectsOf(result.turtle, 'urn:uuid:note-1', HAS_ENCOUNTER)).toEqual(subjects);
+    expect(objectsOf(result.turtle, 'urn:uuid:note-2', HAS_ENCOUNTER)).toEqual(subjects);
+    expect(danglingEncounterEdges(result.turtle)).toEqual([]);
+  });
+
+  it('is a fixed point: reconciling the merged pod again changes nothing', async () => {
+    const first = await runReconciliation([
+      { content: `${PREFIXES}${ccdaEncounter('urn:uuid:enc-ccda', CSN)}`, systemName: 'providence-ccda' },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}`, systemName: 'providence-fhir' },
+    ]);
+    const second = await runReconciliation([
+      { content: first.turtle, systemName: 'existing-pod', existingPod: true },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}`, systemName: 'providence-fhir' },
+    ]);
+    const third = await runReconciliation([
+      { content: second.turtle, systemName: 'existing-pod', existingPod: true },
+      { content: `${PREFIXES}${fhirEncounter('urn:uuid:enc-fhir', CSN)}`, systemName: 'providence-fhir' },
+    ]);
+
+    expect(encounterSubjects(second.turtle)).toHaveLength(1);
+    expect(second.turtle).toBe(third.turtle);
+  });
+});

--- a/tests/reconciler-identity-collision.test.ts
+++ b/tests/reconciler-identity-collision.test.ts
@@ -449,6 +449,23 @@ describe('re-converting one source record is not a collision with its own older 
     expect(result.report.summary.identityCollisionsSplit).toBe(1);
   });
 
+  it('needs an ARRIVING copy: two pod files claiming one IRI are not a re-conversion', async () => {
+    // `pod import --reconcile-existing` loads the pod's files as several inputs,
+    // so a subject written into two of them arrives as a bucket with no incoming
+    // conversion in it. Nothing there is authoritative — neither copy just came
+    // out of a converter — so there is no "replace with the incoming one" to do,
+    // and the pair goes to the collision door as before. Reaching for
+    // `incoming[0]` on such a bucket is a crash, not a merge, which is why the
+    // clause is a guard rather than a preference.
+    const result = await runReconciliation([
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'existing-pod', existingPod: true },
+    ]);
+
+    expect(result.report.summary.identityCollisionsSplit).toBe(1);
+    expect(encounterSubjects(result.turtle)).toHaveLength(2);
+  });
+
   it('still splits when the two copies name different ORIGINS', async () => {
     // One id string claimed by two organizations is the cross-source collision
     // the origin axis exists to catch. Agreeing on an id is not enough.

--- a/tests/reconciler-identity-collision.test.ts
+++ b/tests/reconciler-identity-collision.test.ts
@@ -237,6 +237,104 @@ describe('a re-import is still a re-import', () => {
   });
 });
 
+describe('a merge survivor is not a collision with the source it absorbed', () => {
+  /**
+   * THE THIRD REASON two records can share an IRI, and the one the two above do
+   * not cover.
+   *
+   * A near-duplicate merge writes the UNION of the group's facts onto the
+   * winner's subject. On the next import the winner's own source arrives again
+   * and converts to the same IRI carrying only its OWN facts — strictly fewer
+   * than the pod now holds. That is neither a re-import (the contents differ)
+   * nor a collision (nothing disagrees: the pod's copy is that record plus what
+   * a sibling contributed), and treating it as a collision splits the survivor
+   * away from its own source, grows the pod by one on the first re-sync, and
+   * raises a conflict describing a disagreement that does not exist.
+   *
+   * The exemption is evidence-based rather than heuristic: it applies only when
+   * a record in the bucket carries `cascade:mergedFrom` naming the very IRI in
+   * question — the pod itself saying "I already absorbed this" — AND the
+   * arriving copy states nothing the survivor does not already state.
+   */
+  const MERGED_IRI = 'urn:uuid:enc-merge-survivor';
+  const PRE = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+`;
+
+  /** The pod's copy: the merge winner, carrying the loser's facts and lineage. */
+  const POD_SURVIVOR = `${PRE}<${MERGED_IRI}> a clinical:Encounter ;
+  cascade:sourceSystem "epic-fhir" ;
+  cascade:sourceRecordId "1.2.999:20100000001" ;
+  clinical:sourceRecordId "enc-1" ;
+  clinical:facilityName "NORTHGATE DERMATOLOGY" ;
+  clinical:encounterDate "2025-04-01"^^<http://www.w3.org/2001/XMLSchema#date> ;
+  cascade:documentType "summarization" ;
+  cascade:mergedFrom <${MERGED_IRI}>, <urn:uuid:enc-absorbed> ;
+  prov:wasDerivedFrom <${MERGED_IRI}>, <urn:uuid:enc-absorbed> ;
+  cascade:reconciliationStatus "merged" .
+`;
+
+  /** A fresh conversion of the winner's own source: the same record, thinner. */
+  const FRESH_SOURCE = `${PRE}<${MERGED_IRI}> a clinical:Encounter ;
+  cascade:sourceSystem "epic-fhir" ;
+  cascade:sourceRecordId "1.2.999:20100000001" ;
+  clinical:sourceRecordId "enc-1" ;
+  clinical:facilityName "NORTHGATE DERMATOLOGY" .
+`;
+
+  const encounterSubjects = (ttl: string): string[] =>
+    new Parser({ format: 'Turtle' })
+      .parse(ttl)
+      .filter(
+        (q) =>
+          q.predicate.value === RDF_TYPE &&
+          q.object.value === 'https://ns.cascadeprotocol.org/clinical/v1#Encounter',
+      )
+      .map((q) => q.subject.value)
+      .sort();
+
+  it('does not split the survivor away from a thinner re-import of its own source', async () => {
+    const result = await runReconciliation([
+      { content: POD_SURVIVOR, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_SOURCE, systemName: 'epic-fhir' },
+    ]);
+
+    expect(result.report.summary.identityCollisionsSplit).toBe(0);
+    expect(result.report.summary.conflictsUnresolved).toBe(0);
+    expect(encounterSubjects(result.turtle)).toEqual([MERGED_IRI]);
+    // And the absorbed facts are still there: the thin copy did not overwrite.
+    expect(result.turtle).toContain('summarization');
+  });
+
+  it('still splits when the arriving copy CONTRADICTS the survivor', async () => {
+    // The exemption is about a subset, never about a disagreement. A different
+    // clinic on the same IRI is the collision the whole mechanism exists for,
+    // and merge lineage must not buy an exemption from it.
+    const contradicting = FRESH_SOURCE.replace('NORTHGATE DERMATOLOGY', 'BALLARD EMERGENCY CENTER');
+    const result = await runReconciliation([
+      { content: POD_SURVIVOR, systemName: 'existing-pod', existingPod: true },
+      { content: contradicting, systemName: 'epic-fhir' },
+    ]);
+
+    expect(result.report.summary.identityCollisionsSplit).toBe(1);
+    expect(encounterSubjects(result.turtle)).toHaveLength(2);
+  });
+
+  it('grants no exemption to a record that never merged', async () => {
+    // Same subset relationship, no lineage. Two records claiming one IRI where
+    // one states strictly less is still a collision when nothing in the pod
+    // says the two were ever reconciled.
+    const noLineage = POD_SURVIVOR.split(' ;\n  cascade:mergedFrom')[0] + ' .\n';
+    const result = await runReconciliation([
+      { content: noLineage, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_SOURCE, systemName: 'epic-fhir' },
+    ]);
+
+    expect(result.report.summary.identityCollisionsSplit).toBe(1);
+  });
+});
+
 describe('the content fingerprint that separates the two cases', () => {
   it('is blind to the order properties were written in', async () => {
     const a = (await parseTurtle(`${PREFIXES}

--- a/tests/reconciler-identity-collision.test.ts
+++ b/tests/reconciler-identity-collision.test.ts
@@ -237,49 +237,68 @@ describe('a re-import is still a re-import', () => {
   });
 });
 
-describe('a merge survivor is not a collision with the source it absorbed', () => {
+describe('re-converting one source record is not a collision with its own older copy', () => {
   /**
    * THE THIRD REASON two records can share an IRI, and the one the two above do
    * not cover.
    *
-   * A near-duplicate merge writes the UNION of the group's facts onto the
-   * winner's subject. On the next import the winner's own source arrives again
-   * and converts to the same IRI carrying only its OWN facts — strictly fewer
-   * than the pod now holds. That is neither a re-import (the contents differ)
-   * nor a collision (nothing disagrees: the pod's copy is that record plus what
-   * a sibling contributed), and treating it as a collision splits the survivor
-   * away from its own source, grows the pod by one on the first re-sync, and
-   * raises a conflict describing a disagreement that does not exist.
+   * Converters get better. When they do, a re-import of a pod's own retained
+   * source produces the SAME subject IRI (identity is keyed on the source's id,
+   * which has not changed) carrying DIFFERENT content: more facts than before,
+   * and sometimes a corrected value where the old converter chose wrongly. The
+   * fingerprint sees two materially different records on one IRI and calls it a
+   * collision, which is the one thing it is not: there is one source record
+   * here, converted twice.
    *
-   * The exemption is evidence-based rather than heuristic: it applies only when
-   * a record in the bucket carries `cascade:mergedFrom` naming the very IRI in
-   * question — the pod itself saying "I already absorbed this" — AND the
-   * arriving copy states nothing the survivor does not already state.
+   * Measured on a real pod re-imported through the enriched converters: 723
+   * identity-collision conflicts, and every one of the 54 encounters split into
+   * an old thin twin and a new rich one. The thin twins carried no visit
+   * identifier — the very field the new converter had just started emitting — so
+   * the encounter matcher could not put them back together either, and the pod
+   * ended at 112 encounter subjects instead of 58.
+   *
+   * WHAT MAKES IT NOT A COLLISION, AND IT IS THE SOURCE'S OWN ANSWER
+   * ---------------------------------------------------------------
+   * The two records agree on the source record's IDENTITY: they state the same
+   * id on the same source-id predicate, contradict on no source-id predicate
+   * they both state, and come from the same origin. That is the source saying
+   * "these are one record", exactly as it does for the encounter matcher one
+   * layer up.
+   *
+   * WHAT HAPPENS THEN. The incoming conversion is authoritative for every
+   * predicate it states — that is what makes a corrected value arrive as a
+   * correction rather than as a question — and predicates it does NOT state are
+   * kept from the pod's copy, which is what carries the reconciler's lineage and
+   * any fact a sibling source contributed through an earlier merge.
+   *
+   * Two DIFFERENT source records that collide on one IRI keep the split-and-
+   * conflict path unchanged. So does a pair with no source id to agree on.
    */
-  const MERGED_IRI = 'urn:uuid:enc-merge-survivor';
+  const IRI = 'urn:uuid:enc-reconverted';
   const PRE = `@prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
 @prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 `;
 
-  /** The pod's copy: the merge winner, carrying the loser's facts and lineage. */
-  const POD_SURVIVOR = `${PRE}<${MERGED_IRI}> a clinical:Encounter ;
+  /** The pod's copy, written by the OLD converter: thin, and wrong about who. */
+  const POD_OLD = `${PRE}<${IRI}> a clinical:Encounter ;
   cascade:sourceSystem "epic-fhir" ;
-  cascade:sourceRecordId "1.2.999:20100000001" ;
+  cascade:sourceIdentity "org:providence" ;
   clinical:sourceRecordId "enc-1" ;
-  clinical:facilityName "NORTHGATE DERMATOLOGY" ;
-  clinical:encounterDate "2025-04-01"^^<http://www.w3.org/2001/XMLSchema#date> ;
-  cascade:documentType "summarization" ;
-  cascade:mergedFrom <${MERGED_IRI}>, <urn:uuid:enc-absorbed> ;
-  prov:wasDerivedFrom <${MERGED_IRI}>, <urn:uuid:enc-absorbed> ;
-  cascade:reconciliationStatus "merged" .
+  clinical:encounterType "Office Visit" ;
+  clinical:providerName "Lucas Camden Smith, MD" ;
+  cascade:reconciliationStatus "canonical" .
 `;
 
-  /** A fresh conversion of the winner's own source: the same record, thinner. */
-  const FRESH_SOURCE = `${PRE}<${MERGED_IRI}> a clinical:Encounter ;
+  /** The same source record through the NEW converter: richer, and corrected. */
+  const FRESH_NEW = `${PRE}<${IRI}> a clinical:Encounter ;
   cascade:sourceSystem "epic-fhir" ;
-  cascade:sourceRecordId "1.2.999:20100000001" ;
+  cascade:sourceIdentity "org:providence" ;
   clinical:sourceRecordId "enc-1" ;
+  cascade:sourceRecordId "1.2.999:20100000001" ;
+  clinical:encounterType "Office Visit" ;
+  clinical:providerName "Khiem Tran, MD" ;
+  clinical:encounterStatus "finished" ;
   clinical:facilityName "NORTHGATE DERMATOLOGY" .
 `;
 
@@ -294,41 +313,149 @@ describe('a merge survivor is not a collision with the source it absorbed', () =
       .map((q) => q.subject.value)
       .sort();
 
-  it('does not split the survivor away from a thinner re-import of its own source', async () => {
+  const objectsOf = (ttl: string, predicate: string): string[] =>
+    new Parser({ format: 'Turtle' })
+      .parse(ttl)
+      .filter((q) => q.predicate.value === predicate)
+      .map((q) => q.object.value)
+      .sort();
+
+  it('collapses the enriched re-conversion onto one subject, with no conflict', async () => {
     const result = await runReconciliation([
-      { content: POD_SURVIVOR, systemName: 'existing-pod', existingPod: true },
-      { content: FRESH_SOURCE, systemName: 'epic-fhir' },
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
     ]);
 
     expect(result.report.summary.identityCollisionsSplit).toBe(0);
     expect(result.report.summary.conflictsUnresolved).toBe(0);
-    expect(encounterSubjects(result.turtle)).toEqual([MERGED_IRI]);
-    // And the absorbed facts are still there: the thin copy did not overwrite.
-    expect(result.turtle).toContain('summarization');
+    expect(encounterSubjects(result.turtle)).toEqual([IRI]);
   });
 
-  it('still splits when the arriving copy CONTRADICTS the survivor', async () => {
-    // The exemption is about a subset, never about a disagreement. A different
-    // clinic on the same IRI is the collision the whole mechanism exists for,
-    // and merge lineage must not buy an exemption from it.
-    const contradicting = FRESH_SOURCE.replace('NORTHGATE DERMATOLOGY', 'BALLARD EMERGENCY CENTER');
+  it('keeps the newly emitted fields, which is what the re-import was FOR', async () => {
     const result = await runReconciliation([
-      { content: POD_SURVIVOR, systemName: 'existing-pod', existingPod: true },
-      { content: contradicting, systemName: 'epic-fhir' },
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
+    ]);
+
+    // The visit identifier the old converter never wrote, on THE surviving
+    // subject. Scoped to it deliberately: with the pair split apart the field is
+    // still somewhere in the output, on a second subject the matcher one layer
+    // up will never join — which is how a re-import intended to FIX the
+    // duplication produced more of it.
+    const subjects = encounterSubjects(result.turtle);
+    expect(subjects).toEqual([IRI]);
+    const onSurvivor = (predicate: string): string[] =>
+      new Parser({ format: 'Turtle' })
+        .parse(result.turtle)
+        .filter((q) => q.subject.value === IRI && q.predicate.value === predicate)
+        .map((q) => q.object.value)
+        .sort();
+    expect(onSurvivor('https://ns.cascadeprotocol.org/core/v1#sourceRecordId')).toContain(
+      '1.2.999:20100000001',
+    );
+    expect(onSurvivor('https://ns.cascadeprotocol.org/clinical/v1#facilityName')).toEqual([
+      'NORTHGATE DERMATOLOGY',
+    ]);
+  });
+
+  it('adopts a CORRECTED value rather than raising a question about it', async () => {
+    // The converter is authoritative for its own source record. Wave 1 changed
+    // which participant becomes providerName; the pod holds the old choice and
+    // the fix is worthless if it arrives as a conflict for a person to answer.
+    const result = await runReconciliation([
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
+    ]);
+
+    expect(
+      objectsOf(result.turtle, 'https://ns.cascadeprotocol.org/clinical/v1#providerName'),
+    ).toEqual(['Khiem Tran, MD']);
+  });
+
+  it('preserves lineage and the facts an earlier merge absorbed from a sibling', async () => {
+    // The pod's copy is a merge survivor: it carries a fact that came from a
+    // DIFFERENT source record. Replacing it wholesale with the incoming
+    // conversion would un-merge every cross-transport union on every re-import.
+    const podSurvivor =
+      POD_OLD.trimEnd().slice(0, -1) +
+      `;
+  cascade:documentType "summarization" ;
+  cascade:mergedFrom <${IRI}>, <urn:uuid:enc-absorbed> ;
+  prov:wasDerivedFrom <${IRI}>, <urn:uuid:enc-absorbed> .
+`;
+    const result = await runReconciliation([
+      { content: podSurvivor, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
+    ]);
+
+    expect(encounterSubjects(result.turtle)).toEqual([IRI]);
+    // The sibling's contribution: stated by neither the old nor the new
+    // conversion of THIS source record, and still true of the visit.
+    expect(objectsOf(result.turtle, 'https://ns.cascadeprotocol.org/core/v1#documentType')).toEqual([
+      'summarization',
+    ]);
+    expect(
+      objectsOf(result.turtle, 'https://ns.cascadeprotocol.org/core/v1#mergedFrom'),
+    ).toContain('urn:uuid:enc-absorbed');
+    // And the enrichment still landed.
+    expect(
+      objectsOf(result.turtle, 'https://ns.cascadeprotocol.org/clinical/v1#facilityName'),
+    ).toEqual(['NORTHGATE DERMATOLOGY']);
+  });
+
+  it('is a fixed point: the same sequence run again changes nothing', async () => {
+    const first = await runReconciliation([
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
+    ]);
+    const second = await runReconciliation([
+      { content: first.turtle, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
+    ]);
+    const third = await runReconciliation([
+      { content: second.turtle, systemName: 'existing-pod', existingPod: true },
+      { content: FRESH_NEW, systemName: 'epic-fhir' },
+    ]);
+
+    expect(second.turtle).toBe(third.turtle);
+    expect(second.report.summary.identityCollisionsSplit).toBe(0);
+    expect(third.report.summary.identityCollisionsSplit).toBe(0);
+  });
+
+  it('still splits two DIFFERENT source records that claim one IRI', async () => {
+    // The source ids CONTRADICT, so nothing says these are one record and the
+    // split-and-conflict path is exactly right. This is the case the whole
+    // mechanism exists for and the exemption must not reach it.
+    const otherRecord = FRESH_NEW.replace('"enc-1"', '"enc-2"');
+    const result = await runReconciliation([
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: otherRecord, systemName: 'epic-fhir' },
     ]);
 
     expect(result.report.summary.identityCollisionsSplit).toBe(1);
     expect(encounterSubjects(result.turtle)).toHaveLength(2);
   });
 
-  it('grants no exemption to a record that never merged', async () => {
-    // Same subset relationship, no lineage. Two records claiming one IRI where
-    // one states strictly less is still a collision when nothing in the pod
-    // says the two were ever reconciled.
-    const noLineage = POD_SURVIVOR.split(' ;\n  cascade:mergedFrom')[0] + ' .\n';
+  it('still splits when neither record states a source id to agree on', async () => {
+    // Content-hashed identity with no id anywhere. There is no evidence that the
+    // two are one record, so differing content is a collision as before.
+    const strip = (t: string) =>
+      t.replace(/\n  clinical:sourceRecordId "[^"]*" ;/, '').replace(/\n  cascade:sourceRecordId "[^"]*" ;/, '');
     const result = await runReconciliation([
-      { content: noLineage, systemName: 'existing-pod', existingPod: true },
-      { content: FRESH_SOURCE, systemName: 'epic-fhir' },
+      { content: strip(POD_OLD), systemName: 'existing-pod', existingPod: true },
+      { content: strip(FRESH_NEW), systemName: 'epic-fhir' },
+    ]);
+
+    expect(result.report.summary.identityCollisionsSplit).toBe(1);
+  });
+
+  it('still splits when the two copies name different ORIGINS', async () => {
+    // One id string claimed by two organizations is the cross-source collision
+    // the origin axis exists to catch. Agreeing on an id is not enough.
+    const otherOrg = FRESH_NEW.replace('org:providence', 'org:swedish');
+    const result = await runReconciliation([
+      { content: POD_OLD, systemName: 'existing-pod', existingPod: true },
+      { content: otherOrg, systemName: 'epic-fhir' },
     ]);
 
     expect(result.report.summary.identityCollisionsSplit).toBe(1);

--- a/tests/sources-coverage.test.ts
+++ b/tests/sources-coverage.test.ts
@@ -119,8 +119,11 @@ describe('cascade sources coverage', () => {
     // Deduplicated: the encounter appearing in both bundles is one resource.
     expect(result.stdout).toContain('11 unique of 12 read');
     expect(result.stdout).toMatch(/Encounter \(2 resources\)/);
-    expect(result.stdout).toMatch(/2 {2}Encounter\.identifier\s+pending 3\.254/);
-    expect(result.stdout).toMatch(/Encounter\.reasonCode\s+pending 3\.254/);
+    expect(result.stdout).toMatch(/2 {2}Encounter\.reasonCode\s+pending 3\.254/);
+    // The identifier is EMITTED now (it is the encounter join key), so it must
+    // not appear as a dropped path at all — only its `use` qualifier does.
+    expect(result.stdout).not.toMatch(/Encounter\.identifier\s+pending/);
+    expect(result.stdout).toMatch(/2 {2}Encounter\.identifier\[0\]\.use\s+acknowledged/);
     expect(result.stdout).toMatch(/Observation\.specimen\s+pending 3\.256/);
     // The disclosure says where the data still is, not only that it is missing.
     expect(result.stdout).toContain('retained under sources/');


### PR DESCRIPTION
## What changes

**Encounter identifier is emitted from the FHIR path.** `convertEncounter` writes
every `Encounter.identifier` entry as `cascade:sourceRecordId`, normalized to
`<system>:<value>` with FHIR's `urn:oid:` prefix stripped, which is the exact
spelling the C-CDA path already writes an `<encounter><id root= extension=/>`
in. `Encounter.id` stays on `clinical:sourceRecordId` (the FHIR server's row id,
`sh:maxCount 1` on `clinical:EncounterShape`, and the join key a
`Reference.reference` string points at). Subject-IRI minting is untouched.

**C-CDA encounters state the canonical `clinical:` spellings.** The section now
emits `clinical:encounterType` and `clinical:sourceRecordId` — the two the
shapes constrain and the FHIR path already used — and keeps dual-writing the
`cascade:` spellings for one release, since readers exist.

**`clinical:Encounter` becomes a reconcilable type.** New matcher keyed solely
on the identifier above: no identifier on either side, no merge, and no
type-and-date fallback tier. A merge takes the union of the group's facts, the
survivor records `cascade:mergedFrom` / `prov:wasDerivedFrom` for every absorbed
subject, and every `clinical:hasEncounter` edge is rewritten to the survivor
(reconciled records and passthrough alike). The same-source guard gains one
exemption, for two records the source itself gave one identifier — a C-CDA
export re-declares one encounter in every document written under it.

**Re-converting one source record is no longer an identity collision.**
Re-importing a pod's own retained sources through improved converters produces
the same subject IRIs carrying different content — more fields, and sometimes a
corrected value. The collision door read that as two records claiming one IRI,
split them, and raised a conflict for each. Two conversions of one source record
are now folded together before that door, recognised by the source's own
evidence: agreement on at least one source-id predicate, no contradiction on any
source-id predicate both state, and the same origin. The incoming conversion is
authoritative for every predicate it states, so a corrected value lands as a
correction rather than a question; predicates it does not state are kept from the
pod's copy, which preserves reconciler lineage and any fact an earlier merge
absorbed from a sibling source. A resolved edge is never downgraded to a
placeholder. Two different source records on one IRI, a pair with no source id to
agree on, and a bucket with no arriving copy all keep the split-and-conflict path
unchanged.

**One supporting fix.** `buildResourceRefsFromQuads` selected a record's source
id by quad order, so a record carrying two kinds of source id indexed whichever
the serializer wrote first. Now by predicate priority; without it the Synthea
corpus loses 249 resolved encounter edges.

## Manifest deltas

`Encounter.identifier` deleted (emitted now); `Encounter.identifier[0].use`
added as `acknowledged`. Net 127 -> 127 entries, 59 -> 60 acknowledged, 68 -> 67
pending.

## Verification

- `npm run build` clean.
- Full suite: 160 files, 2561 tests, 0 failed, 0 skipped.
- 19 behaviours observed RED before their fix across 5 suites.
- 10 mutations run against the full suite; 9 caught on the first pass, the tenth
  (the arriving-copy guard) survived and is now pinned by a test that fails
  under it.
- Repair sequence, end to end through the CLI: a pod built by the previous
  release's converters, then re-imported through this branch's. 5 encounter
  subjects for 3 visits -> 3; 0 identity-collision conflicts; 0 dangling
  `hasEncounter` over 3 edges and 3 distinct targets; every visit identifier,
  clinic, corrected provider and `amended` status present. Re-running the
  sequence converges (see below).

### Residual re-import churn, all reproduced on the previous release

Three predicates still accumulate a value per re-import, none of them introduced
here and all three measured on the base commit with the same fixture:
`cascade:mergedSources` (bounded — it converges once the participating systems'
orderings have all been seen, verified at pass 4), `prov:generatedAtTime` on
documents, and `foaf:name` / `foaf:givenName` / `foaf:familyName` in
`profile/card.ttl`. Tracked separately.

All fixtures synthetic; identifier OIDs are in the example-use `.999.` arc.
