### PR TITLE
fix(fhir): stop asserting what the source did not say, and give documents an attribution path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,57 @@ predicate to ask for: `convertObservationVital` re-routes non-canonical vitals i
 two different names depending on a routing table.
 
 A status is reported and never invented — no converter defaults one — because asserting `final`
-about a record whose server never said so is the same defect in the opposite direction.
+about a record whose server never said so is the same defect in the opposite direction. Three
+converters that DID default one are corrected below.
+
+**`AllergyIntolerance.verificationStatus` now reaches the pod too**, on `clinical:verificationStatus`,
+the same predicate `Condition` writes the same FHIR element on. `confirmed` and `refuted` are
+opposite claims about whether the patient is allergic at all, and the pod stated neither, so a
+refuted allergy narrowed treatment exactly as a confirmed one would. The field was already in
+`allergySubjectUri`, so no IRI moves. The `sh:in` binding on this predicate lives on
+`clinical:ConditionShape`, which does not target `health:AllergyRecord`, and nothing in the shape
+set is `sh:closed`, so the allergy value set's extra `presumed` code validates.
+
+**Three converters substituted a confident value where the source said nothing, and no longer do.**
+An absent `Immunization.status` was imported as `completed`, an absent `Condition.clinicalStatus` as
+`active`, and a `Coverage.relationship` that stated no coded value as `self`. A source that said
+nothing was therefore stored indistinguishably from a source that asserted the value — the same
+honesty defect as the amended/final collapse above, inverted: there the pod under-claimed, here it
+over-claimed, on a dose that may never have been given, a problem list where every untyped entry
+read as live, and a dependent's policy that read as the patient's own. Each triple is now omitted
+when the source states nothing, and free text is not mapped onto a code set, because picking a
+member of `ConditionClinicalStatusCodes` or the HL7 SubscriberPolicyholder system out of prose is
+the same guess wearing a different hat.
+
+Each shape was checked before the default came out: `health:ConditionRecordShape`,
+`health:ImmunizationRecordShape` and `coverage:InsurancePlanShape` all constrain these paths with
+`sh:maxCount 1` and a value set, and none asserts `sh:minCount`, so omitting validates. Had one
+required the property, removing the default would have been a `spec` question rather than a
+converter change.
+
+**A clinical note names its writer and the organization holding it.**
+`appendProvenanceQuads` exists precisely to recover the clinician and organization the per-type
+converters dropped, and it read `performer` / `requester` / `recorder` / `asserter` /
+`serviceProvider` — of which a `DocumentReference` states none. So the one pass built for this
+recovered nothing at all for documents, while the source named both outright. It now also reads
+`author` (falling back to `authenticator` when a document names no author) onto
+`clinical:providerName`, and `custodian` onto `clinical:sourceEHR`. No new vocabulary: both
+predicates are ones this pass already emits. The endpoint host still wins over the custodian display
+for `sourceEHR`, unchanged, so one source axis does not split into two spellings.
+
+**The `cascade:encounterType` dual-write is retired.**
+`clinical:encounterType` became canonical when the C-CDA encounter learned to state its type at all,
+and the `cascade:` spelling was dual-written for one release while its readers migrated. All three
+readers were in this repository and all three now read the canonical predicate. `clinical:` is
+canonical because `clinical:EncounterShape` constrains it and says nothing about the `cascade:` one,
+so the retired spelling was a fact no shape could check. Pods written before this release still hold
+the old triple; it is inert.
+
+`cascade:sourceRecordId` on encounters is **not** part of that retirement and is not scheduled for
+one. It is the cross-transport join key — the predicate the FHIR path writes `Encounter.identifier`
+on and the reconciler's encounter matcher keys on — and `clinical:sourceRecordId` cannot take it
+over, being `sh:maxCount 1` and already carrying the FHIR server's resource id. Deleting that single
+line was measured to turn 12 tests RED across three files.
 
 Two statuses are **acknowledged drops** rather than silent ones, each with a written reason in the
 converter. `Coverage.status` has no predicate that can hold it truthfully: the coverage namespace
@@ -76,6 +126,15 @@ carrying an `id` is unaffected, and the two fields newly serialized on Condition
 AllergyIntolerance were already in their keys, so no IRI moves there at all. The mechanical audit in
 `clinical-identity.test.ts` gained a row for each.
 
+**Removing the three defaults moves no IRI either**, and the reason is structural rather than
+lucky: all three identity keys read the RAW source element, never the serialized value.
+`immunizationSubjectUri` keys `resource.status` and says so; `conditionSubjectUri` keys
+`codeableConceptKey(resource.clinicalStatus)`; `convertCoverage` mints through `mintSubjectUri`,
+which seeds from `resource.id` or a hash of the raw resource. The id-less IRIs were captured before
+the change and are pinned as literals, so an edit that lets a serialized value back into a key fails
+in the suite rather than in a pod. `AllergyIntolerance.verificationStatus` was likewise already
+keyed, with a comment anticipating this exact change.
+
 ### Tests
 
 `tests/fhir-field-coverage-wave1.test.ts` (27 cases). 16 were observed RED against the parent commit
@@ -84,6 +143,25 @@ acknowledged drops and are not counted as evidence. Two further cases in
 `tests/clinical-identity.test.ts` were likewise observed RED. The role table was additionally
 probed by deletion: removing a single rank entry, and removing the unranked fallback, each turns the
 suite red.
+
+`tests/fhir-absent-fields-and-attribution.test.ts` (23 cases) covers the four corrections above. 11
+were observed RED before the converters changed; the 12 that pass either way are the stability pins
+(a stated status is still emitted, unchanged) and the four identity pins, which had to be green
+BEFORE the change for the no-IRI-movement claim to mean anything. One case in
+`tests/fhir-field-coverage-wave1.test.ts` was amended: a stability pin in a block titled "a status is
+reported, never invented" asserted `health:status` was `active` on a Condition that states no
+clinical status, which was the invention itself.
+
+One field-coverage fixture changed. `documentreference.json` named the same physician as `author`
+and as `authenticator`, so with either element deleted the other produced the same output and the
+differential could not observe the attribution fix at all — the manifest would have described the
+fixture rather than the converter. The note is now authored by the resident and attested by the
+attending, which is both the ordinary shape of a supervised note and the shape that lets the
+instrument see the difference. The rule is written into `test-fixtures/field-coverage/FIXTURES.md`.
+
+Drop manifests: 127 entries to 126 — six flipped to emitted and deleted, five added for narrower
+losses the fixes exposed one level down, and `DocumentReference.authenticator` moved from pending to
+acknowledged. Pending 67 to 63; acknowledged 60 to 63.
 
 ---
 

--- a/src/lib/ccda-converter/sections/encounters.ts
+++ b/src/lib/ccda-converter/sections/encounters.ts
@@ -146,7 +146,7 @@ export function buildEncounterRecord(
   const quads: Quad[] = [];
   quads.push(makeQuad(subj, namedNode(NS.rdf + 'type'), namedNode(NS.clinical + 'Encounter')));
   quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceSystem'), literal(sourceSystem)));
-  // THE TYPE, IN THE CANONICAL SPELLING AND THE OLD ONE.
+  // THE TYPE, IN THE CANONICAL SPELLING ONLY.
   //
   // `clinical:EncounterShape` constrains `clinical:encounterType` and says
   // nothing about `cascade:encounterType`, and the FHIR path has always written
@@ -155,13 +155,17 @@ export function buildEncounterRecord(
   // the encounters in a pod that holds both. `clinical:` is canonical because
   // the shapes already say so.
   //
-  // The `cascade:` spelling is dual-written for one release rather than
-  // migrated in place: readers exist (this repo's own C-CDA tests, and anything
-  // downstream that learned the old spelling), and retiring a predicate is a
-  // change with its own blast radius and its own measurement.
+  // The `cascade:` spelling was dual-written for ONE release while its readers
+  // migrated. All three were in this repo (`ccda-converter.test.ts`,
+  // `ccda-encounter-dates.test.ts`, `encounter-identifier-join.test.ts`); all
+  // three now read `clinical:`, and the dual write is retired. A pod converted
+  // before this release still holds the old triple, which is inert: nothing
+  // reads it and no shape checks it.
+  //
+  // `cascade:sourceRecordId` below is NOT the same case and is not going
+  // anywhere — see the note there.
   if (displayName) {
     quads.push(makeQuad(subj, namedNode(NS.clinical + 'encounterType'), literal(displayName)));
-    quads.push(makeQuad(subj, namedNode(NS.cascade + 'encounterType'), literal(displayName)));
   }
   // Kept, unchanged and untyped, because the reconciler reads
   // health:effectiveDate. Moving a record's date out from under a matcher in the
@@ -189,11 +193,18 @@ export function buildEncounterRecord(
     if (q) quads.push(q);
   }
 
-  // THE VISIT'S IDENTIFIER, on both spellings, for the same reason as the type
-  // above. `clinical:sourceRecordId` is what
-  // clinical:EncounterShape constrains; `cascade:sourceRecordId` is what the
-  // reconciler's encounter matcher and the FHIR path's `Encounter.identifier`
-  // emission both key on, so it is also the cross-transport join key and stays.
+  // THE VISIT'S IDENTIFIER, on both spellings, and BOTH ARE PERMANENT.
+  //
+  // This is deliberately not the type's story. `clinical:sourceRecordId` is what
+  // clinical:EncounterShape constrains, at `sh:maxCount 1`, and on the FHIR
+  // transport it already carries the FHIR server's resource id — so the visit
+  // identifier cannot move there without evicting it.
+  // `cascade:sourceRecordId` is what the reconciler's encounter matcher and the
+  // FHIR path's `Encounter.identifier` emission both key on, which makes it THE
+  // CROSS-TRANSPORT JOIN KEY: retiring it would silently stop the two halves of
+  // a duplicate visit from being recognised as one. Measured — deleting that one
+  // line turns 12 tests RED across three files. Pinned in
+  // `tests/encounter-identifier-join.test.ts`.
   if (sourceId) {
     quads.push(makeQuad(subj, namedNode(NS.clinical + 'sourceRecordId'), literal(sourceId)));
     quads.push(makeQuad(subj, namedNode(NS.cascade + 'sourceRecordId'), literal(sourceId)));

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -392,8 +392,24 @@ export function convertCondition(resource: any): ConversionResult & { _quads: Qu
     quads.push(tripleStr(subjectUri, NS.health + 'snomedSemanticTag', semanticTagMatch[1]));
   }
 
-  const clinicalStatus = resource.clinicalStatus?.coding?.[0]?.code ?? 'active';
-  quads.push(tripleStr(subjectUri, NS.health + 'status', clinicalStatus));
+  // Condition.clinicalStatus — active | recurrence | relapse | inactive |
+  // remission | resolved.
+  //
+  // NO DEFAULT. This read `?? 'active'`, so a problem list whose entries state
+  // no clinical status arrived as a list of ACTIVE problems — the pod asserting
+  // a person still has every condition anyone ever recorded for them.
+  //
+  // Omitting is safe against the shape: `health:ConditionRecordShape` constrains
+  // `health:status` with `sh:maxCount 1` and an `sh:in` value set, and asserts
+  // no `sh:minCount` — checked before this line changed.
+  //
+  // No IRI moves: `conditionSubjectUri` keys
+  // `codeableConceptKey(resource?.clinicalStatus)`, the raw element, so identity
+  // never saw the default.
+  const clinicalStatus = resource.clinicalStatus?.coding?.[0]?.code;
+  if (clinicalStatus) {
+    quads.push(tripleStr(subjectUri, NS.health + 'status', clinicalStatus));
+  }
 
   // Condition.verificationStatus — `confirmed` and `refuted` are OPPOSITE claims
   // about whether the patient has the problem at all, and the pod stated neither.
@@ -537,6 +553,24 @@ export function convertAllergyIntolerance(resource: any): ConversionResult & { _
   const allergyClinicalStatus = resource.clinicalStatus?.coding?.[0]?.code;
   if (allergyClinicalStatus) {
     quads.push(tripleStr(subjectUri, STATUS_PREDICATE, allergyClinicalStatus));
+  }
+
+  // AllergyIntolerance.verificationStatus — confirmed | unconfirmed | presumed |
+  // refuted | entered-in-error. `confirmed` and `refuted` are OPPOSITE claims
+  // about whether the patient is allergic at all, and the pod stated neither, so
+  // a refuted allergy narrowed treatment exactly as a confirmed one would.
+  //
+  // `clinical:verificationStatus` is the same predicate `convertCondition`
+  // writes this FHIR element on. Its `sh:in` binding lives on
+  // `clinical:ConditionShape`, which targets `clinical:Condition` and therefore
+  // does not reach a `health:AllergyRecord`; nothing in the shape set is
+  // `sh:closed`, so the triple validates. The allergy value set includes
+  // `presumed`, which Condition's does not, and nothing constrains it here.
+  //
+  // Already inside `allergySubjectUri`, so no IRI moves.
+  const allergyVerificationStatus = resource.verificationStatus?.coding?.[0]?.code;
+  if (allergyVerificationStatus) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'verificationStatus', allergyVerificationStatus));
   }
 
   if (Array.isArray(resource.category) && resource.category.length > 0) {

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -207,9 +207,10 @@ export function convertPatient(resource: any): ConversionResult & { _quads: Quad
  * manufacturer and the encounter.
  *
  * `vaccineName` is NOT a key field: the converter defaults it to 'Unknown
- * Vaccine'. Neither is the serialized status, which defaults to 'completed' —
- * the key reads `resource.status` raw, so an absent status stays absent instead
- * of arriving as a constant.
+ * Vaccine'. The status is keyed RAW — `resource.status`, not the serialized
+ * value — so an absent status stays absent instead of arriving as a constant.
+ * That is also why removing the serializer's `?? 'completed'` moved no IRI: the
+ * key never saw the default.
  */
 function immunizationSubjectUri(resource: any, warnings: string[]): string {
   return idOrContentUri('Immunization', resource, {
@@ -217,7 +218,8 @@ function immunizationSubjectUri(resource: any, warnings: string[]): string {
     vaccine: codeableConceptKey(resource?.vaccineCode),
     // Full precision, and `occurrenceString` where the source gives prose.
     occurrence: resource?.occurrenceDateTime ?? resource?.occurrenceString,
-    // Raw, not the serialized `?? 'completed'`.
+    // Raw. The serializer no longer defaults, but keying the raw element is what
+    // made that change free of IRI movement, so it stays stated.
     status: resource?.status,
     lotNumber: resource?.lotNumber,
     dose: structuredKey(resource?.doseQuantity),
@@ -252,7 +254,23 @@ export function convertImmunization(resource: any): ConversionResult & { _quads:
     warnings.push(`Immunization date is a string: ${resource.occurrenceString}`);
   }
 
-  quads.push(tripleStr(subjectUri, NS.health + 'status', resource.status ?? 'completed'));
+  // Immunization.status — completed | entered-in-error | not-done.
+  //
+  // NO DEFAULT. This read `resource.status ?? 'completed'`, so a source that
+  // stated nothing was stored indistinguishably from a source that asserted the
+  // dose was given. That is the amended/final collapse inverted: there the pod
+  // under-claimed, here it over-claimed, on the one field whose whole job is to
+  // say whether the vaccine went in.
+  //
+  // Omitting is safe against the shape: `health:ImmunizationRecordShape`
+  // constrains `health:status` with `sh:maxCount 1` and an `sh:in` value set,
+  // and asserts no `sh:minCount` — checked before this line changed.
+  //
+  // No IRI moves: `immunizationSubjectUri` keys `resource?.status` RAW and says
+  // so in as many words, so identity never saw the default in the first place.
+  if (resource.status) {
+    quads.push(tripleStr(subjectUri, NS.health + 'status', resource.status));
+  }
 
   const codings = extractCodings(resource.vaccineCode);
   for (const c of codings) {
@@ -393,8 +411,24 @@ export function convertCoverage(resource: any): ConversionResult & { _quads: Qua
     }
   }
 
-  if (resource.relationship) {
-    const relCode = resource.relationship.coding?.[0]?.code ?? 'self';
+  // Coverage.relationship — the policyholder's relation to the patient.
+  //
+  // NO DEFAULT. The guard was `if (resource.relationship)` and the value was
+  // `coding[0].code ?? 'self'`, so a relationship that was PRESENT but stated
+  // only as text became the pod asserting the policy is the patient's own. On a
+  // dependent's plan that is the wrong answer to the only question an insurance
+  // record is asked. Free text is not mapped onto the code set either: the
+  // `sh:in` list is the HL7 SubscriberPolicyholder system and picking a member
+  // of it from prose would be the same guess wearing a different hat.
+  //
+  // Omitting is safe against the shape: `coverage:InsurancePlanShape` constrains
+  // this path at `sh:Warning` with `sh:maxCount 1` and no `sh:minCount`.
+  //
+  // No IRI moves: `convertCoverage` mints through `mintSubjectUri`, which seeds
+  // from `resource.id` or from a hash of the RAW resource — never from a
+  // serialized value this function computed.
+  const relCode = resource.relationship?.coding?.[0]?.code;
+  if (relCode) {
     quads.push(tripleStr(subjectUri, NS.coverage + 'subscriberRelationship', relCode));
   }
 

--- a/src/lib/fhir-converter/field-coverage/manifests/allergyintolerance.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/allergyintolerance.ts
@@ -22,11 +22,10 @@ export const ALLERGY_INTOLERANCE_DROPS: FieldDropManifest = {
       reason:
         'The coded clinical status is what is read, and it is emitted. The text is not consulted at all, so an allergy stating its status ONLY as text still arrives without one — mapping free text onto a status code set would be a guess, and the vendor output this was measured against always states the coding.',
     },
-    'AllergyIntolerance.verificationStatus': {
-      disposition: 'pending',
-      backlog: '3.256',
+    'AllergyIntolerance.verificationStatus.text': {
+      disposition: 'acknowledged',
       reason:
-        'confirmed, unconfirmed, refuted or entered-in-error. A refuted allergy presented as confirmed narrows treatment for no reason.',
+        'The coded verification status is what is read, and it is emitted on clinical:verificationStatus. The text is not consulted, so an allergy stating confirmed-or-refuted ONLY as text still arrives without it; mapping free text onto that code set would be a guess.',
     },
     'AllergyIntolerance.type': {
       disposition: 'pending',

--- a/src/lib/fhir-converter/field-coverage/manifests/condition.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/condition.ts
@@ -17,10 +17,10 @@ export const CONDITION_DROPS: FieldDropManifest = {
       reason:
         "The problem's identifier in the issuing system, and the join key for the same problem arriving over two transports.",
     },
-    'Condition.clinicalStatus': {
+    'Condition.clinicalStatus.text': {
       disposition: 'acknowledged',
       reason:
-        "Redundant with the converter's default: health:status is emitted from the stated clinical status, but an ABSENT clinicalStatus is emitted as 'active'. Deleting a stated 'active' therefore changes nothing, while a stated 'resolved' does move the output. The defaulting is the part worth knowing: a source that says nothing is reported as active.",
+        'The coded clinical status is what is read, and it is emitted. The text is not consulted, so a problem stating its status ONLY as text arrives without one — mapping free text onto ConditionClinicalStatusCodes would be a guess, and guessing "active" is precisely the defaulting that was removed here.',
     },
     'Condition.verificationStatus.text': {
       disposition: 'acknowledged',

--- a/src/lib/fhir-converter/field-coverage/manifests/coverage.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/coverage.ts
@@ -47,15 +47,10 @@ export const COVERAGE_DROPS: FieldDropManifest = {
       reason:
         'Read only when the type states no coding. With a coding present the code is emitted as coverage:coverageType and the text restates it.',
     },
-    'Coverage.relationship.coding': {
-      disposition: 'acknowledged',
-      reason:
-        "Redundant with the converter's default: coverage:subscriberRelationship takes the coded value, and an absent relationship defaults to 'self'. Deleting a stated 'self' therefore changes nothing, while any other stated relationship does move the output.",
-    },
     'Coverage.relationship.text': {
       disposition: 'acknowledged',
       reason:
-        'The coded relationship is what is read; the text restates it and is not consulted.',
+        "The coded relationship is what is read; the text restates it and is not consulted. A relationship stated ONLY as text now yields no triple at all, rather than the 'self' this converter used to substitute — the sh:in list is the HL7 SubscriberPolicyholder system and picking a member of it out of prose would be the same guess.",
     },
     'Coverage.payor[0].reference': {
       disposition: 'acknowledged',

--- a/src/lib/fhir-converter/field-coverage/manifests/documentreference.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/documentreference.ts
@@ -6,6 +6,12 @@ import type { FieldDropManifest } from '../types.js';
  * `docStatus` is emitted now, so an amended note is no longer byte-identical to
  * a final one. `status` still is not: a superseded or retracted document reads
  * as a live one.
+ *
+ * Attribution is no longer absent either: `appendProvenanceQuads` reads `author`
+ * (falling back to `authenticator`) and `custodian`, so a note names its writer
+ * and the organization holding it. What remains dropped is narrower — the
+ * co-author, the practitioner references themselves, and the author/attester
+ * DISTINCTION — and each is stated below.
  */
 export const DOCUMENT_REFERENCE_DROPS: FieldDropManifest = {
   resourceType: 'DocumentReference',
@@ -40,23 +46,25 @@ export const DOCUMENT_REFERENCE_DROPS: FieldDropManifest = {
       reason:
         "A pod holds one person's records, so the subject link is the pod itself.",
     },
-    'DocumentReference.author': {
-      disposition: 'pending',
-      backlog: '3.256',
+    'DocumentReference.author[1]': {
+      disposition: 'acknowledged',
       reason:
-        'Who wrote the note. The provenance recovery pass reads performer/requester/recorder/asserter/serviceProvider and DocumentReference states none of them, so the author is lost on every document.',
+        'Only the first author reaches clinical:providerName, which is sh:maxCount 1 on every shape that constrains it, so a co-author cannot be added without producing records that fail validation. Naming the writer is the fact a note most needs; a second author would need a repeatable contributor predicate that does not exist.',
+    },
+    'DocumentReference.author[0].reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Practitioner resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName.',
     },
     'DocumentReference.authenticator': {
-      disposition: 'pending',
-      backlog: '3.256',
+      disposition: 'acknowledged',
       reason:
-        'Who attested the note. Distinct from the author on any note signed by a supervising clinician.',
+        'Read only when the document names no author; with an author present that value is the provider. Attestation as a fact DISTINCT from authorship — who signed a note someone else wrote — would need its own predicate, and none exists, so what is dropped here is the distinction rather than the name.',
     },
-    'DocumentReference.custodian': {
-      disposition: 'pending',
-      backlog: '3.256',
+    'DocumentReference.custodian.reference': {
+      disposition: 'acknowledged',
       reason:
-        'The organization holding the document, which is this record\'s source EHR. provenance.ts does not read `custodian`, so a bundle whose only organization signal is this field derives no source label.',
+        'Organization resources are not imported as records, so the reference would dangle. The display is emitted as clinical:sourceEHR.',
     },
     'DocumentReference.description': {
       disposition: 'pending',

--- a/src/lib/fhir-converter/field-coverage/manifests/immunization.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/immunization.ts
@@ -17,11 +17,6 @@ export const IMMUNIZATION_DROPS: FieldDropManifest = {
       reason:
         'The registry or EHR identifier for the dose, and the join key for the same dose arriving from a state registry and from a clinic.',
     },
-    'Immunization.status': {
-      disposition: 'acknowledged',
-      reason:
-        "Redundant with the converter's default: health:status is emitted, but an ABSENT status is emitted as 'completed', so deleting a 'completed' status changes nothing. A source stating not-done or entered-in-error does move the output — and a source stating nothing is reported as completed, which is the defaulting this entry exists to make visible.",
-    },
     'Immunization.patient': {
       disposition: 'acknowledged',
       reason: "A pod holds one person's records, so the patient link is the pod itself.",

--- a/src/lib/fhir-converter/provenance.ts
+++ b/src/lib/fhir-converter/provenance.ts
@@ -3,7 +3,8 @@
  * source EHR / organization.
  *
  * Apple Health (and most FHIR) carry these inline on `performer` / `requester` /
- * `recorder` / `asserter` and in the endpoint host of provider reference URLs,
+ * `recorder` / `asserter` — and, on DocumentReference, on `author` /
+ * `authenticator` / `custodian` — and in the endpoint host of provider reference URLs,
  * but the per-type converters historically read them for only three types
  * (DiagnosticReport, Encounter, Immunization). Everything else dropped the
  * provider that the source actually provided, which violates the "Cascade does
@@ -43,14 +44,43 @@ import { sourceIdentity, sourceLabel, type SourceIdentity } from '../source-iden
  */
 export const SOURCE_EHR_UNKNOWN = 'unknown';
 
-/** Resource fields, in priority order, that name the performing/ordering agent. */
+/**
+ * Resource fields, in priority order, that name the performing/ordering agent.
+ *
+ * `author` and `authenticator` are DocumentReference's spelling of the same
+ * thing, and their absence is why this pass — the one that exists to recover
+ * attribution the per-type converters dropped — did nothing whatsoever for
+ * documents. A DocumentReference states none of the first five fields, so every
+ * clinical note in a pod named neither its writer nor its source organization
+ * while the source stated both outright.
+ *
+ * Order is the claim: the AUTHOR wrote the note, and the authenticator is read
+ * only when no author is stated (a note signed by a supervising clinician names
+ * both, and the writer is the one `clinical:providerName` means). One value is
+ * emitted, never one per author — the predicate is `sh:maxCount 1` on every
+ * shape that constrains it.
+ */
 const PROVIDER_FIELDS = [
   'performer',
   'requester',
   'recorder',
   'asserter',
   'serviceProvider',
+  'author',
+  'authenticator',
 ] as const;
+
+/**
+ * Resource fields naming the ORGANIZATION that holds the record.
+ *
+ * `DocumentReference.custodian` is "the organization responsible for the
+ * document" by definition, so unlike a provider display it needs no
+ * institution-word guess to be read as one — `INSTITUTION_KEYWORDS` exists to
+ * decide whether an ambiguous display is a clinic or a clinician, and a
+ * custodian is never a question. It is consulted only after the endpoint host,
+ * which stays the preferred signal for the reason given on `extractSourceEhr`.
+ */
+const ORGANIZATION_FIELDS = ['custodian'] as const;
 
 /** FHIR resource types that represent a clinical record with a performing agent. */
 const CLINICAL_RECORD_TYPES = new Set([
@@ -158,6 +188,10 @@ function sourceHost(resource: unknown): string | undefined {
 export function extractSourceEhr(resource: any): string | undefined {
   const host = sourceHost(resource);
   if (host) return host;
+  for (const field of ORGANIZATION_FIELDS) {
+    const d = displayOf(resource?.[field]);
+    if (d) return d;
+  }
   const display = extractProviderName(resource);
   if (display && INSTITUTION_KEYWORDS.test(display) && !PERSON_ROLE.test(display)) {
     return display;

--- a/test-fixtures/field-coverage/FIXTURES.md
+++ b/test-fixtures/field-coverage/FIXTURES.md
@@ -21,6 +21,17 @@ observed Epic R4 output; vendor-specific identifier systems appear as
 real organization's assigning-authority arc, and vendor extension URLs use
 `vendor.example`.
 
+Where two elements can express the same value, the fixture states **different**
+values for them wherever a real record plausibly would. The differential deletes
+one element at a time, so two elements agreeing on a value both measure as
+dropped — with either one gone the other still produces the same output — and the
+manifest then describes the fixture rather than the converter.
+`documentreference.json` is the case that taught this: its `author` and
+`authenticator` both named the attending physician, so when the provenance pass
+learned to read them, neither could be observed to flip. The note is now authored
+by the resident and attested by the attending, which is both the ordinary shape of
+a supervised note and the shape that lets the instrument see the difference.
+
 References are deliberately **relative** (`Practitioner/fc-practitioner-attender`)
 rather than absolute. The provenance pass derives a record's source EHR from the
 first absolute reference host it finds anywhere in a resource, so an absolute URL

--- a/test-fixtures/field-coverage/documentreference.json
+++ b/test-fixtures/field-coverage/documentreference.json
@@ -42,12 +42,12 @@
   "date": "2025-04-01T18:22:00Z",
   "author": [
     {
-      "reference": "Practitioner/fc-practitioner-attender",
-      "display": "Amara Okoye, MD"
-    },
-    {
       "reference": "Practitioner/fc-practitioner-resident",
       "display": "Noor Habib, MD"
+    },
+    {
+      "reference": "Practitioner/fc-practitioner-attender",
+      "display": "Amara Okoye, MD"
     }
   ],
   "authenticator": {

--- a/tests/ccda-converter.test.ts
+++ b/tests/ccda-converter.test.ts
@@ -483,7 +483,7 @@ describe('C-CDA converter — encounter extraction and hasEncounter edges (R3)',
 
     // Real fields come through: type (from @_displayName), date (from
     // effectiveTime/low), and the source id (root:extension).
-    expect(encValue(CASCADE + 'encounterType')).toBe('Office Visit');
+    expect(encValue(CLINICAL + 'encounterType')).toBe('Office Visit');
     expect(encValue(HEALTH + 'effectiveDate')).toBe('2025-03-10');
     expect(encValue(CASCADE + 'sourceRecordId')).toBe(
       '1.2.840.114350.1.13.999.2.7.3.111.8:VISIT-778899',

--- a/tests/ccda-encounter-dates.test.ts
+++ b/tests/ccda-encounter-dates.test.ts
@@ -99,7 +99,7 @@ function encounterByType(quads: Quad[], type: string): string | undefined {
   );
   return quads.find(
     (q) =>
-      q.predicate.value === CASCADE + 'encounterType' &&
+      q.predicate.value === CLINICAL + 'encounterType' &&
       q.object.value === type &&
       isEncounter.has(q.subject.value),
   )?.subject.value;

--- a/tests/encounter-identifier-join.test.ts
+++ b/tests/encounter-identifier-join.test.ts
@@ -175,12 +175,32 @@ describe('3.208: the C-CDA encounter states its type and id in the canonical cli
     expect(valuesOf(quads, CLINICAL + 'encounterType')).toEqual(['Office Visit']);
   });
 
-  it('keeps dual-writing the cascade: spellings this release', async () => {
-    // The readers are real and still on the old spelling: the pathology corpus
-    // harness's SOURCE_RECORD_ID list and the reconciler's source-id path.
-    // Retiring the dual write is its own change, with its own measurement.
+  it('keeps cascade:sourceRecordId — it is the cross-transport join key, not a legacy spelling', async () => {
+    // NOT a compatibility shim and NOT scheduled for retirement. This is the
+    // predicate the FHIR path writes `Encounter.identifier` on and the one the
+    // reconciler's encounter matcher keys on, so it is the only place the two
+    // transports state the same visit under the same name. `clinical:` cannot
+    // take over: `clinical:EncounterShape` pins `clinical:sourceRecordId` at
+    // `sh:maxCount 1` and it already carries the FHIR server's resource id.
+    //
+    // Deleting either line below breaks encounter deduplication across
+    // transports, silently, with no other test failing.
     const quads = await ccdaTwinQuads();
     expect(encounterSourceIds(quads, CASCADE + 'sourceRecordId')).toEqual([CSN]);
-    expect(valuesOf(quads, CASCADE + 'encounterType')).toEqual(['Office Visit']);
+    expect(encounterSourceIds(quads, CLINICAL + 'sourceRecordId')).toEqual([CSN]);
+  });
+
+  it('no longer writes the retired cascade:encounterType spelling', async () => {
+    // 3.269. `clinical:encounterType` became canonical in the wave that made the
+    // C-CDA encounter state its type at all, and the `cascade:` spelling was
+    // dual-written for one release while its readers migrated. All three were in
+    // this repo; all three now read the canonical predicate.
+    //
+    // `clinical:EncounterShape` constrains `clinical:encounterType` and says
+    // nothing about the `cascade:` one, so the retired spelling was a fact no
+    // shape could check.
+    const quads = await ccdaTwinQuads();
+    expect(valuesOf(quads, CASCADE + 'encounterType')).toEqual([]);
+    expect(valuesOf(quads, CLINICAL + 'encounterType')).toEqual(['Office Visit']);
   });
 });

--- a/tests/fhir-absent-fields-and-attribution.test.ts
+++ b/tests/fhir-absent-fields-and-attribution.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Three FHIR import defects that share one shape: the pod states something the
+ * source did not.
+ *
+ * 1. DEFAULT-MASKING (3.257). `convertImmunization` wrote
+ *    `resource.status ?? 'completed'`, `convertCondition` wrote
+ *    `clinicalStatus ?? 'active'`, and `convertCoverage` wrote
+ *    `relationship.coding[0].code ?? 'self'`. A source that said NOTHING was
+ *    therefore stored indistinguishably from a source that asserted the value —
+ *    the honesty defect of 3.256 inverted. There the pod under-claimed (an
+ *    amended result read as final); here it over-claims (silence reads as a
+ *    completed dose, an active problem, a self-held policy).
+ *
+ *    None of the three properties carries `sh:minCount` in its shape
+ *    (`health:ImmunizationRecordShape`, `health:ConditionRecordShape`,
+ *    `coverage:InsurancePlanShape` all state `sh:maxCount 1` only), so omitting
+ *    the triple validates. That was checked before the defaults were removed:
+ *    a required property would have made this a spec-repo question instead.
+ *
+ * 2. `AllergyIntolerance.verificationStatus` (3.256 remainder). `confirmed` and
+ *    `refuted` are OPPOSITE claims about whether the patient is allergic at all,
+ *    and the pod stated neither. `convertCondition` already emits the same FHIR
+ *    element on `clinical:verificationStatus`; the allergy converter did not.
+ *
+ * 3. DOCUMENTREFERENCE ATTRIBUTION (3.259). `appendProvenanceQuads` exists
+ *    precisely to recover the clinician and organization "the per-type
+ *    converters historically dropped for most types" — and it read
+ *    performer/requester/recorder/asserter/serviceProvider, of which a
+ *    DocumentReference states NONE. A clinical note therefore landed in the pod
+ *    naming neither its writer nor its source organization, while the source
+ *    stated both outright in `author` / `authenticator` / `custodian`.
+ *
+ * IDENTITY, PINNED RATHER THAN ASSUMED
+ * ------------------------------------
+ * Removing a default could move an IRI, which is a duplicate record on every pod
+ * that already holds one. It does not here, and the reason is structural: all
+ * three identity keys read the RAW source element, never the converter's
+ * serialized value (`immunizationSubjectUri` says so in as many words;
+ * `conditionSubjectUri` keys `codeableConceptKey(resource?.clinicalStatus)`; the
+ * Coverage path hashes the raw resource through `mintSubjectUri`). The IRIs
+ * below were captured from the id-less path BEFORE the change and are pinned as
+ * literals, so a future edit that reintroduces a serialized value into a key
+ * fails here rather than in a user's pod.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  convertAllergyIntolerance,
+  convertCondition,
+  convertClinicalDocument,
+} from '../src/lib/fhir-converter/converters-clinical.js';
+import {
+  convertCoverage,
+  convertImmunization,
+} from '../src/lib/fhir-converter/converters-demographics.js';
+import { appendProvenanceQuads } from '../src/lib/fhir-converter/provenance.js';
+import { NS } from '../src/lib/fhir-converter/types.js';
+
+type Converted = {
+  _quads: Array<{
+    subject: { value: string };
+    predicate: { value: string };
+    object: { value: string };
+  }>;
+};
+
+function valuesOf(result: Converted, predicate: string): string[] {
+  return result._quads.filter((q) => q.predicate.value === predicate).map((q) => q.object.value);
+}
+
+/** The record subject a converter minted. */
+function subjectOf(result: Converted): string {
+  return result._quads[0].subject.value;
+}
+
+/** A DocumentReference converted the way the import path converts it: with the provenance pass. */
+function convertDocument(resource: Record<string, unknown>): Converted {
+  const result = convertClinicalDocument(resource);
+  appendProvenanceQuads(resource, result._quads);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 3.257 — silence is not an assertion
+// ---------------------------------------------------------------------------
+
+describe('3.257: an absent status is absent in the pod, not a confident default', () => {
+  const immunization = () => ({
+    resourceType: 'Immunization',
+    id: 'imm-no-status',
+    vaccineCode: {
+      coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '208', display: 'COVID-19 mRNA' }],
+      text: 'COVID-19 mRNA Vaccine',
+    },
+    occurrenceDateTime: '2021-04-15T09:00:00Z',
+  });
+
+  const condition = () => ({
+    resourceType: 'Condition',
+    id: 'cond-no-status',
+    code: {
+      coding: [{ system: 'http://snomed.info/sct', code: '73211009', display: 'Diabetes Mellitus' }],
+      text: 'Diabetes Mellitus',
+    },
+    onsetDateTime: '2020-03-15',
+  });
+
+  const coverage = () => ({
+    resourceType: 'Coverage',
+    id: 'cov-no-relationship',
+    subscriberId: 'XYZ123456',
+    payor: [{ display: 'Blue Cross Blue Shield' }],
+    type: { coding: [{ code: 'HIP' }] },
+  });
+
+  it('an Immunization stating no status gets no health:status', () => {
+    const resource = immunization();
+    expect(valuesOf(convertImmunization(resource), NS.health + 'status')).toEqual([]);
+  });
+
+  it('an Immunization stating a status still gets it, unchanged', () => {
+    // The half that must NOT change: `not-done` is the value whose loss would
+    // tell a reader a dose was given when the source says it was not.
+    for (const status of ['completed', 'not-done', 'entered-in-error']) {
+      const resource = { ...immunization(), status };
+      expect(valuesOf(convertImmunization(resource), NS.health + 'status')).toEqual([status]);
+    }
+  });
+
+  it('a Condition stating no clinicalStatus gets no health:status', () => {
+    expect(valuesOf(convertCondition(condition()), NS.health + 'status')).toEqual([]);
+  });
+
+  it('a Condition stating a clinicalStatus still gets it, unchanged', () => {
+    for (const code of ['active', 'resolved', 'remission']) {
+      const resource = { ...condition(), clinicalStatus: { coding: [{ code }] } };
+      expect(valuesOf(convertCondition(resource), NS.health + 'status')).toEqual([code]);
+    }
+  });
+
+  it('a Condition whose clinicalStatus states only text gets no health:status', () => {
+    // Mapping free text onto ConditionClinicalStatusCodes would be a guess, and
+    // guessing "active" is the defect this test exists for.
+    const resource = { ...condition(), clinicalStatus: { text: 'Active' } };
+    expect(valuesOf(convertCondition(resource), NS.health + 'status')).toEqual([]);
+  });
+
+  it('a Coverage stating no relationship gets no coverage:subscriberRelationship', () => {
+    expect(valuesOf(convertCoverage(coverage()), NS.coverage + 'subscriberRelationship')).toEqual(
+      [],
+    );
+  });
+
+  it('a Coverage whose relationship states only text gets no subscriberRelationship', () => {
+    // This is the reachable half of the defect: the guard was
+    // `if (resource.relationship)`, so a relationship present but uncoded fell
+    // through to 'self' — the pod asserting the policy is the patient's own.
+    const resource = { ...coverage(), relationship: { text: 'Spouse' } };
+    expect(valuesOf(convertCoverage(resource), NS.coverage + 'subscriberRelationship')).toEqual([]);
+  });
+
+  it('a Coverage stating a coded relationship still gets it, unchanged', () => {
+    for (const code of ['self', 'spouse', 'child', 'injured']) {
+      const resource = { ...coverage(), relationship: { coding: [{ code }] } };
+      expect(valuesOf(convertCoverage(resource), NS.coverage + 'subscriberRelationship')).toEqual([
+        code,
+      ]);
+    }
+  });
+});
+
+describe('3.257: removing the defaults moves no IRI', () => {
+  // Captured from this exact input on the parent commit, with the defaults still
+  // in place. The id-less path is the one at risk: with an `id` the IRI comes
+  // from the id and no content can reach it.
+  it('an id-less Immunization keeps the IRI it had before the default was removed', () => {
+    const resource = {
+      resourceType: 'Immunization',
+      vaccineCode: {
+        coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '208', display: 'COVID-19 mRNA' }],
+        text: 'COVID-19 mRNA Vaccine',
+      },
+      occurrenceDateTime: '2021-04-15T09:00:00Z',
+      lotNumber: 'EL9264',
+    };
+    expect(subjectOf(convertImmunization(resource))).toBe(
+      'urn:uuid:6e216961-08bd-5ec3-abf5-2196d4fbbfe0',
+    );
+  });
+
+  it('an id-less Condition keeps the IRI it had before the default was removed', () => {
+    const resource = {
+      resourceType: 'Condition',
+      code: {
+        coding: [
+          { system: 'http://snomed.info/sct', code: '73211009', display: 'Diabetes Mellitus' },
+        ],
+        text: 'Diabetes Mellitus',
+      },
+      onsetDateTime: '2020-03-15',
+    };
+    expect(subjectOf(convertCondition(resource))).toBe(
+      'urn:uuid:91238efa-b784-56b5-979e-fe772bba6323',
+    );
+  });
+
+  it('an id-less Coverage keeps the IRI it had before the default was removed', () => {
+    const resource = {
+      resourceType: 'Coverage',
+      subscriberId: 'XYZ123456',
+      payor: [{ display: 'Blue Cross Blue Shield' }],
+      type: { coding: [{ code: 'HIP' }] },
+      relationship: { text: 'Self' },
+    };
+    expect(subjectOf(convertCoverage(resource))).toBe(
+      'urn:uuid:1fa3e863-f511-58dc-b334-1454d5de42d0',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3.256 remainder — the allergy's verification status
+// ---------------------------------------------------------------------------
+
+describe('3.256: an allergy states whether it was confirmed or refuted', () => {
+  const allergy = () => ({
+    resourceType: 'AllergyIntolerance',
+    id: 'allergy-verification-1',
+    code: { coding: [{ display: 'Penicillin' }], text: 'Penicillin' },
+    category: ['medication'],
+  });
+
+  it('emits the coded verification status on clinical:verificationStatus', () => {
+    for (const code of ['confirmed', 'unconfirmed', 'presumed', 'refuted', 'entered-in-error']) {
+      const resource = { ...allergy(), verificationStatus: { coding: [{ code }] } };
+      expect(
+        valuesOf(convertAllergyIntolerance(resource), NS.clinical + 'verificationStatus'),
+      ).toEqual([code]);
+    }
+  });
+
+  it('a refuted allergy is no longer byte-identical to a confirmed one', () => {
+    const statements = (code: string) =>
+      convertAllergyIntolerance({ ...allergy(), verificationStatus: { coding: [{ code }] } })
+        ._quads.map((q) => `${q.predicate.value} ${q.object.value}`)
+        .sort()
+        .join('\n');
+    expect(statements('refuted')).not.toBe(statements('confirmed'));
+  });
+
+  it('an allergy stating no verification status gets no triple', () => {
+    expect(
+      valuesOf(convertAllergyIntolerance(allergy()), NS.clinical + 'verificationStatus'),
+    ).toEqual([]);
+  });
+
+  it('a verification status stated only as text is not guessed at', () => {
+    const resource = { ...allergy(), verificationStatus: { text: 'Confirmed' } };
+    expect(
+      valuesOf(convertAllergyIntolerance(resource), NS.clinical + 'verificationStatus'),
+    ).toEqual([]);
+  });
+
+  it('moves no IRI: verificationStatus was already in the allergy identity key', () => {
+    // Pinned against the value this id-less allergy minted BEFORE the field was
+    // serialized. `allergySubjectUri` has keyed it from the start, deliberately,
+    // so serializing it now is a fact added to a record that already existed
+    // under this name.
+    const resource = {
+      resourceType: 'AllergyIntolerance',
+      code: { coding: [{ display: 'Penicillin' }], text: 'Penicillin' },
+      category: ['medication'],
+      verificationStatus: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification',
+            code: 'refuted',
+          },
+        ],
+      },
+    };
+    expect(subjectOf(convertAllergyIntolerance(resource))).toBe(
+      'urn:uuid:383529fb-5ad3-5aef-9db7-1ab0e8e3a77d',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3.259 — a clinical note names its writer and its holder
+// ---------------------------------------------------------------------------
+
+describe('3.259: DocumentReference attribution reaches the pod', () => {
+  const document = () => ({
+    resourceType: 'DocumentReference',
+    id: 'doc-attribution-1',
+    type: { text: 'Progress Notes' },
+    date: '2025-04-01T18:22:00Z',
+    author: [
+      { reference: 'Practitioner/resident', display: 'Noor Habib, MD' },
+      { reference: 'Practitioner/attender', display: 'Amara Okoye, MD' },
+    ],
+    authenticator: { reference: 'Practitioner/attender', display: 'Amara Okoye, MD' },
+    custodian: { reference: 'Organization/northgate', display: 'Northgate Health Network' },
+  });
+
+  it('names the author as the provider', () => {
+    expect(valuesOf(convertDocument(document()), NS.clinical + 'providerName')).toEqual([
+      'Noor Habib, MD',
+    ]);
+  });
+
+  it('falls back to the authenticator when the document names no author', () => {
+    const resource = document();
+    delete (resource as Record<string, unknown>).author;
+    expect(valuesOf(convertDocument(resource), NS.clinical + 'providerName')).toEqual([
+      'Amara Okoye, MD',
+    ]);
+  });
+
+  it('names the custodian as the source organization', () => {
+    expect(valuesOf(convertDocument(document()), NS.clinical + 'sourceEHR')).toEqual([
+      'Northgate Health Network',
+    ]);
+  });
+
+  it('emits exactly one provider and one source, never one per author', () => {
+    // `clinical:providerName` is `sh:maxCount 1` on every shape that constrains
+    // it. A pass that emitted one per author would produce records that fail
+    // validation on any document with two.
+    const quads = convertDocument(document());
+    expect(valuesOf(quads, NS.clinical + 'providerName')).toHaveLength(1);
+    expect(valuesOf(quads, NS.clinical + 'sourceEHR')).toHaveLength(1);
+  });
+
+  it('still prefers the source FHIR server host over the custodian display', () => {
+    // STABILITY PIN. The host is the low-cardinality, unambiguous signal and has
+    // always won; a custodian must not quietly displace it and split one
+    // source axis into two spellings.
+    const resource = document();
+    resource.author = [
+      { reference: 'https://haiku.swedish.org/api/FHIR/R4/Practitioner/1', display: 'Noor Habib, MD' },
+    ];
+    expect(valuesOf(convertDocument(resource), NS.clinical + 'sourceEHR')).toEqual(['swedish.org']);
+  });
+
+  it('a document stating none of the three still gets nothing invented', () => {
+    const resource = document();
+    delete (resource as Record<string, unknown>).author;
+    delete (resource as Record<string, unknown>).authenticator;
+    delete (resource as Record<string, unknown>).custodian;
+    const quads = convertDocument(resource);
+    expect(valuesOf(quads, NS.clinical + 'providerName')).toEqual([]);
+    expect(valuesOf(quads, NS.clinical + 'sourceEHR')).toEqual([]);
+  });
+
+  it('never overwrites a provider a converter already set', () => {
+    // The pass is additive and idempotent by contract. Running it twice must
+    // not double the triples it added the first time.
+    const resource = document();
+    const result = convertClinicalDocument(resource);
+    appendProvenanceQuads(resource, result._quads);
+    appendProvenanceQuads(resource, result._quads);
+    expect(valuesOf(result, NS.clinical + 'providerName')).toEqual(['Noor Habib, MD']);
+    expect(valuesOf(result, NS.clinical + 'sourceEHR')).toEqual(['Northgate Health Network']);
+  });
+});

--- a/tests/fhir-field-coverage-wave1.test.ts
+++ b/tests/fhir-field-coverage-wave1.test.ts
@@ -283,9 +283,21 @@ describe('STABILITY PIN: a status is reported, never invented', () => {
     expect(valuesOf(convertClinicalDocument(noDocStatus) as Converted, STATUS)).toEqual([]);
   });
 
-  it('Condition with no verificationStatus emits none, and still emits clinicalStatus', () => {
+  it('Condition with neither status element emits neither', () => {
+    // AMENDED for 3.257. This asserted `health:status` was 'active' on a
+    // Condition that states no clinicalStatus at all — the converter's default,
+    // read back as though the source had said it. That is the invention this
+    // very describe block is named after, in the direction nobody was looking:
+    // a problem list where every untyped entry reads as a live problem.
     const result = convertCondition(conditionResource()) as Converted;
     expect(valuesOf(result, VERIFICATION_STATUS)).toEqual([]);
+    expect(valuesOf(result, NS.health + 'status')).toEqual([]);
+  });
+
+  it('Condition that states a clinicalStatus still emits it', () => {
+    const result = convertCondition(
+      conditionResource({ clinicalStatus: { coding: [{ code: 'active' }] } }),
+    ) as Converted;
     expect(valueOf(result, NS.health + 'status')).toBe('active');
   });
 


### PR DESCRIPTION
Four corrections on the FHIR/C-CDA import path. No new vocabulary; no shape files touched.

### 1. Absent status fields are no longer reported as confident values

An absent `Immunization.status` imported as `completed`, an absent `Condition.clinicalStatus` as `active`, and a `Coverage.relationship` stating no coded value as `self`. Silence was stored indistinguishably from an assertion. Each triple is now omitted when the source states nothing; free text is not mapped onto a code set.

Each shape was checked for `sh:minCount` before the default came out. `health:ImmunizationRecordShape`, `health:ConditionRecordShape` and `coverage:InsurancePlanShape` all constrain these paths with `sh:maxCount 1` and a value set and none asserts `sh:minCount`, so omitting validates.

### 2. `AllergyIntolerance.verificationStatus` is emitted

On `clinical:verificationStatus`, the predicate `Condition` already writes the same FHIR element on. `confirmed` and `refuted` are opposite claims about whether the patient is allergic at all, and the pod stated neither.

### 3. DocumentReference attribution

`appendProvenanceQuads` exists to recover clinician and organization attribution and read `performer` / `requester` / `recorder` / `asserter` / `serviceProvider`, of which a `DocumentReference` states none — so it recovered nothing at all for documents. It now reads `author` (falling back to `authenticator`) onto `clinical:providerName` and `custodian` onto `clinical:sourceEHR`. The endpoint host still wins over the custodian display, unchanged.

### 4. `cascade:encounterType` dual-write retired

All three readers migrated to `clinical:encounterType` first. `clinical:EncounterShape` constrains the canonical spelling and says nothing about the `cascade:` one.

`cascade:sourceRecordId` on encounters is **not** part of this and is not scheduled for retirement: it is the cross-transport join key, and `clinical:sourceRecordId` cannot take it over (`sh:maxCount 1`, already carrying the FHIR server resource id).

### Identity

No IRI moves. All four identity keys read the raw source element rather than the serialized value, and `AllergyIntolerance.verificationStatus` was already keyed. Id-less IRIs are pinned as literals captured before the change.

### Verification

| | |
|---|---|
| New suite `tests/fhir-absent-fields-and-attribution.test.ts` | 23 cases, 11 observed RED before the converters changed |
| Identity pins in that file | 4, green before AND after |
| Amended existing cases | 1 (a wave-1 stability pin that asserted the default) |
| Migrated readers | 3 |
| Drop manifests | 127 → 126 entries; pending 67 → 63, acknowledged 60 → 63 |
| Deleting `cascade:sourceRecordId` | 12 tests RED across 3 files |
| `tsc` | clean |
| Full suite | 161 files, 2586 passed, 0 failed, 0 skipped |
| `check:shapes-drift` | 20 files byte-identical, 6 VOCAB_VERSIONS rows agree |
| `lint` | unchanged (12 pre-existing errors on both sides) |

One field-coverage fixture changed: `documentreference.json` named the same physician as `author` and as `authenticator`, so the differential could not observe the attribution fix at all. The note is now authored by the resident and attested by the attending. The rule is written into `test-fixtures/field-coverage/FIXTURES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
