### PR TITLE
Wave 4: sync clinical v1.16 / coverage v1.5 shapes and adopt them in the converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,89 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+**The FHIR converters now emit the thirteen predicates clinical v1.16 and coverage v1.5 authored,
+so the facts that had nowhere to go stop being dropped.** Every one of these was a written-down
+omission on a drop manifest; each manifest entry is deleted in the same change as the emission that
+closes it.
+
+`convertEncounter` — a visit record went from nine facts to the resource the server actually sent:
+
+| Source element | Predicate |
+|---|---|
+| `Encounter.reasonCode` (all of them, `0..*`) | `clinical:encounterReason` |
+| `Encounter.hospitalization.admitSource` | `clinical:admitSource` |
+| `Encounter.hospitalization.dischargeDisposition` | `clinical:dischargeDisposition` |
+| `Encounter.class.display` / `.system` | `clinical:encounterClassDisplay` / `clinical:encounterClassSystem` |
+| `Encounter.participant[]` | `clinical:hasParticipant` → `clinical:EncounterParticipant` nodes carrying `participantName`, `participantRole`, `participantRoleCode`, `participantSpecialty` |
+| `Encounter.identifier` (all of them, `0..*`) | `clinical:businessIdentifier` |
+
+The class CODE is unchanged and still emitted: the display is stored alongside it, never instead of
+it, because the code is what a round-trip export must restore. `clinical:providerName` is also
+unchanged — it is the one-name summary slot an application displays, and the participations are the
+full record.
+
+Participation nodes are the first structured sub-node this converter mints, so their IRIs come from
+a single chokepoint, `encounterParticipantUri`, and are a pure function of the encounter's subject
+IRI and the participation's own stated content. Not the array index, which is a property of the
+serialization rather than of the data: FHIR does not promise `participant[]` order across two reads,
+and an index-keyed IRI would re-mint a node whose content never changed. Re-import therefore adds
+nothing. `tests/encounter-participant-identity.test.ts` proves it across two processes run from two
+different working directories against the built artifact, because an in-process check shares a
+module cache and one `process.cwd()` and cannot see a defect keyed on either.
+
+`convertClinicalDocument`:
+
+| Source element | Predicate |
+|---|---|
+| `DocumentReference.status` | `clinical:documentReferenceStatus` |
+| `DocumentReference.author` (every one) | `clinical:documentAuthorName` |
+| `DocumentReference.authenticator` | `clinical:authenticatorName` |
+
+`docStatus` stays on `clinical:status`. The two status elements are separate because
+"entered-in-error" appears in BOTH value sets and means the filing was a mistake in one and the
+clinical content is repudiated in the other; a reader seeing it on one shared predicate could not
+tell which had been said. Authorship and attestation are separate for the same kind of reason: a
+resident writes and an attending signs, and recording the signer as an author asserts they wrote
+the content.
+
+`convertCoverage` emits `coverage:status`. FHIR makes `Coverage.status` `1..1` with a required
+binding and marks it a MODIFIER element, so a cancelled policy imported indistinguishably from an
+active one was a wrong answer to the only question an insurance record is asked. No status is
+defaulted anywhere above: a source that states nothing is stored stating nothing.
+
 ### Changed
+
+**The encounter reconciler matches on `clinical:businessIdentifier`, keeping a compatibility read of
+`cascade:sourceRecordId`.** One visit identifier is written in two spellings — FHIR token form
+`{system}|{value}` with the system verbatim on the canonical predicate, and the frozen colon form
+`{system}:{value}` with `urn:oid:` stripped on the compatibility one — so the same identifier is two
+unequal strings. Identifier sets are therefore intersected PER PREDICATE, each in its own form, and
+no code path converts between them. Comparing across the forms fails silently in both directions: it
+misses real matches (`urn:oid:1.2.3|X` against `1.2.3:X`) and can manufacture false ones (a
+system-less token value containing a colon, read as a colon-form `system:value`). Converters
+dual-emit, so pods repaired before this release still converge on the frozen predicate and retiring
+it is not yet schedulable.
+
+**Reverse converters read back every predicate the import path writes.** `cascade convert --to fhir`
+was discarding the pod's own corrections: `restoreLaboratoryReport` hardcoded `status: 'final'`,
+`restoreClinicalDocument` hardcoded `'current'`, `restoreInsurancePlan` hardcoded `'active'`, and
+nothing read `clinical:status` or `clinical:verificationStatus` on any type. An amended report, a
+superseded filing, a cancelled plan and a REFUTED condition or allergy all exported as the confident
+default. Now restored: both DocumentReference statuses, every author, the authenticator, the whole
+`Encounter.class` Coding, every reason, the hospitalization pair, every participation with its role
+and specialty, the business identifiers split back out of token form, `coverage:status`, and the
+wave-1 statuses on Observation (lab and vital), DiagnosticReport, Condition and AllergyIntolerance.
+The hardcoded literals survive only as fallbacks for records written before the predicates existed,
+on the three elements FHIR makes `1..1`.
+
+**Structural sub-nodes are stored and validated but not counted as records.** A participation is
+routed into `clinical/encounters.ttl` beside the encounter that owns it — pods are partitioned by
+type and `cascade validate` validates each file independently, so a `clinical:hasParticipant` edge
+crossing a file boundary would be unresolvable — and it is excluded from "Records imported", the
+per-type summary and the source breakdown. Counting it would have reported one Synthea bundle's 44
+visits as 57 encounters.
 
 **Embedded shapes re-synced from `spec`: core 3.6 → 3.7, health 2.7 → 2.8, clinical 1.15 → 1.16,
 coverage 1.4 → 1.5.** spec PR the-cascade-protocol/spec#31; tags `vocab/core-v3.7`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+**Embedded shapes re-synced from `spec`: core 3.6 → 3.7, health 2.7 → 2.8, clinical 1.15 → 1.16,
+coverage 1.4 → 1.5.** spec PR the-cascade-protocol/spec#31; tags `vocab/core-v3.7`,
+`vocab/health-v2.8`, `vocab/clinical-v1.16`, `vocab/coverage-v1.5`. All 20 files in `src/shapes/`
+are byte-identical to `spec` (`npm run check:shapes-drift`), and `VOCAB_VERSIONS` records the
+rationale per vocabulary.
+
+What the release makes available to `cascade validate` and to the converters:
+
+| Vocabulary | Added |
+|---|---|
+| `clinical` v1.16 | `encounterReason`, `admitSource`, `dischargeDisposition`, `encounterClassDisplay`, `encounterClassSystem`; the `clinical:EncounterParticipant` class reached by `clinical:hasParticipant`, with `participantName` / `participantRole` / `participantRoleCode` / `participantSpecialty`; `documentReferenceStatus`, `documentAuthorName`, `authenticatorName`; `businessIdentifier` |
+| `coverage` v1.5 | `coverage:status` — FHIR `Coverage.status`, a required binding (`active` \| `cancelled` \| `draft` \| `entered-in-error`) that this vocabulary previously had nowhere to put |
+| `core` v3.7 | The `cascade:Attachment` vocabulary for content-addressed binary storage. Bundled so it validates; no converter emits it yet |
+| `health` v2.8 | SHACL only — no class or property added, removed or renamed |
+
+`clinical.shapes.ttl` also declares `clinical:status` with a per-class FHIR value set on the five
+shapes whose records already carried it, all at `sh:Warning` per the core v3.5 ratchet, and adds
+`clinical:EncounterParticipantShape`. `clinical:observationStatus` is deprecated in favour of
+`clinical:status`; it was emitted by no converter, so nothing changes on the write side.
+
+Shapes-only in this commit. The converter work that emits the new predicates follows.
+
 ### Fixed
 
 **Record `status` now reaches the pod, so an amended result is no longer identical to a final one.**

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -117,9 +117,36 @@
 #   from spec. That drift predates this change and belongs to its own sync; the
 #   sync script was run and those two files were deliberately reverted.
 #
-core=3.6
-health=2.7
-clinical=1.15
-coverage=1.4
+# 2026-08-28 — core 3.6→3.7, health 2.7→2.8, clinical 1.15→1.16, coverage 1.4→1.5
+#   The wave-4 field-coverage vocabulary release. spec PR
+#   the-cascade-protocol/spec#31; tags vocab/core-v3.7, vocab/health-v2.8,
+#   vocab/clinical-v1.16, vocab/coverage-v1.5. Shapes re-synced with
+#   scripts/sync-shapes-from-spec.sh; every file in src/shapes/ is now
+#   byte-identical to spec (npm run check:shapes-drift).
+#   - clinical v1.16 adds the nine encounter facts convertEncounter had nowhere
+#     to put (encounterReason, admitSource, dischargeDisposition,
+#     encounterClassDisplay, encounterClassSystem, and the
+#     clinical:EncounterParticipant node reached by clinical:hasParticipant with
+#     participantName / participantRole / participantRoleCode /
+#     participantSpecialty); the three document terms
+#     (documentReferenceStatus, documentAuthorName, authenticatorName); and
+#     clinical:businessIdentifier, the domain-free repeatable business-identifier
+#     predicate whose VALUE FORM is FHIR token form "{system}|{value}".
+#     clinical:observationStatus is deprecated in favour of clinical:status.
+#   - clinical.shapes.ttl declares clinical:status with a per-class FHIR value
+#     set on the five shapes whose records already carried it, all at
+#     sh:Warning, and adds clinical:EncounterParticipantShape.
+#   - coverage v1.5 adds coverage:status (FHIR Coverage.status, required
+#     binding: active | cancelled | draft | entered-in-error), constrained at
+#     sh:Violation because no pod has ever written the predicate.
+#   - health v2.8 is SHACL only: no class or property added, removed or renamed.
+#   - core v3.7 adds the cascade:Attachment vocabulary (hasAttachment,
+#     attachmentPath, attachmentMediaType, contentHash, hashAlgorithm,
+#     byteSize, attachmentTitle) for content-addressed binary storage. Synced
+#     and bundled; no converter emits it yet (root backlog 3.276).
+core=3.7
+health=2.8
+clinical=1.16
+coverage=1.5
 checkup=3.3
 pots=1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.20.4",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-cascade-protocol/cli",
-      "version": "0.20.4",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmod/vcf": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.20.4",
+  "version": "0.21.0",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"

--- a/src/commands/pod/helpers.ts
+++ b/src/commands/pod/helpers.ts
@@ -18,7 +18,12 @@ import { openPod } from '../../lib/pod-read.js';
 // The registry of record files and the pod file-system helpers moved into
 // `lib/` so the read layer can use them without importing a command module.
 
-export { DATA_TYPES, type DataTypeInfo } from '../../lib/pod-data-types.js';
+export {
+  DATA_TYPES,
+  type DataTypeInfo,
+  STRUCTURAL_SUBNODE_TYPES,
+  isStructuralSubNode,
+} from '../../lib/pod-data-types.js';
 export {
   resolvePodDir,
   isDirectory,

--- a/src/commands/pod/import.ts
+++ b/src/commands/pod/import.ts
@@ -41,6 +41,7 @@ import {
 import { detectSource, type FileSourceMeta, type CompletenessCheck } from '../../lib/source-adapters/registry.js';
 import {
   DATA_TYPES,
+  isStructuralSubNode,
   resolvePodDir,
   fileExists,
   applyCardIdentityName,
@@ -996,6 +997,11 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
       const sourceBreakdown: Record<string, number> = {};
       const SRC_EHR_IRI = 'https://ns.cascadeprotocol.org/clinical/v1#sourceEHR';
       for (const [, quads] of subjectQuads) {
+        // Records only, on the same rule as `recordsAdded` below. This block and
+        // the "Records imported" line are printed together in one summary, so
+        // counting structural sub-nodes here and not there would put two
+        // different totals for the same import three lines apart.
+        if (isStructuralSubNode(quads)) continue;
         const ehr = quads.find((q) => q.predicate.value === SRC_EHR_IRI);
         const key = ehr ? ehr.object.value : SOURCE_EHR_UNKNOWN;
         sourceBreakdown[key] = (sourceBreakdown[key] ?? 0) + 1;
@@ -1029,10 +1035,17 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
 
         const allNewQuads = subjectQArrays.flat();
 
-        let recordsAdded = subjectQArrays.length;
+        // Every subject in this bucket is WRITTEN; only the ones that are
+        // records are COUNTED. A structural sub-node is stored, validated and
+        // read back like anything else, but it is not a thing the person has one
+        // of, and counting it would report a visit's four participations as four
+        // more encounters. See `isStructuralSubNode`.
+        const countableSubjects = subjectQArrays.filter((quads) => !isStructuralSubNode(quads));
+
+        let recordsAdded = countableSubjects.length;
         // Of those, the subjects this file did not already hold. Equal to
         // recordsAdded on a fresh file; zero on a fully duplicate re-import.
-        let recordsNew = subjectQArrays.length;
+        let recordsNew = countableSubjects.length;
         const isNewFile = !(await fileExists(targetFile));
 
         // Every write below goes through the ONE bucket chokepoint, so the
@@ -1055,9 +1068,9 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
                 return incoming;
               },
             });
-            recordsAdded = subjectQArrays.length;
+            recordsAdded = countableSubjects.length;
             if (!isNewFile) {
-              recordsNew = subjectQArrays.filter(
+              recordsNew = countableSubjects.filter(
                 (quads) => quads.length > 0 && !priorSubjects.has(quads[0].subject.value),
               ).length;
             }
@@ -1077,7 +1090,8 @@ export function registerImportSubcommand(pod: Command, program: Command): void {
                 for (const [subjectUri, quads] of subjectQuads) {
                   if (routeTypeKey(quads) === typeKey && !bySubject.has(subjectUri)) {
                     bySubject.set(subjectUri, quads);
-                    addedCount++;
+                    // Written either way; counted only if it is a record.
+                    if (!isStructuralSubNode(quads)) addedCount++;
                   }
                 }
                 return Array.from(bySubject.values()).flat();

--- a/src/lib/fhir-converter/cascade-to-fhir-clinical.ts
+++ b/src/lib/fhir-converter/cascade-to-fhir-clinical.ts
@@ -95,6 +95,18 @@ export function restoreConditionRecord(pv: PV, _warnings: string[]): FhirResourc
     };
   }
 
+  // 3.262: `Condition.verificationStatus` has been emitted since wave 1 and was
+  // read back by nothing, so `confirmed` and `refuted` — opposite claims about
+  // whether the patient has the condition at all — exported identically.
+  const verification = getFirst(NS.clinical + 'verificationStatus');
+  if (verification) {
+    fhirResource.verificationStatus = {
+      coding: [
+        { system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: verification },
+      ],
+    };
+  }
+
   const onset = getFirst(NS.health + 'onsetDate');
   if (onset) fhirResource.onsetDateTime = onset;
 
@@ -124,6 +136,32 @@ export function restoreAllergyRecord(pv: PV, _warnings: string[]): FhirResource 
     resourceType: 'AllergyIntolerance',
     code: { text: getFirst(NS.health + 'allergen') ?? '' },
   };
+
+  // 3.262: both of AllergyIntolerance's status elements, emitted since wave 1
+  // and read back by neither. A REFUTED allergy exported as an unqualified one
+  // narrows treatment exactly as a confirmed allergy would.
+  const clinicalStatus = getFirst(NS.clinical + 'status');
+  if (clinicalStatus) {
+    fhirResource.clinicalStatus = {
+      coding: [
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+          code: clinicalStatus,
+        },
+      ],
+    };
+  }
+  const allergyVerification = getFirst(NS.clinical + 'verificationStatus');
+  if (allergyVerification) {
+    fhirResource.verificationStatus = {
+      coding: [
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification',
+          code: allergyVerification,
+        },
+      ],
+    };
+  }
 
   const cat = getFirst(NS.health + 'allergyCategory');
   if (cat) fhirResource.category = [cat];
@@ -158,6 +196,15 @@ export function restoreLabResultRecord(pv: PV, _warnings: string[]): FhirResourc
     code: { text: getFirst(NS.health + 'testName') ?? '' },
     category: [{ coding: [{ code: 'laboratory' }] }],
   };
+
+  // 3.262: `Observation.status` reaches the pod on clinical:status (wave 1) and
+  // was read back by nothing, so an AMENDED result exported as though nothing
+  // had been amended — the same collapse on the way out that wave 1 fixed on
+  // the way in. Observation.status is 1..1, so a record written before wave 1,
+  // which states none, is exported without one rather than with an invented
+  // value; that is a gap the pod can show, where "final" would be a claim.
+  const obsStatus = getFirst(NS.clinical + 'status');
+  if (obsStatus) fhirResource.status = obsStatus;
 
   const codingArr: any[] = [];
   for (const uri of pv.get(NS.health + 'testCode') ?? []) {
@@ -204,6 +251,10 @@ export function restoreVitalSign(pv: PV, warnings: string[]): FhirResource {
     code: {},
     category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] }],
   };
+
+  // 3.262: same element, same predicate, same omission as the lab branch above.
+  const vitalStatus = getFirst(NS.clinical + 'status');
+  if (vitalStatus) fhirResource.status = vitalStatus;
 
   const loincUri = getFirst(NS.clinical + 'loincCode');
   if (loincUri) {
@@ -272,12 +323,40 @@ export function restoreClinicalDocument(pv: PV, _warnings: string[]): FhirResour
 
   const fhirResource: FhirResource = {
     resourceType: 'DocumentReference',
-    status: 'current',
+    // `status` is 1..1 in FHIR, so the resource must carry one; "current" stands
+    // in only when the pod states none, which is every record written before the
+    // predicate existed. Where the pod DOES state it, the pod wins — a
+    // superseded document exported as current is the forward defect (3.256)
+    // reappearing on the way out.
+    status: getFirst(NS.clinical + 'documentReferenceStatus') ?? 'current',
     type: { text: getFirst(NS.clinical + 'documentType') ?? '' },
   };
 
+  // docStatus is 0..1 and is written only when the pod states it: unlike
+  // `status` there is no value FHIR forces the resource to carry, so inventing
+  // one would assert a document lifecycle the pod never recorded.
+  const docStatus = getFirst(NS.clinical + 'status');
+  if (docStatus) fhirResource.docStatus = docStatus;
+
   const docDate = getFirst(NS.clinical + 'documentDate');
   if (docDate) fhirResource.date = docDate;
+
+  // EVERY author, in stored order, and the authenticator as its own element.
+  // Restoring the authenticator as an author (or dropping it) would re-lose the
+  // distinction the forward converter exists to keep: who signed a note is not
+  // who wrote it.
+  const authors = pv.get(NS.clinical + 'documentAuthorName') ?? [];
+  if (authors.length > 0) {
+    fhirResource.author = authors.map((display) => ({ display }));
+  } else {
+    // Pre-v1.16 records carry only the single display name. One author is a
+    // truer restoration than none.
+    const providerName = getFirst(NS.clinical + 'providerName');
+    if (providerName) fhirResource.author = [{ display: providerName }];
+  }
+
+  const authenticator = getFirst(NS.clinical + 'authenticatorName');
+  if (authenticator) fhirResource.authenticator = { display: authenticator };
 
   const contentType = getFirst(NS.clinical + 'contentType');
   const docUrl = getFirst(NS.clinical + 'documentUrl');
@@ -300,7 +379,18 @@ export function restoreClinicalDocument(pv: PV, _warnings: string[]): FhirResour
 // Encounter
 // ---------------------------------------------------------------------------
 
-export function restoreEncounter(pv: PV, _warnings: string[]): FhirResource {
+/**
+ * @param resolveNode reads the predicate-value map of another subject in the
+ *   same graph, so `clinical:hasParticipant` edges can be followed to their
+ *   `clinical:EncounterParticipant` nodes. Optional: a caller with only one
+ *   subject in hand restores everything except the participations, which is what
+ *   this function did before clinical v1.16 gave participations a node at all.
+ */
+export function restoreEncounter(
+  pv: PV,
+  _warnings: string[],
+  resolveNode?: (iri: string) => PV | undefined,
+): FhirResource {
   const getFirst = (pred: string) => pv.get(pred)?.[0];
 
   const fhirResource: FhirResource = {
@@ -308,11 +398,37 @@ export function restoreEncounter(pv: PV, _warnings: string[]): FhirResource {
     status: getFirst(NS.clinical + 'encounterStatus') ?? 'finished',
   };
 
+  // The class Coding, restored WHOLE. Writing back only the code would export a
+  // bare vendor category id (`"5"`) with nothing saying which system it came
+  // from — readable by nobody and mappable by no one, which is the state
+  // clinical v1.16 was authored to end.
   const encClass = getFirst(NS.clinical + 'encounterClass');
-  if (encClass) fhirResource.class = { code: encClass };
+  const classDisplay = getFirst(NS.clinical + 'encounterClassDisplay');
+  const classSystem = getFirst(NS.clinical + 'encounterClassSystem');
+  if (encClass || classDisplay || classSystem) {
+    fhirResource.class = {};
+    if (encClass) fhirResource.class.code = encClass;
+    if (classDisplay) fhirResource.class.display = classDisplay;
+    if (classSystem) fhirResource.class.system = classSystem;
+  }
 
   const encType = getFirst(NS.clinical + 'encounterType');
   if (encType) fhirResource.type = [{ text: encType }];
+
+  // Every reason, because Encounter.reasonCode is 0..* and the pod holds them
+  // all. Restored as `.text`, which is the element the forward converter read.
+  const reasons = pv.get(NS.clinical + 'encounterReason') ?? [];
+  if (reasons.length > 0) fhirResource.reasonCode = reasons.map((text) => ({ text }));
+
+  const admitSource = getFirst(NS.clinical + 'admitSource');
+  const dischargeDisposition = getFirst(NS.clinical + 'dischargeDisposition');
+  if (admitSource || dischargeDisposition) {
+    fhirResource.hospitalization = {};
+    if (admitSource) fhirResource.hospitalization.admitSource = { text: admitSource };
+    if (dischargeDisposition) {
+      fhirResource.hospitalization.dischargeDisposition = { text: dischargeDisposition };
+    }
+  }
 
   const start = getFirst(NS.clinical + 'encounterStart');
   const end = getFirst(NS.clinical + 'encounterEnd');
@@ -322,14 +438,80 @@ export function restoreEncounter(pv: PV, _warnings: string[]): FhirResource {
     if (end) fhirResource.period.end = end;
   }
 
-  const provName = getFirst(NS.clinical + 'providerName');
-  if (provName) fhirResource.participant = [{ individual: { display: provName } }];
+  // Participants: the participation NODES where the graph has them, and the
+  // single summary name only where it has none.
+  //
+  // The order matters and is not a preference. Restoring providerName as a
+  // participant AS WELL would emit the treating clinician twice, once with their
+  // role and once without — and a consumer reading `participant[]` cannot tell
+  // the duplicate from a second real participation. The nodes carry strictly
+  // more than the summary slot does, including the summary name itself, so where
+  // they exist they are the whole answer.
+  const participantIris = pv.get(NS.clinical + 'hasParticipant') ?? [];
+  const participants: any[] = [];
+  for (const iri of participantIris) {
+    const node = resolveNode?.(iri);
+    if (!node) continue;
+    const first = (pred: string) => node.get(pred)?.[0];
+    const entry: any = {};
+    const name = first(NS.clinical + 'participantName');
+    if (name) entry.individual = { display: name };
+
+    const role = first(NS.clinical + 'participantRole');
+    const roleCodes = node.get(NS.clinical + 'participantRoleCode') ?? [];
+    if (role || roleCodes.length > 0) {
+      const type: any = {};
+      if (role) type.text = role;
+      if (roleCodes.length > 0) type.coding = roleCodes.map((code) => ({ code }));
+      entry.type = [type];
+    }
+
+    const specialty = first(NS.clinical + 'participantSpecialty');
+    if (specialty) {
+      // Round-tripped through an extension because that is where the source
+      // carried it and where the forward converter reads it. FHIR has no
+      // Encounter.participant.specialty element; the standard's home for the
+      // fact is PractitionerRole.specialty, and minting a PractitionerRole here
+      // would invent a resource the pod does not hold.
+      entry.extension = [
+        {
+          url: 'https://ns.cascadeprotocol.org/fhir/StructureDefinition/participant-specialty',
+          valueCodeableConcept: { text: specialty },
+        },
+      ];
+    }
+    if (Object.keys(entry).length > 0) participants.push(entry);
+  }
+  if (participants.length > 0) {
+    fhirResource.participant = participants;
+  } else {
+    const provName = getFirst(NS.clinical + 'providerName');
+    if (provName) fhirResource.participant = [{ individual: { display: provName } }];
+  }
 
   const facility = getFirst(NS.clinical + 'facilityName');
   if (facility) fhirResource.serviceProvider = { display: facility };
 
   const srcId = getFirst(NS.clinical + 'sourceRecordId');
   if (srcId) fhirResource.id = srcId;
+
+  // Business identifiers, split back out of the token form they are stored in.
+  //
+  // This is the ONE place the token form is decomposed, and it is sound here in
+  // a way it is never sound in the matcher: `{system}|{value}` is produced by
+  // this codebase and `|` is not a character FHIR permits in an Identifier.system
+  // URI, so the FIRST `|` is unambiguously the separator. A value with no `|`
+  // was written bare, meaning the source stated no system — and no system is
+  // invented for it here either.
+  const businessIds = pv.get(NS.clinical + 'businessIdentifier') ?? [];
+  if (businessIds.length > 0) {
+    fhirResource.identifier = businessIds.map((token) => {
+      const cut = token.indexOf('|');
+      return cut === -1
+        ? { value: token }
+        : { system: token.slice(0, cut), value: token.slice(cut + 1) };
+    });
+  }
 
   return fhirResource;
 }
@@ -343,7 +525,12 @@ export function restoreLaboratoryReport(pv: PV, _warnings: string[]): FhirResour
 
   const fhirResource: FhirResource = {
     resourceType: 'DiagnosticReport',
-    status: 'final',
+    // 3.262: this was a hardcoded 'final'. The forward converter has emitted
+    // DiagnosticReport.status on clinical:status since wave 1, so an `amended`
+    // or `entered-in-error` report exported as `final` was the pod's own
+    // correction being discarded on the way out. The literal remains as the
+    // fallback for records written before that, because status is 1..1.
+    status: getFirst(NS.clinical + 'status') ?? 'final',
     code: { text: getFirst(NS.clinical + 'panelName') ?? '' },
   };
 

--- a/src/lib/fhir-converter/cascade-to-fhir-demographics.ts
+++ b/src/lib/fhir-converter/cascade-to-fhir-demographics.ts
@@ -97,7 +97,12 @@ export function restoreInsurancePlan(pv: PV, _warnings: string[]): FhirResource 
 
   const fhirResource: FhirResource = {
     resourceType: 'Coverage',
-    status: 'active',
+    // 3.262 / coverage v1.5. This was a hardcoded 'active', which exported a
+    // CANCELLED plan as one still in force — and `Coverage.status` is a FHIR
+    // modifier element, so that is not a missing answer but a wrong one. The
+    // literal remains only as the fallback for records written before the
+    // predicate existed, because the element is 1..1.
+    status: getFirst(NS.coverage + 'status') ?? 'active',
   };
 
   const providerName = getFirst(NS.coverage + 'providerName');

--- a/src/lib/fhir-converter/cascade-to-fhir.ts
+++ b/src/lib/fhir-converter/cascade-to-fhir.ts
@@ -71,6 +71,31 @@ export async function convertCascadeToFhir(turtle: string): Promise<{
     subjects.get(subj)!.push(q);
   }
 
+  /** Predicate-value map for one subject. */
+  const pvOf = (quadsForSubject: Quad[]): Map<string, string[]> => {
+    const map = new Map<string, string[]>();
+    for (const q of quadsForSubject) {
+      const pred = q.predicate.value;
+      if (!map.has(pred)) map.set(pred, []);
+      map.get(pred)!.push(q.object.value);
+    }
+    return map;
+  };
+
+  /**
+   * Read another subject in this graph, for restorers that have to follow an
+   * edge to a structural SUB-NODE — today only `clinical:hasParticipant`.
+   *
+   * A sub-node is not a resource of its own: it exists to be read back into the
+   * FHIR BackboneElement it came from. Passing a reader, rather than dispatching
+   * on the node's own type, is what keeps that true — the node is reached from
+   * the encounter that owns it and from nowhere else.
+   */
+  const resolveNode = (iri: string): Map<string, string[]> | undefined => {
+    const quadsForSubject = subjects.get(iri);
+    return quadsForSubject ? pvOf(quadsForSubject) : undefined;
+  };
+
   for (const [subjectUri, subjectQuads] of subjects) {
     // Find rdf:type
     const typeQuad = subjectQuads.find(q => q.predicate.value === NS.rdf + 'type');
@@ -78,13 +103,16 @@ export async function convertCascadeToFhir(turtle: string): Promise<{
 
     const rdfType = typeQuad.object.value;
 
+    // Structural sub-nodes are restored BY the record that owns them, never as
+    // resources of their own. `clinical:EncounterParticipant` mirrors FHIR's
+    // Encounter.participant BackboneElement, which has no independent existence
+    // in FHIR at all; emitting one as a top-level resource would invent a
+    // resource type, and falling through to the unknown-type branch below would
+    // warn about a node this converter handles perfectly well.
+    if (rdfType === NS.clinical + 'EncounterParticipant') continue;
+
     // Build predicate->value map
-    const pv = new Map<string, string[]>();
-    for (const q of subjectQuads) {
-      const pred = q.predicate.value;
-      if (!pv.has(pred)) pv.set(pred, []);
-      pv.get(pred)!.push(q.object.value);
-    }
+    const pv = pvOf(subjectQuads);
 
     // Dispatch to per-type handler
     let resource: any | null = null;
@@ -110,7 +138,7 @@ export async function convertCascadeToFhir(turtle: string): Promise<{
     } else if (rdfType === NS.clinical + 'ClinicalDocument') {
       resource = restoreClinicalDocument(pv, warnings);
     } else if (rdfType === NS.clinical + 'Encounter') {
-      resource = restoreEncounter(pv, warnings);
+      resource = restoreEncounter(pv, warnings, resolveNode);
     } else if (rdfType === NS.clinical + 'LaboratoryReport') {
       resource = restoreLaboratoryReport(pv, warnings);
     } else if (rdfType === NS.clinical + 'MedicationAdministration') {

--- a/src/lib/fhir-converter/converters-clinical.ts
+++ b/src/lib/fhir-converter/converters-clinical.ts
@@ -42,6 +42,8 @@ import {
   codeableConceptSetKey,
   structuredKey,
   canonicalSetKey,
+  encounterParticipantUri,
+  type EncounterParticipation,
 } from './types.js';
 import {
   referencePlaceholder,
@@ -1148,23 +1150,60 @@ export function convertClinicalDocument(resource: any): ConversionResult & { _qu
   const docType = codeableConceptText(resource.type) ?? 'Unknown Document';
   quads.push(tripleStr(subjectUri, NS.clinical + 'documentType', docType));
 
-  // DocumentReference.docStatus — preliminary | final | amended | entered-in-error.
-  // This is the status of the DOCUMENT, which is what clinical:ClinicalDocument
-  // models, so it is the one that belongs on clinical:status.
+  // A DocumentReference carries TWO independent status elements, and from
+  // clinical v1.16 each has its own predicate.
   //
-  // ACKNOWLEDGED DROP: `DocumentReference.status` (current | superseded |
-  // entered-in-error) is a statement about the REFERENCE rather than about the
-  // document, and putting it on the same predicate would leave a reader seeing
-  // `entered-in-error` unable to tell which of the two elements said so. It
-  // needs its own predicate, which does not exist.
+  // docStatus is the status of the DOCUMENT (preliminary | final | amended |
+  // entered-in-error) and stays on clinical:status, which is what
+  // clinical:ClinicalDocument models and what every other converter here spells
+  // FHIR `.status` as.
+  //
+  // status is the status of the REFERENCE (current | superseded |
+  // entered-in-error): whether this pod entry is still the current pointer to
+  // the document. Sharing one predicate was not merely lossy, it was ambiguous
+  // in the costliest case — "entered-in-error" appears in BOTH value sets, and
+  // means the FILING was a mistake in one and the clinical CONTENT is repudiated
+  // in the other. A reader could not tell which had been said.
+  //
+  // Neither is defaulted. A document whose source states no status is stored
+  // stating none.
   if (resource.docStatus) {
     quads.push(tripleStr(subjectUri, STATUS_PREDICATE, resource.docStatus));
+  }
+  if (resource.status) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'documentReferenceStatus', resource.status));
   }
 
   // Date
   const docDate = resource.date ?? resource.indexed;
   if (docDate) {
     quads.push(tripleDateTime(subjectUri, NS.clinical + 'documentDate', docDate));
+  }
+
+  // EVERY author, and separately the authenticator.
+  //
+  // `DocumentReference.author` is 0..*, and until clinical v1.16 the only
+  // predicate available was `clinical:providerName`, which is `sh:maxCount 1` on
+  // every shape that constrains it — so a note co-signed by a resident and an
+  // attending arrived naming one of them, with nothing recording that the other
+  // had been discarded. `clinical:providerName` is unchanged and still holds the
+  // single display name (written by the provenance pass from the first author);
+  // this predicate holds all of them, that one included.
+  //
+  // The authenticator is a DIFFERENT FACT, not another author. A resident writes
+  // and an attending signs: recording only the author loses the signature, which
+  // is the part of a note carrying clinical and legal weight, and recording the
+  // signer as an author asserts they wrote the content, which the source did not
+  // say. FHIR keeps them as two elements for that reason and so does this.
+  for (const author of Array.isArray(resource.author) ? resource.author : []) {
+    const display = author?.display;
+    if (typeof display === 'string' && display.trim().length > 0) {
+      quads.push(tripleStr(subjectUri, NS.clinical + 'documentAuthorName', display.trim()));
+    }
+  }
+  const authenticator = resource.authenticator?.display;
+  if (typeof authenticator === 'string' && authenticator.trim().length > 0) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'authenticatorName', authenticator.trim()));
   }
 
   // Content type and URL from first attachment
@@ -1435,6 +1474,125 @@ function encounterIdentifierTokens(resource: any): string[] {
   return tokens;
 }
 
+/**
+ * Every business identifier an `Encounter` states, in FHIR TOKEN form.
+ *
+ * `{system}|{value}`, the ratified way to write a system-qualified identifier as
+ * one string (https://hl7.org/fhir/R4/search.html#token), which `spec` names
+ * normatively on `clinical:businessIdentifier` as of clinical v1.16. Where the
+ * source states no system the BARE VALUE is written and no system is invented.
+ *
+ * THE SYSTEM IS VERBATIM. It is NOT stripped of `urn:oid:`, and the difference
+ * from {@link encounterIdentifierTokens} directly below is the entire point:
+ * that function produces the FROZEN colon form for `cascade:sourceRecordId`, a
+ * compatibility artifact whose spelling can never change because changing it
+ * would unjoin every pair of encounters already matched on it. This one produces
+ * the canonical form. Two spellings, two predicates, and per the ratified
+ * migration plan a value of one form is never compared
+ * against a value of the other.
+ *
+ * @see https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.identifier
+ */
+function encounterBusinessIdentifiers(resource: any): string[] {
+  const identifiers = Array.isArray(resource?.identifier) ? resource.identifier : [];
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const identifier of identifiers) {
+    const value = typeof identifier?.value === 'string' ? identifier.value.trim() : '';
+    // Same rule as the colon form: an identifier with no value identifies
+    // nothing, and `system|` would sit in the join space matching every other
+    // value-less identifier from that system.
+    if (!value) continue;
+    const system = typeof identifier?.system === 'string' ? identifier.system.trim() : '';
+    const token = system ? `${system}|${value}` : value;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+/**
+ * The specialty a participant acted in, where the source carries one.
+ *
+ * FHIR models this as `PractitionerRole.specialty`, but servers routinely convey
+ * it on `Encounter.participant` as an EXTENSION rather than by publishing a
+ * resolvable PractitionerRole — which is why `clinical:participantSpecialty`
+ * carries a string rather than an edge, and why this reads an extension at all.
+ *
+ * The url is matched on containing `specialty` rather than on one vendor's exact
+ * StructureDefinition URI. A fixed URI list would silently drop the value from
+ * every server whose URI is not on it, and the failure would look exactly like
+ * "this server does not send specialty" — the class of silent loss this whole
+ * effort exists to end. The value is read from `valueCodeableConcept`,
+ * `valueCoding.display` or `valueString`, which is every spelling observed.
+ *
+ * @see https://hl7.org/fhir/R4/practitionerrole-definitions.html#PractitionerRole.specialty
+ */
+function participantSpecialty(participant: any): string | undefined {
+  for (const ext of Array.isArray(participant?.extension) ? participant.extension : []) {
+    const url = typeof ext?.url === 'string' ? ext.url : '';
+    if (!/specialty/i.test(url)) continue;
+    const fromConcept = codeableConceptText(ext.valueCodeableConcept);
+    if (fromConcept && fromConcept.trim().length > 0) return fromConcept.trim();
+    const display = ext?.valueCoding?.display;
+    if (typeof display === 'string' && display.trim().length > 0) return display.trim();
+    if (typeof ext?.valueString === 'string' && ext.valueString.trim().length > 0) {
+      return ext.valueString.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Every participation an `Encounter` describes, reduced to the facts
+ * `clinical:EncounterParticipant` models.
+ *
+ * A participation the source said NOTHING about — no name, no role, no
+ * specialty — yields no entry. A node carrying only a link back to its own
+ * encounter asserts that somebody participated while describing nobody, which
+ * is a claim the source did not make and which no reader could act on.
+ *
+ * Roles are collected in BOTH spellings because they answer different questions:
+ * `participantRole` is the label that makes a stored name interpretable to a
+ * reader, and `participantRoleCode` is what a consumer selects on. FHIR binds
+ * `participant.type` only EXTENSIBLY, so a server may send a local code and stay
+ * conformant; nothing here filters against a value set, because rejecting an
+ * unrecognised role would discard the participant along with it.
+ *
+ * The LABEL is the first one stated and the CODES are all of them, matching the
+ * cardinalities `clinical:EncounterParticipantShape` asserts (role 0..1, role
+ * code 0..*). One participation with two typed roles therefore keeps both codes
+ * and one label, rather than losing a code or failing validation with two
+ * labels.
+ */
+function encounterParticipations(resource: any): EncounterParticipation[] {
+  const out: EncounterParticipation[] = [];
+  for (const participant of Array.isArray(resource?.participant) ? resource.participant : []) {
+    const rawName = participant?.individual?.display;
+    const name = typeof rawName === 'string' && rawName.trim().length > 0 ? rawName.trim() : undefined;
+
+    let role: string | undefined;
+    const roleCodes: string[] = [];
+    for (const type of Array.isArray(participant?.type) ? participant.type : []) {
+      const label = codeableConceptText(type);
+      if (role === undefined && typeof label === 'string' && label.trim().length > 0) {
+        role = label.trim();
+      }
+      for (const coding of Array.isArray(type?.coding) ? type.coding : []) {
+        const code = typeof coding?.code === 'string' ? coding.code.trim() : '';
+        if (code && !roleCodes.includes(code)) roleCodes.push(code);
+      }
+    }
+
+    const specialty = participantSpecialty(participant);
+
+    if (!name && role === undefined && roleCodes.length === 0 && !specialty) continue;
+    out.push({ name, role, roleCodes, specialty });
+  }
+  return out;
+}
+
 export function convertEncounter(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
   const subjectUri = mintSubjectUri(resource, warnings);
@@ -1443,19 +1601,31 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
   quads.push(tripleType(subjectUri, NS.clinical + 'Encounter'));
   quads.push(...commonTriples(subjectUri));
 
-  // Encounter class (ambulatory, emergency, inpatient, etc.)
+  // Encounter class (ambulatory, emergency, inpatient, etc.) — the Coding
+  // MIRRORED, not reduced to one of its parts.
   //
-  // ACKNOWLEDGED DROP: `class.display`. On vendor output the code is often a
-  // local identifier — one Epic account returns `"5"` — while the display beside
-  // it is the readable name (`Appointment`, `HOV`, `Surgery Log`, `Support OP
-  // Encounter`). Both are worth keeping, but there is no predicate for the
-  // display: `clinical:encounterClass` is the code, and `clinical:encounterType`
-  // already carries `type[0]`, which is a different FHIR element. Overwriting
-  // the code with the display is not an option either — the code is what the
-  // reverse converter needs to rebuild `Encounter.class`. Needs vocabulary.
-  const encounterClass = resource.class?.code ?? resource.class?.coding?.[0]?.code;
+  // `Encounter.class` is a Coding bound only EXTENSIBLY, so a conformant server
+  // may send `AMB` from v3-ActCode or a local category id from its own system;
+  // one Epic account returns `"5"`. All three parts are kept because each
+  // answers a question the others cannot: the CODE is what a round-trip export
+  // must restore and what a code-system lookup keys on, the DISPLAY is the only
+  // readable thing when the code is local (`Appointment`, `Hospital Encounter`),
+  // and the SYSTEM is the only thing that distinguishes a ratified ActEncounterCode
+  // from a locally-numbered category that happens to look like one. Storing the
+  // display INSTEAD of the code was never available; storing the code alone left
+  // a bare id on screen. clinical v1.16 authored the other two.
+  const classCoding = resource.class?.coding?.[0];
+  const encounterClass = resource.class?.code ?? classCoding?.code;
   if (encounterClass) {
     quads.push(tripleStr(subjectUri, NS.clinical + 'encounterClass', encounterClass));
+  }
+  const classDisplay = resource.class?.display ?? classCoding?.display;
+  if (typeof classDisplay === 'string' && classDisplay.trim().length > 0) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'encounterClassDisplay', classDisplay.trim()));
+  }
+  const classSystem = resource.class?.system ?? classCoding?.system;
+  if (typeof classSystem === 'string' && classSystem.trim().length > 0) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'encounterClassSystem', classSystem.trim()));
   }
 
   // Status
@@ -1487,11 +1657,92 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
     quads.push(tripleDateTime(subjectUri, NS.clinical + 'encounterEnd', resource.period.end));
   }
 
+  // Why the visit happened, in the chart's own words. REPEATABLE, because
+  // Encounter.reasonCode is 0..* and one visit routinely states several. The
+  // value is CodeableConcept.text where the source gives one, else the first
+  // coding's display: the reason as WRITTEN, never normalized to a code. FHIR
+  // binds this element only PREFERRED, and real exports carry local, free-text
+  // and SNOMED reasons in the same field, so an enum here would reject
+  // conformant data.
+  if (Array.isArray(resource.reasonCode)) {
+    const seenReasons = new Set<string>();
+    for (const reason of resource.reasonCode) {
+      const text = codeableConceptText(reason);
+      if (typeof text !== 'string') continue;
+      const trimmed = text.trim();
+      if (!trimmed || seenReasons.has(trimmed)) continue;
+      seenReasons.add(trimmed);
+      quads.push(tripleStr(subjectUri, NS.clinical + 'encounterReason', trimmed));
+    }
+  }
+
+  // The admission detail. The PRESENCE of Encounter.hospitalization is itself
+  // the structured signal that a visit was an admission rather than an office
+  // visit, and through clinical v1.15 this vocabulary had nowhere to put it, so
+  // that distinction was unrecoverable from the pod. Neither predicate is
+  // defaulted: an absent element means the source did not say, and inventing
+  // "Home or Self Care" for it would be 3.257's defect on a new field.
+  const admitSource = codeableConceptText(resource.hospitalization?.admitSource);
+  if (typeof admitSource === 'string' && admitSource.trim().length > 0) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'admitSource', admitSource.trim()));
+  }
+  const dischargeDisposition = codeableConceptText(resource.hospitalization?.dischargeDisposition);
+  if (typeof dischargeDisposition === 'string' && dischargeDisposition.trim().length > 0) {
+    quads.push(
+      tripleStr(subjectUri, NS.clinical + 'dischargeDisposition', dischargeDisposition.trim()),
+    );
+  }
+
   // Provider: the participant whose declared ROLE says they treated the patient,
   // not merely the one the server listed first. See selectEncounterProviderName.
+  //
+  // UNCHANGED by the participation nodes below, deliberately. This is the SUMMARY
+  // slot — the one name an application displays — and `clinical:providerName` is
+  // `sh:maxCount 1` on every shape that constrains it. The participations are the
+  // full record. Two facts, two predicates; replacing the summary with the record
+  // would break every reader that asks an encounter who the provider was.
   const providerName = selectEncounterProviderName(resource);
   if (providerName) {
     quads.push(tripleStr(subjectUri, NS.clinical + 'providerName', providerName));
+  }
+
+  // The whole care team, each participation as its own node with its role
+  // attached. A name recorded with no role is indistinguishable from a treating
+  // clinician's and cannot be corrected by a reader; that is why the referrer in
+  // slot 0 was previously stored as the provider on 18 of 52 measured encounters
+  // with nothing on the record to say so.
+  //
+  // Node IRIs come from `encounterParticipantUri` and from nowhere else. It is a
+  // pure function of this encounter's subject IRI and the participation's own
+  // content — never the array index, never a clock — so re-importing the same
+  // resource produces the same nodes and adds nothing. See that function for why
+  // the index in particular is disqualified.
+  //
+  // Two participations stating IDENTICAL facts mint one IRI and are written
+  // once. RDF would collapse the repeated triples anyway — a graph is a set —
+  // so the alternative was not two nodes but the same node emitted twice, which
+  // only makes the quad list disagree with the graph it serializes to.
+  const seenParticipants = new Set<string>();
+  for (const participation of encounterParticipations(resource)) {
+    const participantUri = encounterParticipantUri(subjectUri, participation);
+    if (seenParticipants.has(participantUri)) continue;
+    seenParticipants.add(participantUri);
+    quads.push(tripleRef(subjectUri, NS.clinical + 'hasParticipant', participantUri));
+    quads.push(tripleType(participantUri, NS.clinical + 'EncounterParticipant'));
+    if (participation.name) {
+      quads.push(tripleStr(participantUri, NS.clinical + 'participantName', participation.name));
+    }
+    if (participation.role) {
+      quads.push(tripleStr(participantUri, NS.clinical + 'participantRole', participation.role));
+    }
+    for (const code of participation.roleCodes) {
+      quads.push(tripleStr(participantUri, NS.clinical + 'participantRoleCode', code));
+    }
+    if (participation.specialty) {
+      quads.push(
+        tripleStr(participantUri, NS.clinical + 'participantSpecialty', participation.specialty),
+      );
+    }
   }
 
   // Facility: serviceProvider, falling back to the first named location.
@@ -1522,6 +1773,16 @@ export function convertEncounter(resource: any): ConversionResult & { _quads: Qu
   // could only overwrite.
   for (const token of encounterIdentifierTokens(resource)) {
     quads.push(tripleStr(subjectUri, NS.cascade + 'sourceRecordId', token));
+  }
+
+  // The SAME identifiers on the CANONICAL predicate, in FHIR token form. This is
+  // the transition step of the ratified identifier migration plan:
+  // dual-emit, migrate the reconciler's match key to this predicate, and only
+  // then is retiring the frozen spelling above schedulable. Until every pod has
+  // been re-imported, some encounters carry only the old predicate, which is why
+  // the matcher reads both — each in its own form, never one against the other.
+  for (const token of encounterBusinessIdentifiers(resource)) {
+    quads.push(tripleStr(subjectUri, NS.clinical + 'businessIdentifier', token));
   }
 
   quads.push(tripleRef(subjectUri, NS.cascade + 'layerPromotionStatus', NS.cascade + 'FullyMapped'));

--- a/src/lib/fhir-converter/converters-demographics.ts
+++ b/src/lib/fhir-converter/converters-demographics.ts
@@ -339,26 +339,27 @@ export function convertImmunization(resource: any): ConversionResult & { _quads:
 // ---------------------------------------------------------------------------
 
 /**
- * ACKNOWLEDGED DROP: `Coverage.status` (active | cancelled | draft |
- * entered-in-error).
+ * `Coverage.status` reaches the pod as `coverage:status`, from coverage v1.5.
  *
- * Whether a plan is still in force is worth storing — a cancelled policy
- * displayed like a current one is a wrong answer to the only question anyone
- * asks an insurance record. It is not emitted because there is no predicate
- * that can carry it truthfully:
+ * Whether a plan is in force is the only question an insurance record is really
+ * asked, and FHIR marks the element a MODIFIER: a cancelled or erroneous
+ * Coverage must not be read as describing coverage the patient has. It is also
+ * 1..1 with a REQUIRED binding, so it is the one element a conformant Coverage
+ * has to carry — and through coverage v1.4 this vocabulary had no property for
+ * it, so an importer reading a conformant resource had to discard it.
  *
- *   - The coverage: namespace defines no status property for
- *     `coverage:InsurancePlan`. `coverage:claimStatus` is domain-restricted to
- *     `coverage:ClaimRecord` and `coverage:adjudicationStatus` to
- *     `coverage:BenefitStatement`; both would be false here.
- *   - `clinical:status` declares no domain, but clinical: is the EHR clinical
- *     record namespace and an insurance plan is not one of its records. The
- *     health:/clinical: split is documented as historical rather than semantic;
- *     coverage: carries no such note, so borrowing across it would be a
- *     judgement made in a converter about vocabulary scope.
+ * The predicate is `coverage:status` and not `clinical:status`, which the
+ * converter could have borrowed at any point. It was not borrowed because
+ * clinical: is the EHR clinical-record namespace and an insurance plan is not
+ * one of its records; `coverage:claimStatus` and `coverage:adjudicationStatus`
+ * are not substitutes either, since they describe what happened to a CLAIM
+ * rather than whether a plan is in force. Deciding vocabulary scope inside a
+ * converter is what the wait avoided.
  *
- * The fix is a `coverage:status` term, authored through the vocabulary
- * checklist. Until then this is a stated omission rather than a silent one.
+ * NOT DEFAULTED, unlike `coverageType` two fields below (tracked separately): a
+ * source that states no status is stored stating none. Substituting "active"
+ * for a missing modifier element is 3.257's defect on the field where it costs
+ * the most.
  */
 export function convertCoverage(resource: any): ConversionResult & { _quads: Quad[] } {
   const warnings: string[] = [];
@@ -367,6 +368,12 @@ export function convertCoverage(resource: any): ConversionResult & { _quads: Qua
 
   quads.push(tripleType(subjectUri, NS.coverage + 'InsurancePlan'));
   quads.push(...commonTriples(subjectUri));
+
+  // See the note above this function: a modifier element, reported and never
+  // invented.
+  if (resource.status) {
+    quads.push(tripleStr(subjectUri, NS.coverage + 'status', resource.status));
+  }
 
   if (Array.isArray(resource.payor) && resource.payor.length > 0) {
     const payorName = resource.payor[0]?.display ?? 'Unknown Insurance';

--- a/src/lib/fhir-converter/field-coverage/manifests/coverage.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/coverage.ts
@@ -15,12 +15,6 @@ export const COVERAGE_DROPS: FieldDropManifest = {
       reason:
         'Read only as a fallback for coverage:memberId when the resource states no subscriberId. With a subscriberId present that value is the member id.',
     },
-    'Coverage.status': {
-      disposition: 'pending',
-      backlog: '3.256',
-      reason:
-        'active, cancelled or draft. A cancelled policy that reads as active is a plan a person may believe still covers them.',
-    },
     'Coverage.subscriber': {
       disposition: 'acknowledged',
       reason:

--- a/src/lib/fhir-converter/field-coverage/manifests/documentreference.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/documentreference.ts
@@ -3,15 +3,19 @@ import type { FieldDropManifest } from '../types.js';
 /**
  * What `convertClinicalDocument` does not emit.
  *
- * `docStatus` is emitted now, so an amended note is no longer byte-identical to
- * a final one. `status` still is not: a superseded or retracted document reads
- * as a live one.
+ * Both statuses are emitted now, on their own predicates: `docStatus` as
+ * `clinical:status` (wave 1) and `status` as `clinical:documentReferenceStatus`
+ * (wave 4), so a superseded reference no longer reads as a live one and
+ * "entered-in-error" is no longer ambiguous between the two.
  *
- * Attribution is no longer absent either: `appendProvenanceQuads` reads `author`
- * (falling back to `authenticator`) and `custodian`, so a note names its writer
- * and the organization holding it. What remains dropped is narrower — the
- * co-author, the practitioner references themselves, and the author/attester
- * DISTINCTION — and each is stated below.
+ * Attribution is complete too. `appendProvenanceQuads` still writes the single
+ * display name to `clinical:providerName`, and wave 4 adds
+ * `clinical:documentAuthorName` for EVERY author and `clinical:authenticatorName`
+ * for the signer — so a note co-signed by a resident and an attending keeps both,
+ * and who SIGNED it is no longer stored as though they wrote it.
+ *
+ * What is left is the practitioner REFERENCES (resources the pod does not hold,
+ * so the links would dangle) and three fields with no term yet.
  */
 export const DOCUMENT_REFERENCE_DROPS: FieldDropManifest = {
   resourceType: 'DocumentReference',
@@ -29,12 +33,6 @@ export const DOCUMENT_REFERENCE_DROPS: FieldDropManifest = {
       reason:
         'The document\'s own identifier in the issuing system, and the key that would let the same note arriving over two transports be recognised as one note.',
     },
-    'DocumentReference.status': {
-      disposition: 'pending',
-      backlog: '3.256',
-      reason:
-        'current, superseded and entered-in-error import identically, so a retracted document reads as a live one.',
-    },
     'DocumentReference.category': {
       disposition: 'pending',
       backlog: '3.256',
@@ -46,20 +44,20 @@ export const DOCUMENT_REFERENCE_DROPS: FieldDropManifest = {
       reason:
         "A pod holds one person's records, so the subject link is the pod itself.",
     },
-    'DocumentReference.author[1]': {
-      disposition: 'acknowledged',
-      reason:
-        'Only the first author reaches clinical:providerName, which is sh:maxCount 1 on every shape that constrains it, so a co-author cannot be added without producing records that fail validation. Naming the writer is the fact a note most needs; a second author would need a repeatable contributor predicate that does not exist.',
-    },
     'DocumentReference.author[0].reference': {
       disposition: 'acknowledged',
       reason:
-        'Practitioner resources are not imported as records, so the reference would dangle. The display is emitted as clinical:providerName.',
+        'Practitioner resources are not imported as records, so the reference would dangle. The display is emitted as clinical:documentAuthorName and, for the first author, as clinical:providerName.',
     },
-    'DocumentReference.authenticator': {
+    'DocumentReference.author[1].reference': {
       disposition: 'acknowledged',
       reason:
-        'Read only when the document names no author; with an author present that value is the provider. Attestation as a fact DISTINCT from authorship — who signed a note someone else wrote — would need its own predicate, and none exists, so what is dropped here is the distinction rather than the name.',
+        'Same as author[0].reference: a link to a Practitioner resource the pod does not hold. Visible to the differential only now that author[1] itself is emitted, because the walk stops descending at a dropped parent. The co-author\'s NAME reaches the pod as clinical:documentAuthorName.',
+    },
+    'DocumentReference.authenticator.reference': {
+      disposition: 'acknowledged',
+      reason:
+        'Same as the author references: the Practitioner resource is not imported, so the link would dangle. The signer\'s NAME is emitted as clinical:authenticatorName, which is the fact that carries the clinical and legal weight; the reference only says where the source would have looked it up.',
     },
     'DocumentReference.custodian.reference': {
       disposition: 'acknowledged',

--- a/src/lib/fhir-converter/field-coverage/manifests/encounter.ts
+++ b/src/lib/fhir-converter/field-coverage/manifests/encounter.ts
@@ -6,10 +6,17 @@ import type { FieldDropManifest } from '../types.js';
  * Seeded from the differential run over `test-fixtures/field-coverage/encounter.json`,
  * which reproduces the shape measured across 54 Epic R4 Encounters.
  *
- * The clinic, the role-correct provider and the visit's contact serial number
- * now survive. What still does not: the reason, the admission detail, every type
- * coding past the first, and every participant except the one that wins the role
- * ranking — including that participant's own specialty.
+ * WHAT WAVE 4 CLOSED. The reason, the admission detail, the readable class label
+ * and its code system, every participant with its role and specialty, and the
+ * visit's business identifiers on the canonical predicate all reach the pod now,
+ * so their entries are gone from this file rather than downgraded. Eight entries
+ * were deleted; what replaces them are the four SUB-elements the differential can
+ * only see now that it descends into paths their parents used to hide.
+ *
+ * WHAT IS STILL LOST, and it is worth being precise about how little is left:
+ * every `type` coding past the first, `serviceType`, and every `location` past
+ * the one that becomes the facility. All three need vocabulary that clinical
+ * v1.16 did not author.
  */
 export const ENCOUNTER_DROPS: FieldDropManifest = {
   resourceType: 'Encounter',
@@ -41,17 +48,10 @@ export const ENCOUNTER_DROPS: FieldDropManifest = {
       reason:
         'Duration is derivable from the emitted encounterStart and encounterEnd. Storing it as a second fact invites the two to disagree.',
     },
-    'Encounter.reasonCode': {
-      disposition: 'pending',
-      backlog: '3.254',
+    'Encounter.reasonCode[1].coding': {
+      disposition: 'acknowledged',
       reason:
-        'Why the visit happened, which is the single most orienting fact on a visit card. Needs vocabulary: check US Core and IPS Encounter before authoring a clinical: term.',
-    },
-    'Encounter.hospitalization': {
-      disposition: 'pending',
-      backlog: '3.254',
-      reason:
-        'Admit source and discharge disposition. Present on inpatient encounters only, and the part of an admission a reader most wants. Needs vocabulary.',
+        "The coded form of a reason whose text is emitted. clinical:encounterReason carries the reason AS WRITTEN, and FHIR binds Encounter.reasonCode only preferred, so real exports mix local, free-text and SNOMED reasons in one element; a code beside an emitted text adds no fact the pod can act on. Where a coded reason names a record the pod already holds, clinical:indicationReference carries that as a traversable edge instead.",
     },
     'Encounter.location[1]': {
       disposition: 'pending',
@@ -68,18 +68,6 @@ export const ENCOUNTER_DROPS: FieldDropManifest = {
       disposition: 'acknowledged',
       reason:
         "The interval the patient spent at that location. Same reasoning as location[0].status: intra-stay movement needs vocabulary, and the encounter's own period is emitted.",
-    },
-    'Encounter.class.system': {
-      disposition: 'pending',
-      backlog: '3.254',
-      reason:
-        'clinical:encounterClass is emitted as a bare code, so a vendor category id and a v3-ActCode arrive indistinguishable. The system is what makes the code readable.',
-    },
-    'Encounter.class.display': {
-      disposition: 'pending',
-      backlog: '3.254',
-      reason:
-        'The human label for the class ("Appointment", "Hospital Encounter"). Emitting the code without it leaves a bare id on screen.',
     },
     'Encounter.type[0].coding': {
       disposition: 'acknowledged',
@@ -104,29 +92,10 @@ export const ENCOUNTER_DROPS: FieldDropManifest = {
       reason:
         'Same gap as type[1]. Epic routinely states four types on one encounter and three of them reach nothing.',
     },
-    'Encounter.participant[0]': {
-      disposition: 'pending',
-      backlog: '3.254',
+    'Encounter.participant[0].period': {
+      disposition: 'acknowledged',
       reason:
-        'Provider selection now ranks participants by declared role, so this generic-role participant reaches nothing once a treating role is present. Exactly ONE participant becomes clinical:providerName; the rest of the care team, roles included, is still dropped.',
-    },
-    'Encounter.participant[1].extension': {
-      disposition: 'pending',
-      backlog: '3.254',
-      reason:
-        'The specialty extension on the participant who WAS selected. The name reaches the pod and the specialty beside it does not, so "who treated me" arrives without "as what".',
-    },
-    'Encounter.participant[2]': {
-      disposition: 'pending',
-      backlog: '3.254',
-      reason:
-        'Same gap as participant[0]. A visit with four participants keeps one name and loses three, roles and all.',
-    },
-    'Encounter.participant[3]': {
-      disposition: 'pending',
-      backlog: '3.254',
-      reason:
-        'Same gap as participant[0]. A participant losing the ranking is a participant the pod never mentions.',
+        "The interval this individual took part in, as distinct from the encounter's own period. clinical:EncounterParticipant models FHIR's participant as a name, a role and a specialty and deliberately carries no time: a participation interval describes movement WITHIN a visit, the same intra-stay axis Encounter.location[0].period sits on, and the encounter's own period is emitted. Both would need the same vocabulary, and neither should get it piecemeal.",
     },
   },
 };

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -713,6 +713,97 @@ export function medicationUri(
   );
 }
 
+/**
+ * One participation in an encounter, reduced to the facts
+ * `clinical:EncounterParticipant` models.
+ *
+ * The field set is exactly what `clinical:EncounterParticipantShape` permits a
+ * node to carry: one name, one role LABEL, any number of role CODES, one
+ * specialty. That correspondence is deliberate — the IRI below is derived from
+ * these fields, so it is a function of precisely the facts the node states and
+ * of nothing else, which `tests/encounter-participant-identity.test.ts` asserts
+ * directly rather than leaving as a claim.
+ *
+ * `roleCodes` is a SET, not a sequence: `Encounter.participant.type` is a
+ * repeating CodeableConcept whose order carries no meaning, and two servers
+ * listing the same two codes in different order describe one participation.
+ */
+export interface EncounterParticipation {
+  /** `participant.individual.display`. */
+  name?: string;
+  /** The readable role: `type[0].text`, or its first coding's display. */
+  role?: string;
+  /** Coded roles: every `type[].coding[].code`. */
+  roleCodes: string[];
+  /** The specialty the participant acted in, where the source states one. */
+  specialty?: string;
+}
+
+/**
+ * THE ONLY WAY AN `clinical:EncounterParticipant` NODE GETS AN IRI.
+ *
+ * WHY THIS IS A FUNCTION AND NOT FOUR LINES AT THE CALL SITE
+ * ----------------------------------------------------------
+ * This repository has had three identity-determinism incidents, and the shape
+ * was the same one every time: a correct derivation existed somewhere, the next
+ * writer of the next converter did not find it, and minted an IRI from
+ * something that was not the record's content — a clock, a counter, a random
+ * value, an array index. Fixing the sites did not end the class; a chokepoint
+ * did. This is that chokepoint for participation nodes, and
+ * `tests/encounter-participant-identity.test.ts` proves two conversions of one
+ * resource in SEPARATE PROCESSES agree byte for byte.
+ *
+ * THE DERIVATION, AND WHAT IT DELIBERATELY EXCLUDES
+ * ------------------------------------------------
+ * A pure function of two things and nothing else:
+ *
+ *   1. the ENCOUNTER's subject IRI, so one participation belongs to one visit
+ *      and "Amara Okoye, MD, attender" at two different visits is two nodes;
+ *   2. the participation's own CONTENT — name, role, role codes, specialty —
+ *      which is EXACTLY the set of facts the node goes on to state. Nothing
+ *      the IRI depends on is invisible in the record it names.
+ *
+ * Not the array index. An index is a property of the SERIALIZATION, and FHIR
+ * does not promise `participant[]` order across two reads of one resource: an
+ * index-keyed IRI moves when a server reorders the array, which re-mints a node
+ * whose content never changed and duplicates it on the next import. Not the
+ * import time, not a counter, not the input file path.
+ *
+ * That makes re-import idempotent, which is the property the whole re-import
+ * re-import repair path rests on: the same source resource converted
+ * twice produces the same participation IRIs, so the second import adds nothing.
+ *
+ * TWO IDENTICAL PARTICIPATIONS ON ONE ENCOUNTER COLLAPSE TO ONE NODE, and that
+ * is chosen rather than tolerated. If a source lists the same name in the same
+ * role with the same specialty twice, nothing in the record distinguishes them,
+ * and this codebase's stated rule for that case (see `contentHashedUri`) is to
+ * merge what nothing can tell apart rather than mint a second IRI per import —
+ * a duplicate set that grows forever and never announces itself.
+ *
+ * The multi-valued member goes through `canonicalSetKey`, so role-code order and
+ * a repeated role code do not move the IRI. The separator is ',' because this is
+ * a NEW site and core v3.6 requires U+002C of new implementations.
+ *
+ * ONE BOUNDED CAVEAT, stated rather than hidden: `contentHashedUri` builds its
+ * key as `k=v` pairs joined with `|`, so a participant DISPLAY NAME containing
+ * those characters could in principle spell a different field set. It is the
+ * same exposure every other content-keyed converter in this module already
+ * carries for names, and narrowing it would move every identity those converters
+ * have ever written; it is recorded here rather than papered over.
+ */
+export function encounterParticipantUri(
+  encounterUri: string,
+  participation: EncounterParticipation,
+): string {
+  return contentHashedUri('EncounterParticipant', {
+    encounter: encounterUri,
+    name: participation.name,
+    role: participation.role,
+    roleCode: canonicalSetKey(participation.roleCodes, ','),
+    specialty: participation.specialty,
+  });
+}
+
 /** Common triples every Cascade resource gets */
 export function commonTriples(subject: string): Quad[] {
   return [

--- a/src/lib/pod-data-types.ts
+++ b/src/lib/pod-data-types.ts
@@ -134,7 +134,27 @@ export const DATA_TYPES: Record<string, DataTypeInfo> = {
   },
   encounters: {
     label: 'Encounters',
-    rdfTypes: [CASCADE_NAMESPACES.clinical + 'Encounter'],
+    rdfTypes: [
+      CASCADE_NAMESPACES.clinical + 'Encounter',
+      // The participation SUB-NODE lives in the same file as the encounter that
+      // owns it, and that is not a filing convenience.
+      //
+      // Pods are partitioned per type and `cascade validate` validates each file
+      // INDEPENDENTLY, so a `clinical:hasParticipant` edge crossing a file
+      // boundary would be unresolvable to the validator — the same problem that
+      // forced the sh:class constraints off the v1.10 graph edges. Routing it
+      // anywhere else also sends it through `routeTypeKey`'s unknown-type
+      // fallback into the FHIR passthrough bucket, where a Cascade-typed node
+      // would sit among unconverted FHIR JSON and be counted as an imported
+      // record of its own.
+      //
+      // It is deliberately NOT given a bucket of its own. A participation has no
+      // existence apart from its encounter (FHIR models it as a BackboneElement,
+      // which cannot be addressed independently at all), and a file of
+      // participations detached from the visits they belong to would be a list
+      // of names nobody could interpret.
+      CASCADE_NAMESPACES.clinical + 'EncounterParticipant',
+    ],
     directory: 'clinical',
     filename: 'encounters.ttl',
   },
@@ -212,3 +232,32 @@ export const DATA_TYPES: Record<string, DataTypeInfo> = {
     isFhirPassthroughBucket: true,
   },
 };
+
+/**
+ * Subjects that are STRUCTURAL SUB-NODES of a record rather than records.
+ *
+ * A sub-node is stored in the pod, validated by its own shape, and routed into
+ * the same file as the record that owns it — but it is not a thing a person has
+ * one of. `clinical:EncounterParticipant` mirrors FHIR's
+ * `Encounter.participant`, a BackboneElement with no independent existence in
+ * FHIR at all: it exists to say who took part in ONE visit, and it is reached
+ * only from that visit.
+ *
+ * WHY THIS SET EXISTS. Import counts subjects, which was exact for as long as
+ * every subject was a record. The moment a converter minted its first sub-node
+ * that stopped being true, and the arithmetic failed in the direction that
+ * misleads: one Synthea bundle's 44 visits reported as 57 "Encounters", so
+ * "Records imported" and the per-type summary would both have overstated what
+ * the person actually has. The nodes are still written, still validated and
+ * still read back; they are not COUNTED as records, because they are not
+ * records.
+ */
+export const STRUCTURAL_SUBNODE_TYPES: ReadonlySet<string> = new Set([
+  CASCADE_NAMESPACES.clinical + 'EncounterParticipant',
+]);
+
+/** True when a subject's quads describe a structural sub-node, not a record. */
+export function isStructuralSubNode(quads: ReadonlyArray<{ predicate: { value: string }; object: { value: string } }>): boolean {
+  const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+  return quads.some((q) => q.predicate.value === RDF_TYPE && STRUCTURAL_SUBNODE_TYPES.has(q.object.value));
+}

--- a/src/lib/reconciler.ts
+++ b/src/lib/reconciler.ts
@@ -972,14 +972,23 @@ function differingPredicates(
  *
  * Not one predicate, because the importers disagree about which to use and a
  * record routinely carries two that mean different things: a FHIR encounter
- * states the server's row id on `clinical:sourceRecordId` and the visit's
- * identifier on `cascade:sourceRecordId`. Agreement is therefore checked
- * per-predicate, never by flattening them into one bag where a row id could be
- * compared against a visit identifier.
+ * states the server's row id on `clinical:sourceRecordId`, the visit's
+ * identifier in colon form on `cascade:sourceRecordId`, and the same visit
+ * identifier in FHIR token form on `clinical:businessIdentifier`. Agreement is
+ * therefore checked per-predicate, never by flattening them into one bag where a
+ * row id could be compared against a visit identifier, or one form of an
+ * identifier against the other form of the same one.
+ *
+ * `clinical:businessIdentifier` joined this list with clinical v1.16. It
+ * strengthens the NO-CONTRADICTION clause and cannot weaken the AGREEMENT one:
+ * the clause below only considers a predicate BOTH records state, so a pre-v1.16
+ * record that carries no business identifier is unaffected, while two records
+ * that both carry one and disagree are correctly refused as one record.
  */
 const SOURCE_RECORD_ID_PREDICATES: readonly string[] = [
   NS.cascade + 'sourceRecordId',
   NS.clinical + 'sourceRecordId',
+  NS.clinical + 'businessIdentifier',
   NS.health + 'sourceRecordId',
   NS.coverage + 'sourceRecordId',
   NS.clinical + 'fhirResourceId',
@@ -1591,29 +1600,64 @@ function matchVitalSigns(a: ParsedRecord, b: ParsedRecord): MatchResult {
 }
 
 /**
- * The predicate carrying a visit's identifier, on BOTH transports.
+ * The predicates carrying a visit's identifier, CANONICAL FIRST.
  *
- * The C-CDA path writes `<encounter><id root= extension=/>` here as
- * `root:extension`; the FHIR path writes each `Encounter.identifier` entry here
- * as `system:value` with `urn:oid:` stripped. On Epic output those are the same
- * contact serial number written twice, which is what makes a cross-transport
- * join possible at all.
+ * TWO PREDICATES, TWO VALUE FORMS, NEVER COMPARED ACROSS
+ * -----------------------------------------------------
+ * `clinical:businessIdentifier` (clinical v1.16) is canonical and holds the FHIR
+ * TOKEN form, `{system}|{value}`, with the system verbatim. `cascade:sourceRecordId`
+ * is the FROZEN compatibility spelling and holds the colon form, `{system}:{value}`
+ * with `urn:oid:` stripped — the shape the C-CDA path has always written from
+ * `<encounter><id root= extension=/>`, and which the FHIR path dual-writes so the
+ * two transports keep joining.
  *
- * NOT `clinical:sourceRecordId`. On a FHIR encounter that predicate holds
+ * The SAME identifier therefore renders as two different strings, one per
+ * predicate. `urn:oid:1.2.3|X` and `1.2.3:X` are equal identifiers and unequal
+ * values, so a matcher that pooled them into one bag would find no match where
+ * one exists. Worse, the reverse: `a:b` in the colon form and a token-form value
+ * that happens to read `a:b` (an identifier with no system, whose bare value
+ * contains a colon) are UNRELATED and would compare equal. Both failures are
+ * silent. Hence the rule the ratified migration plan states and this structure
+ * enforces: a value is only ever compared against values from the SAME
+ * predicate, and no conversion between the forms exists anywhere in this file.
+ *
+ * ORDER IS THE CANONICAL PREFERENCE and is read by {@link matchEncounters} when
+ * it has to name the identifier a match was made on.
+ *
+ * NEITHER IS `clinical:sourceRecordId`. On a FHIR encounter that predicate holds
  * `Encounter.id`, the FHIR SERVER's row id, which names nothing outside that
- * server and shares no key space with a visit identifier. Reading both would
- * mix two id spaces in one comparison for no gain: the C-CDA path writes the
- * visit identifier to BOTH predicates, so the cascade: one alone already sees
- * every identifier either transport states.
+ * server and shares no key space with a visit identifier.
  */
-const ENCOUNTER_IDENTIFIER_PREDICATE = NS.cascade + 'sourceRecordId';
+const ENCOUNTER_IDENTIFIER_PREDICATES: readonly string[] = [
+  NS.clinical + 'businessIdentifier',
+  NS.cascade + 'sourceRecordId',
+];
 
-/** Every visit identifier a record states, trimmed and de-duplicated. */
-function encounterIdentifiers(r: ParsedRecord): Set<string> {
-  const out = new Set<string>();
-  for (const v of r.properties.get(ENCOUNTER_IDENTIFIER_PREDICATE) ?? []) {
-    const value = v.value.trim();
-    if (value) out.add(value);
+/**
+ * Every visit identifier a record states, KEYED BY THE PREDICATE IT STATED IT ON.
+ *
+ * The single place a stored identifier value is normalized, and the normalization
+ * is deliberately only `trim()`: whitespace is a serialization artifact, and
+ * everything else about a value is load-bearing. In particular this function does
+ * NOT rewrite one form into the other. It cannot, and the attempt is the trap:
+ * recovering `urn:oid:1.2.3|X` from `1.2.3:X` requires guessing that the system
+ * was an OID and re-adding a prefix the colon form deliberately dropped, and
+ * splitting either form on its separator is ambiguous because both separators
+ * occur inside real identifier values.
+ *
+ * Returning a map rather than a set is what makes the never-compare-across rule
+ * structural instead of a comment: a caller physically cannot reach two forms'
+ * values through one lookup.
+ */
+function encounterIdentifiersByPredicate(r: ParsedRecord): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  for (const pred of ENCOUNTER_IDENTIFIER_PREDICATES) {
+    const values = new Set<string>();
+    for (const v of r.properties.get(pred) ?? []) {
+      const value = v.value.trim();
+      if (value) values.add(value);
+    }
+    if (values.size > 0) out.set(pred, values);
   }
   return out;
 }
@@ -1629,28 +1673,58 @@ function encounterIdentifiers(r: ParsedRecord): Set<string> {
  * re-points. An encounter carrying NO identifier therefore never merges with
  * anything — absence of a join key is not evidence of a match.
  *
- * The empty-set guard below is REDUNDANT with the intersection that follows
+ * PER-PREDICATE INTERSECTION, WHICH IS THE MIGRATION IN ONE LINE. Two encounters
+ * match when their identifier sets intersect UNDER SOME ONE PREDICATE, each
+ * predicate compared only against itself in its own value form. See
+ * {@link ENCOUNTER_IDENTIFIER_PREDICATES} for why a cross-form comparison is
+ * wrong in both directions and silent in both.
+ *
+ * That is what lets the canonical predicate become the match key without
+ * stranding anyone. Three populations exist at once during the transition and
+ * all three converge:
+ *
+ *   - both records imported after this release: they carry both predicates and
+ *     intersect under `clinical:businessIdentifier`;
+ *   - both written by a pod repaired BEFORE this release: they carry only
+ *     `cascade:sourceRecordId` and intersect under it, exactly as they did
+ *     before this change;
+ *   - one of each: they intersect under `cascade:sourceRecordId`, which is
+ *     precisely why the frozen predicate is still dual-written and why retiring
+ *     it is not schedulable yet.
+ *
+ * The empty-map guard below is REDUNDANT with the intersection that follows
  * (nothing intersects an empty set) and is kept for the same reason the `b === a`
  * clause in the matching loop is: it states the rule directly, rather than
  * leaving the most important property of this matcher to be inferred from a
  * filter. `tests/reconciler-encounter-dedupe.test.ts` pins the behaviour either
  * way.
  *
- * `matchedOn` names the SHARED identifier and picks it deterministically (the
- * lexicographically smallest of the intersection), because `generateConflictId`
- * builds a persisted conflict id out of this string: a constant there would give
- * every encounter conflict in a pod one id, which is the defect the medication
- * matcher's `partial-name` comment records paying for.
+ * `matchedOn` names the SHARED identifier and picks it deterministically —
+ * canonical predicate first, then the lexicographically smallest of that
+ * predicate's intersection — because `generateConflictId` builds a persisted
+ * conflict id out of this string: a constant there would give every encounter
+ * conflict in a pod one id, which is the defect the medication matcher's
+ * `partial-name` comment records paying for. Records carrying only the frozen
+ * predicate keep exactly the `matchedOn` they had before this change, so no
+ * conflict id already written to a pod moves.
  */
 function matchEncounters(a: ParsedRecord, b: ParsedRecord): MatchResult {
   const noMatch: MatchResult = { match: false, confidence: 0, matchedOn: '' };
-  const idsA = encounterIdentifiers(a);
+  const idsA = encounterIdentifiersByPredicate(a);
   if (idsA.size === 0) return noMatch;
-  const shared = [...encounterIdentifiers(b)].filter((id) => idsA.has(id)).sort();
-  if (shared.length === 0) return noMatch;
-  // The source assigned this identifier to both records. That is the source
-  // stating they are one act, not a similarity score.
-  return { match: true, confidence: 1.0, matchedOn: `encounter-id:${shared[0]}` };
+  const idsB = encounterIdentifiersByPredicate(b);
+
+  for (const pred of ENCOUNTER_IDENTIFIER_PREDICATES) {
+    const valuesA = idsA.get(pred);
+    const valuesB = idsB.get(pred);
+    if (!valuesA || !valuesB) continue;
+    const shared = [...valuesB].filter((id) => valuesA.has(id)).sort();
+    if (shared.length === 0) continue;
+    // The source assigned this identifier to both records. That is the source
+    // stating they are one act, not a similarity score.
+    return { match: true, confidence: 1.0, matchedOn: `encounter-id:${shared[0]}` };
+  }
+  return noMatch;
 }
 
 /**

--- a/src/shapes/clinical.shapes.ttl
+++ b/src/shapes/clinical.shapes.ttl
@@ -14,6 +14,62 @@
 # different data sources (EHR, device, patient-reported).
 #
 # Changelog:
+# v1.16 (2026-08-27): Describe the facts the records now carry. Additive and
+#     strictly widening: nothing that validated under v1.15 stops validating,
+#     and every new finding on an existing predicate is at sh:Warning.
+#
+#     1. clinical:status is declared, with a per-class FHIR value set, on the
+#        shapes whose records carry it. Through v1.15 it was written onto five
+#        record types and declared on none of them, so nothing was closed and
+#        nothing was checked: the value set was unenforced and validation passed
+#        in silence. The sets are verbatim from the FHIR R4 value set each
+#        record type's source resource binds:
+#          clinical:VitalSignShape          Observation.status, 8 codes
+#          clinical:LaboratoryReportShape   DiagnosticReport.status, 10 codes
+#          clinical:ClinicalDocumentShape   see the note on that shape
+#          health:LabResultRecordShape      Observation.status, 8 codes
+#          health:AllergyRecordShape        AllergyIntolerance.clinicalStatus,
+#                                           3 codes
+#        The last two are in health.shapes.ttl v1.5, which is where those two
+#        shapes live. All five are sh:Warning, per the core v3.5 ratchet: a
+#        value existing data carries is reported, not rejected, and the severity
+#        is raised only after a release in which the warning is observably
+#        absent from conforming output.
+#     2. ClinicalDocumentShape's status set is the ten-code diagnostic-report
+#        set rather than the four-code composition set that DocumentReference.
+#        docStatus is bound to. clinical:LaboratoryReportShape reaches this
+#        shape through sh:node, and a lab report converted from a
+#        DiagnosticReport legitimately carries "partial", "corrected" or
+#        "appended". composition-status is a strict subset of
+#        diagnostic-report-status, so the wider set is the only one correct for
+#        every class under this shape. The full argument, and the ratchet step
+#        that would tighten it, are stated at the constraint.
+#     3. NEW property shapes on clinical:ClinicalDocumentShape for
+#        clinical:documentReferenceStatus (sh:in current | superseded |
+#        entered-in-error, FHIR R4 DocumentReference.status, required binding),
+#        clinical:documentAuthorName (repeatable, NO maxCount — the
+#        sh:maxCount 1 on clinical:providerName is what was discarding every
+#        author past the first), clinical:authenticatorName (0..1) and
+#        clinical:businessIdentifier (repeatable).
+#     4. NEW property shapes on clinical:EncounterShape for the nine encounter
+#        facts clinical v1.16 defines: encounterClassDisplay,
+#        encounterClassSystem, encounterReason (repeatable), admitSource,
+#        dischargeDisposition, hasParticipant (repeatable) and
+#        businessIdentifier (repeatable). None of the source-text properties
+#        carries a value set: FHIR binds reasonCode and admitSource PREFERRED
+#        and dischargeDisposition EXAMPLE, and an enum over an example-strength
+#        binding rejects conformant data by construction.
+#        clinical:sourceRecordId keeps sh:maxCount 1 and now says why: it holds
+#        one logical id, and the 0..* business identifiers have their own
+#        predicate.
+#     5. NEW clinical:EncounterParticipantShape, targeting the new
+#        clinical:EncounterParticipant class. Constrains cardinality and
+#        datatype only. It requires no field, because FHIR makes every
+#        sub-element of Encounter.participant optional, and it binds no role
+#        vocabulary, because that binding is extensible at source. It does not
+#        require sh:nodeKind sh:IRI: unlike an Encounter, nothing references a
+#        participation from another file.
+#
 # v1.15 (2026-08-14): Check what was unchecked, keep what was being dropped, and
 #     stop failing records that carry the thing they are failing for missing.
 #     Additive and strictly widening: no graph that validated under v1.14 stops
@@ -225,6 +281,88 @@ clinical:ClinicalDocumentShape a sh:NodeShape ;
         sh:path clinical:hasSection ;
         sh:class clinical:ClinicalSection ;
         sh:name "Sections"@en
+    ] ;
+
+    # ------------------------------------------------------------------
+    # v1.16: the two status axes, and the two attribution axes
+    # ------------------------------------------------------------------
+    #
+    # WHY THE STATUS SET HERE IS THE DIAGNOSTIC-REPORT SET AND NOT THE
+    # COMPOSITION SET. On a DocumentReference-derived record clinical:status
+    # carries DocumentReference.docStatus, whose required binding is
+    # composition-status: preliminary | final | amended | entered-in-error.
+    # But clinical:LaboratoryReportShape reaches these constraints through
+    # sh:node, and a laboratory report is converted from a DiagnosticReport,
+    # whose status value set is the ten-code diagnostic-report-status. Binding
+    # the four-code set here would therefore report a conformant DiagnosticReport
+    # status of "partial", "corrected" or "appended" as out of set on every lab
+    # report in the pod.
+    #
+    # composition-status is a strict SUBSET of diagnostic-report-status, so the
+    # ten-code set is the union of the two value sets that reach this shape and
+    # is the only set that is correct for every class under it. It is bound here
+    # verbatim from https://hl7.org/fhir/R4/valueset-diagnostic-report-status.html
+    #
+    # The narrower composition-status binding for the DocumentReference-derived
+    # document subtypes specifically is deliberately NOT added in this version.
+    # It would have to live on shapes targeting those subtypes alone, and this
+    # release has no measurement of what those records actually carry; per the
+    # core v3.5 ratchet a constraint is added once conforming output is observed,
+    # not on the assumption that it will be. That is the next step here, and it
+    # is one version's work, not a judgement call.
+    sh:property [
+        sh:path clinical:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("registered" "partial" "preliminary" "final" "amended" "corrected"
+               "appended" "cancelled" "entered-in-error" "unknown") ;
+        sh:name "Status"@en ;
+        sh:message "Document status should be one of the FHIR R4 codes a document-class record can carry: the four composition-status codes (preliminary, final, amended, entered-in-error) that DocumentReference.docStatus is bound to, or the ten diagnostic-report-status codes a DiagnosticReport-derived report carries"@en ;
+        sh:severity sh:Warning
+    ] ;
+
+    # FHIR R4 DocumentReference.status, required binding, verbatim.
+    # A DIFFERENT fact from clinical:status above: this is whether the pod's
+    # POINTER to the document is current, and "entered-in-error" here means the
+    # reference was filed in error, not that the clinical content is repudiated.
+    sh:property [
+        sh:path clinical:documentReferenceStatus ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("current" "superseded" "entered-in-error") ;
+        sh:name "Document Reference Status"@en ;
+        sh:message "Document reference status should be one of the FHIR R4 DocumentReferenceStatus codes: current, superseded, entered-in-error"@en ;
+        sh:severity sh:Warning
+    ] ;
+
+    # Repeatable by design: DocumentReference.author is 0..*, and the
+    # sh:maxCount 1 on clinical:providerName is what was discarding every author
+    # after the first. NO maxCount is asserted here.
+    sh:property [
+        sh:path clinical:documentAuthorName ;
+        sh:datatype xsd:string ;
+        sh:name "Document Author Name"@en ;
+        sh:message "Each document author name must be a string"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # DocumentReference.authenticator is 0..1.
+    sh:property [
+        sh:path clinical:authenticatorName ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Authenticator Name"@en ;
+        sh:message "A document has at most one authenticator, matching FHIR R4 DocumentReference.authenticator 0..1"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR .identifier is 0..* on every resource; no maxCount.
+    sh:property [
+        sh:path clinical:businessIdentifier ;
+        sh:datatype xsd:string ;
+        sh:name "Business Identifier"@en ;
+        sh:message "Each business identifier must be a string"@en ;
+        sh:severity sh:Violation
     ] .
 
 # ============================================================================
@@ -373,6 +511,26 @@ clinical:LaboratoryReportShape a sh:NodeShape ;
         sh:minCount 1 ;
         sh:name "Document Date"@en ;
         sh:message "Lab reports must have a document date"@en
+    ] ;
+
+    # v1.16: FHIR R4 DiagnosticReport.status, required binding, verbatim and in
+    # the value set's own order
+    # (https://hl7.org/fhir/R4/valueset-diagnostic-report-status.html). A
+    # laboratory report is converted from a DiagnosticReport, so this is the
+    # value set its clinical:status is drawn from. Restated here rather than
+    # left to the inherited ClinicalDocumentShape constraint, because a reader
+    # of this shape needs to see which of the two document status value sets
+    # applies to a lab report; the two sets are identical here by construction,
+    # since composition-status is a strict subset of this one.
+    sh:property [
+        sh:path clinical:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("registered" "partial" "preliminary" "final" "amended" "corrected"
+               "appended" "cancelled" "entered-in-error" "unknown") ;
+        sh:name "Status"@en ;
+        sh:message "Laboratory report status should be one of the FHIR R4 DiagnosticReportStatus codes: registered, partial, preliminary, final, amended, corrected, appended, cancelled, entered-in-error, unknown"@en ;
+        sh:severity sh:Warning
     ] .
 
 # ============================================================================
@@ -1314,6 +1472,26 @@ clinical:VitalSignShape a sh:NodeShape ;
         sh:name "Data Provenance"@en
     ] ;
 
+    # v1.16: FHIR R4 Observation.status, required binding, verbatim and in the
+    # value set's own order
+    # (https://hl7.org/fhir/R4/valueset-observation-status.html). A vital sign
+    # is converted from an Observation, so this is the value set its
+    # clinical:status is drawn from. sh:Warning, not sh:Violation: this is a
+    # newly bound value set on a predicate existing pods already carry, and the
+    # core v3.5 ratchet is that such a value is reported, never rejected, until
+    # a release in which the warning is observably absent from conforming
+    # output.
+    sh:property [
+        sh:path clinical:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("registered" "preliminary" "final" "amended" "corrected"
+               "cancelled" "entered-in-error" "unknown") ;
+        sh:name "Status"@en ;
+        sh:message "Vital sign status should be one of the FHIR R4 ObservationStatus codes: registered, preliminary, final, amended, corrected, cancelled, entered-in-error, unknown"@en ;
+        sh:severity sh:Warning
+    ] ;
+
     # Required: schemaVersion
     sh:property [
         sh:path cascade:schemaVersion ;
@@ -1826,12 +2004,91 @@ clinical:EncounterShape a sh:NodeShape ;
         sh:severity sh:Violation
     ] ;
 
+    # v1.16: the rest of the Encounter.class Coding. The CODE keeps its
+    # unconstrained sh:datatype above; these two carry the display and the code
+    # system, without which a local class code is unreadable and cannot be told
+    # apart from a ratified ActEncounterCode. No enum on either, for the same
+    # reason the code carries none.
+    sh:property [
+        sh:path clinical:encounterClassDisplay ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Class Display"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:encounterClassSystem ;
+        sh:or ( [ sh:datatype xsd:anyURI ] [ sh:datatype xsd:string ] ) ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Class System"@en ;
+        sh:message "Encounter Class System must be a single xsd:anyURI (an xsd:string is accepted, because serializers differ on which of the two they write for a URI-valued literal)"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # v1.16: why the visit happened, and the admission signals. All three are
+    # verbatim source text and NONE carries a value set: FHIR binds reasonCode
+    # and admitSource only PREFERRED and dischargeDisposition only EXAMPLE, and
+    # an enum on an example-strength binding rejects conformant data by
+    # construction. encounterReason is repeatable because Encounter.reasonCode
+    # is 0..*; the hospitalization fields are 0..1 in the source.
+    sh:property [
+        sh:path clinical:encounterReason ;
+        sh:datatype xsd:string ;
+        sh:name "Encounter Reason"@en ;
+        sh:message "Each encounter reason must be a string"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:admitSource ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Admit Source"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:dischargeDisposition ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Discharge Disposition"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # v1.16: participations. Repeatable, and no sh:class on the object: the
+    # v1.11 note under HasEncounterEdgeShape explains why a class check across
+    # a per-file validation boundary produced only false positives, and while a
+    # participant is written into the same file as its encounter today, that is
+    # a serializer's choice and not something a shape should require. The node
+    # itself is constrained by clinical:EncounterParticipantShape below.
+    sh:property [
+        sh:path clinical:hasParticipant ;
+        sh:name "Has Participant"@en ;
+        sh:severity sh:Violation
+    ] ;
+
     # Optional: source linkage back to the record this was converted from.
+    #
+    # sourceRecordId stays sh:maxCount 1 because it holds ONE thing: the
+    # server-assigned logical id of the resource this record was converted
+    # from. The visit's business identifiers, which are 0..* in FHIR and are
+    # what a cross-transport join keys on, go to clinical:businessIdentifier
+    # below. Through v1.15 both were written to this single-valued predicate,
+    # which is why a second identifier had nowhere to go.
     sh:property [
         sh:path clinical:sourceRecordId ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:name "Source Record ID"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:businessIdentifier ;
+        sh:datatype xsd:string ;
+        sh:name "Business Identifier"@en ;
+        sh:message "Each business identifier must be a string; FHIR Encounter.identifier is 0..* so no maximum is asserted"@en ;
         sh:severity sh:Violation
     ] ;
 
@@ -1882,6 +2139,71 @@ clinical:EncounterTemporalShape a sh:NodeShape ;
     ) ;
     sh:message "Encounter should carry a start, an end or an encounter date so that records linked to it can be placed in time"@en ;
     sh:severity sh:Warning .
+
+# ============================================================================
+# Shape: Encounter Participant (v1.16)
+# ============================================================================
+#
+# One participation in a visit: a name together with the role it was played in.
+# Constrains SHAPE only, for the same reason clinical:EncounterShape does.
+#
+# NO VALUE SET on the role code, deliberately. FHIR R4 binds
+# Encounter.participant.type EXTENSIBLY to encounter-participant-type, which
+# draws twelve concepts from v3-ParticipationType and the FHIR participant-type
+# code system; an extensible binding means a server may send a local code and
+# still be conformant, and rejecting it here would discard the participant along
+# with the code.
+#
+# NO REQUIRED FIELD, deliberately. FHIR makes every sub-element of
+# Encounter.participant optional: participant.type is 0..*, participant.individual
+# is 0..1, and a participation carrying only a period is legal. A minCount here
+# would fail conformant source data. The shape's value is in constraining
+# cardinality and datatype so that a participation cannot carry two names or two
+# specialties, which is where a merge of two records silently corrupts one.
+#
+# The node is NOT constrained to sh:nodeKind sh:IRI. Unlike clinical:Encounter,
+# nothing points at a participation from another file, so requiring an IRI would
+# forbid the blank node a serializer may reasonably write for a structural
+# sub-node.
+
+clinical:EncounterParticipantShape a sh:NodeShape ;
+    sh:targetClass clinical:EncounterParticipant ;
+    rdfs:label "Encounter Participant Shape"@en ;
+    rdfs:comment "Validation constraints for one participation in an encounter. Mirrors FHIR R4 Encounter.participant: constrains cardinality and datatype, and deliberately constrains neither the role vocabulary (extensibly bound at source) nor the presence of any single field (every sub-element is optional at source)."@en ;
+
+    sh:property [
+        sh:path clinical:participantName ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Participant Name"@en ;
+        sh:message "A participation names at most one individual, matching FHIR R4 Encounter.participant.individual 0..1"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:participantRole ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Participant Role"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Repeatable: Encounter.participant.type is 0..*.
+    sh:property [
+        sh:path clinical:participantRoleCode ;
+        sh:datatype xsd:string ;
+        sh:name "Participant Role Code"@en ;
+        sh:message "Each participant role code must be a string; no value set is enforced because FHIR R4 binds Encounter.participant.type extensibly"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path clinical:participantSpecialty ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Participant Specialty"@en ;
+        sh:severity sh:Violation
+    ] .
 
 # ============================================================================
 # Graph Edge Property Shapes (v1.10)

--- a/src/shapes/clinical.ttl
+++ b/src/shapes/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-08-14"^^xsd:date ;
-    owl:versionInfo "1.15" ;
+    dct:modified "2026-08-27"^^xsd:date ;
+    owl:versionInfo "1.16" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -326,8 +326,9 @@ clinical:seriesPanelMembership a owl:ObjectProperty ;
 
 clinical:providerName a owl:DatatypeProperty ;
     rdfs:label "Provider Name"@en ;
-    rdfs:comment "Insurance company or plan provider name."@en ;
-    rdfs:domain clinical:CoverageRecord ;
+    rdfs:comment """Name of the party a record names as its provider. On a clinical:CoverageRecord this is the insurance company or plan provider; on an encounter, a document or any other clinical record it is the responsible clinician or organization.
+
+DOMAIN DELIBERATELY ABSENT (v1.16). Through v1.15 this property declared rdfs:domain clinical:CoverageRecord while being written on every clinical record type this vocabulary defines and constrained on encounters by clinical:EncounterShape. An OWL reasoner reading that domain infers that every encounter and every document carrying a provider name IS a coverage record, which is false of the data and of the intent. The domain is therefore dropped rather than widened to a union, following the v1.11 treatment of clinical:indicationReference and matching clinical:sourceEHR, clinical:status, clinical:recordDate and clinical:sourceRecordId, which are cross-class in the same way and carry no domain either. Where the property means something specific to one class, that is stated in SHACL on that class's shape. No emitted triple changes and nothing that validated before stops validating."""@en ;
     rdfs:range xsd:string .
 
 clinical:memberId a owl:DatatypeProperty ;
@@ -420,6 +421,43 @@ clinical:fhirResourceId a owl:DatatypeProperty ;
 clinical:fhirResourceType a owl:DatatypeProperty ;
     rdfs:label "FHIR Resource Type"@en ;
     rdfs:comment "FHIR resource type (e.g., 'DiagnosticReport', 'Composition')"@en ;
+    rdfs:domain clinical:ClinicalDocument ;
+    rdfs:range xsd:string .
+
+# --- Document status, authorship and attestation (v1.16) --------------------
+#
+# A document carries TWO independent status facts and, separately, two
+# independent attribution facts. Through v1.15 each pair had one predicate, so
+# each pair's second member was dropped on import.
+
+clinical:documentReferenceStatus a owl:DatatypeProperty ;
+    rdfs:label "Document Reference Status"@en ;
+    rdfs:comment """Status of the REFERENCE to a document: whether this pod entry is the current pointer to the document, has been replaced by a later one, or was created in error. FHIR alignment: DocumentReference.status (1..1, required binding to https://hl7.org/fhir/R4/valueset-document-reference-status.html), values current | superseded | entered-in-error.
+
+DISTINCT FROM clinical:status, which on a document carries DocumentReference.docStatus, "the status of the underlying document" (required binding to composition-status: preliminary | final | amended | entered-in-error). FHIR keeps these as two elements because they answer different questions: a document can be a final, unamended clinical note (docStatus "final") whose reference has since been superseded by a corrected filing (status "superseded"). Folding them onto one predicate is not merely lossy, it is ambiguous in the one case where ambiguity is most costly: "entered-in-error" appears in BOTH value sets and means the reference was filed in error in one and the clinical content is repudiated in the other."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-document-reference-status.html> ;
+    rdfs:domain clinical:ClinicalDocument ;
+    rdfs:range xsd:string .
+
+clinical:documentAuthorName a owl:DatatypeProperty ;
+    rdfs:label "Document Author Name"@en ;
+    rdfs:comment """Name of a party responsible for the content of a document. FHIR alignment: DocumentReference.author, "identifies who is responsible for adding the information to the document", Reference(Practitioner | PractitionerRole | Organization | Device | Patient | RelatedPerson) 0..* (https://hl7.org/fhir/R4/documentreference-definitions.html#DocumentReference.author).
+
+REPEATABLE, 0..*, because the source element is. A note co-signed by a resident and an attending, or authored by a clinician and an organization, has two authors; through v1.15 the only predicate available was clinical:providerName, which clinical:ClinicalDocumentShape and the record shapes constrain to sh:maxCount 1, so every author after the first was discarded on import with nothing recording that it had happened.
+
+RELATION TO clinical:providerName. providerName is retained and unchanged: on a document it holds the single name an application displays as the responsible provider, and is written from the first author where a source has several. documentAuthorName holds every author the source stated, including that one. A consumer wanting the complete attribution reads documentAuthorName; a consumer wanting one display name may keep reading providerName."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/documentreference-definitions.html#DocumentReference.author> ;
+    rdfs:domain clinical:ClinicalDocument ;
+    rdfs:range xsd:string .
+
+clinical:authenticatorName a owl:DatatypeProperty ;
+    rdfs:label "Authenticator Name"@en ;
+    rdfs:comment """Name of the person or organization that ATTESTED a document: who signed it, as opposed to who wrote it. FHIR alignment: DocumentReference.authenticator, "which person or organization authenticates that this document is valid", Reference(Practitioner | PractitionerRole | Organization) 0..1 (https://hl7.org/fhir/R4/documentreference-definitions.html#DocumentReference.authenticator). The same fact is Composition.attester.party in a Composition and legalAuthenticator in a C-CDA header.
+
+Attestation is a different fact from authorship and is routinely a different person: a resident authors, an attending signs. Recording only the author loses the signature, which is the part of a note that carries clinical and legal weight; recording the authenticator as if it were an author asserts that the signer wrote the content, which the source did not say.
+
+NOT MODELLED THIS RELEASE: FHIR Composition.attester also carries a mode (personal | professional | legal | official, required binding) and a time (https://hl7.org/fhir/R4/composition-definitions.html#Composition.attester). Neither is added here, because DocumentReference — the resource both import paths actually read — carries a bare authenticator reference with no mode and no timestamp, and a predicate whose only possible value would be invented is worse than its absence. Add them when a Composition-reading path exists to populate them."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/documentreference-definitions.html#DocumentReference.authenticator> ;
     rdfs:domain clinical:ClinicalDocument ;
     rdfs:range xsd:string .
 
@@ -785,8 +823,19 @@ clinical:clinicalStatus a owl:DatatypeProperty ;
 
 clinical:verificationStatus a owl:DatatypeProperty ;
     rdfs:label "Verification Status"@en ;
-    rdfs:comment "Verification status (unconfirmed, provisional, differential, confirmed, refuted)"@en ;
-    rdfs:domain clinical:Condition ;
+    rdfs:comment """How certain the recording clinician is that the asserted finding is real. Permitted values depend on the record class and are constrained per-shape, not on this property.
+
+FHIR R4 sources, both required bindings:
+  Condition.verificationStatus          unconfirmed | provisional | differential |
+                                        confirmed | refuted | entered-in-error
+                                        https://hl7.org/fhir/R4/valueset-condition-ver-status.html
+  AllergyIntolerance.verificationStatus  unconfirmed | confirmed | refuted |
+                                        entered-in-error
+                                        https://hl7.org/fhir/R4/valueset-allergyintolerance-verification.html
+
+DOMAIN DELIBERATELY ABSENT (v1.16). Through v1.15 this property declared rdfs:domain clinical:Condition while an importer writes it on allergy records too, which is exactly what FHIR does: verificationStatus is an element of AllergyIntolerance as well as of Condition, and the two are different value sets over the same idea. The domain is dropped rather than widened to a union, for the reason given on clinical:providerName: a domain union on a cross-class predicate makes a reasoner infer that an allergy record is a Condition. Nothing is invented and no value changes meaning; the per-class value set belongs in SHACL, where the two bindings can differ."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-condition-ver-status.html> ,
+                 <https://hl7.org/fhir/R4/valueset-allergyintolerance-verification.html> ;
     rdfs:range xsd:string .
 
 clinical:icd10Code a owl:DatatypeProperty ;
@@ -1006,13 +1055,34 @@ clinical:performingLab a owl:DatatypeProperty ;
 
 clinical:observationStatus a owl:DatatypeProperty ;
     rdfs:label "Observation Status"@en ;
-    rdfs:comment "FHIR observation-status code: final, preliminary, amended, corrected, cancelled, entered-in-error. See http://hl7.org/fhir/observation-status"@en ;
-    rdfs:domain clinical:LabResult ;
-    rdfs:range xsd:string .
+    rdfs:comment """FHIR R4 observation-status code (https://hl7.org/fhir/R4/valueset-observation-status.html).
+
+DEPRECATED in clinical v1.16: use clinical:status, which is the domain-free status carrier every import path already writes, and whose per-class FHIR value sets are bound by SHACL from v1.16 on.
+
+Retired rather than re-domained, and the reason is worth stating so it is not reversed by mistake. This property was defined in v1.4 with rdfs:domain clinical:LabResult, a class deprecated in v1.13 in favour of health:LabResultRecord and which no import path emits; it is bound by no shape and written by no converter. Re-domaining it onto health:LabResultRecord would give an Observation-derived record TWO status predicates with the same FHIR source element behind both, which is the ambiguity this release exists to remove, not a second place to look. Retained, not removed, on the same terms as the four classes deprecated in v1.13: any pod that happens to carry it stays valid and readers must continue to accept it."""@en ;
+    rdfs:range xsd:string ;
+    owl:deprecated true ;
+    rdfs:seeAlso clinical:status ;
+    owl:versionInfo "Deprecated in clinical v1.16; superseded by clinical:status" .
 
 clinical:sourceRecordId a owl:DatatypeProperty ;
     rdfs:label "Source Record ID"@en ;
-    rdfs:comment "FHIR resource identifier from the source system for traceability"@en ;
+    rdfs:comment """The LOGICAL id the source system assigned the resource this record was converted from: FHIR Resource.id (https://hl7.org/fhir/R4/resource.html#id), or the equivalent row identifier of another transport. Server-assigned, opaque, and stable only within the system that issued it.
+
+This is NOT a business identifier. FHIR draws the distinction explicitly: Resource.id is "the logical id of the resource, as used in the URL", while .identifier carries "business identifiers assigned to this resource by the performer or other systems" (https://hl7.org/fhir/R4/datatypes.html#Identifier). The two id spaces do not join: one system's logical id for a visit and another system's business identifier for the same visit are different strings, and the same string in the two spaces means nothing in common. Write a business identifier to clinical:businessIdentifier, added in v1.16 for exactly this reason."""@en ;
+    rdfs:seeAlso clinical:businessIdentifier ;
+    rdfs:range xsd:string .
+
+clinical:businessIdentifier a owl:DatatypeProperty ;
+    rdfs:label "Business Identifier"@en ;
+    rdfs:comment """An identifier the source system publishes for the real-world thing a record describes, as opposed to the server row it happens to live in. FHIR alignment: the .identifier element (Identifier 0..*) carried by every FHIR resource, https://hl7.org/fhir/R4/datatypes.html#Identifier. On an encounter this is Encounter.identifier, "identifier(s) by which this encounter is known" (https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.identifier), which US Core marks Must Support on its Encounter profile (https://hl7.org/fhir/us/core/StructureDefinition-us-core-encounter.html); a visit or contact serial number is the ordinary value.
+
+REPEATABLE, 0..*, because the source element is. A resource that publishes three identifiers has three, and keeping only one discards the very value another transport may key on.
+
+VALUE FORM. Where the source states an Identifier.system, the value is written as the FHIR token form "{system}|{value}" (https://hl7.org/fhir/R4/search.html#token), which is the ratified way to write a system-qualified identifier as one string and is what makes two identifiers comparable across transports without a side table. Where the source states no system, the bare value is written. An implementation MUST NOT invent a system.
+
+WHY IT IS SEPARATE FROM clinical:sourceRecordId. Through v1.15 a converter had one predicate for both id spaces, so a consumer reading a value could not tell whether it held a server row id or a business identifier, and reconciling two transports on it either compared unrelated strings or refused to compare related ones. The two are now distinct predicates because they are distinct facts. Domain is deliberately absent: the source element exists on every FHIR resource, so restricting it to encounters would be false in the same way the domains corrected elsewhere in v1.16 were false."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#Identifier> ;
     rdfs:range xsd:string .
 
 clinical:panelMembership a owl:ObjectProperty ;
@@ -1352,6 +1422,79 @@ clinical:isActive a owl:DatatypeProperty ;
 # Changelog
 # ============================================================================
 #
+# Version 1.16 (2026-08-27)
+# - FIFTEEN new terms (14 properties and 1 class), two domains dropped, one
+#   property deprecated, and the
+#   first per-class value sets on clinical:status. Everything here comes from a
+#   field-coverage measurement against real R4 exports: each term below is a
+#   source element that a conformant server sends and this vocabulary had
+#   nowhere to put, so an importer dropped it. Every term cites the FHIR R4
+#   element it mirrors by canonical URL; nothing is invented.
+# - ENCOUNTER (9 terms). clinical:encounterReason (Encounter.reasonCode 0..*,
+#   preferred binding, US Core Must Support); clinical:admitSource and
+#   clinical:dischargeDisposition (Encounter.hospitalization.admitSource /
+#   .dischargeDisposition, the only structured signal separating an admission
+#   from an office visit, and dischargeDisposition is US Core Must Support);
+#   clinical:encounterClassDisplay and clinical:encounterClassSystem, which
+#   restore the other two parts of the Encounter.class Coding — the code stays
+#   in clinical:encounterClass for round-trip, and because the binding is only
+#   extensible a local code such as "5" is unreadable and unmappable without
+#   its display and system. And the participation structure:
+#   clinical:EncounterParticipant (new class), clinical:hasParticipant,
+#   clinical:participantName, clinical:participantRole,
+#   clinical:participantRoleCode, clinical:participantSpecialty. FHIR models
+#   participation as a repeating BackboneElement carrying a role AND an
+#   individual, and US Core marks all three Must Support; the rejected
+#   alternative, a flat family of role-qualified predicates, cannot represent
+#   two participants in one role and silently drops the local role codes an
+#   extensible binding permits. The full argument is above the class.
+# - IDENTITY (1 term). clinical:businessIdentifier, domain-free and repeatable,
+#   for the .identifier element every FHIR resource carries; on an encounter,
+#   Encounter.identifier (US Core Must Support). clinical:sourceRecordId keeps
+#   its meaning and now states it: the server-assigned LOGICAL id
+#   (Resource.id). FHIR draws this distinction explicitly and the two id spaces
+#   do not join, so one predicate holding both made a stored value
+#   uninterpretable. MIGRATION: a converter that has been writing a business
+#   identifier to clinical:sourceRecordId must move it; the two predicates are
+#   not interchangeable and a reader cannot repair the confusion after the
+#   fact.
+# - DOCUMENTS (3 terms). clinical:documentReferenceStatus for
+#   DocumentReference.status (current | superseded | entered-in-error), which
+#   is a different assertion from the docStatus clinical:status carries — the
+#   code "entered-in-error" is in BOTH value sets and means different things in
+#   each, so sharing one predicate was ambiguous exactly where ambiguity costs
+#   most. clinical:authenticatorName for DocumentReference.authenticator: who
+#   SIGNED a document, routinely not who wrote it. clinical:documentAuthorName,
+#   repeatable, for DocumentReference.author 0..*; clinical:providerName is
+#   sh:maxCount 1 on the document shapes, so every author past the first was
+#   discarded. providerName is retained and unchanged as the single display
+#   name.
+# - DOMAINS DROPPED (2). clinical:providerName declared rdfs:domain
+#   clinical:CoverageRecord while being written on every clinical record type,
+#   and clinical:verificationStatus declared rdfs:domain clinical:Condition
+#   while FHIR carries verificationStatus on AllergyIntolerance as well. Both
+#   domains are dropped rather than widened to a union, following the v1.11
+#   treatment of clinical:indicationReference: a union on a cross-class
+#   predicate makes a reasoner infer that an allergy record is a Condition.
+#   Vocabulary-correctness only; no shape encoded either domain, so no pod is
+#   affected.
+# - DEPRECATED (1). clinical:observationStatus, owl:deprecated true,
+#   superseded by clinical:status. Defined in v1.4 with rdfs:domain
+#   clinical:LabResult — a class deprecated in v1.13 that no path emits — bound
+#   by no shape and written by no converter. Retired rather than re-domained:
+#   re-domaining would give an Observation-derived record two status predicates
+#   with one FHIR element behind both, which is the ambiguity this release
+#   removes. Retained not removed, on the v1.13 terms.
+# - SHACL. clinical:status gains per-class FHIR value sets on the shapes whose
+#   records carry it, all at sh:Warning per the core v3.5 ratchet; new
+#   clinical:EncounterParticipantShape; the new encounter, identifier and
+#   document properties declared on their shapes. Detail in
+#   clinical.shapes.ttl's own changelog.
+# - COMPATIBILITY. Additive and strictly widening. Every graph that validated
+#   under v1.15 validates under v1.16 at the same severity, with new findings
+#   at sh:Warning only. No class or property is removed or renamed, and the one
+#   deprecation removes nothing.
+#
 # Version 1.15 (2026-08-14)
 # - ONE new property, clinical:interpretationSourceCode: the source's verbatim
 #   interpretation code, written only when that code is a member of neither
@@ -1629,7 +1772,57 @@ clinical:encounterClass a owl:DatatypeProperty ;
     rdfs:domain clinical:Encounter ;
     rdfs:range xsd:string ;
     rdfs:label "Encounter Class"@en ;
-    rdfs:comment "Values: ambulatory, emergency, inpatient, home-health"@en .
+    rdfs:comment """The CODE of Encounter.class, verbatim as the source sent it. FHIR R4 Encounter.class is a Coding, 1..1, bound extensibly to the v3-ActCode ActEncounterCode value set (https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.class), so a conformant server may send AMB, EMER, IMP, HH — or a local code from its own system. Both are stored here unchanged, because the code is what a round-trip export must put back.
+
+A local code is not readable on its own. From v1.16 the accompanying Coding.display goes to clinical:encounterClassDisplay and the Coding.system to clinical:encounterClassSystem, so a value like "5" can be read as what it says it is and can be recognised as not being an ActEncounterCode. Writers SHOULD emit all three when the source states them."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.class> .
+
+clinical:encounterClassDisplay a owl:DatatypeProperty ;
+    rdfs:domain clinical:Encounter ;
+    rdfs:range xsd:string ;
+    rdfs:label "Encounter Class Display"@en ;
+    rdfs:comment """Human-readable display of Encounter.class, verbatim from Coding.display, "a representation of the meaning of the code in the system, following the rules of the system" (https://hl7.org/fhir/R4/datatypes.html#Coding).
+
+Added in v1.16 alongside, never instead of, clinical:encounterClass. The code stays because it is what a round-trip export must restore and what a code-system lookup keys on; the display is stored because where the code comes from a local system, and Encounter.class is bound only extensibly so it often does, the code alone is unreadable and unmappable. This mirrors the Coding datatype rather than choosing between its parts."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#Coding> .
+
+clinical:encounterClassSystem a owl:DatatypeProperty ;
+    rdfs:domain clinical:Encounter ;
+    rdfs:range xsd:anyURI ;
+    rdfs:label "Encounter Class System"@en ;
+    rdfs:comment """The code system Encounter.class's code is drawn from, verbatim from Coding.system: "the identification of the code system that defines the meaning of the symbol in the code" (https://hl7.org/fhir/R4/datatypes.html#Coding). Typically http://terminology.hl7.org/CodeSystem/v3-ActCode, or a urn:oid: URI where the source used a local system.
+
+Stored because it is the only thing that distinguishes a ratified ActEncounterCode from a locally-numbered category that happens to look like one. Without it a consumer cannot tell whether a stored class code is safe to map."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#Coding> .
+
+clinical:encounterReason a owl:DatatypeProperty ;
+    rdfs:domain clinical:Encounter ;
+    rdfs:range xsd:string ;
+    rdfs:label "Encounter Reason"@en ;
+    rdfs:comment """Why the visit happened, in the chart's own words. FHIR alignment: Encounter.reasonCode, "reason the encounter takes place, expressed as a code", CodeableConcept 0..*, preferred binding to https://hl7.org/fhir/R4/valueset-encounter-reason.html (https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.reasonCode). US Core marks it Must Support on its Encounter profile (https://hl7.org/fhir/us/core/StructureDefinition-us-core-encounter.html).
+
+Value is CodeableConcept.text where the source states it, otherwise the first coding's display: the reason as written, not a normalization of it. REPEATABLE, 0..*, because the source element is.
+
+NO VALUE SET is bound to this property or its shape. The FHIR binding is PREFERRED, the weakest binding that still names a value set, and real exports carry local, free-text and SNOMED CT reasons in the same field. An enum here would reject conformant data. Where a coded reason resolves to a record already in the pod, clinical:indicationReference / clinical:parsedIndicationReference carry the traversable edge; this property carries what the source said."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.reasonCode> .
+
+clinical:admitSource a owl:DatatypeProperty ;
+    rdfs:domain clinical:Encounter ;
+    rdfs:range xsd:string ;
+    rdfs:label "Admit Source"@en ;
+    rdfs:comment """Where the patient came from before this encounter. FHIR alignment: Encounter.hospitalization.admitSource, "from where patient was admitted (physician referral, transfer)", CodeableConcept 0..1, preferred binding to https://hl7.org/fhir/R4/valueset-encounter-admit-source.html (https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.hospitalization.admitSource).
+
+Value is CodeableConcept.text or the first coding's display, verbatim. Presence of an Encounter.hospitalization element is itself the structured signal that an encounter was an admission rather than an office visit, and through v1.15 this vocabulary had nowhere to put it, so that distinction was unrecoverable from the pod. No value set is bound, for the reason given on clinical:encounterReason: the FHIR binding is preferred, not required."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.hospitalization.admitSource> .
+
+clinical:dischargeDisposition a owl:DatatypeProperty ;
+    rdfs:domain clinical:Encounter ;
+    rdfs:range xsd:string ;
+    rdfs:label "Discharge Disposition"@en ;
+    rdfs:comment """Where the patient went after this encounter. FHIR alignment: Encounter.hospitalization.dischargeDisposition, "category or kind of location after discharge", CodeableConcept 0..1 (https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.hospitalization.dischargeDisposition). The R4 base binding is EXAMPLE strength; US Core marks the element Must Support and binds it preferred to its own USEncounterDischargeDisposition value set (https://hl7.org/fhir/us/core/StructureDefinition-us-core-encounter.html).
+
+Value is CodeableConcept.text or the first coding's display, verbatim: "Home or Self Care", "Non-Healthcare Facility Point of Origin". No value set is bound here, and an example-strength binding is the clearest possible case for not binding one."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.hospitalization.dischargeDisposition> .
 
 clinical:encounterStatus a owl:DatatypeProperty ;
     rdfs:domain clinical:Encounter ;
@@ -1657,6 +1850,87 @@ clinical:facilityName a owl:DatatypeProperty ;
     rdfs:domain clinical:Encounter ;
     rdfs:range xsd:string ;
     rdfs:label "Facility Name"@en .
+
+# ============================================================================
+# New Class: clinical:EncounterParticipant
+# Added in v1.16 — supports FHIR Encounter.participant conversion
+# ============================================================================
+#
+# WHY A STRUCTURED NODE RATHER THAN ROLE-QUALIFIED PREDICATES
+# ----------------------------------------------------------
+# FHIR R4 models participation as Encounter.participant, a BackboneElement 0..*
+# holding a type (CodeableConcept 0..*, extensibly bound to
+# https://hl7.org/fhir/R4/valueset-encounter-participant-type.html) and an
+# individual (Reference(Practitioner | PractitionerRole | RelatedPerson) 0..1).
+# US Core marks participant, participant.type and participant.individual all
+# Must Support on its Encounter profile. The standard's own shape is a repeating
+# structure precisely because a name means something different depending on the
+# role attached to it, and the pairing is what carries the meaning.
+#
+# The alternative considered and rejected was a family of role-qualified flat
+# predicates on the Encounter itself (an attending name, a referrer name, and so
+# on). It fails on both axes of the real data: the role vocabulary is
+# EXTENSIBLE, so any fixed family of predicates silently drops the local roles a
+# server is entitled to send; and a visit routinely carries several participants
+# in the SAME role, which a one-predicate-per-role scheme cannot represent
+# without reintroducing the maxCount-1 loss it was meant to fix.
+#
+# The node deliberately holds the participant's DISPLAY NAME rather than a
+# reference to a Practitioner record. This vocabulary defines no practitioner
+# class, and inventing one to hold a display string would be a larger claim than
+# the source supports; the exports these records are converted from carry
+# participant.individual.display and nothing resolvable behind it.
+#
+# Modelled with no rdfs:subClassOf, matching clinical:ClinicalSection and
+# clinical:ClinicalNarrative, the other structural sub-nodes in this vocabulary.
+# A participation is not an entity in the PROV sense and is not asserted to be
+# one.
+
+clinical:EncounterParticipant a owl:Class ;
+    rdfs:label "Encounter Participant"@en ;
+    rdfs:comment "One participation in an encounter: a named person together with the role they played in that visit, and their specialty where the source states it. Mirrors the FHIR R4 Encounter.participant BackboneElement (https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.participant). Attached to the encounter with clinical:hasParticipant."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.participant> .
+
+clinical:hasParticipant a owl:ObjectProperty ;
+    rdfs:domain clinical:Encounter ;
+    rdfs:range clinical:EncounterParticipant ;
+    rdfs:label "Has Participant"@en ;
+    rdfs:comment "Links an encounter to one of its participations. REPEATABLE, 0..*, matching FHIR R4 Encounter.participant. An encounter commonly carries an attender, a referrer and an authorizing physician at once, and which of them actually saw the patient is only answerable if all of them are kept with their roles attached."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.participant> .
+
+clinical:participantName a owl:DatatypeProperty ;
+    rdfs:domain clinical:EncounterParticipant ;
+    rdfs:range xsd:string ;
+    rdfs:label "Participant Name"@en ;
+    rdfs:comment "Display name of the person who participated, verbatim from Encounter.participant.individual.display (Reference(Practitioner | PractitionerRole | RelatedPerson) 0..1). A display name, not a resolvable reference: see the note above this class for why no practitioner record is minted."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.participant.individual> .
+
+clinical:participantRole a owl:DatatypeProperty ;
+    rdfs:domain clinical:EncounterParticipant ;
+    rdfs:range xsd:string ;
+    rdfs:label "Participant Role"@en ;
+    rdfs:comment "Human-readable role this participant played in the encounter, from Encounter.participant.type CodeableConcept.text or the first coding's display: \"attender\", \"referrer\", \"consultant\". The label is what makes a stored name interpretable; a name recorded with no role is indistinguishable from a treating clinician's and cannot be corrected by a reader."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/encounter-definitions.html#Encounter.participant.type> .
+
+clinical:participantRoleCode a owl:DatatypeProperty ;
+    rdfs:domain clinical:EncounterParticipant ;
+    rdfs:range xsd:string ;
+    rdfs:label "Participant Role Code"@en ;
+    rdfs:comment """Coded role from Encounter.participant.type, verbatim. FHIR R4 binds this element EXTENSIBLY to https://hl7.org/fhir/R4/valueset-encounter-participant-type.html, which draws twelve concepts from two code systems: http://terminology.hl7.org/CodeSystem/v3-ParticipationType (ATND attender, PPRF primary performer, SPRF secondary performer, CON consultant, ADM admitter, DIS discharger, REF referrer, CALLBCK, ESC, PART) and http://terminology.hl7.org/CodeSystem/participant-type (translator, emergency).
+
+REPEATABLE, 0..*, because Encounter.participant.type is. NO sh:in is bound, in either direction: the binding is extensible, so a server may send a local role code and remain conformant, and rejecting one would discard the participant along with it."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-encounter-participant-type.html> .
+
+clinical:participantSpecialty a owl:DatatypeProperty ;
+    rdfs:domain clinical:EncounterParticipant ;
+    rdfs:range xsd:string ;
+    rdfs:label "Participant Specialty"@en ;
+    rdfs:comment """The clinical specialty this participant acted in during the encounter, as a display string: \"Dermatology\", \"Sleep Medicine\".
+
+STANDARDS BASIS. The specialty of a practitioner acting in a particular role is FHIR R4 PractitionerRole.specialty, CodeableConcept 0..*, preferred binding to https://hl7.org/fhir/R4/valueset-c80-practice-codes.html (https://hl7.org/fhir/R4/practitionerrole-definitions.html#PractitionerRole.specialty). That is the element whose semantics this property mirrors. It is recorded on the participation rather than on a practitioner because specialty in FHIR is a property of the ROLE, not of the person: the same clinician has different specialties in different roles, and it is the one they acted in on this visit that describes the visit.
+
+Servers commonly convey it on Encounter.participant as an extension rather than by resolving a PractitionerRole, which is why the value is carried here as a string rather than as an edge. No value set is bound: the source binding is preferred, and exports carry local specialty labels."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/practitionerrole-definitions.html#PractitionerRole.specialty> .
 
 # ============================================================================
 # New Class: clinical:MedicationAdministration

--- a/src/shapes/core.shapes.ttl
+++ b/src/shapes/core.shapes.ttl
@@ -7,13 +7,13 @@
 # ============================================================================
 # Cascade Protocol -- Core Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.6 (2026-08-14)
+# Version: 1.7 (2026-08-27)
 # Validates: cascade:PatientProfile, cascade:Address, cascade:EmergencyContact,
 #            cascade:PharmacyInfo, cascade:AdvanceDirectives, cascade:ProxyAgent,
 #            cascade:ExportManifest, cascade:RecordSummary,
-#            cascade:InteractionScenario, and the values of
-#            cascade:sourceIdentity and cascade:dataAbsentReason wherever
-#            they appear
+#            cascade:InteractionScenario, cascade:Attachment, and the values of
+#            cascade:sourceIdentity, cascade:dataAbsentReason and
+#            cascade:hasAttachment wherever they appear
 #
 # Severity levels:
 #   sh:Violation -- Must fix (blocks operations)
@@ -700,8 +700,211 @@ cascade:DataAbsentReasonShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Attachment (core v3.7)
+# ============================================================================
+#
+# WHAT IS REQUIRED, AND WHY EXACTLY THESE THREE
+# ---------------------------------------------
+# An attachment node exists to let a consumer find bytes and know it found the
+# right ones. Three facts are what that takes, and each is a Violation because
+# without any one of them the node does not do its job:
+#   - cascade:attachmentPath, or there is nothing to open;
+#   - cascade:contentHash, or nothing distinguishes the right bytes from any
+#     other bytes at that path;
+#   - cascade:hashAlgorithm, or the digest cannot be recomputed and so cannot be
+#     checked, which makes the second requirement decorative.
+# This is the whole of the Violation set. A media type is sh:Warning: a stored
+# document with no stated type is awkward to render but not lost, and a missing
+# one must not invalidate the record that points at it.
+#
+# THE PATH CONSTRAINT IS A SAFETY CONSTRAINT, NOT A TIDINESS ONE
+# --------------------------------------------------------------
+# The pattern is stated POSITIVELY, as a sequence of "/"-separated segments each
+# of which begins with an alphanumeric and continues in the character set
+# pod-structure.md section 7.2 already requires of a Pod filename. Written that
+# way it excludes, by construction and without any lookahead, the three things
+# that must not appear: a leading "/" (absolute), a "://" (a URL, since ":" is
+# outside the set), and a ".." or "." segment (a segment must start with an
+# alphanumeric).
+#
+# Stating it positively is not a stylistic choice. SHACL evaluates sh:pattern
+# with XPath fn:matches, whose regular expression language is XSD 1.1 and has NO
+# lookahead assertion, so a "reject these three things" pattern is not
+# expressible here at all and an engine that happened to accept one would be
+# applying its host language's regex rather than the specification's.
+#
+# The exclusions matter. An absolute path or a file: URL breaks the moment a Pod
+# is copied or re-rooted, which Pods routinely are. A ".." segment is worse than
+# broken: it makes an attachment reference a way to read a file outside the Pod,
+# so a consumer that resolves paths naively can be walked out of the store by
+# data. Rejecting it in the shape means the check exists once, here, rather than
+# in every consumer that remembers to write it.
+#
+# THE DIGEST FORM IS CONSTRAINED BECAUSE IT IS ALSO A FILENAME
+# ------------------------------------------------------------
+# Lowercase hex, at least 32 characters. Uppercase and base64 are rejected not
+# on taste but because this string names a file: base64's alphabet contains "/"
+# and its case-sensitivity is unsafe on a case-insensitive filesystem, and two
+# spellings of one digest would defeat the deduplication that content addressing
+# exists to provide. The length floor rejects a truncated or placeholder digest
+# without pinning the algorithm, which cascade:hashAlgorithm names explicitly.
+#
+# NO sh:in ON THE ALGORITHM. RFC 6920's registry gains entries over time and an
+# enum here would have to be revised to accept a stronger hash, which is the
+# wrong direction for a constraint whose whole purpose is to let the algorithm
+# be replaced. The pattern accepts a registry-shaped token; core.ttl states that
+# new implementations write sha-256.
+#
+# Severity note: these are Violations rather than Warnings and no ratchet is
+# being skipped. The core v3.5 ratchet governs REQUIRING a property that
+# existing data could not have carried. Nothing here is required of an existing
+# record: cascade:AttachmentShape evaluates only nodes typed cascade:Attachment,
+# a class no pod written before v3.7 contains.
+
+cascade:AttachmentShape a sh:NodeShape ;
+    sh:targetClass cascade:Attachment ;
+    rdfs:label "Attachment Shape"@en ;
+    rdfs:comment "Validation constraints for the metadata node describing a binary document stored in a Pod. Requires what it takes to find the bytes and verify them: a pod-relative path, a digest, and the algorithm the digest was computed with."@en ;
+
+    sh:property [
+        sh:path cascade:attachmentPath ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*)*$" ;
+        sh:name "Attachment Path"@en ;
+        sh:message "cascade:attachmentPath must be exactly one pod-relative path whose segments each begin with an alphanumeric and use only [a-zA-Z0-9._-], the character set pod-structure.md requires of Pod filenames. That form excludes an absolute path, a URL, and any '..' segment: the first two break when a Pod is copied, and the third lets an attachment reference read a file outside the Pod."@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:contentHash ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9a-f]{32,}$" ;
+        sh:name "Content Hash"@en ;
+        sh:message "cascade:contentHash must be exactly one lowercase hexadecimal digest of at least 32 characters, with no algorithm prefix. Uppercase hex and base64 are rejected because this value is also the file's name: base64 contains '/' and is case-sensitive, and two spellings of one digest defeat content addressing."@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:hashAlgorithm ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[a-z0-9][a-z0-9-]*$" ;
+        sh:name "Hash Algorithm"@en ;
+        sh:message "cascade:hashAlgorithm must be exactly one token from the IANA Named Information Hash Algorithm Registry (RFC 6920), such as 'sha-256'. It is not enumerated here because the registry grows and this property exists precisely so the algorithm can be replaced."@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # Media type: the FORM of the value is a Violation (two media types on one
+    # set of bytes is a defect, and a value that is not type/subtype is not a
+    # media type), while its PRESENCE is only a Warning, checked separately
+    # below so the two severities are unambiguous.
+    sh:property [
+        sh:path cascade:attachmentMediaType ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:pattern "^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*$" ;
+        sh:name "Attachment Media Type"@en ;
+        sh:message "cascade:attachmentMediaType must be a single IANA media type in RFC 6838 type/subtype form, for example 'application/pdf'"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:byteSize ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Byte Size"@en ;
+        sh:message "cascade:byteSize must be a single non-negative integer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:attachmentTitle ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Attachment Title"@en ;
+        sh:message "cascade:attachmentTitle must be a single string"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# Presence of a media type, kept in its own shape so its severity is
+# unambiguous: this is sh:Warning while every constraint in
+# cascade:AttachmentShape above is sh:Violation. Stored bytes with no stated
+# type are awkward to render but not lost, so a missing one must not invalidate
+# the record that points at them.
+cascade:AttachmentMediaTypeShape a sh:NodeShape ;
+    sh:targetClass cascade:Attachment ;
+    rdfs:label "Attachment Media Type Shape"@en ;
+    sh:property [
+        sh:path cascade:attachmentMediaType ;
+        sh:minCount 1 ;
+        sh:name "Attachment Media Type"@en ;
+        sh:message "An attachment should state its media type; without one, the only way to render the stored bytes is guesswork"@en ;
+        sh:severity sh:Warning
+    ] .
+
+# Open-world edge shape, matching the clinical: record-to-record edge shapes:
+# targets the subjects that USE the predicate, so nothing fires unless the edge
+# is present, asserts no minCount, and reports at sh:Warning.
+#
+# Deliberately NO sh:class on the object, for the reason clinical v1.11 recorded
+# when it removed one: Cascade pods store records partitioned into per-type
+# files and the reference validator validates each file independently, so an
+# edge whose target lives in a sibling file could never satisfy sh:class and the
+# constraint would produce a warning on every well-formed edge and none on a
+# malformed one. sh:nodeKind sh:IRI is retained, because an attachment must be
+# addressable from the file that points at it.
+cascade:HasAttachmentEdgeShape a sh:PropertyShape ;
+    sh:targetSubjectsOf cascade:hasAttachment ;
+    sh:path cascade:hasAttachment ;
+    sh:nodeKind sh:IRI ;
+    sh:severity sh:Warning ;
+    sh:message "cascade:hasAttachment should reference a cascade:Attachment by IRI, so that the record and the attachment can live in different files"@en ;
+    sh:name "Has Attachment Edge"@en .
+
+# ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.7 (2026-08-27)
+# - Added cascade:AttachmentShape, cascade:AttachmentMediaTypeShape and
+#   cascade:HasAttachmentEdgeShape for the core v3.7 attachment vocabulary.
+# - AttachmentShape requires exactly the three facts without which an
+#   attachment node cannot do its job, at sh:Violation: the pod-relative path,
+#   the digest, and the algorithm the digest was computed with. The third is
+#   what makes the second checkable rather than decorative.
+# - The path pattern is stated POSITIVELY, as "/"-separated segments each
+#   beginning with an alphanumeric in the character set pod-structure.md
+#   section 7.2 already requires of Pod filenames. That form excludes an
+#   absolute path, a URL and any ".." segment by construction. It is not
+#   written as an exclusion because SHACL evaluates sh:pattern with XPath
+#   fn:matches, whose XSD 1.1 regular expressions have no lookahead; a
+#   "reject these" pattern would only work on engines applying their host
+#   language's regex instead of the specification's.
+# - The digest is constrained to lowercase hex of at least 32 characters,
+#   because the value is also a filename: base64 contains "/" and is
+#   case-sensitive, and two spellings of one digest defeat the deduplication
+#   content addressing exists to provide. The algorithm carries a
+#   registry-shaped pattern and NO sh:in — RFC 6920's registry grows, and an
+#   enum would have to be revised to accept a stronger hash, which is the wrong
+#   direction for a property whose purpose is to let the algorithm be replaced.
+# - Media type is split across two shapes so the severities are unambiguous:
+#   its FORM (single value, RFC 6838 type/subtype) is a Violation, its PRESENCE
+#   only a Warning in AttachmentMediaTypeShape. Bytes with no stated type are
+#   awkward to render, not lost.
+# - HasAttachmentEdgeShape is open-world (sh:targetSubjectsOf, sh:Warning,
+#   sh:nodeKind sh:IRI, no minCount) and carries NO sh:class, for the reason
+#   clinical v1.11 recorded when it removed one: per-file validation makes a
+#   cross-file sh:class produce warnings only on well-formed edges.
+# - No ratchet is skipped by the Violations here. The core v3.5 ratchet governs
+#   REQUIRING something existing data could not have carried; AttachmentShape
+#   evaluates only nodes typed cascade:Attachment, a class no pod written
+#   before v3.7 contains.
 #
 # Version 1.6 (2026-08-14)
 # - Added DataAbsentReasonShape for core v3.6's cascade:dataAbsentReason.

--- a/src/shapes/core.ttl
+++ b/src/shapes/core.ttl
@@ -19,8 +19,8 @@
     dct:description "Core vocabulary for schema versioning, data provenance, identity management, and patient demographics across all Cascade Protocol applications"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-10-31"^^xsd:date ;
-    dct:modified "2026-08-14"^^xsd:date ;
-    owl:versionInfo "3.6" ;
+    dct:modified "2026-08-27"^^xsd:date ;
+    owl:versionInfo "3.7" ;
     rdfs:comment "This vocabulary defines cross-cutting concepts used by all Cascade Protocol health data applications: schema versioning, data provenance, patient demographics (PatientProfile), and supporting identity classes (Address, PharmacyInfo, AdvanceDirectives). Domain-specific vocabularies (e.g., pots:, ecg:, glucose:) import this core vocabulary."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/core/v1.0/> .
 
@@ -812,6 +812,53 @@ WHAT THIS IS NOT. It is not an interpretation, and it is not a substitute for on
 
 # ============================================================================
 # Changelog
+#
+# Version 3.7 (2026-08-27)
+# - Defined pod attachments: one class and seven properties for binary
+#   documents stored alongside a Pod's RDF. cascade:Attachment,
+#   cascade:hasAttachment, cascade:attachmentPath,
+#   cascade:attachmentMediaType, cascade:contentHash, cascade:hashAlgorithm,
+#   cascade:byteSize, cascade:attachmentTitle. The class mirrors the FHIR R4
+#   Attachment datatype and each property cites the element it mirrors; the
+#   companion pod layout is normative in pod-structure.md section 4.3.
+# - THE BYTES ARE A FILE, NOT A LITERAL. FHIR permits either, via
+#   Attachment.data (inline base64) or Attachment.url. Cascade takes the second
+#   because a Pod is not a message: Turtle files here are parse-critical, read
+#   in full by every consumer to answer any question, so an unbounded base64
+#   literal is paid for by readers that will never look at the attachment. The
+#   Turtle carries a small metadata node and the bytes live as an ordinary
+#   file, which the retained sources/ directory already establishes as a shape
+#   a Pod can have.
+# - THE FILE NAME IS THE DIGEST. Content addressing is not a storage
+#   optimisation here, it is what makes the metadata checkable: a consumer
+#   hashes what it read and compares it with where it read it from, and nothing
+#   has to be trusted to keep name and content in agreement. Deduplication
+#   across sources and idempotent re-import follow from it without a mechanism.
+#   The name carries the digest and nothing else, because a media type or an
+#   extension in the name would be a second claim about the same bytes that
+#   nothing verifies; the media type is stated in RDF instead.
+# - THE ALGORITHM IS NAMED, AND IS NOT FHIR'S. Attachment.hash fixes SHA-1 and
+#   base64 in the specification. Neither is followed. SHA-1 is collision-broken
+#   and a collision in a content-addressed store is a mechanism for one
+#   document to silently replace another, so cascade:hashAlgorithm carries an
+#   explicit IANA Named Information Hash Algorithm Registry token (RFC 6920)
+#   and sha-256 is required of new implementations. The digest is lowercase hex
+#   rather than base64 because it is also a filename, and base64's alphabet
+#   includes "/" and is case-sensitive.
+# - IMPLEMENTATION-DEFINED THIS RELEASE, stated so it is a decision and not an
+#   omission: encryption at rest for attachment files, and how the directory
+#   participates in Pod sync. An implementation may encrypt these files by
+#   whatever means it already encrypts a Pod; this vocabulary says nothing
+#   about it, so nothing here is revised when a ratified answer arrives.
+# - SHACL: cascade:AttachmentShape and cascade:HasAttachmentEdgeShape
+#   (core.shapes.ttl 1.6 to 1.7). The node shape requires the three facts an
+#   attachment is useless without, at sh:Violation: the path, the digest and
+#   the algorithm. Its media type is sh:Warning, because a stored document with
+#   no stated media type is still recoverable and a missing one must not
+#   invalidate the record. The edge shape is open-world, sh:targetSubjectsOf.
+# - COMPATIBILITY. Purely additive. Both shapes evaluate only nodes that carry
+#   the new terms, so every pod written before v3.7 validates exactly as it did.
+#   No class or property was removed, renamed or deprecated.
 #
 # Version 3.6 (2026-08-14)
 # - Added cascade:dataAbsentReason (owl:DatatypeProperty, domain owl:Thing,
@@ -1647,3 +1694,134 @@ cascade:loincCode a owl:ObjectProperty ;
     rdfs:comment "LOINC reference for an observation, as an IRI."@en ;
     rdfs:seeAlso <http://loinc.org/> ;
     owl:versionInfo "Added in core v3.4" .
+
+# ============================================================================
+# Attachments (v3.7)
+# ============================================================================
+#
+# A clinical record frequently POINTS AT a document that is not RDF: the PDF a
+# DiagnosticReport was rendered as, the scanned page behind a DocumentReference.
+# Until v3.7 a Pod had nowhere to put those bytes, so the pointer was kept and
+# the content was not, and a record that says "the report is at this URL" stops
+# being answerable the moment the URL stops resolving or the session that could
+# fetch it ends.
+#
+# WHY BYTES GO IN A FILE AND NOT IN THE TURTLE
+# --------------------------------------------
+# FHIR's Attachment datatype permits either: Attachment.data carries base64
+# bytes inline, Attachment.url points at them
+# (https://hl7.org/fhir/R4/datatypes.html#Attachment). A Pod is not a message,
+# and the trade is different here. Turtle files in a Pod are parse-critical:
+# every consumer reads them in full to answer any question, so an unbounded
+# base64 literal is paid for by every reader on every query, including the ones
+# that will never look at the attachment. Bytes therefore live as ordinary files
+# and the Turtle carries a small metadata node. The retained sources/ directory
+# is the existing precedent for non-Turtle content in a Pod.
+#
+# WHY THE FILES ARE CONTENT-ADDRESSED
+# -----------------------------------
+# The file's name IS its digest, so the name is verifiable against the bytes and
+# nothing else has to be trusted to keep them in agreement. Three properties
+# follow from that and none of them needs a mechanism: the same document
+# arriving from two sources is stored once; re-importing is idempotent without a
+# dedupe pass; and a consumer can tell whether the bytes it holds are the ones
+# the metadata describes. A media type or an extension in the filename would be
+# a second, unverifiable claim about the same bytes, so the name carries only
+# the digest and the media type is stated in RDF.
+#
+# The layout, the digest form and the directory are normative in
+# pod-structure.md section 4.3. In summary: attachments/{algorithm}/{digest},
+# with the digest lowercase hex and no extension.
+#
+# HASH ALGORITHM: DELIBERATELY NOT FHIR'S
+# ---------------------------------------
+# FHIR R4 Attachment.hash is "the calculated hash of the data using SHA-1,
+# represented using base64". Cascade deliberately does not follow it. SHA-1 is
+# collision-broken, and a collision in a content-addressed store is not a
+# theoretical concern about signatures but a mechanism by which one document
+# silently overwrites another. The algorithm is therefore named explicitly in
+# cascade:hashAlgorithm, using a token registry FHIR has no equivalent of, and
+# sha-256 is required of new implementations.
+#
+# DELIBERATELY OUT OF SCOPE THIS RELEASE
+# --------------------------------------
+# Encryption at rest for attachment files, and how an attachment directory
+# participates in Pod sync, are IMPLEMENTATION-DEFINED in v3.7. Both are real
+# and both are deferred rather than forgotten: an implementation may encrypt
+# these files by whatever means it already encrypts a Pod, and this vocabulary
+# states nothing about it, so nothing here has to be revised when a ratified
+# answer arrives.
+
+cascade:Attachment a owl:Class ;
+    rdfs:label "Attachment"@en ;
+    rdfs:comment "Metadata for a binary document stored alongside a Pod's RDF: its media type, its content digest, and the pod-relative location of the bytes. Mirrors the FHIR R4 Attachment datatype (https://hl7.org/fhir/R4/datatypes.html#Attachment), with the bytes held as a content-addressed file rather than inline. Attached to the record it renders with cascade:hasAttachment."@en ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#Attachment> ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:hasAttachment a owl:ObjectProperty ;
+    rdfs:label "Has Attachment"@en ;
+    rdfs:comment """Links a record to a cascade:Attachment holding a binary rendering of it. FHIR alignment: DiagnosticReport.presentedForm (Attachment 0..*, "rich text representation of the entire result as issued by the diagnostic service", https://hl7.org/fhir/R4/diagnosticreport-definitions.html#DiagnosticReport.presentedForm) and DocumentReference.content.attachment (https://hl7.org/fhir/R4/documentreference-definitions.html#DocumentReference.content).
+
+REPEATABLE, because both source elements are: one report legitimately has a PDF and an HTML rendering of the same content.
+
+The domain is intentionally broad, any record that can be rendered as a document, so it is left unrestricted here and constrained by SHACL, matching clinical:hasEncounter and the other cross-class edges in these vocabularies. The range IS committed, because unlike a clinical reference this edge always points at a node this vocabulary defines."""@en ;
+    rdfs:range cascade:Attachment ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/diagnosticreport-definitions.html#DiagnosticReport.presentedForm> ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:attachmentPath a owl:DatatypeProperty ;
+    rdfs:label "Attachment Path"@en ;
+    rdfs:comment """Location of the bytes, as a path relative to the Pod root: for example "attachments/sha-256/3f786850e387550fdab836ed7e6dc881de23001b". FHIR alignment: Attachment.url, "a location where the data can be accessed".
+
+RELATIVE, NEVER ABSOLUTE. A Pod is copied, exported and re-rooted, and an absolute path or a file: URL breaks on the first of those. A path that leaves the Pod (any segment equal to "..") is malformed rather than merely discouraged: it turns an attachment reference into a way to read a file the Pod does not contain.
+
+This is not the URL the bytes were originally fetched from. Where that matters it is ordinary provenance and belongs on the attachment as prov:wasDerivedFrom, not in this property."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/datatypes.html#Attachment> ;
+    rdfs:domain cascade:Attachment ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:attachmentMediaType a owl:DatatypeProperty ;
+    rdfs:label "Attachment Media Type"@en ;
+    rdfs:comment """IANA media type of the bytes, for example "application/pdf" or "text/html". FHIR alignment: Attachment.contentType, "identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data". Registered names and syntax are RFC 6838 (https://www.rfc-editor.org/rfc/rfc6838); the same fact is what DCAT states with dcat:mediaType (https://www.w3.org/TR/vocab-dcat-3/), which takes an IRI rather than the literal FHIR and this property carry.
+
+Stated in RDF rather than in the file name, because the file name is the digest and must stay verifiable against the bytes. A media type in a filename is a claim nothing checks."""@en ;
+    rdfs:seeAlso <https://www.rfc-editor.org/rfc/rfc6838> ;
+    rdfs:domain cascade:Attachment ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:contentHash a owl:DatatypeProperty ;
+    rdfs:label "Content Hash"@en ;
+    rdfs:comment """Digest of the attachment bytes, LOWERCASE HEXADECIMAL, with no algorithm prefix and no separator. The algorithm is stated separately in cascade:hashAlgorithm, and this value is byte-for-byte the file's name under attachments/{algorithm}/, which is what makes the store verifiable: a consumer hashes what it read and compares it with where it read it from.
+
+Lowercase hex rather than the base64 FHIR uses for Attachment.hash, because this value is also a filename: base64's alphabet includes "/" and its case-sensitivity is unsafe on a case-insensitive filesystem. A single canonical spelling also means two Pods holding the same document hold the same string, which is the whole point of addressing by content."""@en ;
+    rdfs:domain cascade:Attachment ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:hashAlgorithm a owl:DatatypeProperty ;
+    rdfs:label "Hash Algorithm"@en ;
+    rdfs:comment """Algorithm cascade:contentHash was computed with, named by its token in the IANA Named Information Hash Algorithm Registry (RFC 6920, https://www.rfc-editor.org/rfc/rfc6920): "sha-256", "sha-512". New implementations MUST write "sha-256".
+
+Stated rather than assumed. An unlabelled digest cannot be verified by a consumer that does not already know how it was produced, and cannot be migrated when an algorithm weakens without rewriting every reference; naming it makes both a matter of reading one triple. This is also why FHIR's Attachment.hash is not followed: it fixes SHA-1 in the specification, and a collision-capable digest in a content-addressed store is a mechanism for one document to silently replace another."""@en ;
+    rdfs:seeAlso <https://www.rfc-editor.org/rfc/rfc6920> ;
+    rdfs:domain cascade:Attachment ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:byteSize a owl:DatatypeProperty ;
+    rdfs:label "Byte Size"@en ;
+    rdfs:comment "Size of the attachment in bytes. FHIR alignment: Attachment.size, \"the number of bytes of data that make up this attachment (before base64 encoding, if that is done)\"; the same quantity DCAT states with dcat:byteSize. Recorded so a consumer can decide whether to read a file before opening it, and so a truncated copy is detectable without rehashing."@en ;
+    rdfs:seeAlso <https://www.w3.org/TR/vocab-dcat-3/> ;
+    rdfs:domain cascade:Attachment ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.7" .
+
+cascade:attachmentTitle a owl:DatatypeProperty ;
+    rdfs:label "Attachment Title"@en ;
+    rdfs:comment "Label to show in place of the bytes, verbatim from the source. FHIR alignment: Attachment.title, \"a label or set of text to display in place of the data\". Without it the only thing a reader can display for an attachment is a digest."@en ;
+    rdfs:domain cascade:Attachment ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.7" .

--- a/src/shapes/coverage.shapes.ttl
+++ b/src/shapes/coverage.shapes.ttl
@@ -82,6 +82,33 @@ coverage:InsurancePlanShape a sh:NodeShape ;
         sh:severity sh:Violation
     ] ;
 
+    # v1.2: coverage:status — FHIR R4 Coverage.status, required binding to
+    # https://hl7.org/fhir/R4/valueset-fm-status.html, verbatim.
+    #
+    # The VALUE is a Violation while coverage:coverageType's value, two
+    # constraints above, is only a Warning. The two are not inconsistent: FHIR
+    # binds Coverage.type EXTENSIBLY, where a payer may conformantly send a code
+    # from outside the value set, and binds Coverage.status REQUIRED, where it
+    # may not. The severity follows the binding strength of the element the data
+    # is converted from, which is the rule coverage v1.4 established here.
+    #
+    # PRESENCE is deliberately NOT required, although the source element is
+    # 1..1. This property is new in coverage v1.5 and no pod contains it, so a
+    # minCount would turn every existing plan record red for a property no
+    # producer has yet had the chance to write — the exact failure the core v3.5
+    # ratchet exists to prevent. Add sh:minCount 1 at sh:Warning once producers
+    # emit it, and raise to sh:Violation only after a release in which that
+    # warning is observably absent from conforming output.
+    sh:property [
+        sh:path coverage:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("active" "cancelled" "draft" "entered-in-error") ;
+        sh:name "Status"@en ;
+        sh:message "Coverage status must be one of the FHIR R4 fm-status codes: active, cancelled, draft, entered-in-error"@en ;
+        sh:severity sh:Violation
+    ] ;
+
     # ------------------------------------------------------------------
     # WARNING (sh:Warning) — Important for coverage verification
     # ------------------------------------------------------------------
@@ -273,6 +300,15 @@ coverage:CoverageTypeVocabularyShape a sh:NodeShape ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.2 (2026-08-27) — coverage v1.5
+# - coverage:InsurancePlanShape declares coverage:status, bound to the four
+#   fm-status codes FHIR R4 requires of Coverage.status: active, cancelled,
+#   draft, entered-in-error. Value at sh:Violation, because that binding is
+#   REQUIRED and because no pod has ever carried the property, so the constraint
+#   cannot invalidate existing data. Presence deliberately not required this
+#   version; the ratchet to minCount is stated at the constraint.
+# - Additive. Nothing that validated under v1.1 fails under v1.2.
 #
 # Version 1.1 (2026-08-08) — coverage v1.4
 # - coverage:subscriberRelationship: the sh:in list is now the HL7

--- a/src/shapes/coverage.ttl
+++ b/src/shapes/coverage.ttl
@@ -18,8 +18,8 @@
     dct:description "Domain vocabulary for patient-owned insurance, benefits, and financial health data. Layer 2 vocabulary resolving the overlap between checkup:InsuranceInfo (patient-reported) and clinical:CoverageRecord (EHR-imported) with a unified, standardized representation."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-02-18"^^xsd:date ;
-    dct:modified "2026-08-08"^^xsd:date ;
-    owl:versionInfo "1.4" ;
+    dct:modified "2026-08-27"^^xsd:date ;
+    owl:versionInfo "1.5" ;
     rdfs:comment "Insurance and benefits data is cross-cutting: not clinical (it's administrative/financial), not app-specific (any health app benefits from knowing coverage), and contributed by both patient self-report and EHR import. This vocabulary provides a single Layer 2 domain model that both checkup: (Layer 3, patient-reported) and clinical: (Layer 2, EHR-imported) can reference via the mixed namespace pattern. Recommended Pod storage path: /coverage/"@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/coverage/v1/> .
 
@@ -176,6 +176,29 @@ coverage:rxGroup a owl:DatatypeProperty ;
 #   rdfs:seeAlso mappings to HL7 ClaimResponse.adjudication and CARIN IG adjudication codes.
 #
 # v1.2 (2026-03-16): Added coverage:DenialNotice class, coverage:AppealRecord class, and 11 new properties for denial/appeal workflow.
+#
+# Version 1.5 (2026-08-27)
+# - ONE new property, coverage:status, for FHIR R4 Coverage.status: a code,
+#   1..1 at source, REQUIRED binding to
+#   https://hl7.org/fhir/R4/valueset-fm-status.html — active | cancelled |
+#   draft | entered-in-error. Through v1.4 coverage:InsurancePlan had no status
+#   property at all, so the one element FHIR requires a Coverage resource to
+#   carry had nowhere to go. coverage:claimStatus and
+#   coverage:adjudicationStatus were not substitutes: they belong to the
+#   denial/appeal workflow and describe a claim, not whether a plan is in force.
+#   FHIR marks Coverage.status a modifier element, which is the reason this is
+#   not a nice-to-have: a cancelled plan read as an active one is a wrong answer
+#   to "am I covered", not a missing one.
+# - SHACL (coverage.shapes.ttl 1.1 to 1.2): the VALUE is constrained at
+#   sh:Violation, because the FHIR binding is required and no pod has ever
+#   carried this property, so a constraint here cannot invalidate existing data.
+#   PRESENCE is deliberately not required in this version: no producer has yet
+#   had the chance to write it, and a minCount would turn every existing plan
+#   record red for something nobody could have supplied. The ratchet is the one
+#   core v3.5 wrote down — presence at sh:Warning once producers emit it, then
+#   sh:Violation after a release in which that warning is observably absent.
+# - COMPATIBILITY. Additive. Every graph that validated under v1.4 validates
+#   under v1.5 unchanged.
 #
 # Version 1.4 (2026-08-08)
 # - SHACL only; no class or property added, removed or renamed.
@@ -380,6 +403,21 @@ coverage:relatedClaim a owl:ObjectProperty ;
     rdfs:range coverage:ClaimRecord ;
     rdfs:label "Related Claim"@en ;
     rdfs:comment "Links an ExplanationOfBenefit to its corresponding Claim."@en .
+
+# ============================================================================
+# v1.5 InsurancePlan Properties
+# ============================================================================
+
+coverage:status a owl:DatatypeProperty ;
+    rdfs:label "Status"@en ;
+    rdfs:comment """Lifecycle state of the coverage record itself: whether the plan is in force, was cancelled, is still a draft, or was entered in error. FHIR alignment: Coverage.status, code 1..1, REQUIRED binding to https://hl7.org/fhir/R4/valueset-fm-status.html, values active | cancelled | draft | entered-in-error (https://hl7.org/fhir/R4/coverage-definitions.html#Coverage.status). FHIR marks the element a modifier: a cancelled or erroneous Coverage must not be read as describing coverage the patient has.
+
+Through v1.4 this vocabulary had no status property for coverage:InsurancePlan at all, so an importer reading a conformant Coverage resource had to discard the one element FHIR requires it to carry. coverage:claimStatus and coverage:adjudicationStatus are not substitutes: their domains are coverage:DenialNotice and the claim workflow, and they describe what happened to a claim, not whether the plan is in force.
+
+DISTINCT FROM coverage:effectiveStart / coverage:effectiveEnd. A date range says when the plan is meant to apply; the status says what the payer currently asserts about the record. A plan whose effective period has not ended can still be cancelled, and a plan can be drafted before any period is stated."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-fm-status.html> ;
+    rdfs:domain coverage:InsurancePlan ;
+    rdfs:range xsd:string .
 
 # ============================================================================
 # v1.2 DenialNotice Properties

--- a/src/shapes/health.shapes.ttl
+++ b/src/shapes/health.shapes.ttl
@@ -9,7 +9,7 @@
 # ============================================================================
 # Cascade Protocol — Health & Wellness Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.4 (2026-08-14)
+# Version: 1.5 (2026-08-27)
 # Validates: health:SelfReport, health:VO2MaxStatistics, health:HRVStatistics,
 #            health:BPStatistics, health:MetricTrend, health:ActivitySnapshot,
 #            health:SleepSnapshot, health:HealthProfile,
@@ -25,7 +25,35 @@
 # - sh:Warning = Should address (important for completeness) - e.g., missing period
 # - sh:Info = Nice to have (suggested enrichment) - e.g., optional context fields
 #
-# Validates against: health.ttl v2.6 (2026-08-08)
+# Validates against: health.ttl v2.8 (2026-08-27)
+#
+# CHANGELOG
+# v1.5 (2026-08-27): Bind the status a health: record already carries.
+#     Shapes-only, additive, and every new finding is at sh:Warning.
+#
+#     Three property shapes, on two existing node shapes, for two predicates in
+#     the clinical: namespace. The namespace is not a mistake: clinical:status
+#     and clinical:verificationStatus are the domain-free carriers both import
+#     paths write onto these records, and minting health: spellings for them
+#     would give one fact two predicates.
+#
+#     1. health:LabResultRecordShape declares clinical:status with the 8 codes
+#        of FHIR R4 Observation.status, required binding, verbatim.
+#     2. health:AllergyRecordShape declares clinical:status with the 3 codes of
+#        FHIR R4 AllergyIntolerance.clinicalStatus. Three, not four:
+#        "entered-in-error" belongs to the verification axis, and admitting it
+#        here would merge "no longer reacts" with "never real".
+#     3. health:AllergyRecordShape declares clinical:verificationStatus with
+#        the 4 codes of FHIR R4 AllergyIntolerance.verificationStatus. The
+#        allergy set has no "provisional" or "differential"; that Condition
+#        carries two codes an allergy does not is why clinical v1.16 dropped
+#        that property's rdfs:domain rather than widening it.
+#
+#     All three at sh:Warning, per the core v3.5 ratchet: existing pods carry
+#     these predicates and this is the first release to bind their values, so a
+#     value outside the set is reported and never rejected. Raise to
+#     sh:Violation only after a release in which the warning is observably
+#     absent from conforming output.
 # ============================================================================
 
 # ============================================================================
@@ -956,6 +984,33 @@ health:LabResultRecordShape a sh:NodeShape ;
         sh:severity sh:Violation
     ] ;
 
+    # v1.5: clinical:status on a health: record, declared here because this is
+    # where the shape for this class lives.
+    #
+    # A lab result record is converted from a FHIR Observation, so the value set
+    # is Observation.status, required binding, verbatim and in the value set's
+    # own order (https://hl7.org/fhir/R4/valueset-observation-status.html).
+    # Naming the codes matters beyond conformance: "amended" and "corrected"
+    # are what distinguish a superseded result from the one that replaced it,
+    # and a record whose status is unchecked cannot be trusted to make that
+    # distinction.
+    #
+    # The predicate is clinical:, not health:, and that is deliberate: it is the
+    # domain-free status carrier both import paths already write, and minting a
+    # health: spelling for it would give one fact two predicates. sh:Warning per
+    # the core v3.5 ratchet, since existing pods carry this predicate and this
+    # is the first release to bind its value.
+    sh:property [
+        sh:path clinical:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("registered" "preliminary" "final" "amended" "corrected"
+               "cancelled" "entered-in-error" "unknown") ;
+        sh:name "Status"@en ;
+        sh:message "Lab result status should be one of the FHIR R4 ObservationStatus codes: registered, preliminary, final, amended, corrected, cancelled, entered-in-error, unknown"@en ;
+        sh:severity sh:Warning
+    ] ;
+
     sh:property [
         sh:path health:performedDate ;
         sh:or ( [ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] ) ;
@@ -1253,6 +1308,51 @@ health:AllergyRecordShape a sh:NodeShape ;
         sh:name "Schema Version"@en ;
         sh:message "Allergy must declare exactly one schemaVersion in major.minor form"@en ;
         sh:severity sh:Violation
+    ] ;
+
+    # v1.5: clinical:status on an allergy record carries FHIR R4
+    # AllergyIntolerance.clinicalStatus, required binding to
+    # http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical:
+    # active | inactive | resolved
+    # (https://hl7.org/fhir/R4/valueset-allergyintolerance-clinical.html).
+    #
+    # THREE codes, not four. "entered-in-error" belongs to
+    # AllergyIntolerance.verificationStatus, a different element with a
+    # different value set, which this vocabulary carries on
+    # clinical:verificationStatus. Admitting it here would merge "the patient no
+    # longer reacts to this" with "this allergy was never real", which are
+    # opposite clinical facts and the one pair a safety-relevant record must
+    # never conflate.
+    #
+    # sh:Warning per the core v3.5 ratchet: existing pods carry this predicate
+    # and this is the first release to bind its value.
+    sh:property [
+        sh:path clinical:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("active" "inactive" "resolved") ;
+        sh:name "Status"@en ;
+        sh:message "Allergy clinical status should be one of the FHIR R4 AllergyIntolerance clinical status codes: active, inactive, resolved. A repudiated record is entered-in-error on clinical:verificationStatus, which is a different element"@en ;
+        sh:severity sh:Warning
+    ] ;
+
+    # v1.5: clinical:verificationStatus on an allergy record. FHIR R4
+    # AllergyIntolerance.verificationStatus, required binding, verbatim
+    # (https://hl7.org/fhir/R4/valueset-allergyintolerance-verification.html).
+    # FOUR codes: the allergy value set does not contain the "provisional" and
+    # "differential" that Condition.verificationStatus carries, because a
+    # differential diagnosis is not a thing one has about an allergy. This is
+    # why clinical v1.16 dropped that property's rdfs:domain clinical:Condition
+    # rather than widening it: the two classes bind the same predicate to two
+    # different value sets, which is a SHACL job and not an rdfs:domain one.
+    sh:property [
+        sh:path clinical:verificationStatus ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("unconfirmed" "confirmed" "refuted" "entered-in-error") ;
+        sh:name "Verification Status"@en ;
+        sh:message "Allergy verification status should be one of the FHIR R4 AllergyIntolerance verification status codes: unconfirmed, confirmed, refuted, entered-in-error"@en ;
+        sh:severity sh:Warning
     ] .
 
 # ============================================================================

--- a/src/shapes/health.ttl
+++ b/src/shapes/health.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for consumer-generated wellness observations from wearable devices and HealthKit. Maps Cascade wellness properties to established SNOMED CT and LOINC codes following the three-layer ontology architecture."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-01-29"^^xsd:date ;
-    dct:modified "2026-08-14"^^xsd:date ;
-    owl:versionInfo "2.7" ;
+    dct:modified "2026-08-27"^^xsd:date ;
+    owl:versionInfo "2.8" ;
     rdfs:comment """Three-layer ontology for wellness data:
         Layer 1 (Established standards): SNOMED CT concept IDs + LOINC observation codes
         Layer 2 (Cascade health vocabulary): health: namespace properties linking to Layer 1
@@ -30,6 +30,28 @@
     rdfs:seeAlso <https://cascadeprotocol.org/docs/health/v1/> .
 
 # Changelog:
+# v2.8 (2026-08-27): SHACL only; no class or property added, removed, renamed
+#     or deprecated in this file. Two health: record shapes gain the value sets
+#     for a status their records already carry. Summarised here because the
+#     version number lives in this file; full detail in health.shapes.ttl v1.5.
+#
+#     health:LabResultRecordShape declares clinical:status bound to the 8 codes
+#     of FHIR R4 Observation.status. health:AllergyRecordShape declares
+#     clinical:status bound to the 3 codes of AllergyIntolerance.clinicalStatus
+#     and clinical:verificationStatus bound to the 4 codes of
+#     AllergyIntolerance.verificationStatus. Through v2.7 an importer wrote
+#     these predicates onto these records and no shape declared them, so the
+#     value sets were unenforced and validation passed in silence.
+#
+#     The predicates stay in the clinical: namespace deliberately. They are the
+#     domain-free carriers both import paths already write; a health: spelling
+#     would give one fact two predicates, which is the defect health v2.5 spent
+#     a release removing. Paired with clinical v1.16, which drops the
+#     rdfs:domain that made clinical:verificationStatus look Condition-only.
+#
+#     All three constraints are sh:Warning, per the core v3.5 ratchet. Nothing
+#     that validated under v2.7 stops validating.
+#
 # v2.7 (2026-08-14): Let a source's absence and a source's unrecognised code
 #     both survive import. Additive: one new property, one widened value set,
 #     and nothing that validated under v2.6 stops validating.

--- a/tests/encounter-business-identifier-match.test.ts
+++ b/tests/encounter-business-identifier-match.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The encounter match key moves to `clinical:businessIdentifier`, and no pod is
+ * stranded doing it.
+ *
+ * WHAT IS BEING MIGRATED, AND WHY IT IS DELICATE
+ * ----------------------------------------------
+ * A visit's identifier is written twice, in two different spellings:
+ *
+ *   clinical:businessIdentifier   FHIR token form, `{system}|{value}`, system
+ *                                 VERBATIM. Canonical from clinical v1.16.
+ *   cascade:sourceRecordId        colon form, `{system}:{value}`, `urn:oid:`
+ *                                 stripped. FROZEN — the C-CDA path has always
+ *                                 written this shape, and re-spelling it in
+ *                                 place would unjoin every encounter pair
+ *                                 already matched on it.
+ *
+ * So ONE identifier is TWO unequal strings. The whole risk of this migration is
+ * that a matcher comparing across the forms fails silently in both directions:
+ * it finds no match where one exists (`urn:oid:1.2.3|X` against `1.2.3:X`), and
+ * it can find a match where none exists (a system-less token-form value that
+ * happens to contain a colon, read as a colon-form `system:value`). Neither
+ * shows up as an error; both show up as a pod that is quietly wrong about how
+ * many visits a person had.
+ *
+ * THE RULE, STATED ONCE: values are compared only against values from the SAME
+ * predicate, in that predicate's own form, and no code path converts between the
+ * forms. These cases hold that rule from the outside — through
+ * `runReconciliation`, not against the private matcher — so they keep holding if
+ * the internals are rearranged.
+ *
+ * THREE POPULATIONS COEXIST during the transition and each is a case below:
+ * records written after this release (both predicates), records written by a pod
+ * repaired before it (frozen predicate only), and one of each. All three must
+ * converge, which is the reason the frozen predicate is still dual-written.
+ *
+ * All data is synthetic and PHI-free; the identifier OIDs are in the example-use
+ * `.999.` arc.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+import { runReconciliation } from '../src/lib/reconciler.js';
+
+const CLINICAL = 'https://ns.cascadeprotocol.org/clinical/v1#';
+const CASCADE = 'https://ns.cascadeprotocol.org/core/v1#';
+const ENCOUNTER_TYPE = CLINICAL + 'Encounter';
+
+const PREFIXES = `@prefix cascade: <${CASCADE}> .
+@prefix clinical: <${CLINICAL}> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+`;
+
+const OID = '1.2.840.114350.1.13.999.2.7.3.698084.8';
+const CSN = '20100000001';
+/** The same identifier, in each predicate's own form. */
+const TOKEN_FORM = `urn:oid:${OID}|${CSN}`;
+const COLON_FORM = `${OID}:${CSN}`;
+
+interface EncounterOpts {
+  subject: string;
+  system: string;
+  /** Value for `clinical:businessIdentifier`, omitted for a pre-v1.16 record. */
+  businessIdentifier?: string;
+  /** Value for the frozen `cascade:sourceRecordId`, omitted to test in isolation. */
+  legacyIdentifier?: string;
+}
+
+function encounter(o: EncounterOpts): string {
+  const lines = [
+    `<${o.subject}> a clinical:Encounter`,
+    `  cascade:sourceSystem "${o.system}"`,
+    `  cascade:sourceIdentity "org:northgate"`,
+    `  cascade:dataProvenance cascade:EHRVerified`,
+    `  cascade:schemaVersion "1.0"`,
+    `  clinical:encounterType "Office Visit"`,
+    `  clinical:encounterStart "2025-04-01T16:00:00Z"^^xsd:dateTime`,
+  ];
+  if (o.businessIdentifier) lines.push(`  clinical:businessIdentifier "${o.businessIdentifier}"`);
+  if (o.legacyIdentifier) lines.push(`  cascade:sourceRecordId "${o.legacyIdentifier}"`);
+  return `${lines.join(' ;\n')} .\n`;
+}
+
+async function encounterSubjectCount(...docs: string[]): Promise<number> {
+  const result = await runReconciliation(
+    docs.map((content, i) => ({ content: PREFIXES + content, systemName: `sys-${i}` })),
+  );
+  const quads = new Parser().parse(result.turtle);
+  return new Set(
+    quads
+      .filter((q) => q.predicate.value.endsWith('22-rdf-syntax-ns#type') && q.object.value === ENCOUNTER_TYPE)
+      .map((q) => q.subject.value),
+  ).size;
+}
+
+describe('the canonical predicate is a match key', () => {
+  it('two records sharing only a businessIdentifier are one visit', async () => {
+    // The migration's whole point. Neither record states the frozen predicate,
+    // so before this change nothing joined them and the pod held two visits.
+    const count = await encounterSubjectCount(
+      encounter({ subject: 'urn:uuid:11111111-1111-5111-8111-111111111111', system: 'fhir-pull', businessIdentifier: TOKEN_FORM }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', businessIdentifier: TOKEN_FORM }),
+    );
+    expect(count).toBe(1);
+  });
+
+  it('two records with DIFFERENT businessIdentifiers stay two visits', async () => {
+    const count = await encounterSubjectCount(
+      encounter({ subject: 'urn:uuid:11111111-1111-5111-8111-111111111111', system: 'fhir-pull', businessIdentifier: TOKEN_FORM }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', businessIdentifier: `urn:oid:${OID}|20100000999` }),
+    );
+    expect(count).toBe(2);
+  });
+
+  it('identifier SETS need only intersect, because the element is 0..*', async () => {
+    // A resource publishing three identifiers has three, and a transport keying
+    // on the second of them must still join.
+    const a = `<urn:uuid:11111111-1111-5111-8111-111111111111> a clinical:Encounter ;
+  cascade:sourceSystem "fhir-pull" ;
+  cascade:sourceIdentity "org:northgate" ;
+  cascade:dataProvenance cascade:EHRVerified ;
+  cascade:schemaVersion "1.0" ;
+  clinical:businessIdentifier "urn:oid:1.2.3|OTHER" ;
+  clinical:businessIdentifier "${TOKEN_FORM}" .
+`;
+    const count = await encounterSubjectCount(
+      a,
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', businessIdentifier: TOKEN_FORM }),
+    );
+    expect(count).toBe(1);
+  });
+});
+
+describe('the frozen predicate still matches, so no repaired pod is stranded', () => {
+  it('two pre-v1.16 records sharing only cascade:sourceRecordId are still one visit', async () => {
+    // The compatibility read. These records were written before this release and
+    // will keep arriving from any pod not yet re-imported.
+    const count = await encounterSubjectCount(
+      encounter({ subject: 'urn:uuid:11111111-1111-5111-8111-111111111111', system: 'fhir-pull', legacyIdentifier: COLON_FORM }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', legacyIdentifier: COLON_FORM }),
+    );
+    expect(count).toBe(1);
+  });
+
+  it('a post-release record joins a pre-release one through the frozen predicate', async () => {
+    // The mixed population, and the reason `cascade:sourceRecordId` is still
+    // dual-written rather than retired in this change: the canonical predicate
+    // alone would have nothing on the old record to intersect with.
+    const count = await encounterSubjectCount(
+      encounter({
+        subject: 'urn:uuid:11111111-1111-5111-8111-111111111111',
+        system: 'fhir-pull',
+        businessIdentifier: TOKEN_FORM,
+        legacyIdentifier: COLON_FORM,
+      }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', legacyIdentifier: COLON_FORM }),
+    );
+    expect(count).toBe(1);
+  });
+});
+
+describe('the two forms are never compared against each other', () => {
+  it('the token form and the colon form of ONE identifier do not join across predicates', async () => {
+    // This is the case a pooled-bag matcher gets wrong in the direction that
+    // looks like success: the identifiers ARE the same visit, but each record
+    // states it on a different predicate in a different form, and there is no
+    // sound way to recover one form from the other. The honest answer is two
+    // subjects and no invented merge — which is exactly why converters
+    // DUAL-EMIT rather than switching predicates, so this situation does not
+    // arise from this codebase's own output.
+    const count = await encounterSubjectCount(
+      encounter({ subject: 'urn:uuid:11111111-1111-5111-8111-111111111111', system: 'fhir-pull', businessIdentifier: TOKEN_FORM }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', legacyIdentifier: COLON_FORM }),
+    );
+    expect(count).toBe(2);
+  });
+
+  it('a colon-shaped token-form value does not join a colon-form value that reads the same', async () => {
+    // The other direction, and the dangerous one. `Encounter.identifier` with no
+    // system is written BARE in token form, so a bare value that happens to
+    // contain a colon renders identically to a colon-form `system:value` — and
+    // they are unrelated identifiers. A matcher that split on separators or
+    // pooled the forms would merge two different visits here.
+    const count = await encounterSubjectCount(
+      encounter({ subject: 'urn:uuid:11111111-1111-5111-8111-111111111111', system: 'fhir-pull', businessIdentifier: 'ACME:4471' }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export', legacyIdentifier: 'ACME:4471' }),
+    );
+    expect(count).toBe(2);
+  });
+
+  it('an encounter stating no identifier at all still never merges', async () => {
+    // Unchanged by the migration, and restated because it is the property that
+    // stops "Office Visit on 2025-04-01" from collapsing two genuinely separate
+    // visits. Absence of a join key is not evidence of a match.
+    const count = await encounterSubjectCount(
+      encounter({ subject: 'urn:uuid:11111111-1111-5111-8111-111111111111', system: 'fhir-pull' }),
+      encounter({ subject: 'urn:uuid:22222222-2222-5222-8222-222222222222', system: 'ccda-export' }),
+    );
+    expect(count).toBe(2);
+  });
+});

--- a/tests/encounter-participant-identity.test.ts
+++ b/tests/encounter-participant-identity.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Encounter participation nodes get their IRIs from one door, and that door is
+ * deterministic.
+ *
+ * WHY THIS SUITE EXISTS AT ALL
+ * ----------------------------
+ * This is the first structured SUB-NODE the FHIR converter mints — every other
+ * subject it writes is a record whose IRI comes from the source's own id — and
+ * a sub-node has no id of its own to key on. That is exactly the situation in
+ * which this repository has, three separate times, minted an identity from
+ * something that was not the record's content: a clock, a counter, a random
+ * value, an array index. The consequence is the same every time and it is
+ * silent: re-importing one document produces a second identity for each node,
+ * so nothing reconciles and the pod grows on every sync.
+ *
+ * The cure that worked before was not fixing sites, it was a chokepoint.
+ * `encounterParticipantUri` is the chokepoint; this file is the proof that it
+ * holds, and `tests/identity-chokepoint.test.ts` is the fence that stops a
+ * second way in from being added.
+ *
+ * WHAT IS PROVEN, IN ORDER OF STRENGTH
+ * ------------------------------------
+ *   1. The IRI is a function of the encounter IRI and the participation's own
+ *      stated content, and of NOTHING else — proven positively (change a fact,
+ *      the IRI moves) and negatively (change the array order or a non-emitted
+ *      neighbouring element, the IRI does not).
+ *   2. Re-conversion is idempotent, so a second import of the same source adds
+ *      no subject. This is the property the re-import repair path rests
+ *      on, checked here through `runReconciliation` rather than by inspecting
+ *      converter output twice.
+ *   3. Two SEPARATE PROCESSES, run from two DIFFERENT working directories,
+ *      against the BUILT artifact in `dist/`, agree byte for byte. An
+ *      in-process determinism check shares a module cache, a module-level
+ *      random seed and one `process.cwd()`, so a defect keyed on any of those
+ *      is invisible to it — which is precisely how the path-dependent VCF IRI
+ *      defect stayed green for months.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+
+import { convertEncounter } from '../src/lib/fhir-converter/converters-clinical.js';
+import { runReconciliation } from '../src/lib/reconciler.js';
+import { NS, quadsToTurtle } from '../src/lib/fhir-converter/types.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+const HAVE_DIST = fs.existsSync(path.join(DIST, 'lib', 'fhir-converter', 'fhir-to-cascade.js'));
+
+const RDF_TYPE = NS.rdf + 'type';
+const PARTICIPANT_CLASS = NS.clinical + 'EncounterParticipant';
+const PARTICIPANT_NAME = NS.clinical + 'participantName';
+
+type Quadish = {
+  subject: { value: string };
+  predicate: { value: string };
+  object: { value: string };
+};
+type Converted = { _quads: Quadish[] };
+
+/**
+ * The measured Epic shape: a referrer in slot 0, the treating attender with a
+ * specialty extension in slot 1.
+ */
+function encounterResource(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    resourceType: 'Encounter',
+    id: 'enc-derm-1',
+    status: 'finished',
+    class: { system: 'urn:oid:1.2.840.114350.1.72.1.7.1', code: '5', display: 'Appointment' },
+    identifier: [{ system: 'urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.8', value: '20100000001' }],
+    participant: [
+      {
+        type: [{ text: 'referrer', coding: [{ code: 'REF', display: 'referrer' }] }],
+        individual: { display: 'Lucia Marsh, MD' },
+      },
+      {
+        type: [{ text: 'attender', coding: [{ code: 'ATND', display: 'attender' }] }],
+        extension: [
+          {
+            url: 'https://vendor.example/fhir/StructureDefinition/participant-specialty',
+            valueCodeableConcept: { text: 'Dermatology' },
+          },
+        ],
+        individual: { display: 'Amara Okoye, MD' },
+      },
+    ],
+    period: { start: '2025-04-01T16:00:00Z', end: '2025-04-01T16:40:00Z' },
+    ...overrides,
+  };
+}
+
+/** The participation node IRIs a conversion minted, sorted. */
+function participantIris(resource: Record<string, unknown>): string[] {
+  const result = convertEncounter(structuredClone(resource)) as Converted;
+  return result._quads
+    .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === PARTICIPANT_CLASS)
+    .map((q) => q.subject.value)
+    .sort();
+}
+
+/** The IRI of the participation whose name is `name`. */
+function iriOfNamed(resource: Record<string, unknown>, name: string): string | undefined {
+  const result = convertEncounter(structuredClone(resource)) as Converted;
+  return result._quads.find(
+    (q) => q.predicate.value === PARTICIPANT_NAME && q.object.value === name,
+  )?.subject.value;
+}
+
+// ---------------------------------------------------------------------------
+// 1. A function of the content, and of nothing else
+// ---------------------------------------------------------------------------
+
+describe('the participation IRI is a pure function of (encounter IRI, participation content)', () => {
+  it('two conversions of the same resource mint the same IRIs', () => {
+    expect(participantIris(encounterResource())).toEqual(participantIris(encounterResource()));
+  });
+
+  it('the IRIs do not depend on ARRAY ORDER', () => {
+    // The single most tempting wrong key. An index is a property of the
+    // SERIALIZATION: FHIR does not promise participant[] order across two reads
+    // of one resource, so an index-keyed IRI moves when a server reorders the
+    // array and duplicates a node whose content never changed.
+    const forward = encounterResource();
+    const reversed = encounterResource({
+      participant: [...(encounterResource().participant as unknown[])].reverse(),
+    });
+    expect(participantIris(reversed)).toEqual(participantIris(forward));
+  });
+
+  it('the IRIs do not depend on an unrelated element of the same encounter', () => {
+    // The encounter's own IRI is keyed on `resource.id`, which does not move,
+    // so changing a fact about the VISIT must not re-mint its PARTICIPATIONS.
+    const withOtherFacility = encounterResource({
+      location: [{ location: { display: 'SOMEWHERE ELSE' } }],
+    });
+    expect(participantIris(withOtherFacility)).toEqual(participantIris(encounterResource()));
+  });
+
+  it('changing the participation NAME moves that IRI and leaves the other alone', () => {
+    const base = encounterResource();
+    const renamed = encounterResource({
+      participant: [
+        (base.participant as any[])[0],
+        { ...(base.participant as any[])[1], individual: { display: 'Someone Else, MD' } },
+      ],
+    });
+    expect(iriOfNamed(renamed, 'Lucia Marsh, MD')).toBe(iriOfNamed(base, 'Lucia Marsh, MD'));
+    expect(iriOfNamed(renamed, 'Someone Else, MD')).not.toBe(iriOfNamed(base, 'Amara Okoye, MD'));
+  });
+
+  it('changing the SPECIALTY moves the IRI, because it is a fact the node states', () => {
+    // Stated as its own case because it is the invariant that makes the IRI
+    // honest: every fact the node carries is in its key, so two nodes that
+    // differ in any stated fact are two IRIs, and two nodes with one IRI are
+    // identical in every stated fact.
+    const other = encounterResource({
+      participant: [
+        (encounterResource().participant as any[])[0],
+        {
+          ...(encounterResource().participant as any[])[1],
+          extension: [
+            {
+              url: 'https://vendor.example/fhir/StructureDefinition/participant-specialty',
+              valueCodeableConcept: { text: 'Sleep Medicine' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(iriOfNamed(other, 'Amara Okoye, MD')).not.toBe(
+      iriOfNamed(encounterResource(), 'Amara Okoye, MD'),
+    );
+  });
+
+  it('the same participation at a DIFFERENT encounter is a different node', () => {
+    // A participation belongs to a visit. "Amara Okoye, MD, attender" is not one
+    // thing shared between two visits; it is two participations, and merging
+    // them would attach one visit's care team to another.
+    const otherVisit = encounterResource({ id: 'enc-derm-2' });
+    expect(iriOfNamed(otherVisit, 'Amara Okoye, MD')).not.toBe(
+      iriOfNamed(encounterResource(), 'Amara Okoye, MD'),
+    );
+  });
+
+  it('two participations that state identical facts collapse to one node', () => {
+    // Chosen, not tolerated. Nothing in the record distinguishes them, and this
+    // codebase's rule for that case is to merge what nothing can tell apart
+    // rather than mint a second IRI per import — a duplicate set that grows
+    // forever and never announces itself.
+    const twice = encounterResource({
+      participant: [
+        { type: [{ text: 'attender' }], individual: { display: 'Amara Okoye, MD' } },
+        { type: [{ text: 'attender' }], individual: { display: 'Amara Okoye, MD' } },
+      ],
+    });
+    expect(participantIris(twice)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Re-import adds nothing
+// ---------------------------------------------------------------------------
+
+describe('re-import is idempotent: the 3.268 repair path stays safe', () => {
+  async function importTwice(): Promise<{ subjects: Set<string>; conflicts: number }> {
+    const converted = convertEncounter(encounterResource()) as Converted;
+    const turtle = await quadsToTurtle(converted._quads as never);
+    const provenance = `@prefix cascade: <${NS.cascade}> .\n`;
+
+    // Pass 1: a fresh pod. Pass 2: the pod's own content fed back in alongside a
+    // re-conversion of the same source, which is exactly what
+    // `pod import --reconcile-existing` does on a repair run.
+    const first = await runReconciliation([
+      { content: provenance + turtle, systemName: 'northgate-fhir' },
+    ]);
+    const second = await runReconciliation([
+      { content: first.turtle, systemName: 'northgate-fhir', existingPod: true },
+      { content: provenance + turtle, systemName: 'northgate-fhir' },
+    ]);
+
+    const quads = new Parser().parse(second.turtle);
+    return {
+      subjects: new Set(quads.map((q) => q.subject.value)),
+      conflicts: second.conflicts?.length ?? 0,
+    };
+  }
+
+  it('a second import of the same source produces no new subject and no conflict', async () => {
+    const converted = convertEncounter(encounterResource()) as Converted;
+    const turtle = await quadsToTurtle(converted._quads as never);
+    const once = await runReconciliation([
+      { content: `@prefix cascade: <${NS.cascade}> .\n` + turtle, systemName: 'northgate-fhir' },
+    ]);
+    const onceSubjects = new Set(new Parser().parse(once.turtle).map((q) => q.subject.value));
+
+    const twice = await importTwice();
+
+    // Byte-stable: not merely the same COUNT of subjects, the same subjects.
+    expect([...twice.subjects].sort()).toEqual([...onceSubjects].sort());
+    expect(twice.conflicts).toBe(0);
+  });
+
+  it('both participation nodes survive the round trip', async () => {
+    // Guards the vacuous pass: "no growth" is trivially true of an output that
+    // dropped the nodes entirely, and a participation node is not a reconcilable
+    // record type, so it travels the passthrough path.
+    const twice = await importTwice();
+    const participants = [...twice.subjects].filter((s) =>
+      participantIris(encounterResource()).includes(s),
+    );
+    expect(participants).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Across processes and directories, against the built artifact
+// ---------------------------------------------------------------------------
+
+const SCRIPT = `
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+
+const dist = process.env.CASCADE_DIST;
+const { convertEncounter } = await import(
+  pathToFileURL(path.join(dist, 'lib/fhir-converter/converters-clinical.js')).href
+);
+
+const resource = JSON.parse(process.env.CASCADE_ENCOUNTER);
+const result = convertEncounter(resource);
+const PARTICIPANT = 'https://ns.cascadeprotocol.org/clinical/v1#EncounterParticipant';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+process.stdout.write(JSON.stringify({
+  iris: result._quads
+    .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === PARTICIPANT)
+    .map((q) => q.subject.value)
+    .sort(),
+  cwd: process.cwd(),
+}));
+`;
+
+const tempDirs: string[] = [];
+function tempDir(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+let scriptPath = '';
+function mintInFreshProcess(cwd: string): { iris: string[]; cwd: string } {
+  if (!scriptPath) {
+    scriptPath = path.join(tempDir('cascade-participant-script-'), 'mint.mjs');
+    fs.writeFileSync(scriptPath, SCRIPT);
+  }
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CASCADE_DIST: DIST,
+      CASCADE_ENCOUNTER: JSON.stringify(encounterResource()),
+    },
+  });
+  return JSON.parse(stdout) as { iris: string[]; cwd: string };
+}
+
+describe.skipIf(!HAVE_DIST)('participation IRIs survive the process and the directory', () => {
+  it('two fresh processes in two different directories mint byte-identical IRIs', () => {
+    const a = mintInFreshProcess(tempDir('cascade-participant-a-'));
+    const b = mintInFreshProcess(tempDir('cascade-participant-b-'));
+
+    // The directories must actually differ, or the comparison proves nothing.
+    expect(a.cwd).not.toBe(b.cwd);
+    expect(a.iris).toHaveLength(2);
+    expect(a.iris).toEqual(b.iris);
+  });
+
+  it('a fresh process agrees with this one, so the built artifact matches the source', () => {
+    const fresh = mintInFreshProcess(tempDir('cascade-participant-c-'));
+    expect(fresh.iris).toEqual(participantIris(encounterResource()));
+  });
+});

--- a/tests/fhir-field-coverage-wave1.test.ts
+++ b/tests/fhir-field-coverage-wave1.test.ts
@@ -306,36 +306,53 @@ describe('STABILITY PIN: a status is reported, never invented', () => {
   });
 });
 
-describe('ACKNOWLEDGED DROP: statuses with no predicate to carry them', () => {
+/**
+ * CLOSED BY WAVE 4. All three drops this block guarded had one cause — no
+ * predicate could carry the value — and clinical v1.16 / coverage v1.5 authored
+ * all three terms, so the block now asserts the emissions instead of the
+ * omissions.
+ *
+ * The `coverage:status` case is worth keeping a note on because it is what a
+ * tripwire is FOR. It did not merely document a gap; it failed, by itself, on
+ * the commit that synced the new vocabulary in, before any converter had been
+ * touched — which is how the omission got closed in the same change as the term
+ * that closed it rather than outliving the reason for it by a release.
+ *
+ * The emission behaviour is asserted in depth in `fhir-field-coverage-wave4.test.ts`.
+ * What stays here is the half these cases uniquely hold: that the NEW value did
+ * not displace the OLD one. The code is not overwritten by the display, and the
+ * document's status is not overwritten by the reference's.
+ */
+describe('WAS an acknowledged drop: statuses that now have a predicate', () => {
   const SHAPES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'shapes');
 
-  it('Coverage.status is not emitted, and the coverage vocabulary still has nowhere to put it', () => {
-    // Two halves on purpose. The first states today's behaviour; the second is
-    // the tripwire that makes this a REVIEWABLE omission rather than a silent
-    // one — the day a `coverage:status` term is authored, this fails and sends
-    // the reader back here to emit it.
+  it('Coverage.status is emitted, on the coverage: term the vocabulary now defines', () => {
     const result = convertCoverage(coverageResource({ status: 'cancelled' })) as Converted;
+    expect(valuesOf(result, NS.coverage + 'status')).toEqual(['cancelled']);
+    // Still NOT on clinical:status. The predicate was authored in coverage:
+    // rather than borrowed from clinical:, and borrowing it later would be the
+    // same scope decision made in a converter that this wave avoided making.
     expect(valuesOf(result, STATUS)).toEqual([]);
-    expect(result._quads.some((q) => q.object.value === 'cancelled')).toBe(false);
 
     const vocab = fs.readFileSync(path.join(SHAPES, 'coverage.ttl'), 'utf8');
-    expect(/^coverage:status\s+a\s+owl:/m.test(vocab), 'coverage:status now exists — emit it').toBe(false);
+    expect(/^coverage:status\s+a\s+owl:/m.test(vocab), 'the bundled vocabulary must define the term being emitted').toBe(true);
   });
 
-  it('Encounter.class.display is not emitted, and the class CODE is not overwritten by it', () => {
+  it('Encounter.class.display is emitted and the class CODE is not overwritten by it', () => {
     // The code is what the reverse converter needs to rebuild Encounter.class,
-    // so "store the readable one instead" is not an available shortcut. Both
-    // want keeping; only one predicate exists.
+    // so "store the readable one instead" was never an available shortcut. Both
+    // are kept now, on predicates of their own.
     const result = convertEncounter(encounterResource({ class: { code: '5', display: 'Appointment' } })) as Converted;
     expect(valueOf(result, ENCOUNTER_CLASS)).toBe('5');
-    expect(result._quads.some((q) => q.object.value === 'Appointment')).toBe(false);
+    expect(valuesOf(result, NS.clinical + 'encounterClassDisplay')).toEqual(['Appointment']);
   });
 
-  it('DocumentReference.status (the reference, not the document) is not conflated with docStatus', () => {
+  it('DocumentReference.status and docStatus land on their own predicates, unconflated', () => {
     // `status: current` and `docStatus: final` are different elements. Exactly
-    // one value reaches clinical:status, and it is the document's.
+    // one value reaches clinical:status, and it is still the document's.
     const result = convertClinicalDocument(documentReference({ status: 'current', docStatus: 'final' })) as Converted;
     expect(valuesOf(result, STATUS)).toEqual(['final']);
+    expect(valuesOf(result, NS.clinical + 'documentReferenceStatus')).toEqual(['current']);
   });
 });
 

--- a/tests/fhir-field-coverage-wave4.test.ts
+++ b/tests/fhir-field-coverage-wave4.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Wave 4: the fields that had nowhere to go until clinical v1.16 / coverage v1.5.
+ *
+ * WHAT THIS WAVE IS
+ * -----------------
+ * Waves 1-3 fixed everything the existing vocabulary could already carry, and
+ * each one ended by writing down what it could not. Those written-down drops
+ * became `spec` PR #31. This suite is the other half of that transaction: every
+ * predicate the release authored, emitted by the converter that had been
+ * dropping the field, and asserted here so the vocabulary cannot go back to
+ * being defined-but-unwritten.
+ *
+ * The three groups, and the defect each one closes:
+ *
+ *   ENCOUNTER. `convertEncounter` emitted nine facts about a visit while the
+ *   source stated the reason, the admission detail, the readable class label and
+ *   the whole care team. Measured over 54 Epic R4 Encounters: `reasonCode`
+ *   present on 44 and emitted 0 times; `hospitalization` on 11, emitted 0;
+ *   `class.display` on 58, emitted 0 (the pod said `encounterClass "5"` where
+ *   the resource said `Appointment`); 128 participants across 56 encounters, of
+ *   which 52 names were kept and every role, every specialty and every
+ *   participant past the selected one was discarded.
+ *
+ *   IDENTIFIERS. Per the ratified migration plan, `clinical:businessIdentifier`
+ *   is the canonical home for `Encounter.identifier` and uses FHIR TOKEN form,
+ *   `{system}|{value}`, with the system verbatim. `cascade:sourceRecordId` keeps
+ *   emitting the FROZEN colon form. The two forms are never compared against
+ *   each other; `tests/encounter-identifier-join.test.ts` holds that seam.
+ *
+ *   DOCUMENTS AND COVERAGE. A DocumentReference carries two independent status
+ *   elements and two independent attribution facts, and through v1.15 each pair
+ *   had one predicate, so each pair's second member was dropped: a superseded
+ *   reference read as a live one, and a note signed by an attending read as
+ *   though the attending wrote it. `Coverage.status` is the one element FHIR
+ *   REQUIRES a Coverage to carry and the coverage vocabulary had no property for
+ *   it at all, so a cancelled policy imported indistinguishably from an active
+ *   one.
+ *
+ * Every fixture is synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  convertClinicalDocument,
+  convertEncounter,
+} from '../src/lib/fhir-converter/converters-clinical.js';
+import { convertCoverage } from '../src/lib/fhir-converter/converters-demographics.js';
+import { NS } from '../src/lib/fhir-converter/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Quadish = {
+  subject: { value: string };
+  predicate: { value: string };
+  object: { value: string };
+};
+type Converted = { _quads: Quadish[] };
+
+function valuesOf(result: Converted, predicate: string): string[] {
+  return result._quads.filter((q) => q.predicate.value === predicate).map((q) => q.object.value);
+}
+
+function valueOf(result: Converted, predicate: string): string | undefined {
+  return valuesOf(result, predicate)[0];
+}
+
+/** The values of `predicate` on ONE subject, rather than anywhere in the output. */
+function valuesOn(result: Converted, subject: string, predicate: string): string[] {
+  return result._quads
+    .filter((q) => q.subject.value === subject && q.predicate.value === predicate)
+    .map((q) => q.object.value);
+}
+
+const RDF_TYPE = NS.rdf + 'type';
+const ENCOUNTER_CLASS = NS.clinical + 'encounterClass';
+const CLASS_DISPLAY = NS.clinical + 'encounterClassDisplay';
+const CLASS_SYSTEM = NS.clinical + 'encounterClassSystem';
+const REASON = NS.clinical + 'encounterReason';
+const ADMIT_SOURCE = NS.clinical + 'admitSource';
+const DISCHARGE = NS.clinical + 'dischargeDisposition';
+const HAS_PARTICIPANT = NS.clinical + 'hasParticipant';
+const PARTICIPANT_NAME = NS.clinical + 'participantName';
+const PARTICIPANT_ROLE = NS.clinical + 'participantRole';
+const PARTICIPANT_ROLE_CODE = NS.clinical + 'participantRoleCode';
+const PARTICIPANT_SPECIALTY = NS.clinical + 'participantSpecialty';
+const PARTICIPANT_CLASS = NS.clinical + 'EncounterParticipant';
+const BUSINESS_ID = NS.clinical + 'businessIdentifier';
+const CASCADE_SOURCE_RECORD_ID = NS.cascade + 'sourceRecordId';
+const PROVIDER_NAME = NS.clinical + 'providerName';
+const DOC_REFERENCE_STATUS = NS.clinical + 'documentReferenceStatus';
+const DOC_AUTHOR_NAME = NS.clinical + 'documentAuthorName';
+const AUTHENTICATOR_NAME = NS.clinical + 'authenticatorName';
+const STATUS = NS.clinical + 'status';
+const COVERAGE_STATUS = NS.coverage + 'status';
+
+/**
+ * The measured Epic shape, reduced: a dermatology office visit whose first
+ * participant slot holds a REFERRER, whose treating clinician is the attender
+ * with the specialty extension, and which states two reasons, an admission
+ * detail, a local class code with its display, and a contact serial number.
+ */
+function encounterResource(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    resourceType: 'Encounter',
+    id: 'enc-derm-1',
+    status: 'finished',
+    class: {
+      system: 'urn:oid:1.2.840.114350.1.72.1.7.1',
+      code: '5',
+      display: 'Appointment',
+    },
+    identifier: [
+      {
+        system: 'urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.8',
+        value: '20100000001',
+      },
+    ],
+    reasonCode: [
+      { text: 'Derm Problem' },
+      {
+        coding: [
+          { system: 'http://snomed.info/sct', code: '185349003', display: 'Encounter for check up' },
+        ],
+      },
+    ],
+    hospitalization: {
+      admitSource: { text: 'From outpatient department' },
+      dischargeDisposition: {
+        coding: [{ system: 'http://terminology.hl7.org/CodeSystem/discharge-disposition', code: 'home', display: 'Home' }],
+      },
+    },
+    participant: [
+      {
+        type: [{ text: 'referrer', coding: [{ system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType', code: 'REF', display: 'referrer' }] }],
+        individual: { display: 'Lucia Marsh, MD' },
+      },
+      {
+        type: [{ text: 'attender', coding: [{ system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType', code: 'ATND', display: 'attender' }] }],
+        extension: [
+          {
+            url: 'https://vendor.example/fhir/StructureDefinition/participant-specialty',
+            valueCodeableConcept: { text: 'Dermatology' },
+          },
+        ],
+        individual: { display: 'Amara Okoye, MD' },
+      },
+    ],
+    period: { start: '2025-04-01T16:00:00Z', end: '2025-04-01T16:40:00Z' },
+    ...overrides,
+  };
+}
+
+function documentReference(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    resourceType: 'DocumentReference',
+    id: 'doc-progress-1',
+    status: 'superseded',
+    docStatus: 'amended',
+    type: { text: 'Progress Notes' },
+    date: '2025-04-01T18:22:00Z',
+    author: [
+      { display: 'Noor Habib, MD' },
+      { display: 'Amara Okoye, MD' },
+    ],
+    authenticator: { display: 'Priya Raman, MD' },
+    ...overrides,
+  };
+}
+
+function coverageResource(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    resourceType: 'Coverage',
+    id: 'cov-ppo-1',
+    status: 'cancelled',
+    type: { coding: [{ code: 'PPO' }] },
+    subscriberId: 'MEM-88213400',
+    payor: [{ display: 'Cascade Mutual Health' }],
+    ...overrides,
+  };
+}
+
+/** The participant nodes a conversion minted, as subject IRIs. */
+function participantNodes(result: Converted): string[] {
+  return result._quads
+    .filter((q) => q.predicate.value === RDF_TYPE && q.object.value === PARTICIPANT_CLASS)
+    .map((q) => q.subject.value);
+}
+
+// ---------------------------------------------------------------------------
+// Encounter: the visit's own facts
+// ---------------------------------------------------------------------------
+
+describe('Encounter reason, admission and class display', () => {
+  it('emits every reasonCode, as the text the chart used', () => {
+    const result = convertEncounter(encounterResource()) as Converted;
+    // Second entry states no `.text`, so the first coding's display is the
+    // reason as written. Neither is normalized to a code: the FHIR binding is
+    // PREFERRED and real exports carry local, free-text and SNOMED reasons in
+    // the same element.
+    expect(valuesOf(result, REASON).sort()).toEqual(['Derm Problem', 'Encounter for check up']);
+  });
+
+  it('emits admitSource and dischargeDisposition from hospitalization', () => {
+    const result = convertEncounter(encounterResource()) as Converted;
+    expect(valueOf(result, ADMIT_SOURCE)).toBe('From outpatient department');
+    expect(valueOf(result, DISCHARGE)).toBe('Home');
+  });
+
+  it('an encounter with no hospitalization element states neither', () => {
+    // Presence of hospitalization is itself the signal that a visit was an
+    // admission. Defaulting either predicate would erase that distinction in
+    // the direction 3.257 was filed for.
+    const noAdmission = encounterResource();
+    delete (noAdmission as Record<string, unknown>).hospitalization;
+    const result = convertEncounter(noAdmission) as Converted;
+    expect(valuesOf(result, ADMIT_SOURCE)).toEqual([]);
+    expect(valuesOf(result, DISCHARGE)).toEqual([]);
+  });
+
+  it('emits the class display and system ALONGSIDE the code, never instead of it', () => {
+    // The code is what a round-trip export must restore, so "store the readable
+    // one instead" was never available. All three, or the value is either
+    // unreadable or unrestorable.
+    const result = convertEncounter(encounterResource()) as Converted;
+    expect(valueOf(result, ENCOUNTER_CLASS)).toBe('5');
+    expect(valueOf(result, CLASS_DISPLAY)).toBe('Appointment');
+    expect(valueOf(result, CLASS_SYSTEM)).toBe('urn:oid:1.2.840.114350.1.72.1.7.1');
+  });
+
+  it('a class stated as a coding rather than inline is read the same way', () => {
+    const result = convertEncounter(
+      encounterResource({
+        class: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB', display: 'ambulatory' }] },
+      }),
+    ) as Converted;
+    expect(valueOf(result, ENCOUNTER_CLASS)).toBe('AMB');
+    expect(valueOf(result, CLASS_DISPLAY)).toBe('ambulatory');
+    expect(valueOf(result, CLASS_SYSTEM)).toBe('http://terminology.hl7.org/CodeSystem/v3-ActCode');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Encounter: the care team
+// ---------------------------------------------------------------------------
+
+describe('Encounter participants', () => {
+  it('emits one EncounterParticipant node per participation, not one name', () => {
+    const result = convertEncounter(encounterResource()) as Converted;
+    const nodes = participantNodes(result);
+    expect(nodes).toHaveLength(2);
+    expect(valuesOf(result, HAS_PARTICIPANT).sort()).toEqual([...nodes].sort());
+  });
+
+  it('each node carries the name, the role, the role code and the specialty', () => {
+    const result = convertEncounter(encounterResource()) as Converted;
+    const nodes = participantNodes(result);
+    const byName = new Map(
+      nodes.map((n) => [valuesOn(result, n, PARTICIPANT_NAME)[0], n] as const),
+    );
+
+    const attender = byName.get('Amara Okoye, MD');
+    expect(attender, 'the attender must be a node of its own').toBeDefined();
+    expect(valuesOn(result, attender!, PARTICIPANT_ROLE)).toEqual(['attender']);
+    expect(valuesOn(result, attender!, PARTICIPANT_ROLE_CODE)).toEqual(['ATND']);
+    expect(valuesOn(result, attender!, PARTICIPANT_SPECIALTY)).toEqual(['Dermatology']);
+
+    const referrer = byName.get('Lucia Marsh, MD');
+    expect(referrer, 'the referrer is kept too, WITH its role').toBeDefined();
+    expect(valuesOn(result, referrer!, PARTICIPANT_ROLE)).toEqual(['referrer']);
+    expect(valuesOn(result, referrer!, PARTICIPANT_ROLE_CODE)).toEqual(['REF']);
+    // The source stated no specialty for this one, and none is invented.
+    expect(valuesOn(result, referrer!, PARTICIPANT_SPECIALTY)).toEqual([]);
+  });
+
+  it('STABILITY PIN: the single providerName slot still selects by role, unchanged', () => {
+    // Participants are the full record; providerName is the summary slot an
+    // application displays. Wave 1 fixed WHICH name lands in it and this change
+    // must not disturb that: the attender wins, not the referrer in slot 0.
+    const result = convertEncounter(encounterResource()) as Converted;
+    expect(valuesOf(result, PROVIDER_NAME)).toEqual(['Amara Okoye, MD']);
+  });
+
+  it('a participant with a name but no role is kept, with no role invented', () => {
+    const result = convertEncounter(
+      encounterResource({ participant: [{ individual: { display: 'Jordan Vance, RN' } }] }),
+    ) as Converted;
+    const nodes = participantNodes(result);
+    expect(nodes).toHaveLength(1);
+    expect(valuesOn(result, nodes[0], PARTICIPANT_NAME)).toEqual(['Jordan Vance, RN']);
+    expect(valuesOn(result, nodes[0], PARTICIPANT_ROLE)).toEqual([]);
+    expect(valuesOn(result, nodes[0], PARTICIPANT_ROLE_CODE)).toEqual([]);
+  });
+
+  it('a participation the source stated nothing about mints no node', () => {
+    // An empty participation is not a person the pod can say anything about,
+    // and a node carrying only a link back to its encounter asserts a
+    // participation that the source did not describe.
+    const result = convertEncounter(
+      encounterResource({ participant: [{ period: { start: '2025-04-01T16:00:00Z' } }] }),
+    ) as Converted;
+    expect(participantNodes(result)).toEqual([]);
+    expect(valuesOf(result, HAS_PARTICIPANT)).toEqual([]);
+  });
+
+  it('an encounter with no participant array emits no participation', () => {
+    const bare = encounterResource();
+    delete (bare as Record<string, unknown>).participant;
+    const result = convertEncounter(bare) as Converted;
+    expect(participantNodes(result)).toEqual([]);
+  });
+
+  it('keeps every role CODE a participation states, and exactly one role LABEL', () => {
+    // The asymmetry is the shape's, not an accident: clinical:participantRole is
+    // sh:maxCount 1 and clinical:participantRoleCode is 0..*, matching FHIR's
+    // repeating participant.type. Emitting two labels would produce a record
+    // that fails validation; dropping the second CODE would lose a role the
+    // source stated. So: all the codes, the first label.
+    const result = convertEncounter(
+      encounterResource({
+        participant: [
+          {
+            type: [
+              { coding: [{ code: 'ATND', display: 'attender' }] },
+              { coding: [{ code: 'PPRF', display: 'primary performer' }] },
+            ],
+            individual: { display: 'Amara Okoye, MD' },
+          },
+        ],
+      }),
+    ) as Converted;
+    const node = participantNodes(result)[0];
+    expect(valuesOn(result, node, PARTICIPANT_ROLE_CODE).sort()).toEqual(['ATND', 'PPRF']);
+    expect(valuesOn(result, node, PARTICIPANT_ROLE)).toEqual(['attender']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Encounter: identifiers
+// ---------------------------------------------------------------------------
+
+describe('Encounter business identifiers', () => {
+  it('emits businessIdentifier in FHIR token form, system VERBATIM', () => {
+    // Token form is `{system}|{value}` per FHIR search. The system is NOT
+    // stripped of `urn:oid:` here: that stripping belongs to the frozen colon
+    // form and to nothing else, and inventing a second spelling of a canonical
+    // form is how the two id spaces became indistinguishable in the first place.
+    const result = convertEncounter(encounterResource()) as Converted;
+    expect(valuesOf(result, BUSINESS_ID)).toEqual([
+      'urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.8|20100000001',
+    ]);
+  });
+
+  it('an identifier with no system is written bare, and no system is invented', () => {
+    const result = convertEncounter(
+      encounterResource({ identifier: [{ value: '20100000001' }] }),
+    ) as Converted;
+    expect(valuesOf(result, BUSINESS_ID)).toEqual(['20100000001']);
+  });
+
+  it('emits every identifier the resource states, because the element is 0..*', () => {
+    const result = convertEncounter(
+      encounterResource({
+        identifier: [
+          { system: 'urn:oid:1.2.3', value: 'A' },
+          { system: 'http://example.org/visit', value: 'B' },
+        ],
+      }),
+    ) as Converted;
+    expect(valuesOf(result, BUSINESS_ID).sort()).toEqual([
+      'http://example.org/visit|B',
+      'urn:oid:1.2.3|A',
+    ]);
+  });
+
+  it('an identifier with no value emits nothing on either predicate', () => {
+    // A system with no value identifies nothing, and `system|` would sit in the
+    // join space matching every other value-less identifier from that system.
+    const result = convertEncounter(
+      encounterResource({ identifier: [{ system: 'urn:oid:1.2.3' }] }),
+    ) as Converted;
+    expect(valuesOf(result, BUSINESS_ID)).toEqual([]);
+    expect(valuesOf(result, CASCADE_SOURCE_RECORD_ID)).toEqual([]);
+  });
+
+  it('FROZEN: cascade:sourceRecordId keeps the colon form, urn:oid: stripped', () => {
+    // The compatibility artifact. It is dual-written unchanged so that pods
+    // repaired before this release still converge, and it is never re-spelled:
+    // changing it in place would unjoin every encounter pair already matched on
+    // it. Retirement is schedulable only after the canonical predicate is
+    // everywhere.
+    const result = convertEncounter(encounterResource()) as Converted;
+    expect(valuesOf(result, CASCADE_SOURCE_RECORD_ID)).toEqual([
+      '1.2.840.114350.1.13.999.2.7.3.698084.8:20100000001',
+    ]);
+  });
+
+  it('the two forms are DIFFERENT strings for one identifier, and both are present', () => {
+    // Stated as its own case because it is the invariant the matcher depends
+    // on: a colon-form value and a token-form value for the same identifier do
+    // not compare equal, so a matcher that pooled them would either miss real
+    // matches or manufacture false ones.
+    const result = convertEncounter(encounterResource()) as Converted;
+    const token = valuesOf(result, BUSINESS_ID)[0];
+    const colon = valuesOf(result, CASCADE_SOURCE_RECORD_ID)[0];
+    expect(token).toBeDefined();
+    expect(colon).toBeDefined();
+    expect(token).not.toBe(colon);
+  });
+
+  it('STABILITY PIN: clinical:sourceRecordId still holds the SERVER row id', () => {
+    const result = convertEncounter(encounterResource()) as Converted;
+    expect(valuesOf(result, NS.clinical + 'sourceRecordId')).toEqual(['enc-derm-1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DocumentReference
+// ---------------------------------------------------------------------------
+
+describe('DocumentReference status, authorship and attestation', () => {
+  it('emits documentReferenceStatus from status, and keeps docStatus on clinical:status', () => {
+    // The pair FHIR keeps separate because "entered-in-error" appears in BOTH
+    // value sets and means different things in each.
+    const result = convertClinicalDocument(documentReference()) as Converted;
+    expect(valueOf(result, DOC_REFERENCE_STATUS)).toBe('superseded');
+    expect(valueOf(result, STATUS)).toBe('amended');
+  });
+
+  it('a DocumentReference stating neither status emits neither', () => {
+    const bare = documentReference();
+    delete (bare as Record<string, unknown>).status;
+    delete (bare as Record<string, unknown>).docStatus;
+    const result = convertClinicalDocument(bare) as Converted;
+    expect(valuesOf(result, DOC_REFERENCE_STATUS)).toEqual([]);
+    expect(valuesOf(result, STATUS)).toEqual([]);
+  });
+
+  it('emits EVERY author, not only the first', () => {
+    const result = convertClinicalDocument(documentReference()) as Converted;
+    expect(valuesOf(result, DOC_AUTHOR_NAME)).toEqual(['Noor Habib, MD', 'Amara Okoye, MD']);
+  });
+
+  it('emits the authenticator as attestation, distinct from authorship', () => {
+    // A resident authors and an attending signs. Recording only the author
+    // loses the signature; recording the signer as an author asserts they wrote
+    // the content, which the source did not say.
+    const result = convertClinicalDocument(documentReference()) as Converted;
+    expect(valueOf(result, AUTHENTICATOR_NAME)).toBe('Priya Raman, MD');
+    expect(valuesOf(result, DOC_AUTHOR_NAME)).not.toContain('Priya Raman, MD');
+  });
+
+  it('a document with no authenticator states none', () => {
+    const noAuth = documentReference();
+    delete (noAuth as Record<string, unknown>).authenticator;
+    const result = convertClinicalDocument(noAuth) as Converted;
+    expect(valuesOf(result, AUTHENTICATOR_NAME)).toEqual([]);
+  });
+
+  it('an author with a reference but no display contributes no name', () => {
+    const result = convertClinicalDocument(
+      documentReference({ author: [{ reference: 'Practitioner/p1' }, { display: 'Noor Habib, MD' }] }),
+    ) as Converted;
+    expect(valuesOf(result, DOC_AUTHOR_NAME)).toEqual(['Noor Habib, MD']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coverage
+// ---------------------------------------------------------------------------
+
+describe('Coverage status', () => {
+  it('emits coverage:status, so a cancelled plan no longer reads as an active one', () => {
+    const result = convertCoverage(coverageResource()) as Converted;
+    expect(valueOf(result, COVERAGE_STATUS)).toBe('cancelled');
+  });
+
+  it('a Coverage stating no status emits none', () => {
+    // FHIR makes the element 1..1, so a resource without it is non-conformant
+    // at source. Substituting "active" for a missing modifier element is the
+    // 3.257 defect on the field where it costs the most.
+    const bare = coverageResource();
+    delete (bare as Record<string, unknown>).status;
+    const result = convertCoverage(bare) as Converted;
+    expect(valuesOf(result, COVERAGE_STATUS)).toEqual([]);
+  });
+
+  it('the status does not land on clinical:status', () => {
+    // coverage: is its own namespace and an insurance plan is not a clinical
+    // record. Borrowing across the split was the option this release removed.
+    const result = convertCoverage(coverageResource()) as Converted;
+    expect(valuesOf(result, STATUS)).toEqual([]);
+  });
+});

--- a/tests/fhir-field-coverage.test.ts
+++ b/tests/fhir-field-coverage.test.ts
@@ -313,8 +313,12 @@ describe('the measurement itself', () => {
     // lands that fixes one of these, its manifest entry goes stale and the test
     // above fails first, which is the intended order.
     const encounter = COVERAGE.find((c) => c.fixture.resourceType === 'Encounter')!.coverage;
-    // Never read.
-    expect(encounter.dropped).toContain('Encounter.reasonCode');
+    // Never read. Was `Encounter.reasonCode` until wave 4 emitted it, which is
+    // the intended order this comment describes happening: the manifest entry
+    // went stale, the test above failed first, and the exemplar moved to a field
+    // still exhibiting the mode. `serviceType` — the specialty the visit was
+    // booked under — is read by no line of `convertEncounter`.
+    expect(encounter.dropped).toContain('Encounter.serviceType');
     // Read for identity, never written as a fact. `Encounter.identifier` was the
     // exemplar of this mode and is now emitted (wave 2, the encounter join key),
     // so the mode is pinned on the resource that still exhibits it: a

--- a/tests/fhir-round-trip-wave4.test.ts
+++ b/tests/fhir-round-trip-wave4.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Round trip: FHIR -> Cascade -> FHIR, for every predicate the import path
+ * learned to write in waves 1 and 4.
+ *
+ * THE DEFECT
+ * ------------------------------
+ * Wave 1 taught the converters to emit `clinical:status` and
+ * `clinical:verificationStatus`, and the reverse converters were not touched.
+ * Nothing read either predicate back, and several restorers wrote a HARDCODED
+ * status instead — `'final'` on a DiagnosticReport, `'current'` on a
+ * DocumentReference, `'active'` on a Coverage. So a pod holding a correct
+ * `amended`, `superseded`, `refuted` or `cancelled` exported it as the confident
+ * default, which is the same class of defect the import fix had just closed,
+ * pointed the other way: the pod knew, and the export unlearned it.
+ *
+ * Wave 4 adds nine encounter facts, three document facts and a coverage status,
+ * so the same gap would open nine more times if the reverse converters were left
+ * alone again. Every one of them is asserted here.
+ *
+ * WHAT A CASE PROVES, AND WHAT IT DOES NOT
+ * ----------------------------------------
+ * These are ROUND TRIPS, not equality assertions on the whole resource. Cascade
+ * is a lossy target by design (references to resources the pod does not hold are
+ * dropped, codings are narrowed), so "the output equals the input" would be
+ * false for reasons that are not defects. Each case therefore names the ELEMENT
+ * it is about and asserts that element survived the trip, which is exactly the
+ * claim 3.262 says was never checked.
+ *
+ * The trip runs through `convertCascadeToFhir` — the real entry point, parsing
+ * real Turtle — rather than by handing a restorer a hand-built map, so a
+ * predicate that is emitted but never serialized, or serialized but never
+ * parsed, fails here too.
+ *
+ * All fixtures are synthetic and PHI-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { convertFhirResourceToQuads } from '../src/lib/fhir-converter/fhir-to-cascade.js';
+import { convertCascadeToFhir } from '../src/lib/fhir-converter/cascade-to-fhir.js';
+import { quadsToTurtle, TURTLE_PREFIXES } from '../src/lib/fhir-converter/types.js';
+
+/** FHIR in, Cascade Turtle, FHIR back out. The resource of the given type. */
+async function roundTrip(resource: Record<string, unknown>): Promise<Record<string, any>> {
+  const converted = convertFhirResourceToQuads(structuredClone(resource));
+  if (!converted) throw new Error(`no conversion for ${String(resource.resourceType)}`);
+  const turtle = await quadsToTurtle(converted._quads);
+  const { resources } = await convertCascadeToFhir(turtle);
+  const match = resources.find((r) => r.resourceType === resource.resourceType);
+  if (!match) {
+    throw new Error(
+      `round trip lost the ${String(resource.resourceType)}; got ${resources.map((r) => r.resourceType).join(', ') || '<nothing>'}`,
+    );
+  }
+  return match;
+}
+
+// A prefix table is required by quadsToTurtle's writer; assert it exists so a
+// refactor that empties it fails here rather than producing unparseable output.
+expect(Object.keys(TURTLE_PREFIXES).length).toBeGreaterThan(0);
+
+// ---------------------------------------------------------------------------
+// Encounter
+// ---------------------------------------------------------------------------
+
+const ENCOUNTER = {
+  resourceType: 'Encounter',
+  id: 'enc-derm-1',
+  status: 'finished',
+  class: { system: 'urn:oid:1.2.840.114350.1.72.1.7.1', code: '5', display: 'Appointment' },
+  identifier: [
+    { system: 'urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.8', value: '20100000001' },
+    { value: 'BARE-4471' },
+  ],
+  type: [{ text: 'Office Visit' }],
+  reasonCode: [{ text: 'Derm Problem' }, { text: 'Annual skin check' }],
+  hospitalization: {
+    admitSource: { text: 'From outpatient department' },
+    dischargeDisposition: { text: 'Home' },
+  },
+  participant: [
+    {
+      type: [{ text: 'referrer', coding: [{ code: 'REF' }] }],
+      individual: { display: 'Lucia Marsh, MD' },
+    },
+    {
+      type: [{ text: 'attender', coding: [{ code: 'ATND' }] }],
+      extension: [
+        {
+          url: 'https://vendor.example/fhir/StructureDefinition/participant-specialty',
+          valueCodeableConcept: { text: 'Dermatology' },
+        },
+      ],
+      individual: { display: 'Amara Okoye, MD' },
+    },
+  ],
+  period: { start: '2025-04-01T16:00:00Z', end: '2025-04-01T16:40:00Z' },
+};
+
+describe('Encounter round trip', () => {
+  it('restores the class Coding WHOLE, not just the code', async () => {
+    const out = await roundTrip(ENCOUNTER);
+    expect(out.class).toEqual({
+      code: '5',
+      display: 'Appointment',
+      system: 'urn:oid:1.2.840.114350.1.72.1.7.1',
+    });
+  });
+
+  it('restores every reasonCode', async () => {
+    const out = await roundTrip(ENCOUNTER);
+    expect((out.reasonCode ?? []).map((r: any) => r.text).sort()).toEqual([
+      'Annual skin check',
+      'Derm Problem',
+    ]);
+  });
+
+  it('restores admitSource and dischargeDisposition', async () => {
+    const out = await roundTrip(ENCOUNTER);
+    expect(out.hospitalization?.admitSource?.text).toBe('From outpatient department');
+    expect(out.hospitalization?.dischargeDisposition?.text).toBe('Home');
+  });
+
+  it('restores every participant with its role, role code and specialty', async () => {
+    const out = await roundTrip(ENCOUNTER);
+    const byName = new Map<string, any>(
+      (out.participant ?? []).map((p: any) => [p.individual?.display, p]),
+    );
+    expect([...byName.keys()].sort()).toEqual(['Amara Okoye, MD', 'Lucia Marsh, MD']);
+
+    const attender = byName.get('Amara Okoye, MD');
+    expect(attender.type?.[0]?.text).toBe('attender');
+    expect(attender.type?.[0]?.coding?.map((c: any) => c.code)).toEqual(['ATND']);
+    expect(attender.extension?.[0]?.valueCodeableConcept?.text).toBe('Dermatology');
+
+    expect(byName.get('Lucia Marsh, MD').type?.[0]?.text).toBe('referrer');
+  });
+
+  it('does NOT re-emit the summary provider as a second participant', async () => {
+    // The treating clinician is already one of the participations. Adding the
+    // providerName slot back as another entry would emit the same person twice,
+    // once with a role and once without, and no consumer could tell the
+    // duplicate from a real second participation.
+    const out = await roundTrip(ENCOUNTER);
+    const names = (out.participant ?? []).map((p: any) => p.individual?.display);
+    expect(names.filter((n: string) => n === 'Amara Okoye, MD')).toHaveLength(1);
+  });
+
+  it('restores identifiers from the token form, splitting system from value', async () => {
+    const out = await roundTrip(ENCOUNTER);
+    expect(out.identifier).toEqual([
+      { system: 'urn:oid:1.2.840.114350.1.13.999.2.7.3.698084.8', value: '20100000001' },
+      // Written bare because the source stated no system, and none is invented
+      // on the way back either.
+      { value: 'BARE-4471' },
+    ]);
+  });
+
+  it('an encounter with no participation nodes still restores its summary name', async () => {
+    // The pre-v1.16 record, and the reason the fallback exists: those pods hold
+    // a providerName and no participations, and exporting no participant at all
+    // would lose the one name they have.
+    const noParticipants = structuredClone(ENCOUNTER) as Record<string, unknown>;
+    noParticipants.participant = [{ individual: { display: 'Solo Clinician, MD' } }];
+    const out = await roundTrip(noParticipants);
+    expect(out.participant?.[0]?.individual?.display).toBe('Solo Clinician, MD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DocumentReference
+// ---------------------------------------------------------------------------
+
+const DOCUMENT = {
+  resourceType: 'DocumentReference',
+  id: 'doc-progress-1',
+  status: 'superseded',
+  docStatus: 'amended',
+  type: { text: 'Progress Notes' },
+  date: '2025-04-01T18:22:00Z',
+  author: [{ display: 'Noor Habib, MD' }, { display: 'Amara Okoye, MD' }],
+  authenticator: { display: 'Priya Raman, MD' },
+};
+
+describe('DocumentReference round trip', () => {
+  it('restores BOTH statuses onto their own elements', async () => {
+    // The pair that shared one predicate through clinical v1.15. Before this
+    // change the restorer hardcoded status: 'current', so a superseded filing
+    // came back live.
+    const out = await roundTrip(DOCUMENT);
+    expect(out.status).toBe('superseded');
+    expect(out.docStatus).toBe('amended');
+  });
+
+  it('restores every author', async () => {
+    const out = await roundTrip(DOCUMENT);
+    expect((out.author ?? []).map((a: any) => a.display)).toEqual([
+      'Noor Habib, MD',
+      'Amara Okoye, MD',
+    ]);
+  });
+
+  it('restores the authenticator as an authenticator, not as an author', async () => {
+    const out = await roundTrip(DOCUMENT);
+    expect(out.authenticator?.display).toBe('Priya Raman, MD');
+    expect((out.author ?? []).map((a: any) => a.display)).not.toContain('Priya Raman, MD');
+  });
+
+  it('a document stating no status still exports one, because FHIR requires it', async () => {
+    // `DocumentReference.status` is 1..1. The fallback is the one place a value
+    // is supplied that the pod did not state, and it is confined to records
+    // written before the predicate existed.
+    const bare = structuredClone(DOCUMENT) as Record<string, unknown>;
+    delete bare.status;
+    delete bare.docStatus;
+    const out = await roundTrip(bare);
+    expect(out.status).toBe('current');
+    expect(out.docStatus).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coverage
+// ---------------------------------------------------------------------------
+
+describe('Coverage round trip', () => {
+  const COVERAGE = {
+    resourceType: 'Coverage',
+    id: 'cov-ppo-1',
+    status: 'cancelled',
+    type: { coding: [{ code: 'PPO' }] },
+    subscriberId: 'MEM-88213400',
+    payor: [{ display: 'Cascade Mutual Health' }],
+  };
+
+  it('a cancelled plan does not come back active', async () => {
+    // `Coverage.status` is a FHIR MODIFIER element, so the previous hardcoded
+    // 'active' was not a missing answer on export but a wrong one: it told a
+    // downstream reader the patient had coverage that had been cancelled.
+    const out = await roundTrip(COVERAGE);
+    expect(out.status).toBe('cancelled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The wave-1 statuses the reverse converters had been ignoring
+// ---------------------------------------------------------------------------
+
+describe('wave-1 statuses now survive the round trip too', () => {
+  it('an amended DiagnosticReport does not come back final', async () => {
+    const out = await roundTrip({
+      resourceType: 'DiagnosticReport',
+      id: 'dr-1',
+      status: 'amended',
+      code: { text: 'CBC' },
+      effectiveDateTime: '2025-04-01T16:00:00Z',
+    });
+    expect(out.status).toBe('amended');
+  });
+
+  it('an amended lab Observation keeps its status', async () => {
+    const out = await roundTrip({
+      resourceType: 'Observation',
+      id: 'obs-1',
+      status: 'amended',
+      category: [{ coding: [{ code: 'laboratory' }] }],
+      code: { coding: [{ system: 'http://loinc.org', code: '2951-2' }], text: 'Sodium' },
+      valueQuantity: { value: 140, unit: 'mmol/L' },
+      effectiveDateTime: '2025-04-01T16:00:00Z',
+    });
+    expect(out.status).toBe('amended');
+  });
+
+  it('a corrected vital-sign Observation keeps its status', async () => {
+    const out = await roundTrip({
+      resourceType: 'Observation',
+      id: 'obs-vital-1',
+      status: 'corrected',
+      category: [
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] },
+      ],
+      code: { coding: [{ system: 'http://loinc.org', code: '8867-4' }], text: 'Heart rate' },
+      valueQuantity: { value: 72, unit: '/min' },
+      effectiveDateTime: '2025-04-01T16:00:00Z',
+    });
+    expect(out.status).toBe('corrected');
+  });
+
+  it('a REFUTED Condition does not come back unqualified', async () => {
+    // The opposite claim to `confirmed`, and the one that changes what a reader
+    // does next.
+    const out = await roundTrip({
+      resourceType: 'Condition',
+      id: 'cond-1',
+      clinicalStatus: { coding: [{ code: 'inactive' }] },
+      verificationStatus: { coding: [{ code: 'refuted' }] },
+      code: { text: 'Peanut allergy' },
+    });
+    expect(out.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+    expect(out.clinicalStatus?.coding?.[0]?.code).toBe('inactive');
+  });
+
+  it('a REFUTED AllergyIntolerance keeps both of its status elements', async () => {
+    const out = await roundTrip({
+      resourceType: 'AllergyIntolerance',
+      id: 'allergy-1',
+      clinicalStatus: { coding: [{ code: 'inactive' }] },
+      verificationStatus: { coding: [{ code: 'refuted' }] },
+      code: { text: 'Penicillin' },
+    });
+    expect(out.clinicalStatus?.coding?.[0]?.code).toBe('inactive');
+    expect(out.verificationStatus?.coding?.[0]?.code).toBe('refuted');
+  });
+});

--- a/tests/fhir-standards-alignment.test.ts
+++ b/tests/fhir-standards-alignment.test.ts
@@ -295,7 +295,13 @@ describe('a conformant Epic-shaped FHIR bundle converts and validates', () => {
     // subject no shape targeted, and an unchecked subject reports PASS.
     expect(result.coverage.unshapedSubjects.map((u) => u.types.join(','))).toEqual([]);
     expect(result.coverage.checkedSubjects).toBe(result.coverage.totalSubjects);
-    expect(result.coverage.totalSubjects).toBe(5);
+    // 5 -> 6 with clinical v1.16: the encounter's participation is a subject of
+    // its own now, and `clinical:EncounterParticipantShape` targets it. That the
+    // count moved and `unshapedSubjects` stayed empty is the load-bearing part —
+    // a new subject type reaching the pod with no shape aimed at it would report
+    // PASS while being checked by nothing, which is the exact defect the
+    // Encounter itself exhibited before clinical v1.14 gave it a shape.
+    expect(result.coverage.totalSubjects).toBe(6);
   });
 
   it('raises no warning on a conformant subscriber relationship', () => {

--- a/tests/sources-coverage.test.ts
+++ b/tests/sources-coverage.test.ts
@@ -119,7 +119,17 @@ describe('cascade sources coverage', () => {
     // Deduplicated: the encounter appearing in both bundles is one resource.
     expect(result.stdout).toContain('11 unique of 12 read');
     expect(result.stdout).toMatch(/Encounter \(2 resources\)/);
-    expect(result.stdout).toMatch(/2 {2}Encounter\.reasonCode\s+pending 3\.254/);
+    // `Encounter.reasonCode` stood here until clinical v1.16 gave the reason a
+    // predicate. What is left of the encounter's pending debt is the type
+    // codings past the first, the service type and the second location — all
+    // three still without a term. Pinning one of them keeps this assertion doing
+    // what it did: proving the command reports a PENDING path with its id, not
+    // only acknowledged ones.
+    expect(result.stdout).toMatch(/2 {2}Encounter\.serviceType\s+pending 3\.254/);
+    // And an acknowledged one, so the two dispositions are both exercised.
+    expect(result.stdout).toMatch(/2 {2}Encounter\.participant\[0\]\.period\s+acknowledged/);
+    // The reason is EMITTED now and must not appear as a dropped path at all.
+    expect(result.stdout).not.toMatch(/Encounter\.reasonCode\s+pending/);
     // The identifier is EMITTED now (it is the encounter join key), so it must
     // not appear as a dropped path at all — only its `use` qualifier does.
     expect(result.stdout).not.toMatch(/Encounter\.identifier\s+pending/);


### PR DESCRIPTION
Two commits: the vendored shapes sync, then the converter adoption that uses it.

## 1. `chore(shapes)` — sync from spec

core 3.6 → 3.7, health 2.7 → 2.8, clinical 1.15 → 1.16, coverage 1.4 → 1.5.

`npm run check:shapes-drift`: 20 files byte-identical to spec, 6 `VOCAB_VERSIONS` rows agreeing
with spec and with the `owl:versionInfo` each bundled ontology declares.

One test is RED at this commit and closed by the next: a deliberate tripwire that fires the day a
`coverage:status` term appears in the bundled vocabulary, so the omission it guarded could not
outlive the reason for it. Suite at that commit: 2585 passed, 1 failed, 0 skipped.

## 2. `feat(cli)` — converter adoption

Thirteen predicates emitted, read back, and struck from the drop manifests.

| Converter | Predicates now emitted |
|---|---|
| `convertEncounter` | `encounterReason` (0..*), `admitSource`, `dischargeDisposition`, `encounterClassDisplay`, `encounterClassSystem`, `hasParticipant` → `EncounterParticipant` nodes with `participantName` / `participantRole` / `participantRoleCode` / `participantSpecialty`, `businessIdentifier` (0..*) |
| `convertClinicalDocument` | `documentReferenceStatus`, `documentAuthorName` (every author), `authenticatorName` |
| `convertCoverage` | `coverage:status` |

The class CODE and `clinical:providerName` are unchanged: the display is stored alongside the code,
not instead of it, and the provider slot stays the one-name summary an application displays while
the participations carry the full record.

Participation IRIs come from one chokepoint and are a pure function of (encounter subject IRI,
participation content) — never the array index, which is a property of the serialization rather
than the data. Proven across two processes from two working directories against `dist/`.

Identifiers dual-emit: token form `{system}|{value}` on the canonical predicate, the frozen colon
form unchanged on `cascade:sourceRecordId`. The reconciler intersects identifier sets per predicate
in each predicate's own form; no code path converts between them.

Reverse converters read back all thirteen plus the four wave-1 status predicates, with round-trip
tests for each. Three hardcoded statuses on export are gone (`'final'`, `'current'`, `'active'`),
surviving only as fallbacks for records written before the predicates existed.

Participation nodes are stored and validated but excluded from record counts — counting them
reported one Synthea bundle's 44 visits as 57 encounters.

## Verification

RED first per behavior, each against a confirmed non-empty diff:

| Suite | RED / total | Against |
|---|---|---|
| emissions | 17 / 28 | parent commit |
| round trip | 14 / 17 | reverse converters reverted |
| matcher migration | 2 / 8 | canonical predicate removed from the match-key list |
| participation identity | 6 / 11 | clock-keyed IRI (identity-chokepoint fence also fires) |
| participation identity | 4 / 11 | index-keyed IRI (both cross-process cases included) |

Full suite: **2650 passed, 0 failed, 0 skipped**, 165 files, conformance sibling present.
Shapes drift: 20 byte-identical, 6 rows agree. `npm run build` clean; `tsc --noEmit` clean.

Acceptance, end to end through the CLI: a pod built from a synthetic 2-participant encounter,
imported three times with `--reconcile-existing`. Participation nodes present; `encounters.ttl`
byte-identical between passes 2 and 3; 4 records reported every pass (0 new / 4 already in pod on
re-import); `pod conflicts` exit 0 with none raised; every pod file PASSes `cascade validate`
against the newly embedded shapes, with the encounter file reporting 3 of 3 subjects checked.
