### PR TITLE
chore(shapes): sync from spec — clinical 1.17, coverage 1.6, core 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+**Shapes synced to spec 9b13ae4: clinical v1.17, coverage v1.6, core v3.8 (0.21.1).**
+clinical v1.17 stops `sh:node` escalating the Warning-severity status bindings to
+Violation on the six document subtypes (the warnings now fire named from
+target-class shapes); coverage v1.6 admits `cascade:AIExtracted` provenance on
+`InsurancePlanShape`; core v3.8 defines `cascade:PatientReported`, the provenance
+individual seventeen shapes already accepted. No converter behavior changes;
+validation verdicts on document-subtype statuses soften from spurious rejection
+to the intended named warning.
+
 ### Added
 
 **The FHIR converters now emit the thirteen predicates clinical v1.16 and coverage v1.5 authored,

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -144,9 +144,9 @@
 #     attachmentPath, attachmentMediaType, contentHash, hashAlgorithm,
 #     byteSize, attachmentTitle) for content-addressed binary storage. Synced
 #     and bundled; no converter emits it yet (root backlog 3.276).
-core=3.7
+core=3.8
 health=2.8
-clinical=1.16
-coverage=1.5
+clinical=1.17
+coverage=1.6
 checkup=3.3
 pots=1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-cascade-protocol/cli",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmod/vcf": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-cascade-protocol/cli",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Cascade Protocol CLI - Validate, convert, and manage health data",
   "bin": {
     "cascade": "dist/index.js"

--- a/src/shapes/clinical.shapes.ttl
+++ b/src/shapes/clinical.shapes.ttl
@@ -14,6 +14,78 @@
 # different data sources (EHR, device, patient-reported).
 #
 # Changelog:
+# v1.17 (2026-08-28): Stop sh:node from escalating a nested sh:Warning into a
+#     sh:Violation. Strictly widening: no graph that validated under v1.16 stops
+#     validating, and six document classes stop being REJECTED for a value
+#     v1.16 said would only be reported.
+#
+#     THE DEFECT. SHACL defines conformance as an EMPTY validation result
+#     (https://www.w3.org/TR/shacl/#conformance-checking), and that definition
+#     does not read severities: a nested sh:Warning is a result, so the value
+#     node does not conform, so the referring sh:node constraint fires — at ITS
+#     OWN severity, which with nothing declared is sh:Violation. v1.16 put the
+#     clinical:status and clinical:documentReferenceStatus warnings ON
+#     clinical:ClinicalDocumentShape, which is exactly the shape the six
+#     document subtypes reach through sh:node. So the ratchet v1.16 wrote down
+#     held for clinical:ClinicalDocument and was inverted for
+#     clinical:LaboratoryReport, clinical:ProgressNote,
+#     clinical:DischargeSummary, clinical:ConsultationNote,
+#     clinical:ImagingReport and clinical:VisitSummary: an out-of-set status
+#     rejected the record. Confirmed on two independent engines (pyshacl and
+#     rdf-validate-shacl); on clinical:ProgressNote the underlying warning was
+#     not even reported, only an opaque sh:NodeConstraintComponent naming no
+#     field.
+#
+#     THE FIX, AND WHY IT IS NOT sh:severity ON THE sh:node CONSTRAINT.
+#     Declaring sh:severity sh:Warning next to the sh:node reference would demote
+#     the WHOLE referenced shape: a discharge summary missing clinical:sourceEHR,
+#     or carrying a malformed cascade:schemaVersion, would stop being rejected
+#     too. sh:severity is a property of the shape a constraint belongs to and
+#     cannot be applied to one nested result. The escalation is therefore removed
+#     at the source instead: a shape that is used as an sh:node referent carries
+#     Violation-severity constraints ONLY, and every non-Violation constraint is
+#     declared on a shape that TARGETS the classes it applies to. Warnings then
+#     reach a document subtype the same way they reach clinical:ClinicalDocument,
+#     by sh:targetClass, and are reported as themselves.
+#
+#     1. clinical:ClinicalDocumentShape loses its two Warning property shapes
+#        (clinical:status, clinical:documentReferenceStatus). It keeps every
+#        Violation-severity constraint and stays the sh:node referent for the
+#        six subtypes, which is now sound because it carries no non-Violation
+#        constraint.
+#     2. NEW clinical:DocumentReferenceStatusShape: the
+#        clinical:documentReferenceStatus binding, verbatim from v1.16, at
+#        sh:Warning, targeting all SEVEN document classes.
+#     3. NEW clinical:DocumentStatusShape: the clinical:status binding, verbatim
+#        from v1.16, at sh:Warning, targeting all SEVEN document classes.
+#     4. clinical:LaboratoryReportShape loses the clinical:status restatement
+#        v1.16 put on it. Its value set was the same ten codes, so nothing it
+#        enforced is lost; it kept only a lab-specific message, and that message
+#        is now folded into the shared one, which names DiagnosticReport
+#        explicitly. It could NOT be kept as a lab-only shape beside
+#        clinical:DocumentStatusShape: SHACL class targets follow
+#        rdfs:subClassOf* wherever the axioms are in the validated graph, and
+#        the conformance harness loads them, so two shapes binding
+#        clinical:status would report a laboratory report's status twice there
+#        and once under a validator that omits the axioms. Measured during this
+#        fix, not assumed. The full argument, and what it means for the
+#        composition-status ratchet, is at clinical:DocumentStatusShape.
+#     5. clinical:LaboratoryReportShape keeps its documentDate constraint and
+#        the sh:node reference, both unchanged.
+#
+#     GUARD. scripts/check-nested-severity.py fails any sh:node or
+#     sh:qualifiedValueShape reference into a shape carrying sh:Warning or
+#     sh:Info, against a baseline in scripts/nested-severity-baseline.json that
+#     can only shrink. No existing check could see this class: it is not an
+#     entailment question, so check-shape-targets.py is silent on it, and spec
+#     runs no SHACL validator (see the root backlog on that).
+#
+#     DOC FIX. Item 4 of the v1.16 entry below said "the nine encounter facts"
+#     and then listed seven property shapes. The encounter group is eleven terms
+#     (ten properties and clinical:EncounterParticipant); seven of them are
+#     property shapes on clinical:EncounterShape. Corrected in place; no
+#     constraint changes.
+#
 # v1.16 (2026-08-27): Describe the facts the records now carry. Additive and
 #     strictly widening: nothing that validated under v1.15 stops validating,
 #     and every new finding on an existing predicate is at sh:Warning.
@@ -51,11 +123,15 @@
 #        sh:maxCount 1 on clinical:providerName is what was discarding every
 #        author past the first), clinical:authenticatorName (0..1) and
 #        clinical:businessIdentifier (repeatable).
-#     4. NEW property shapes on clinical:EncounterShape for the nine encounter
-#        facts clinical v1.16 defines: encounterClassDisplay,
+#     4. NEW property shapes on clinical:EncounterShape for seven of the facts
+#        clinical v1.16 defines: encounterClassDisplay,
 #        encounterClassSystem, encounterReason (repeatable), admitSource,
-#        dischargeDisposition, hasParticipant (repeatable) and
-#        businessIdentifier (repeatable). None of the source-text properties
+#        dischargeDisposition, hasParticipant (repeatable) and the domain-free
+#        businessIdentifier (repeatable). The encounter group itself is eleven
+#        terms — ten properties and clinical:EncounterParticipant — and the four
+#        it does not list here are the participation sub-properties, constrained
+#        by clinical:EncounterParticipantShape in item 5.
+#        None of the source-text properties
 #        carries a value set: FHIR binds reasonCode and admitSource PREFERRED
 #        and dischargeDisposition EXAMPLE, and an enum over an example-strength
 #        binding rejects conformant data by construction.
@@ -284,56 +360,21 @@ clinical:ClinicalDocumentShape a sh:NodeShape ;
     ] ;
 
     # ------------------------------------------------------------------
-    # v1.16: the two status axes, and the two attribution axes
+    # v1.16: the two attribution axes
     # ------------------------------------------------------------------
     #
-    # WHY THE STATUS SET HERE IS THE DIAGNOSTIC-REPORT SET AND NOT THE
-    # COMPOSITION SET. On a DocumentReference-derived record clinical:status
-    # carries DocumentReference.docStatus, whose required binding is
-    # composition-status: preliminary | final | amended | entered-in-error.
-    # But clinical:LaboratoryReportShape reaches these constraints through
-    # sh:node, and a laboratory report is converted from a DiagnosticReport,
-    # whose status value set is the ten-code diagnostic-report-status. Binding
-    # the four-code set here would therefore report a conformant DiagnosticReport
-    # status of "partial", "corrected" or "appended" as out of set on every lab
-    # report in the pod.
-    #
-    # composition-status is a strict SUBSET of diagnostic-report-status, so the
-    # ten-code set is the union of the two value sets that reach this shape and
-    # is the only set that is correct for every class under it. It is bound here
-    # verbatim from https://hl7.org/fhir/R4/valueset-diagnostic-report-status.html
-    #
-    # The narrower composition-status binding for the DocumentReference-derived
-    # document subtypes specifically is deliberately NOT added in this version.
-    # It would have to live on shapes targeting those subtypes alone, and this
-    # release has no measurement of what those records actually carry; per the
-    # core v3.5 ratchet a constraint is added once conforming output is observed,
-    # not on the assumption that it will be. That is the next step here, and it
-    # is one version's work, not a judgement call.
-    sh:property [
-        sh:path clinical:status ;
-        sh:datatype xsd:string ;
-        sh:maxCount 1 ;
-        sh:in ("registered" "partial" "preliminary" "final" "amended" "corrected"
-               "appended" "cancelled" "entered-in-error" "unknown") ;
-        sh:name "Status"@en ;
-        sh:message "Document status should be one of the FHIR R4 codes a document-class record can carry: the four composition-status codes (preliminary, final, amended, entered-in-error) that DocumentReference.docStatus is bound to, or the ten diagnostic-report-status codes a DiagnosticReport-derived report carries"@en ;
-        sh:severity sh:Warning
-    ] ;
-
-    # FHIR R4 DocumentReference.status, required binding, verbatim.
-    # A DIFFERENT fact from clinical:status above: this is whether the pod's
-    # POINTER to the document is current, and "entered-in-error" here means the
-    # reference was filed in error, not that the clinical content is repudiated.
-    sh:property [
-        sh:path clinical:documentReferenceStatus ;
-        sh:datatype xsd:string ;
-        sh:maxCount 1 ;
-        sh:in ("current" "superseded" "entered-in-error") ;
-        sh:name "Document Reference Status"@en ;
-        sh:message "Document reference status should be one of the FHIR R4 DocumentReferenceStatus codes: current, superseded, entered-in-error"@en ;
-        sh:severity sh:Warning
-    ] ;
+    # THE TWO STATUS AXES ARE NOT HERE, AND MUST NOT BE MOVED HERE. v1.16
+    # declared clinical:status and clinical:documentReferenceStatus on this
+    # shape, at sh:Warning. Six subtype shapes reach this shape through sh:node,
+    # and SHACL defines conformance as an EMPTY result set, so a nested Warning
+    # made the node non-conforming and the sh:node constraint fired at its own
+    # default severity: every one of those six classes REJECTED a status value
+    # this vocabulary says should only be reported. From v1.17 the two bindings
+    # live on clinical:DocumentStatusShape and
+    # clinical:DocumentReferenceStatusShape, which reach the same classes by
+    # sh:targetClass instead. Everything declared on THIS shape is a
+    # sh:Violation for that reason, and scripts/check-nested-severity.py fails
+    # the build if a non-Violation constraint is added to it.
 
     # Repeatable by design: DocumentReference.author is 0..*, and the
     # sh:maxCount 1 on clinical:providerName is what was discarding every author
@@ -511,27 +552,18 @@ clinical:LaboratoryReportShape a sh:NodeShape ;
         sh:minCount 1 ;
         sh:name "Document Date"@en ;
         sh:message "Lab reports must have a document date"@en
-    ] ;
-
-    # v1.16: FHIR R4 DiagnosticReport.status, required binding, verbatim and in
-    # the value set's own order
-    # (https://hl7.org/fhir/R4/valueset-diagnostic-report-status.html). A
-    # laboratory report is converted from a DiagnosticReport, so this is the
-    # value set its clinical:status is drawn from. Restated here rather than
-    # left to the inherited ClinicalDocumentShape constraint, because a reader
-    # of this shape needs to see which of the two document status value sets
-    # applies to a lab report; the two sets are identical here by construction,
-    # since composition-status is a strict subset of this one.
-    sh:property [
-        sh:path clinical:status ;
-        sh:datatype xsd:string ;
-        sh:maxCount 1 ;
-        sh:in ("registered" "partial" "preliminary" "final" "amended" "corrected"
-               "appended" "cancelled" "entered-in-error" "unknown") ;
-        sh:name "Status"@en ;
-        sh:message "Laboratory report status should be one of the FHIR R4 DiagnosticReportStatus codes: registered, partial, preliminary, final, amended, corrected, appended, cancelled, entered-in-error, unknown"@en ;
-        sh:severity sh:Warning
     ] .
+
+# NOTE (v1.17): the clinical:status binding v1.16 restated here is gone, and
+# must not be restored. It cannot live on this shape, because this shape is an
+# sh:node referent and a nested sh:Warning would be reported as a sh:Violation
+# on the referring shape. It cannot live on a lab-only shape beside
+# clinical:DocumentStatusShape either, because SHACL class targets follow
+# rdfs:subClassOf* wherever the axioms are present, so both shapes would match a
+# laboratory report and report its status twice. The single binding over all
+# seven document classes, with a message that names DiagnosticReport, is at
+# clinical:DocumentStatusShape below; its value set is the same ten codes this
+# restatement carried.
 
 # ============================================================================
 # Shape: Imaging Report
@@ -576,6 +608,115 @@ clinical:VisitSummaryShape a sh:NodeShape ;
         sh:maxCount 1 ;
         sh:name "Encounter Date"@en ;
         sh:message "Visit summary must specify the encounter date"@en
+    ] .
+
+# ============================================================================
+# Shapes: the two document status axes (v1.17)
+# ============================================================================
+#
+# WHY THESE ARE SEPARATE SHAPES WITH THEIR OWN sh:targetClass, RATHER THAN
+# PROPERTY SHAPES ON clinical:ClinicalDocumentShape.
+#
+# The six subtype shapes above reach clinical:ClinicalDocumentShape through
+# sh:node. SHACL defines conformance as an empty validation result
+# (https://www.w3.org/TR/shacl/#conformance-checking); the definition does not
+# consult severity, so a nested sh:Warning is enough to make the value node
+# non-conforming, and the sh:node constraint then reports at the severity of the
+# shape it is written on — sh:Violation, none being declared. A Warning
+# published on the referenced shape is therefore a Violation on every class that
+# references it. That is what v1.16 shipped, and it inverted the ratchet it had
+# just written down.
+#
+# Declaring sh:severity sh:Warning beside the sh:node reference is not the fix.
+# Severity attaches to a shape, not to one nested result, so it would demote the
+# entire referenced shape: a document missing clinical:sourceEHR or carrying a
+# malformed cascade:schemaVersion would stop being rejected. The referenced
+# shape keeps only Violation-severity constraints, and anything softer is
+# targeted directly at the classes it applies to, as here.
+#
+# The invariant is machine-checked: scripts/check-nested-severity.py fails any
+# sh:node or sh:qualifiedValueShape reference into a shape carrying sh:Warning
+# or sh:Info.
+
+# FHIR R4 DocumentReference.status, required binding, verbatim.
+# A DIFFERENT fact from clinical:status: this is whether the pod's POINTER to
+# the document is current, and "entered-in-error" here means the reference was
+# filed in error, not that the clinical content is repudiated. It applies to
+# every document class, laboratory reports included, because the pointer exists
+# independently of what the document is.
+clinical:DocumentReferenceStatusShape a sh:NodeShape ;
+    sh:targetClass clinical:ClinicalDocument ;
+    sh:targetClass clinical:ProgressNote ;
+    sh:targetClass clinical:DischargeSummary ;
+    sh:targetClass clinical:ConsultationNote ;
+    sh:targetClass clinical:LaboratoryReport ;
+    sh:targetClass clinical:ImagingReport ;
+    sh:targetClass clinical:VisitSummary ;
+    rdfs:label "Document Reference Status Shape"@en ;
+    rdfs:comment "Advisory binding of clinical:documentReferenceStatus to FHIR R4 DocumentReferenceStatus, on every document class. Warning severity, per the core v3.5 ratchet."@en ;
+
+    sh:property [
+        sh:path clinical:documentReferenceStatus ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("current" "superseded" "entered-in-error") ;
+        sh:name "Document Reference Status"@en ;
+        sh:message "Document reference status should be one of the FHIR R4 DocumentReferenceStatus codes: current, superseded, entered-in-error"@en ;
+        sh:severity sh:Warning
+    ] .
+
+# WHY THE STATUS SET HERE IS THE DIAGNOSTIC-REPORT SET AND NOT THE COMPOSITION
+# SET. On a DocumentReference-derived record clinical:status carries
+# DocumentReference.docStatus, whose required binding is composition-status:
+# preliminary | final | amended | entered-in-error. composition-status is a
+# strict SUBSET of diagnostic-report-status, so the ten-code set is the union of
+# the two value sets a document-class record can draw from, and binding the
+# four-code set to a class that may carry "partial", "corrected" or "appended"
+# would report conformant data as out of set. It is bound here verbatim from
+# https://hl7.org/fhir/R4/valueset-diagnostic-report-status.html
+#
+# WHY ONE SHAPE OVER ALL SEVEN CLASSES, AND NOT A PER-CLASS SPLIT. The obvious
+# alternative was two shapes with disjoint targets, so that a laboratory report
+# could carry a message naming DiagnosticReport and the note/summary subtypes
+# one naming DocumentReference. It does not work, and the reason is the same
+# entailment question validation/index.md is about, seen from the other side:
+# SHACL's class targets are resolved over SHACL-instances, and that relation
+# follows rdfs:subClassOf* wherever the axioms are present in the graph being
+# validated. The conformance harness loads exactly those axioms. A shape
+# targeting clinical:ClinicalDocument therefore ALSO reaches every subtype
+# there, so a second shape binding clinical:status to clinical:LaboratoryReport
+# reports the same field twice under an axiom-loading validator and once under
+# one that omits them. Measured, not assumed: the split emitted two warnings on
+# a laboratory report and one on a progress note. One shape, one property shape,
+# every class named explicitly — so the target set is stated rather than
+# inferred, and the same node is reported exactly once either way.
+#
+# The narrower composition-status binding for the five note/summary subtypes is
+# still the next step here and is deliberately NOT taken in this version: what
+# is missing is a measurement of what those records actually carry, and per the
+# core v3.5 ratchet a constraint is added once conforming output is observed.
+# Whoever takes it should read the paragraph above first — the narrowing cannot
+# be a second shape laid over a subset of these classes, for exactly that reason.
+clinical:DocumentStatusShape a sh:NodeShape ;
+    sh:targetClass clinical:ClinicalDocument ;
+    sh:targetClass clinical:ProgressNote ;
+    sh:targetClass clinical:DischargeSummary ;
+    sh:targetClass clinical:ConsultationNote ;
+    sh:targetClass clinical:LaboratoryReport ;
+    sh:targetClass clinical:ImagingReport ;
+    sh:targetClass clinical:VisitSummary ;
+    rdfs:label "Document Status Shape"@en ;
+    rdfs:comment "Advisory binding of clinical:status on every document class. The value set is the ten-code diagnostic-report-status, which is the union of the two sets a document-class record can draw from, since composition-status is a strict subset of it. Warning severity, per the core v3.5 ratchet."@en ;
+
+    sh:property [
+        sh:path clinical:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("registered" "partial" "preliminary" "final" "amended" "corrected"
+               "appended" "cancelled" "entered-in-error" "unknown") ;
+        sh:name "Status"@en ;
+        sh:message "Document status should be one of the FHIR R4 codes a document-class record can carry: the four composition-status codes (preliminary, final, amended, entered-in-error) that DocumentReference.docStatus is bound to, or the ten diagnostic-report-status codes (registered, partial, preliminary, final, amended, corrected, appended, cancelled, entered-in-error, unknown) that a DiagnosticReport-derived report such as a laboratory report carries"@en ;
+        sh:severity sh:Warning
     ] .
 
 # ============================================================================

--- a/src/shapes/clinical.ttl
+++ b/src/shapes/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-08-27"^^xsd:date ;
-    owl:versionInfo "1.16" ;
+    dct:modified "2026-08-28"^^xsd:date ;
+    owl:versionInfo "1.17" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -1422,6 +1422,39 @@ clinical:isActive a owl:DatatypeProperty ;
 # Changelog
 # ============================================================================
 #
+# Version 1.17 (2026-08-28)
+# - NO new terms, and no term changes meaning. This version is a SHACL severity
+#   correction plus one prose fix; clinical.ttl itself changes only in this
+#   changelog, its dct:modified and its owl:versionInfo.
+# - SHACL. v1.16 declared the clinical:status and clinical:documentReferenceStatus
+#   value sets at sh:Warning on clinical:ClinicalDocumentShape. Six document
+#   subtype shapes reach that shape through sh:node, and SHACL defines
+#   conformance as an EMPTY validation result
+#   (https://www.w3.org/TR/shacl/#conformance-checking) — a definition that does
+#   not consult severity. A nested Warning therefore made the node
+#   non-conforming, and the sh:node constraint reported at its own default
+#   severity. clinical:LaboratoryReport, clinical:ProgressNote,
+#   clinical:DischargeSummary, clinical:ConsultationNote, clinical:ImagingReport
+#   and clinical:VisitSummary all REJECTED status values v1.16 said would only
+#   be reported, and on clinical:ProgressNote the underlying warning was not
+#   surfaced at all. Confirmed on pyshacl and on rdf-validate-shacl. The two
+#   bindings now live on clinical:DocumentStatusShape and
+#   clinical:DocumentReferenceStatusShape, which reach all seven document
+#   classes by sh:targetClass; clinical:ClinicalDocumentShape keeps only
+#   Violation-severity constraints, which is what makes it safe to reference.
+#   Value sets, messages and severities are otherwise unchanged. Detail in
+#   clinical.shapes.ttl's own changelog.
+# - COMPATIBILITY. Strictly widening, in the direction that matters: no graph
+#   that validated under v1.16 stops validating, and six classes of record stop
+#   being rejected for a value this vocabulary always said was advisory. A
+#   consumer that was suppressing document-status violations to work around the
+#   defect can stop.
+# - DOC FIX. The v1.16 entry below counted its encounter group as nine terms;
+#   the group is eleven (ten properties and clinical:EncounterParticipant),
+#   which is what makes its own FIFTEEN total add up: 11 encounter + 1 identity
+#   + 3 documents. Corrected in place, along with the matching miscounts in
+#   CHANGELOG.md and clinical.shapes.ttl. No term is added, removed or renamed.
+#
 # Version 1.16 (2026-08-27)
 # - FIFTEEN new terms (14 properties and 1 class), two domains dropped, one
 #   property deprecated, and the
@@ -1430,7 +1463,8 @@ clinical:isActive a owl:DatatypeProperty ;
 #   source element that a conformant server sends and this vocabulary had
 #   nowhere to put, so an importer dropped it. Every term cites the FHIR R4
 #   element it mirrors by canonical URL; nothing is invented.
-# - ENCOUNTER (9 terms). clinical:encounterReason (Encounter.reasonCode 0..*,
+# - ENCOUNTER (11 terms: 10 properties and 1 class). clinical:encounterReason
+#   (Encounter.reasonCode 0..*,
 #   preferred binding, US Core Must Support); clinical:admitSource and
 #   clinical:dischargeDisposition (Encounter.hospitalization.admitSource /
 #   .dischargeDisposition, the only structured signal separating an admission

--- a/src/shapes/core.ttl
+++ b/src/shapes/core.ttl
@@ -19,8 +19,8 @@
     dct:description "Core vocabulary for schema versioning, data provenance, identity management, and patient demographics across all Cascade Protocol applications"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-10-31"^^xsd:date ;
-    dct:modified "2026-08-27"^^xsd:date ;
-    owl:versionInfo "3.7" ;
+    dct:modified "2026-08-28"^^xsd:date ;
+    owl:versionInfo "3.8" ;
     rdfs:comment "This vocabulary defines cross-cutting concepts used by all Cascade Protocol health data applications: schema versioning, data provenance, patient demographics (PatientProfile), and supporting identity classes (Address, PharmacyInfo, AdvanceDirectives). Domain-specific vocabularies (e.g., pots:, ecg:, glucose:) import this core vocabulary."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/core/v1.0/> .
 
@@ -58,6 +58,20 @@ cascade:SelfReported a owl:Class ;
     rdfs:subClassOf cascade:ConsumerGenerated ;
     rdfs:label "Self-Reported"@en ;
     rdfs:comment "Data manually entered by the patient (symptom logs, medication adherence, intake form fields)."@en .
+
+# Added in core v3.8. Seventeen SHACL constraints across the clinical, health and
+# coverage shapes had accepted cascade:PatientReported since their first release,
+# and the health vocabulary's provenance guidance instructs consumers to key on
+# it — but the individual itself was never defined, so any consumer deriving the
+# provenance set from this ontology rejected a value every shape permits. A
+# direct subclass of cascade:DataProvenance rather than of ClinicalGenerated or
+# ConsumerGenerated: a patient's reported history reaches a record through
+# either setting, and the parent must not assert one.
+cascade:PatientReported a owl:Class ;
+    rdfs:subClassOf cascade:DataProvenance ;
+    rdfs:label "Patient-Reported"@en ;
+    rdfs:comment "Information originating from the patient's own account and recorded by another party or system (history related to a clinician, imported questionnaire responses). Distinct from cascade:SelfReported, where the patient enters the data directly."@en ;
+    owl:versionInfo "Added in core v3.8" .
 
 cascade:ConsumerWellness a owl:Class ;
     rdfs:subClassOf cascade:ConsumerGenerated ;

--- a/src/shapes/coverage.shapes.ttl
+++ b/src/shapes/coverage.shapes.ttl
@@ -6,7 +6,13 @@
 
 # ============================================================================
 # Cascade Protocol — Coverage Vocabulary SHACL Validation Shapes
-# Version: 1.0 (Phase 4, 2026-02-18)
+# Version: 1.3 (coverage v1.6, 2026-08-28)
+#
+# This header is not read by any gate, which is how it sat at "1.0 (Phase 4,
+# 2026-02-18)" through the 1.1 and 1.2 revisions recorded in the changelog at
+# the foot of this file. The changelog is the authority; keep this line in step
+# with it.
+#
 # Validates: coverage:InsurancePlan
 #
 # Layer 2 domain-specific vocabulary for patient-owned insurance and benefits data.
@@ -234,9 +240,16 @@ coverage:InsurancePlanShape a sh:NodeShape ;
     # ------------------------------------------------------------------
 
     # Required: provenance
+    #
+    # cascade:AIExtracted (a ClinicalGenerated subclass, core v3.3) is in the
+    # list from coverage v1.6. Every clinical and health record shape gained it
+    # in clinical v1.9 and this one was missed, so an insurance card read by a
+    # document-extraction pipeline carried the correct provenance for what it
+    # was and was REJECTED at sh:Violation for saying so. Photographing a card
+    # is one of the most likely AI-extraction paths there is.
     sh:property [
         sh:path cascade:dataProvenance ;
-        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported) ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:name "Data Provenance"@en ;
@@ -300,6 +313,19 @@ coverage:CoverageTypeVocabularyShape a sh:NodeShape ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.3 (2026-08-28) — coverage v1.6
+# - coverage:InsurancePlanShape's cascade:dataProvenance sh:in list gains
+#   cascade:AIExtracted. BEHAVIOUR CHANGE, and the only one in this version: an
+#   insurance plan whose provenance is cascade:AIExtracted was REJECTED at
+#   sh:Violation and now validates. Every clinical and health record shape
+#   gained this member in clinical v1.9, when core v3.3 introduced the class;
+#   this shape was missed, so the one document type a patient is most likely to
+#   capture with a camera was the one that could not say how it was captured.
+# - Strictly widening. Nothing that validated under 1.2 fails under 1.3, and one
+#   class of previously-rejected conformant record now passes. No pod needs
+#   rewriting: this list is a value set, not a requirement.
+# - The header at the top of this file, stale since 1.0, now states 1.3.
 #
 # Version 1.2 (2026-08-27) — coverage v1.5
 # - coverage:InsurancePlanShape declares coverage:status, bound to the four

--- a/src/shapes/coverage.ttl
+++ b/src/shapes/coverage.ttl
@@ -18,8 +18,8 @@
     dct:description "Domain vocabulary for patient-owned insurance, benefits, and financial health data. Layer 2 vocabulary resolving the overlap between checkup:InsuranceInfo (patient-reported) and clinical:CoverageRecord (EHR-imported) with a unified, standardized representation."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-02-18"^^xsd:date ;
-    dct:modified "2026-08-27"^^xsd:date ;
-    owl:versionInfo "1.5" ;
+    dct:modified "2026-08-28"^^xsd:date ;
+    owl:versionInfo "1.6" ;
     rdfs:comment "Insurance and benefits data is cross-cutting: not clinical (it's administrative/financial), not app-specific (any health app benefits from knowing coverage), and contributed by both patient self-report and EHR import. This vocabulary provides a single Layer 2 domain model that both checkup: (Layer 3, patient-reported) and clinical: (Layer 2, EHR-imported) can reference via the mixed namespace pattern. Recommended Pod storage path: /coverage/"@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/coverage/v1/> .
 
@@ -176,6 +176,21 @@ coverage:rxGroup a owl:DatatypeProperty ;
 #   rdfs:seeAlso mappings to HL7 ClaimResponse.adjudication and CARIN IG adjudication codes.
 #
 # v1.2 (2026-03-16): Added coverage:DenialNotice class, coverage:AppealRecord class, and 11 new properties for denial/appeal workflow.
+#
+# Version 1.6 (2026-08-28)
+# - NO new terms. A SHACL value-set correction plus one stale header; coverage.ttl
+#   changes only in this changelog, its dct:modified and its owl:versionInfo.
+# - SHACL (coverage.shapes.ttl 1.2 to 1.3). coverage:InsurancePlanShape's
+#   cascade:dataProvenance list gains cascade:AIExtracted. BEHAVIOUR CHANGE: an
+#   insurance plan carrying that provenance was rejected at sh:Violation and now
+#   validates. The class has existed since core v3.3, and every clinical and
+#   health record shape accepted it from clinical v1.9; this shape was missed.
+#   The gap mattered more here than the oversight suggests, because an insurance
+#   card is a photograph before it is data, so AI extraction is a primary path
+#   into this class rather than an exotic one.
+# - COMPATIBILITY. Strictly widening. Nothing that validated under v1.5 fails
+#   under v1.6, no pod needs rewriting, and one class of conformant record stops
+#   being rejected.
 #
 # Version 1.5 (2026-08-27)
 # - ONE new property, coverage:status, for FHIR R4 Coverage.status: a code,


### PR DESCRIPTION
Shapes sync to the spec PR #32 merge (9b13ae4). Document-subtype status values now warn named instead of spuriously rejecting (acceptance: the conformance WARN fixture validates with exactly one named warning through the embedded shapes); `cascade:AIExtracted` admitted on InsurancePlanShape; `cascade:PatientReported` defined. No converter changes. Full suite 165 files / 2650 tests / 0 failures / 0 skips. `check:shapes-drift`: 20 files byte-identical, 6 VOCAB_VERSIONS rows agree. Version 0.21.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)