### PR TITLE
fix(identity): order identity keys by code point, not locale collation

### DIFF
--- a/gen-goldens.mjs
+++ b/gen-goldens.mjs
@@ -1,0 +1,16 @@
+import { contentHashedUri, medicationUri, encounterParticipantUri } from './dist/lib/fhir-converter/types.js';
+const cases = [
+  ['FHIR Patient', () => contentHashedUri('Patient', { dob:'1985-03-15', sex:'male', name:'n-8f3a', identifier:'i-2b7c', maritalStatus:'M', address:'a-91de', deceased:undefined })],
+  ['FHIR Condition', () => contentHashedUri('Condition', { patient:'urn:uuid:pat-1', code:'http://snomed.info/sct|44054006', onset:'2019-06-01T09:30:00Z', abatement:undefined, clinicalStatus:'active', verificationStatus:'confirmed', category:'problem-list-item', encounter:'Encounter/e1', note:'nt-77aa' })],
+  ['FHIR Observation (lab)', () => contentHashedUri('Observation', { patient:'urn:uuid:pat-1', loincCode:'2339-0', effective:'2024-01-10T07:00:00Z', value:'95 mg/dL', specimen:'Specimen/s1', category:'laboratory', status:'final' })],
+  ['FHIR Immunization', () => contentHashedUri('Immunization', { patient:'Patient/p1', vaccine:'http://hl7.org/fhir/sid/cvx|140', occurrence:'2023-10-02', status:'completed', lotNumber:'AB-1234', dose:'d-4411', site:'LA', route:'IM', manufacturer:'Acme Biologics', encounter:'Encounter/e2', performer:'Dr. Okoye', location:'Clinic North', note:'nt-1234' })],
+  ['FHIR AllergyIntolerance', () => contentHashedUri('AllergyIntolerance', { patient:'Patient/p1', code:'http://snomed.info/sct|91936005', clinicalStatus:'active', verificationStatus:'confirmed', type:'allergy', category:'medication', criticality:'high', onset:'2011-04-02', reaction:'rx-55ff', note:'nt-9090' })],
+  ['Medication (shared key)', () => medicationUri({ rxNormCode:'314076', medicationName:'Lisinopril 10 MG Oral Tablet', startDate:'2022-02-01', patient:'urn:uuid:pat-1' })],
+  ['EncounterParticipant', () => encounterParticipantUri('urn:uuid:enc-1', { name:'Amara Okoye, MD', role:'attender', roleCodes:['PPRF','ATND'], specialty:'Cardiology' })],
+  ['C-CDA LabResult', () => contentHashedUri('LabResult', { loincCode:'2339-0', testName:'Glucose', value:'95', unit:'mg/dL', effective:'20240110070000', refRange:'70-99' })],
+  ['C-CDA problem', () => contentHashedUri('Condition', { conditionName:'Type 2 diabetes mellitus', snomedCode:'44054006', icd10Code:'E11.9', onsetDate:'2019-06-01', status:'active' })],
+  ['C-CDA narrative section', () => contentHashedUri('ClinicalDocument', { document:'urn:uuid:doc-1', section:'11450-4', source:'sec-hash-abc' })],
+  ['C-CDA patient', () => contentHashedUri('Patient', { name:'Jane Q Public', dob:'19850315', sex:'F', address:'a-77bb', telecom:'tel:+15555550123' })],
+  ['C-CDA lab panel', () => contentHashedUri('LaboratoryReport', { panelCode:'24323-8', panelName:'Comprehensive metabolic panel', date:'20240110', effective:'20240110070000', members:'m-3311', encounters:'e-4422' })],
+];
+for (const [name, fn] of cases) console.log(name + '\t' + fn());

--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -402,7 +402,7 @@ export function mintSubjectUri(resource: any, warnings?: string[]): string {
  *   "{resourceType}::{sortedKeyValuePairs}"
  *   where sortedKeyValuePairs =
  *     entries of contentFields where value is non-null and non-empty after .trim()
- *     sorted ascending by key (localeCompare)
+ *     sorted ascending by key, by Unicode code point (NOT locale collation)
  *     mapped as "key=value"
  *     joined with "|"
  *
@@ -460,9 +460,46 @@ export function contentHashedUri(
   // coerced to string before trimming: the type says string, but real-world
   // FHIR (e.g. an Apple Health Patient) can slip a non-string field through, and
   // String(s) === s for valid string inputs, so the derived URI is unchanged.
+  //
+  // THE COMPARATOR IS EXPLICIT AND MUST STAY THAT WAY.
+  //
+  // This sorted with `a.localeCompare(b)` until 2026-09. `localeCompare` asks
+  // ICU for the READER'S alphabet, and every Latin-script collation puts
+  // `alpha` before `Zeta` where code point puts `Zeta` first ('Z' is U+005A,
+  // 'a' is U+0061). That made the identity string, and therefore the URI, a
+  // function of the importing machine's locale as well as of the record — the
+  // one property an identifier may not have. The same document imported on two
+  // differently-configured machines would mint two URIs, so the pod would
+  // duplicate instead of reconcile and every cross-reference written by the
+  // other machine would dangle. `spec/ontologies/core/v1/core.ttl`,
+  // `cascade:cascadeUri`, "CANONICAL FORM OF A MULTI-VALUED IDENTITY INPUT
+  // (v3.6, NORMATIVE)", step 3, names the rule and its reason in one line:
+  //
+  //   "Sort ascending by Unicode code point. (Code point, not locale
+  //    collation: a locale-dependent order would make identity depend on
+  //    the machine.)"
+  //
+  // `<`/`>` on JS strings compare UTF-16 CODE UNITS. That is the same order as
+  // code point for every character in the BMP, which is every character any
+  // identity key in this repo contains: every one is a lowercase-initial ASCII
+  // camelCase field name written literally in source, never a value derived
+  // from patient data, so no code or system URI can reach the comparator as a
+  // KEY. The two orders part only above U+FFFF, where a surrogate pair sorts
+  // by its lead unit (U+D800..U+DBFF) rather than by its scalar value — so an
+  // astral-plane key would sort below one in U+E000..U+FFFF. No such key exists
+  // and none can arrive without a source edit, but the caveat is stated rather
+  // than left implicit, because "code unit" and "code point" are not synonyms.
+  //
+  // Written out rather than left to `.sort()`'s default because a bare
+  // `.sort()` is indistinguishable at a glance from someone forgetting the
+  // comparator; `canonicalSetKey` below relies on that same default order, and
+  // this comparator is exactly it. `tests/identity-chokepoint.test.ts` bans
+  // `localeCompare` anywhere under the identity modules so the next writer
+  // cannot reintroduce it, and `tests/uri-generation.test.ts` pins both the
+  // ordering and the resulting URIs.
   const content = Object.entries(contentFields)
     .filter(([, v]) => v != null && String(v).trim().length > 0)
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([k, v]) => `${k}=${String(v)}`)
     .join('|');
 

--- a/tests/identity-chokepoint.test.ts
+++ b/tests/identity-chokepoint.test.ts
@@ -309,6 +309,35 @@ describe('identity minting has exactly one door', () => {
     ).toEqual([]);
   });
 
+  it('no identity-minting module orders anything by LOCALE COLLATION', () => {
+    // The same defect class as a clock in a key, wearing different clothes.
+    // `localeCompare` asks ICU for the reader's alphabet, so a key set ordered
+    // with it is ordered by the MACHINE: `alpha` before `Zeta` in every
+    // Latin-script collation, `Zeta` first by code point. core.ttl says which
+    // one identity uses, and says why in the same breath:
+    //
+    //   "Sort ascending by Unicode code point. (Code point, not locale
+    //    collation: a locale-dependent order would make identity depend on
+    //    the machine.)"
+    //     -- spec/ontologies/core/v1/core.ttl, cascade:cascadeUri,
+    //        "CANONICAL FORM OF A MULTI-VALUED IDENTITY INPUT (v3.6, NORMATIVE)"
+    //
+    // No exemption, for the same reason randomness has none here: an importer
+    // sorts things only to build keys. Sorting for DISPLAY is fine and lives
+    // in `commands/` and the validator, which are outside these modules.
+    const offenders: string[] = [];
+    for (const file of FILES) {
+      if (!isUnder(file, IDENTITY_MODULES)) continue;
+      const code = stripComments(CODE.get(file)!);
+      if (/\blocaleCompare\s*\(/.test(code)) offenders.push(`${file}: localeCompare()`);
+    }
+    expect(
+      offenders,
+      'Order identity keys with an explicit code-unit comparator: (a, b) => a < b ? -1 : a > b ? 1 : 0. ' +
+        'A locale-ordered key mints a different URI on a differently-configured machine.',
+    ).toEqual([]);
+  });
+
   it('ctx.importedAt appears in no identity key anywhere', () => {
     const offenders: string[] = [];
     for (const file of FILES) {

--- a/tests/uri-generation.test.ts
+++ b/tests/uri-generation.test.ts
@@ -437,7 +437,9 @@ describe('production identity key sets mint unchanged URIs', () => {
     // claim: the two orderings agree on these key sets BECAUSE the names are
     // drawn from this shape. A key carrying an uppercase initial, an
     // underscore, or a non-ASCII character would be the case where they part.
-    // Collected from every literal key object passed to an identity minter.
+    // The 64 field names at today's identity call sites, plus `family` and
+    // `given` from the Patient key this repo shipped historically, so pods
+    // written before that key widened are covered too.
     const PRODUCTION_KEYS = [
       'abatement', 'address', 'allergenName', 'category', 'clinicalStatus', 'code',
       'condition', 'conditionName', 'criticality', 'cvxCode', 'date', 'deceased',

--- a/tests/uri-generation.test.ts
+++ b/tests/uri-generation.test.ts
@@ -22,6 +22,7 @@ import {
   codeableConceptKey,
   codeableConceptSetKey,
   canonicalSetKey,
+  encounterParticipantUri,
 } from '../src/lib/fhir-converter/types.js';
 
 describe('deterministicUuid cross-SDK contract', () => {
@@ -217,5 +218,247 @@ describe('canonical form of a set-valued identity input (core v3.6)', () => {
     expect(codeableConceptSetKey(['food', 'medication'])).toBe(
       codeableConceptSetKey(['medication', 'food']),
     );
+  });
+});
+
+/**
+ * ORDERING OF IDENTITY KEYS — code point, never locale collation.
+ *
+ * `spec/ontologies/core/v1/core.ttl`, `cascade:cascadeUri`, "CANONICAL FORM OF
+ * A MULTI-VALUED IDENTITY INPUT (v3.6, NORMATIVE)", step 3:
+ *
+ *   "Sort ascending by Unicode code point. (Code point, not locale collation:
+ *    a locale-dependent order would make identity depend on the machine.)"
+ *
+ * The parenthetical is the whole reason this block exists. `localeCompare`
+ * asks ICU for the reader's alphabet, and every Latin-script collation puts
+ * `alpha` before `Zeta` while code point puts `Zeta` first, because 'Z' is
+ * U+005A and 'a' is U+0061. An identity built on the first answer is a
+ * function of the importing MACHINE as well as the record, which is the one
+ * property an identifier may not have: the same document imported on two
+ * laptops would mint two URIs, the pod would duplicate instead of reconcile,
+ * and every cross-reference written by the other machine would dangle.
+ *
+ * A note on what these tests can and cannot prove. The bug is that behaviour
+ * VARIES by machine, so a test cannot be red everywhere by construction — on a
+ * hypothetical host whose collation happened to agree with code point, the
+ * broken comparator would pass. The first test below is therefore a guard on
+ * the guard: it asserts this host's collator really does disagree on the exact
+ * key pairs used, so a green run of the rest means the code is right and not
+ * that the environment was blind. The expected URIs are hard-coded rather than
+ * recomputed, so nothing here can be satisfied by re-deriving the answer from
+ * the code under test.
+ */
+describe('identity keys sort by code point, not locale collation', () => {
+  const byCodePoint = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+  /** The key pairs used below, and which order each ordering rule produces. */
+  const DIVERGENT_PAIRS: ReadonlyArray<readonly [string, string]> = [
+    ['Zeta', 'alpha'],  // uppercase letter vs lowercase letter
+    ['Code', 'code'],   // same letters, case differs
+    ['_x', 'Ax'],       // punctuation vs letter
+  ];
+
+  it('this host really does order these keys two different ways', () => {
+    for (const [a, b] of DIVERGENT_PAIRS) {
+      expect(byCodePoint(a, b), `${a} vs ${b} by code point`).not.toBe(0);
+      expect(
+        Math.sign(new Intl.Collator('en-US').compare(a, b)),
+        `${a} vs ${b}: collation must DISAGREE with code point, or the tests below are vacuous`,
+      ).toBe(-Math.sign(byCodePoint(a, b)));
+    }
+  });
+
+  it('an uppercase key sorts before a lowercase one', () => {
+    // Code point: "T::Zeta=1|alpha=2". Locale collation: "T::alpha=2|Zeta=1",
+    // which hashes to urn:uuid:23dee717-0913-50c5-b55e-edbd27b48c0c.
+    expect(contentHashedUri('T', { Zeta: '1', alpha: '2' })).toBe(
+      'urn:uuid:79a0280d-d048-5472-8f04-b96813250037',
+    );
+  });
+
+  it('two keys differing only in case sort uppercase first', () => {
+    // Code point: "M::Code=1|code=2". Locale collation puts `code` first
+    // (tertiary weight), giving urn:uuid:99819f32-b865-5df3-bc87-9ee6eeaafa84.
+    expect(contentHashedUri('M', { Code: '1', code: '2' })).toBe(
+      'urn:uuid:9e28702a-b965-5cb6-80c3-41ab12c1cd59',
+    );
+  });
+
+  it('a leading underscore sorts AFTER a letter, where collation puts it first', () => {
+    // '_' is U+005F, above 'A' at U+0041, so code point gives "K::Ax=2|_x=1".
+    // Collation treats punctuation as sorting before letters and would give
+    // "K::_x=1|Ax=2" -> urn:uuid:9d454219-8a8d-55b1-b8f0-9b7e86a853da.
+    expect(contentHashedUri('K', { _x: '1', Ax: '2' } as Record<string, string>)).toBe(
+      'urn:uuid:f2e00c2e-ca9c-5052-b49a-61012ce918b6',
+    );
+  });
+
+  it('the order is the same one the rest of this module already uses', () => {
+    // Array.prototype.sort with no comparator IS the code-unit order, and the
+    // set-key canonicalizer has always used it. The chokepoint now agrees with
+    // its own neighbour rather than contradicting it.
+    expect(canonicalSetKey(['alpha', 'Zeta'], ',')).toBe('Zeta,alpha');
+    expect(['alpha', 'Zeta'].sort().join(',')).toBe('Zeta,alpha');
+  });
+});
+
+/**
+ * GOLDEN IDENTITIES — the migration proof, kept executable.
+ *
+ * Every field-name set that reaches `contentHashedUri` in production, one row
+ * per identity site, with the URI each one mints. These values were computed
+ * against the PREVIOUS comparator (`localeCompare`) and are asserted against
+ * the current one, so this block is the standing evidence that switching the
+ * comparator moved NO identifier that any existing pod can contain: every one
+ * of these key sets is drawn from lowercase-initial ASCII camelCase names, on
+ * which the two orderings agree exactly.
+ *
+ * These are contract values in the sense the header of this file describes. A
+ * failure here is not a test to update: it means live records have been
+ * re-minted and existing pods would duplicate on their next import.
+ */
+describe('production identity key sets mint unchanged URIs', () => {
+  it('FHIR Patient', () => {
+    expect(
+      contentHashedUri('Patient', {
+        dob: '1985-03-15', sex: 'male', name: 'n-8f3a', identifier: 'i-2b7c',
+        maritalStatus: 'M', address: 'a-91de', deceased: undefined,
+      }),
+    ).toBe('urn:uuid:9b1014a4-5129-5585-9972-f1ec31d2f6f8');
+  });
+
+  it('FHIR Condition', () => {
+    expect(
+      contentHashedUri('Condition', {
+        patient: 'urn:uuid:pat-1', code: 'http://snomed.info/sct|44054006',
+        onset: '2019-06-01T09:30:00Z', abatement: undefined, clinicalStatus: 'active',
+        verificationStatus: 'confirmed', category: 'problem-list-item',
+        encounter: 'Encounter/e1', note: 'nt-77aa',
+      }),
+    ).toBe('urn:uuid:16b124fd-1e20-577a-9cde-3b264c14eaf6');
+  });
+
+  it('FHIR Observation (lab)', () => {
+    expect(
+      contentHashedUri('Observation', {
+        patient: 'urn:uuid:pat-1', loincCode: '2339-0', effective: '2024-01-10T07:00:00Z',
+        value: '95 mg/dL', specimen: 'Specimen/s1', category: 'laboratory', status: 'final',
+      }),
+    ).toBe('urn:uuid:e7f2278c-1335-55fd-935b-4260633df9f5');
+  });
+
+  it('FHIR Immunization', () => {
+    expect(
+      contentHashedUri('Immunization', {
+        patient: 'Patient/p1', vaccine: 'http://hl7.org/fhir/sid/cvx|140',
+        occurrence: '2023-10-02', status: 'completed', lotNumber: 'AB-1234', dose: 'd-4411',
+        site: 'LA', route: 'IM', manufacturer: 'Acme Biologics', encounter: 'Encounter/e2',
+        performer: 'Dr. Okoye', location: 'Clinic North', note: 'nt-1234',
+      }),
+    ).toBe('urn:uuid:a92218dd-a69e-5b2a-86e2-a144eecc5e9c');
+  });
+
+  it('FHIR AllergyIntolerance', () => {
+    expect(
+      contentHashedUri('AllergyIntolerance', {
+        patient: 'Patient/p1', code: 'http://snomed.info/sct|91936005',
+        clinicalStatus: 'active', verificationStatus: 'confirmed', type: 'allergy',
+        category: 'medication', criticality: 'high', onset: '2011-04-02',
+        reaction: 'rx-55ff', note: 'nt-9090',
+      }),
+    ).toBe('urn:uuid:5bb5bf10-7303-5dd4-accf-eee3bf25668a');
+  });
+
+  it('the shared medication key (FHIR and C-CDA both mint here)', () => {
+    expect(
+      medicationUri({
+        rxNormCode: '314076', medicationName: 'Lisinopril 10 MG Oral Tablet',
+        startDate: '2022-02-01', patient: 'urn:uuid:pat-1',
+      }),
+    ).toBe('urn:uuid:f8eb9e78-ba76-529d-8966-bfb2f0a7cbec');
+  });
+
+  it('EncounterParticipant', () => {
+    expect(
+      encounterParticipantUri('urn:uuid:enc-1', {
+        name: 'Amara Okoye, MD', role: 'attender',
+        roleCodes: ['PPRF', 'ATND'], specialty: 'Cardiology',
+      }),
+    ).toBe('urn:uuid:64a16e02-b594-5af5-8662-5af0e604f284');
+  });
+
+  it('C-CDA lab result', () => {
+    expect(
+      contentHashedUri('LabResult', {
+        loincCode: '2339-0', testName: 'Glucose', value: '95', unit: 'mg/dL',
+        effective: '20240110070000', refRange: '70-99',
+      }),
+    ).toBe('urn:uuid:270dccdc-4dc8-5947-95ae-d7f8a0dd83fd');
+  });
+
+  it('C-CDA lab panel', () => {
+    expect(
+      contentHashedUri('LaboratoryReport', {
+        panelCode: '24323-8', panelName: 'Comprehensive metabolic panel',
+        date: '20240110', effective: '20240110070000', members: 'm-3311', encounters: 'e-4422',
+      }),
+    ).toBe('urn:uuid:fc093d7a-4c08-5d1f-916b-01be53c87d9a');
+  });
+
+  it('C-CDA problem', () => {
+    expect(
+      contentHashedUri('Condition', {
+        conditionName: 'Type 2 diabetes mellitus', snomedCode: '44054006',
+        icd10Code: 'E11.9', onsetDate: '2019-06-01', status: 'active',
+      }),
+    ).toBe('urn:uuid:c751ec99-9688-5e0d-89eb-dcbf32162886');
+  });
+
+  it('C-CDA patient', () => {
+    expect(
+      contentHashedUri('Patient', {
+        name: 'Jane Q Public', dob: '19850315', sex: 'F',
+        address: 'a-77bb', telecom: 'tel:+15555550123',
+      }),
+    ).toBe('urn:uuid:4f000e41-bf1f-53da-8ddb-6f54b4b38cc3');
+  });
+
+  it('C-CDA narrative section', () => {
+    expect(
+      contentHashedUri('ClinicalDocument', {
+        document: 'urn:uuid:doc-1', section: '11450-4', source: 'sec-hash-abc',
+      }),
+    ).toBe('urn:uuid:2f008ac0-75a5-54f1-a7dc-eb1b4217db51');
+  });
+
+  it('every production key name is lowercase-initial ASCII camelCase', () => {
+    // The premise the goldens above rest on, stated as a check rather than a
+    // claim: the two orderings agree on these key sets BECAUSE the names are
+    // drawn from this shape. A key carrying an uppercase initial, an
+    // underscore, or a non-ASCII character would be the case where they part.
+    // Collected from every literal key object passed to an identity minter.
+    const PRODUCTION_KEYS = [
+      'abatement', 'address', 'allergenName', 'category', 'clinicalStatus', 'code',
+      'condition', 'conditionName', 'criticality', 'cvxCode', 'date', 'deceased',
+      'displayName', 'dob', 'document', 'dose', 'effective', 'encounter', 'encounters',
+      'family', 'given', 'icd10Code', 'identifier', 'location', 'loincCode', 'lotNumber',
+      'manufacturer', 'maritalStatus', 'medicationName', 'members', 'name',
+      'normalizedName', 'note', 'occurrence', 'onset', 'onsetDate', 'panelCode',
+      'panelName', 'patient', 'performer', 'reaction', 'refRange', 'relation',
+      'relative', 'role', 'roleCode', 'route', 'rxNormCode', 'section', 'severity',
+      'sex', 'site', 'snomedCode', 'source', 'specialty', 'specimen', 'startDate',
+      'status', 'telecom', 'testName', 'type', 'unit', 'vaccine', 'vaccineName',
+      'value', 'verificationStatus',
+    ];
+    expect(PRODUCTION_KEYS.filter((k) => !/^[a-z][A-Za-z0-9]*$/.test(k))).toEqual([]);
+    // And on THIS set the two orderings are in fact identical, which is the
+    // migration statement itself.
+    const byCodePoint = [...PRODUCTION_KEYS].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    for (const loc of ['en-US', 'de-DE', 'sv-SE', 'tr-TR', 'cs-CZ', 'fr-FR', 'ja-JP']) {
+      const collator = new Intl.Collator(loc).compare;
+      expect([...PRODUCTION_KEYS].sort(collator), `collation differs under ${loc}`)
+        .toEqual(byCodePoint);
+    }
   });
 });


### PR DESCRIPTION
## The defect

`contentHashedUri()` in `src/lib/fhir-converter/types.ts` is the chokepoint every content-derived record IRI in this repo is minted through — the FHIR converters via `idOrContentUri`, the C-CDA converters via `ccdaRecordUri`, medications via the shared `medicationUri` key, and encounter participations via `encounterParticipantUri`. It sorted its identity key set with:

```ts
.sort(([a], [b]) => a.localeCompare(b))
```

`localeCompare` asks ICU for the reader's alphabet. Every Latin-script collation orders `alpha` before `Zeta`; code point orders `Zeta` first, because `Z` is U+005A and `a` is U+0061. So the identity string, and therefore the minted URI, was a function of the importing **machine's locale** as well as of the record. That is the one property an identifier may not have: the same document imported on two differently-configured machines could mint two URIs, so the pod would duplicate instead of reconcile, and every cross-reference written by the other machine would dangle.

The ratified rule, and its reason, are one line of `spec/ontologies/core/v1/core.ttl`, under `cascade:cascadeUri`, "CANONICAL FORM OF A MULTI-VALUED IDENTITY INPUT (v3.6, NORMATIVE)", step 3:

> Sort ascending by Unicode code point. (Code point, not locale collation: a locale-dependent order would make identity depend on the machine.)

`canonicalSetKey` in the same module already gets this right — it uses `.sort()`'s default, which is code-unit order. The chokepoint contradicted its own neighbour.

Tracked as 3.327 / D16.

## The fix

- `contentHashedUri` now sorts with an explicit `(a, b) => a < b ? -1 : a > b ? 1 : 0`. Written out rather than left to a bare `.sort()`, because a bare `.sort()` is indistinguishable at a glance from a forgotten comparator, and this is the line the whole identity story rests on.
- The doc comment above the function said "sorted ascending by key (localeCompare)". Corrected.
- A comment at the comparator records what moved, why, the `core.ttl` citation, and one honest caveat: `<`/`>` on JS strings compare UTF-16 **code units**, which equals code point for every BMP character and therefore for every identity key this repo has, but the two orders would part above U+FFFF. No such key exists and none can arrive without a source edit; the caveat is stated rather than left implicit, because "code unit" and "code point" are not synonyms.

## Migration impact: NO IDENTIFIER MOVES

Existing pods hold URIs minted by the old comparator, so the question that had to be answered before any code changed was whether the fix re-mints any of them. It does not. Three independent lines of evidence.

### 1. Static enumeration — 21 call sites

Every call to `contentHashedUri` / `idOrContentUri` / `ccdaRecordUri` / `medicationUri` was located by walking the TypeScript AST of `src/` and reading the literal key object at each one. For each set, the code-point order was compared against `Intl.Collator` under `en-US`, `de-DE`, `sv-SE`, `tr-TR`, `cs-CZ`, `lt-LT`, `da-DK`, `fr-FR`, `es-ES`, `pl-PL`, and against bare `localeCompare`.

| Site | Key set (code-point order) | Diverges? |
|---|---|---|
| `lib/ccda-converter/narrative.ts:41` | document, section, source | no |
| `lib/ccda-converter/sections/allergies.ts:112` | allergenName, severity | no |
| `lib/ccda-converter/sections/devices.ts:54` | date, displayName | no |
| `lib/ccda-converter/sections/encounters.ts:133` | date, displayName | no |
| `lib/ccda-converter/sections/family-history.ts:80` | code, condition, relation, relative | no |
| `lib/ccda-converter/sections/immunizations.ts:50` | cvxCode, date, vaccineName | no |
| `lib/ccda-converter/sections/labs.ts:201` | effective, loincCode, refRange, testName, unit, value | no |
| `lib/ccda-converter/sections/labs.ts:317` | date, effective, encounters, members, panelCode, panelName | no |
| `lib/ccda-converter/sections/patient.ts:120` | address, dob, name, sex, telecom | no |
| `lib/ccda-converter/sections/problems.ts:99` | conditionName, icd10Code, onsetDate, snomedCode, status | no |
| `lib/ccda-converter/sections/procedures.ts:63` | code, date, displayName | no |
| `lib/ccda-converter/sections/vitals.ts:118` | date, displayName, loincCode, unit, value | no |
| `lib/ccda-converter/sections/vitals.ts:180` | date, loincCode, testName, unit, value | no |
| `lib/fhir-converter/converters-clinical.ts:142` | medicationName, patient, rxNormCode, startDate | no |
| `lib/fhir-converter/converters-clinical.ts:342` | abatement, category, clinicalStatus, code, encounter, note, onset, patient, verificationStatus | no |
| `lib/fhir-converter/converters-clinical.ts:512` | category, clinicalStatus, code, criticality, note, onset, patient, reaction, type, verificationStatus | no |
| `lib/fhir-converter/converters-clinical.ts:770` | category, effective, loincCode, patient, specimen, status, value | no |
| `lib/fhir-converter/converters-demographics.ts:83` | address, deceased, dob, identifier, maritalStatus, name, sex | no |
| `lib/fhir-converter/converters-demographics.ts:216` | dose, encounter, location, lotNumber, manufacturer, note, occurrence, patient, performer, route, site, status, vaccine | no |
| `lib/fhir-converter/types.ts:714` (`medicationUri`) | normalizedName, patient, rxNormCode, startDate | no |
| `lib/fhir-converter/types.ts:811` (`encounterParticipantUri`) | encounter, name, role, roleCode, specialty | no |

**Divergent sites: 0.**

Three further call expressions matched the grep and are *not* independent key sets — they are the chokepoint's own forwarding hops, each passing a parameter straight through: `record-identity.ts:373` (`content`, from `ccdaRecordUri`'s options), `record-identity.ts:401` (`fields`, from `ccdaMedicationUri`), `types.ts:570` (`contentFields`, from `idOrContentUri`). Their key sets are exactly the 21 above.

### 2. Runtime capture — 24 distinct key sets, 3,763 calls

Static analysis cannot see a key assembled dynamically, so the chokepoint was temporarily instrumented to append `Object.keys(contentFields)` on every call, and the **full suite** was run under it (167 files, 2,674 tests, including the 177-scenario pathology corpus and the Epic/Cerner C-CDA vendor corpora). 3,763 calls, 24 distinct key sets, 62 distinct key names. Compared under the same 10 collators plus bare `localeCompare`: **0 divergent sets.** The instrumentation was then reverted by file copy, not `git checkout`, and a zero-line `git diff` confirmed before proceeding.

### 3. Are any identity keys derived from source data?

**No — and this is the part that would have been the real machine-dependence.** The brief asked specifically whether any key (not value) comes from patient data, where mixed case or punctuation in a code or system URI could make the two orders part. Every one of the 21 call sites passes an object literal with plain identifier property names. There are **zero computed property names (`[expr]:`) and zero spreads** in any identity key object anywhere in `src/`. Codes, system URIs and free text appear only as *values*, which are never compared. The union of static and runtime key names is 66 names, every one matching `/^[a-z][A-Za-z0-9]*$/`: lowercase ASCII initial, ASCII letters and digits only, no underscores, no punctuation, no non-ASCII. That shape is exactly why the two orderings agree, and it is now asserted as a test rather than left as a claim.

### 4. End-to-end corpus diff

A second worktree was built at `origin/main` (the pre-fix comparator) and **99 documents** were converted through both builds and diffed:

- 45 from `conformance/fixtures` — 7 C-CDA documents including the Epic and Cerner summarizations, plus the `clinical-fhir` and `genomics` bundles
- 54 from `test-fixtures/` — the pathology corpus, the field-coverage corpus, the Apple Health multi-file corpus

**Byte-identical output** modulo `prov:generatedAtTime` / `clinical:importedAt`, which are per-run timestamps, and **identical URI sets**: the same 152 and 497 distinct `urn:uuid:` IRIs respectively, 649 in total, not one moved.

## Other `localeCompare` occurrences

`grep -rn localeCompare src/` returns five more, all display-only, none on an identity path:

| Site | What it orders | Verdict |
|---|---|---|
| `lib/shacl-validator.ts:419` | unshaped types in a coverage report, tie-break after count | display |
| `lib/shacl-validator.ts:622` | fired shape names in a validation report | display |
| `commands/validate.ts:249` | console ranking of unshaped types | display |
| `commands/pod/import.ts:1327` | the section census printed at the end of an import | display |
| `commands/pod/reconcile.ts:330` | the list of registered record buckets to read | processing order, not identity — see follow-up |

The eight occurrences under `tests/` all order report rows or directory listings for comparison. No second identity code path was introduced; every URI is still minted through the one chokepoint.

## Tests

New guards, all observed RED before the fix:

- `tests/uri-generation.test.ts` — a new `describe` pinning code-point order on three key pairs where collation disagrees, each asserted against a **hard-coded** expected URI so nothing can be satisfied by re-deriving the answer from the code under test:
  - `Zeta` / `alpha` (uppercase vs lowercase letter)
  - `Code` / `code` (case-only difference, collation's tertiary weight)
  - `_x` / `Ax` (punctuation vs letter — code point puts `_` *after* `A`, collation puts it before)
- A first test in that block asserts this host's collator really *does* disagree on those exact pairs, so a green run means the code is right rather than that the environment was blind. The bug is that behaviour varies by machine, so no test can be red by construction everywhere; this is the honest form of that guarantee.
- `tests/uri-generation.test.ts` — 12 golden identities, one per production key set (FHIR Patient / Condition / Observation / Immunization / AllergyIntolerance, the shared medication key, EncounterParticipant, and five C-CDA sets). **These values were computed against the OLD `localeCompare` comparator and are asserted against the new one** — they passed on the unmodified code and still pass, which is the migration statement kept executable. A failure here is not a test to update: it means live records have been re-minted.
- `tests/uri-generation.test.ts` — the 66 production key names asserted to match `/^[a-z][A-Za-z0-9]*$/`, and asserted to sort identically under code point and under seven collators. The premise the goldens rest on, checked rather than claimed.
- `tests/identity-chokepoint.test.ts` — `localeCompare` is now banned outright anywhere under the identity modules, with no exemption, alongside the existing bans on randomness and clocks. Same defect class: a key ordered by the machine. Sorting for display lives in `commands/` and the validator, outside those modules.

### RED evidence

On the unmodified comparator, with a confirmed non-empty `git diff` (243 insertions):

```
 FAIL  tests/uri-generation.test.ts > identity keys sort by code point, not locale collation > an uppercase key sorts before a lowercase one
- urn:uuid:79a0280d-d048-5472-8f04-b96813250037
+ urn:uuid:23dee717-0913-50c5-b55e-edbd27b48c0c

 FAIL  ... > two keys differing only in case sort uppercase first
- urn:uuid:9e28702a-b965-5cb6-80c3-41ab12c1cd59
+ urn:uuid:99819f32-b865-5df3-bc87-9ee6eeaafa84

 FAIL  ... > a leading underscore sorts AFTER a letter, where collation puts it first
- urn:uuid:f2e00c2e-ca9c-5052-b49a-61012ce918b6
+ urn:uuid:9d454219-8a8d-55b1-b8f0-9b7e86a853da

 Test Files  1 failed (1)
      Tests  3 failed | 32 passed (35)
```

```
 FAIL  tests/identity-chokepoint.test.ts > no identity-minting module orders anything by LOCALE COLLATION
- Array []
+ Array [ "lib/fhir-converter/types.ts: localeCompare()" ]

 Test Files  1 failed (1)
      Tests  1 failed | 7 passed (8)
```

The chokepoint guard naming exactly one offender is itself evidence that no other identity module carried the defect.

## Counts

`npm run build` before the suite in both runs, so the ~20 tests that spawn `dist/` ran against current output. `npx tsc --noEmit` run separately, since vitest does not typecheck.

| | Test files | Tests | Failed | Skipped | tsc | build |
|---|---|---|---|---|---|---|
| Baseline (`origin/main`) | 167 passed | **2674 passed** | 0 | 0 | — | 0 |
| After this PR | 167 passed | **2693 passed** | 0 | 0 | 0 errors | 0 |

+19 tests, which is the 18 added to `tests/uri-generation.test.ts` plus 1 to `tests/identity-chokepoint.test.ts`. Zero skips and zero failures in both runs; the worktree had `conformance` and `spec` symlinked as siblings, so `tests/ccda-multivalued-shape.test.ts` ran rather than throwing.

## Follow-up

`commands/pod/reconcile.ts:330` orders the registered record buckets with `localeCompare`. It mints nothing, so no URI depends on it, but it does make the order buckets are READ a function of the machine's locale — and this repo's history says order-dependence is worth closing before it has a consequence. Left out of this PR because it is not an identity site and changing it would widen a targeted fix; being recorded in the backlog separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
