### PR TITLE
fix(mcp): cascade_write stamped an undeclared provenance term on every record

### DIFF
--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -70,7 +70,7 @@ export function buildCapabilities(program: Command): CapabilitiesOutput {
         'cascade-agent server at --agent-url (http://127.0.0.1:8765 by default, i.e. your machine). ' +
         'No telemetry, no analytics, no implicit calls.',
       dataStorage: 'local filesystem only',
-      provenance: 'all agent-written data tagged with AIGenerated provenance',
+      provenance: 'all agent-written data tagged with AIExtracted provenance',
       auditLog: 'all MCP operations logged to provenance/audit-log.ttl',
     },
     tools: describeCommands(program, COMMAND_ENRICHMENT),

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -49,7 +49,7 @@ export function createServer(): McpServer {
         'Cascade Protocol MCP Server — Local-first access to structured health data. ' +
         'Use cascade_capabilities to discover all available tools. ' +
         'All operations are local (zero network calls). ' +
-        'All agent-written data is automatically tagged with AIGenerated provenance. ' +
+        'All agent-written data is automatically tagged with AIExtracted provenance. ' +
         'Set CASCADE_POD_PATH environment variable to specify the default Pod directory.',
     },
   );

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -407,7 +407,7 @@ function registerConvert(server: McpServer): void {
 function registerWrite(server: McpServer): void {
   server.tool(
     'cascade_write',
-    'Write a health record to a Cascade Pod with AIGenerated provenance. The record is serialized as Turtle and appended to the appropriate file in the Pod.',
+    'Write a health record to a Cascade Pod with AIExtracted provenance. The record is serialized as Turtle and appended to the appropriate file in the Pod.',
     {
       path: z.string().optional().describe('Path to the Pod directory. Uses CASCADE_POD_PATH if omitted.'),
       dataType: z
@@ -475,7 +475,7 @@ function registerWrite(server: McpServer): void {
         recordUri,
         file: `${typeInfo.directory}/${typeInfo.filename}`,
         provenance: {
-          type: 'AIGenerated',
+          type: 'AIExtracted',
           agentId: provenance?.agentId ?? 'unknown-agent',
           timestamp,
           reason: provenance?.reason,
@@ -511,7 +511,7 @@ function registerCapabilities(server: McpServer): void {
           // calls, and neither is reachable through an MCP tool.
           networkCalls: 'zero — every tool on this server reads and writes the local filesystem only',
           dataStorage: 'local filesystem only',
-          provenance: 'all agent-written data tagged with AIGenerated provenance',
+          provenance: 'all agent-written data tagged with AIExtracted provenance',
           auditLog: 'all operations logged to provenance/audit-log.ttl in the Pod',
         },
         tools,
@@ -527,8 +527,7 @@ function registerCapabilities(server: McpServer): void {
           'cascade:ClinicalGenerated — Data from clinical/EHR sources',
           'cascade:DeviceGenerated — Data from wearable/medical devices',
           'cascade:SelfReported — Patient-entered data',
-          'cascade:AIExtracted — AI-extracted from existing clinical documents',
-          'cascade:AIGenerated — AI-generated observations, analyses, or recommendations',
+          'cascade:AIExtracted — written by an AI agent, including everything cascade_write records',
         ],
         cliEquivalents: Object.fromEntries(
           tools.filter((tool) => tool.cliEquivalent).map((tool) => [tool.name, tool.cliEquivalent]),
@@ -636,15 +635,30 @@ export function buildRecordTurtle(
     }
   }
 
-  // Add provenance — always AIGenerated for agent-written data
-  lines.push(`    cascade:dataProvenance cascade:AIGenerated ;`);
+  // Always cascade:AIExtracted for agent-written data. The agent does not
+  // choose its own provenance: an agent that could label its output
+  // EHRVerified would defeat the point of recording provenance at all.
+  //
+  // AIExtracted is the vocabulary's only DataProvenance value for
+  // agent-authored content, and the only one admitted by the `sh:in`
+  // constraint every record shape puts on cascade:dataProvenance. This line
+  // used to emit `cascade:AIGenerated`, a term declared nowhere, so every
+  // record written through this path violated its own shape.
+  lines.push(`    cascade:dataProvenance cascade:AIExtracted ;`);
   lines.push(`    cascade:schemaVersion "1.3" ;`);
 
   // Add provenance metadata as blank node
   const agentId = provenance?.agentId ?? 'unknown-agent';
   const reason = provenance?.reason ?? 'Agent-generated record';
   lines.push(`    prov:wasGeneratedBy [`);
-  lines.push(`        a prov:Activity, cascade:AIGenerated ;`);
+  // A bare prov:Activity, deliberately. The obvious-looking subclass here is
+  // cascade:AIExtractionActivity, but that class means an LLM extraction run
+  // over narrative text and its shape requires cascade:extractionModel and
+  // cascade:extractionConfidence — neither of which cascade_write has, because
+  // it is not extracting from a document. Typing the node as one would trade an
+  // undeclared class for a false claim about how the record was produced. The
+  // record's own cascade:dataProvenance above is what marks it agent-written.
+  lines.push(`        a prov:Activity ;`);
   lines.push(`        prov:wasAssociatedWith "${agentId}" ;`);
   lines.push(`        prov:atTime "${timestamp}"^^xsd:dateTime ;`);
   lines.push(`        cascade:generationReason ${escapeTurtleString(reason)}`);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -301,7 +301,7 @@ describe('buildRecordTurtle', () => {
     expect(turtle).toContain('clinical:dosage "81 mg"');
     expect(turtle).toContain('clinical:frequency "daily"');
     expect(turtle).toContain('clinical:status true');
-    expect(turtle).toContain('cascade:dataProvenance cascade:AIGenerated');
+    expect(turtle).toContain('cascade:dataProvenance cascade:AIExtracted');
     expect(turtle).toContain('cascade:schemaVersion "1.3"');
     expect(turtle).toContain('prov:wasGeneratedBy');
     expect(turtle).toContain('"test-agent"');

--- a/tests/mcp-write-conformance.test.ts
+++ b/tests/mcp-write-conformance.test.ts
@@ -83,13 +83,38 @@ const FIXTURE_NAME_FIELDS: Record<string, string[]> = {
  * Fixing them means giving the map a per-type dimension, which is a larger
  * change than this suite's subject.
  */
-const EXPECTED_FAILURES: Record<string, string> = {};
+const EXPECTED_FAILURES: Record<string, string> = {
+  // `isActive: true` maps to `clinical:status`, and formatTurtleValue
+  // serializes a JSON boolean as a bare `true` (xsd:boolean). The shape wants
+  // an xsd:string status word ("active"). One key cannot mean both a boolean
+  // flag and a status vocabulary word.
+  'med-001': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-002': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-003': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-004': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-005': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-006': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-007': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+  'med-011': 'clinical:status — isActive serialized as xsd:boolean, shape requires xsd:string',
+
+  // formatTurtleValue stamps `^^xsd:dateTime` on any key whose name contains
+  // "date" or "time", whatever the value's precision. A date-precision value
+  // ("2031-02-09") becomes an ill-formed xsd:dateTime literal, which is neither
+  // of the two types health:performedDate accepts.
+  'lab-009': 'health:performedDate — date-precision value stamped ^^xsd:dateTime, so it is neither xsd:date nor a well-formed xsd:dateTime',
+
+  // PROPERTY_PREDICATES has no `regulatoryStatus` key, so the field is dropped
+  // and the predicate the Supplement shape requires is simply absent.
+  'supp-001': 'clinical:regulatoryStatus — no PROPERTY_PREDICATES entry, so the field is dropped and the required predicate is missing',
+};
 
 interface Fixture {
   id: string;
   dataType?: string;
   vocabulary?: string;
   input?: Record<string, unknown>;
+  /** `false` marks a fixture built to be REJECTED by the shapes. */
+  shouldAccept?: boolean;
 }
 
 function loadRootFixtures(): Fixture[] {
@@ -97,13 +122,23 @@ function loadRootFixtures(): Fixture[] {
     .readdirSync(FIXTURES_DIR, { withFileTypes: true })
     .filter((e) => e.isFile() && e.name.endsWith('.json'))
     .map((e) => JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, e.name), 'utf-8')) as Fixture)
-    .filter((f) => f.input !== undefined && f.vocabulary !== undefined)
+    // Negative fixtures (`shouldAccept: false`) are records built to violate a
+    // shape — an empty allergen, an interpretation outside the code system. The
+    // write path faithfully serializing one still produces a violation, so
+    // including them would measure the fixture, not the writer.
+    .filter((f) => f.input !== undefined && f.vocabulary !== undefined && f.shouldAccept !== false)
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 }
 
 /** Build the record object an agent would hand `cascade_write` for a fixture. */
 function mcpRecordFor(mcpType: string, input: Record<string, unknown>): Record<string, unknown> {
   const record: Record<string, unknown> = { ...input };
+  // `id` and `type` are the fixture's own RDF discriminators, not record data.
+  // `cascade_write` mints the IRI itself and derives rdf:type from `dataType`,
+  // so an agent would not send either — and leaving `type` in would feed the
+  // class name ("VitalSign") to the tool as the record's display name.
+  delete record.id;
+  delete record.type;
   const nameKey = TYPE_MAPPING[mcpType].nameKey;
   if (record[nameKey] === undefined) {
     for (const field of FIXTURE_NAME_FIELDS[mcpType] ?? []) {

--- a/tests/mcp-write-conformance.test.ts
+++ b/tests/mcp-write-conformance.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Shape conformance for the MCP write path.
+ *
+ * `cascade_write` is the one door an agent has into a Pod, and until this
+ * suite existed nothing checked that what comes out of it satisfies the SHACL
+ * shapes the CLI itself validates Pods against. It did not: every record it
+ * wrote carried `cascade:dataProvenance cascade:AIGenerated`, a term that is
+ * declared nowhere in the vocabulary, so every record violated the
+ * `sh:in` constraint on `cascade:dataProvenance` in its own shape.
+ *
+ * The test drives the real write path — `buildRecordTurtle` plus
+ * `generatePrefixes`, the same two functions `cascade_write` calls — over the
+ * root record fixtures in the conformance corpus, and validates each result
+ * with the CLI's own SHACL validator against the pinned `src/shapes/`.
+ *
+ * Scope is deliberately narrow: shapes only. This is not an identity or
+ * determinism check; the record IRI here is the fixture's own, and nothing
+ * about IRI minting is asserted.
+ *
+ * Fixtures whose remaining violations come from the flat `PROPERTY_PREDICATES`
+ * map rather than from provenance are listed in `EXPECTED_FAILURES` with the
+ * predicate and reason. That list is an inventory of known write-path gaps and
+ * may only shrink: a fixture listed there that starts passing fails the test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  buildRecordTurtle,
+  generatePrefixes,
+  TYPE_MAPPING,
+} from '../src/lib/mcp/tools.js';
+import { DATA_TYPES } from '../src/commands/pod/helpers.js';
+import { loadShapes, validateTurtle } from '../src/lib/shacl-validator.js';
+import { conformancePath, conformanceAvailable } from './helpers/conformance.js';
+
+const FIXTURES_DIR = conformancePath('fixtures');
+
+/**
+ * Fixture `dataType` -> the `cascade_write` `dataType` enum value.
+ *
+ * Only the seven kinds `cascade_write` accepts appear here. Every other
+ * fixture kind is counted as unmapped and reported, not silently dropped.
+ */
+const FIXTURE_TYPE_TO_MCP_TYPE: Record<string, string> = {
+  Medication: 'medications',
+  Condition: 'conditions',
+  Allergy: 'allergies',
+  LabResult: 'lab-results',
+  Immunization: 'immunizations',
+  VitalSign: 'vital-signs',
+  Supplement: 'supplements',
+};
+
+/**
+ * The fixture field holding the record's display name, per MCP data type.
+ *
+ * `cascade_write` takes the name under its own `nameKey` (or `name`); the
+ * fixtures carry it under the vocabulary's property name. Translating it here
+ * is what an agent handing this record to the tool would do, and it keeps the
+ * suite about the write path rather than about a field-name mismatch that is
+ * not part of the tool's contract.
+ */
+const FIXTURE_NAME_FIELDS: Record<string, string[]> = {
+  medications: ['medicationName', 'drugName'],
+  conditions: ['conditionName'],
+  allergies: ['allergen'],
+  'lab-results': ['testName'],
+  immunizations: ['vaccineName'],
+  'vital-signs': ['vitalType', 'type'],
+  supplements: ['supplementName'],
+};
+
+/**
+ * Known write-path gaps, keyed by fixture id. Each entry names the predicate
+ * whose absence or shape causes the remaining violation and why.
+ *
+ * These are NOT provenance failures. They come from `PROPERTY_PREDICATES`
+ * being one flat JSON-key -> predicate map shared by all seven record kinds,
+ * so a key means the same predicate no matter which kind is being written.
+ * Fixing them means giving the map a per-type dimension, which is a larger
+ * change than this suite's subject.
+ */
+const EXPECTED_FAILURES: Record<string, string> = {};
+
+interface Fixture {
+  id: string;
+  dataType?: string;
+  vocabulary?: string;
+  input?: Record<string, unknown>;
+}
+
+function loadRootFixtures(): Fixture[] {
+  return fs
+    .readdirSync(FIXTURES_DIR, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.json'))
+    .map((e) => JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, e.name), 'utf-8')) as Fixture)
+    .filter((f) => f.input !== undefined && f.vocabulary !== undefined)
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/** Build the record object an agent would hand `cascade_write` for a fixture. */
+function mcpRecordFor(mcpType: string, input: Record<string, unknown>): Record<string, unknown> {
+  const record: Record<string, unknown> = { ...input };
+  const nameKey = TYPE_MAPPING[mcpType].nameKey;
+  if (record[nameKey] === undefined) {
+    for (const field of FIXTURE_NAME_FIELDS[mcpType] ?? []) {
+      if (input[field] !== undefined) {
+        record[nameKey] = input[field];
+        break;
+      }
+    }
+  }
+  return record;
+}
+
+describe('MCP write path conforms to the SHACL shapes', () => {
+  if (!conformanceAvailable()) {
+    it.skip('conformance fixtures not available', () => {});
+    return;
+  }
+
+  const fixtures = loadRootFixtures();
+  const mapped = fixtures.filter((f) => f.dataType && FIXTURE_TYPE_TO_MCP_TYPE[f.dataType]);
+  const unmapped = fixtures.filter((f) => !f.dataType || !FIXTURE_TYPE_TO_MCP_TYPE[f.dataType]);
+
+  it('covers the fixture corpus, and reports what cascade_write cannot express', () => {
+    // Not a threshold to tune. It records that the corpus was actually read
+    // and that the split between what the write tool accepts and what it does
+    // not is visible, rather than a silent zero-fixture pass.
+    expect(fixtures.length).toBeGreaterThan(0);
+    expect(mapped.length).toBeGreaterThan(0);
+    // Every mapped fixture type must be a real `cascade_write` enum value.
+    for (const type of Object.values(FIXTURE_TYPE_TO_MCP_TYPE)) {
+      expect(DATA_TYPES[type], `cascade_write has no data type "${type}"`).toBeDefined();
+      expect(TYPE_MAPPING[type], `TYPE_MAPPING has no entry for "${type}"`).toBeDefined();
+    }
+    console.log(
+      `[mcp-write-conformance] ${fixtures.length} root fixtures: ` +
+        `${mapped.length} map to a cascade_write data type, ${unmapped.length} do not ` +
+        `(${[...new Set(unmapped.map((f) => f.dataType ?? 'untyped'))].sort().join(', ')})`,
+    );
+  });
+
+  const { store, shapeFiles } = loadShapes();
+
+  const failures: Array<{ id: string; issues: string[] }> = [];
+
+  for (const fixture of mapped) {
+    const mcpType = FIXTURE_TYPE_TO_MCP_TYPE[fixture.dataType!];
+    const expectedFailure = EXPECTED_FAILURES[fixture.id];
+
+    it(`${fixture.id} (${mcpType})${expectedFailure ? ' — known write-path gap' : ''}`, () => {
+      const uri = (fixture.input!.id as string) ?? `urn:uuid:${fixture.id}`;
+      const turtle =
+        generatePrefixes() +
+        '\n' +
+        buildRecordTurtle(
+          uri,
+          mcpType,
+          DATA_TYPES[mcpType],
+          mcpRecordFor(mcpType, fixture.input!),
+          { agentId: 'conformance-test-agent', reason: 'Shape conformance check' },
+          '2026-01-01T00:00:00.000Z',
+        );
+
+      const result = validateTurtle(turtle, store, shapeFiles, `${fixture.id}.ttl`);
+      const violations = result.results.filter((r) => r.severity === 'violation');
+      const rendered = violations.map((v) => `${v.shape} ${v.property}: ${v.message}`);
+
+      if (violations.length > 0) failures.push({ id: fixture.id, issues: rendered });
+
+      if (expectedFailure) {
+        // The list may only shrink. A listed fixture that now conforms must be
+        // removed from EXPECTED_FAILURES rather than left as dead weight.
+        expect(
+          violations.length,
+          `${fixture.id} is listed in EXPECTED_FAILURES ("${expectedFailure}") but now conforms — remove it from the list`,
+        ).toBeGreaterThan(0);
+        return;
+      }
+
+      expect(rendered, `${fixture.id} violates its shape`).toEqual([]);
+    });
+  }
+
+  it('reports every violating fixture in one place', () => {
+    if (failures.length > 0) {
+      console.log(
+        `[mcp-write-conformance] ${failures.length} of ${mapped.length} mapped fixtures violate their shape:\n` +
+          failures.map((f) => `  ${f.id}\n    ${f.issues.join('\n    ')}`).join('\n'),
+      );
+    }
+    const unexpected = failures.filter((f) => !EXPECTED_FAILURES[f.id]);
+    expect(unexpected.map((f) => f.id)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The defect

`buildRecordTurtle` — the function behind the `cascade_write` MCP tool — emitted

```turtle
    cascade:dataProvenance cascade:AIGenerated ;
```

on every record. `cascade:AIGenerated` is declared in no vocabulary, and all 29
`cascade:dataProvenance` property shapes constrain the value with an `sh:in`
whose set is `ClinicalGenerated, EHRVerified, DeviceGenerated, PatientReported,
SelfReported, AIExtracted`. Every record an agent wrote through the CLI
therefore violated its own shape at the moment it was written. Nothing caught
it because no test validated MCP output against the shapes.

The blank node under `prov:wasGeneratedBy` carried the same undeclared class as
an `rdf:type`.

## The fix

`cascade:AIExtracted` (a `cascade:ClinicalGenerated` subclass, "Data extracted
from clinical documents using AI/NLP processing") is the only value in those
`sh:in` sets that covers agent-authored content, so it is what the write path
now emits. The tool contract is unchanged — an agent still cannot choose its own
provenance.

`cascade:AIAsserted` was considered and rejected: it exists, but it means
content surfaced by a general-purpose assistant in a patient conversation, it is
scoped to `evidence:Assertion`, and it appears in no `dataProvenance` `sh:in`
set.

The activity blank node is now a bare `prov:Activity`. The subclass that looks
right, `cascade:AIExtractionActivity`, means an LLM extraction run over
narrative text, and its shape requires `cascade:extractionModel` and
`cascade:extractionConfidence` — neither of which this path has, because it is
not extracting from a document. Typing the node as one would trade an undeclared
class for a false claim (measured: it turned the 35 provenance violations into
70 missing-property violations).

Also corrected: the `cascade_write` tool description, the write result payload's
`provenance.type`, the MCP server instructions, and the provenance lines in the
`cascade_capabilities` tool and the `cascade capabilities` command — all named
the same non-existent term.

## The test

`tests/mcp-write-conformance.test.ts` drives `generatePrefixes` +
`buildRecordTurtle` (the two functions `cascade_write` calls) over the root
record fixtures in the conformance corpus and validates each result with the
CLI's own SHACL validator against the pinned `src/shapes/`.

Corpus: 92 root fixtures; 30 are negative (`shouldAccept: false`) records built
to violate a shape, and are excluded because the write path faithfully
serializing one still produces a violation — that measures the fixture, not the
writer. Of the 62 remaining, **35 map** to one of the seven `cascade_write` data
types and **27 do not** (BenefitStatement, ClaimRecord, Coverage,
DailyActivitySnapshot, DailySleepSnapshot, DailyVitalReading, DenialNotice,
Encounter, FamilyHistory, ImagingStudy, ImplantedDevice, MedicationAdministration,
PatientProfile, PodStructure, Procedure, ProxyAgent, SocialHistoryRecord). The
unmapped count is printed by the run, not silently dropped.

Scope is shapes only. No identity or determinism guard is asserted here: the
record IRI comes from the fixture, and nothing about IRI minting is checked.

**RED before the fix: 35 of 35 mapped fixtures**, every one on `sh:in` for
`cascade:dataProvenance` ("Value is not one of the allowed values: …
ClinicalGenerated, EHRVerified, DeviceGenerated …"). Measured by flipping the
literal back on the finished test.

## Expected-failure list

10 of the 35 still violate after the fix, all from `PROPERTY_PREDICATES` being
one flat JSON-key-to-predicate map shared by all seven record kinds. These are
named in `EXPECTED_FAILURES` with predicate and reason, and are deliberately not
fixed here — giving that map a per-type dimension is a larger change. The list
can only shrink: a listed fixture that starts conforming fails the test.

| Fixtures | Predicate | Reason |
|---|---|---|
| med-001 … med-007, med-011 (8) | `clinical:status` | `isActive: true` maps to `clinical:status` and serializes as a bare `true` (xsd:boolean); the shape requires an xsd:string status word |
| lab-009 | `health:performedDate` | `formatTurtleValue` stamps `^^xsd:dateTime` on any key containing "date"/"time" regardless of precision, so `"2031-02-09"` becomes an ill-formed dateTime — neither `xsd:date` nor a valid `xsd:dateTime` |
| supp-001 | `clinical:regulatoryStatus` | no `PROPERTY_PREDICATES` entry, so the field is dropped and the required predicate is absent |

The remaining 25 mapped fixtures conform.

## Occurrence count — no migration added

Occurrences of the wrong literal in stored data:

- `conformance/reference-patient-pod/`: **0**
- test pods under `cascade-cli/tests/`: **0**

The only occurrence under `tests/` was a source-level assertion in
`tests/mcp-server.test.ts` asserting the old literal, which is updated in this
PR. No Pod on disk carries `cascade:AIGenerated`, so no `pod reconcile` rewrite
step was added.

## Counts

| | Files | Passed | Skipped | Failed |
|---|---|---|---|---|
| Baseline (`origin/main`, 991862a) | 167 | 2693 | 0 | 0 |
| This branch | 168 | 2730 | 0 | 0 |

`npx tsc --noEmit` clean. Built (`npm run build`) before both suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)