### PR TITLE
fix(identity): order identity keys and set members by Unicode code point

### DIFF
--- a/src/lib/fhir-converter/types.ts
+++ b/src/lib/fhir-converter/types.ts
@@ -352,6 +352,79 @@ const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[
  *   deterministicUuid("hello") == "aaf4c61d-dcc5-58a2-9abe-de0f3b482cd9"
  *   (verify this value before using in any SDK implementation)
  */
+/**
+ * Compare two strings by Unicode CODE POINT, ascending. The identity comparator.
+ *
+ * MIRRORS `compareCodePoints` IN THE TYPESCRIPT SDK (`sdk-typescript`,
+ * `src/utils/deterministic-uri.ts`), deliberately as a second copy rather than
+ * as a dependency: this repository does not depend on that package, and a
+ * shared identity comparator that only one of the two can reach is worse than
+ * two copies that the shared conformance vectors hold to the same answer.
+ * `tests/identity-conformance-vectors.test.ts` is what keeps them honest — both
+ * copies are measured against the same file, so a divergence between them
+ * surfaces as a failing vector in whichever one drifted.
+ *
+ * WHY JAVASCRIPT'S TWO OBVIOUS CHOICES ARE BOTH WRONG HERE.
+ *
+ * Not `localeCompare`. core v3.6 states the rule normatively on
+ * `cascade:cascadeUri`: "Sort ascending by Unicode code point. (Code point, not
+ * locale collation: a locale-dependent order would make identity depend on the
+ * machine.)" A collator orders `alpha` before `Zeta` and `_under` before
+ * `Alpha`; code point orders both the other way, and a collator's answer varies
+ * with locale and ICU build. An identifier is not an identifier if the machine
+ * that minted it is an input. This repository sorted identity keys that way
+ * until 2026-09.
+ *
+ * Not `<`/`>` or a bare `.sort()` either, which is the correction this function
+ * makes. Those compare UTF-16 CODE UNITS. Code-unit order and code-point order
+ * agree across the entire Basic Multilingual Plane and disagree on exactly one
+ * shape of input: an astral-plane character (>= U+10000, encoded as a surrogate
+ * pair whose leading unit is U+D800..U+DBFF) compared with a BMP character at
+ * or above U+E000. The leading surrogate is the lower unit, so the astral
+ * character sorts FIRST by code unit and LAST by code point. So `！` (U+FF01)
+ * and `𝔞` (U+1D51E) order oppositely under the two rules.
+ *
+ * Every JavaScript implementation shared the code-unit behaviour, so no
+ * identifier split BETWEEN them — but none agreed with the spec, and an
+ * implementation whose native string order is by code point (Python's,
+ * Swift's) disagrees with all of them on the same record. The conformance
+ * corpus measures it at both sort sites: `keyOrderVectors/key-order-astral-vs-bmp`
+ * for the keys and `multiValuedFieldVectors/condition-member-order-astral-vs-bmp`
+ * for the members. Both failed here before this function existed.
+ *
+ * WHAT IT COSTS. Correcting the comparator re-mints an identifier only where an
+ * astral character was sorted against a BMP character at or above U+E000, at
+ * either sort site. Every identifier over Basic-Multilingual-Plane content —
+ * every terminology code, date, name and URI this repository has ever hashed —
+ * is bit-identical before and after, because the two orders agree there by
+ * construction.
+ *
+ * Unpaired surrogates (a lone U+D800..U+DFFF, which `codePointAt` reports as
+ * itself) compare by their own value. They are not valid Unicode scalars, no
+ * canonical order for them exists to be right about, and the comparison stays
+ * total and deterministic, which is all identity needs of them.
+ */
+export function compareCodePoints(a: string, b: string): number {
+  if (a === b) return 0;
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    const ca = a.codePointAt(i)!;
+    const cb = b.codePointAt(j)!;
+    if (ca !== cb) return ca < cb ? -1 : 1;
+    // A code point above U+FFFF occupies two UTF-16 code units, everything else
+    // one. `ca === cb` here, so both sides advance by the same amount.
+    const width = ca > 0xffff ? 2 : 1;
+    i += width;
+    j += width;
+  }
+  // One side ran out; the shorter string is a prefix of the longer and sorts
+  // first, which is the same tie-break `<` applies, reached the same way.
+  if (i < a.length) return 1;
+  if (j < b.length) return -1;
+  return 0;
+}
+
 export function deterministicUuid(input: string): string {
   const hash = createHash('sha1').update(input).digest('hex');
   const v = ((parseInt(hash.slice(16, 18), 16) & 0x3f) | 0x80).toString(16).padStart(2, '0');
@@ -463,15 +536,8 @@ export function contentHashedUri(
   //
   // THE COMPARATOR IS EXPLICIT AND MUST STAY THAT WAY.
   //
-  // This sorted with `a.localeCompare(b)` until 2026-09. `localeCompare` asks
-  // ICU for the READER'S alphabet, and every Latin-script collation puts
-  // `alpha` before `Zeta` where code point puts `Zeta` first ('Z' is U+005A,
-  // 'a' is U+0061). That made the identity string, and therefore the URI, a
-  // function of the importing machine's locale as well as of the record — the
-  // one property an identifier may not have. The same document imported on two
-  // differently-configured machines would mint two URIs, so the pod would
-  // duplicate instead of reconcile and every cross-reference written by the
-  // other machine would dangle. `spec/ontologies/core/v1/core.ttl`,
+  // This sorted with `a.localeCompare(b)` until 2026-09, then with `<`/`>`,
+  // and now with `compareCodePoints`. `spec/ontologies/core/v1/core.ttl`,
   // `cascade:cascadeUri`, "CANONICAL FORM OF A MULTI-VALUED IDENTITY INPUT
   // (v3.6, NORMATIVE)", step 3, names the rule and its reason in one line:
   //
@@ -479,27 +545,26 @@ export function contentHashedUri(
   //    collation: a locale-dependent order would make identity depend on
   //    the machine.)"
   //
-  // `<`/`>` on JS strings compare UTF-16 CODE UNITS. That is the same order as
-  // code point for every character in the BMP, which is every character any
-  // identity key in this repo contains: every one is a lowercase-initial ASCII
-  // camelCase field name written literally in source, never a value derived
-  // from patient data, so no code or system URI can reach the comparator as a
-  // KEY. The two orders part only above U+FFFF, where a surrogate pair sorts
-  // by its lead unit (U+D800..U+DBFF) rather than by its scalar value — so an
-  // astral-plane key would sort below one in U+E000..U+FFFF. No such key exists
-  // and none can arrive without a source edit, but the caveat is stated rather
-  // than left implicit, because "code unit" and "code point" are not synonyms.
+  // `localeCompare` asks ICU for the READER'S alphabet, which made the identity
+  // string a function of the importing machine's locale as well as of the
+  // record — the one property an identifier may not have. `<`/`>` fixed that
+  // but compares UTF-16 CODE UNITS, which is code-point order everywhere on the
+  // Basic Multilingual Plane and NOT code-point order once an astral-plane
+  // character meets a BMP character at or above U+E000. See `compareCodePoints`
+  // for the whole statement, including which identifiers move as a result
+  // (only those, and no others).
   //
   // Written out rather than left to `.sort()`'s default because a bare
   // `.sort()` is indistinguishable at a glance from someone forgetting the
-  // comparator; `canonicalSetKey` below relies on that same default order, and
-  // this comparator is exactly it. `tests/identity-chokepoint.test.ts` bans
-  // `localeCompare` anywhere under the identity modules so the next writer
-  // cannot reintroduce it, and `tests/uri-generation.test.ts` pins both the
-  // ordering and the resulting URIs.
+  // comparator — and because the default is the code-unit order this line no
+  // longer uses. `tests/identity-chokepoint.test.ts` bans `localeCompare`
+  // anywhere under the identity modules so the next writer cannot reintroduce
+  // it, `tests/uri-generation.test.ts` pins both the ordering and the resulting
+  // URIs, and `tests/identity-conformance-vectors.test.ts` holds this line to
+  // the shared cross-implementation vectors.
   const content = Object.entries(contentFields)
     .filter(([, v]) => v != null && String(v).trim().length > 0)
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .sort(([a], [b]) => compareCodePoints(a, b))
     .map(([k, v]) => `${k}=${String(v)}`)
     .join('|');
 
@@ -667,7 +732,13 @@ export function canonicalSetKey(parts: string[], separator: string): string | un
     const t = p.trim();
     if (t.length > 0) seen.add(t);
   }
-  return seen.size > 0 ? [...seen].sort().join(separator) : undefined;
+  // `compareCodePoints`, not a bare `.sort()`: the default comparator is UTF-16
+  // code-unit order, which parts from the code-point order core v3.6 requires
+  // as soon as an astral-plane member meets a BMP member at or above U+E000.
+  // This was the LATENT half of that divergence — the key sort had a
+  // conformance vector and this one did not, so a fix reaching only the keys
+  // would have read as fully green while still splitting such a record.
+  return seen.size > 0 ? [...seen].sort(compareCodePoints).join(separator) : undefined;
 }
 
 /**

--- a/tests/identity-conformance-vectors.test.ts
+++ b/tests/identity-conformance-vectors.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The shared conformance identity vectors, executed against this repository's
+ * identity functions.
+ *
+ * WHY THIS FILE EXISTS. `conformance/fixtures/deterministic-ids/test-vectors.json`
+ * is the cross-implementation contract for CDP-UUID: the primitive digest, the
+ * identity string, the canonical form of a set-valued field, and the order of
+ * the identity keys. cascade-cli mints those identifiers and had never read the
+ * file. Its identity behaviour was pinned only by golden values written inside
+ * this repository, which is a test of self-consistency: it catches a drift from
+ * yesterday's cascade-cli, and cannot catch a disagreement with the protocol or
+ * with another implementation, which is the failure that actually splits a
+ * record across two tools.
+ *
+ * WHAT IT ASSERTS. Every group in the file, including `keyOrderVectors` and the
+ * member-order entries in `multiValuedFieldVectors` — not a chosen subset, so a
+ * vector added upstream arrives here as a failing test rather than as silence.
+ *
+ * HOW ARRAY-VALUED FIELDS ARE FED. `contentHashedUri` here takes
+ * `Record<string, string | undefined>`; the canonical form of a set-valued
+ * field is applied by the CALLER, through `canonicalSetKey`, because the
+ * separator is a per-site parameter in this repository (',' at two sites, ';'
+ * at one, each kept because changing it would re-mint every identifier the site
+ * ever produced). So a vector whose `contentFields` holds an array is fed
+ * through `canonicalSetKey(members, ',')` first — the recommended separator,
+ * which is what the file's `expectedUri` values are computed with — and the
+ * composition of the two functions is what the vector measures. That
+ * composition is exactly what every real call site does.
+ *
+ * PATH RESOLUTION. The conformance fixture directory is resolved through the
+ * `conformance` sibling symlink, and `CASCADE_CONFORMANCE_DIR` overrides it for
+ * a run against a conformance feature branch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  deterministicUuid,
+  contentHashedUri,
+  canonicalSetKey,
+} from '../src/lib/fhir-converter/types.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CONFORMANCE_DIR =
+  process.env.CASCADE_CONFORMANCE_DIR ?? path.resolve(HERE, '..', '..', 'conformance');
+const VECTORS_PATH = path.join(
+  CONFORMANCE_DIR,
+  'fixtures',
+  'deterministic-ids',
+  'test-vectors.json',
+);
+
+interface FieldVector {
+  label: string;
+  proves: string[];
+  resourceType: string;
+  contentFields: Record<string, string | string[]>;
+  canonicalIdentityString: string;
+  expectedUri: string;
+}
+
+interface Vectors {
+  version: string;
+  primitiveVectors: Array<{ label: string; input: string; expectedUuid: string }>;
+  contentHashedUriVectors: Array<{ label: string; identityString: string; expectedUri: string }>;
+  multiValuedFieldVectors?: FieldVector[];
+  keyOrderVectors?: FieldVector[];
+}
+
+const vectors = JSON.parse(readFileSync(VECTORS_PATH, 'utf-8')) as Vectors;
+
+/** Apply the canonical form of a set-valued field, as every real call site does. */
+function flatten(fields: Record<string, string | string[]>): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    out[k] = Array.isArray(v) ? canonicalSetKey(v, ',') : v;
+  }
+  return out;
+}
+
+describe('conformance identity vectors', () => {
+  // A `for` loop over an array that has quietly become empty generates zero
+  // `it()` blocks and the suite reports green for having tested nothing.
+  // readFileSync catches a MISSING file; it does not catch a hollowed-out one,
+  // and the two look identical from here.
+  it('every vector group is present and non-empty', () => {
+    expect(vectors.primitiveVectors?.length, 'primitiveVectors').toBeGreaterThan(0);
+    expect(vectors.contentHashedUriVectors?.length, 'contentHashedUriVectors').toBeGreaterThan(0);
+    expect(vectors.multiValuedFieldVectors?.length, 'multiValuedFieldVectors').toBeGreaterThan(0);
+    expect(vectors.keyOrderVectors?.length, 'keyOrderVectors').toBeGreaterThan(0);
+  });
+
+  // The astral vectors are the only ones that discriminate Unicode code-point
+  // order from the UTF-16 code-unit order a JavaScript string comparison
+  // performs. Every other vector passes under either rule, so a checkout that
+  // had lost these two would leave this file fully green while proving nothing
+  // about the property it was added to protect. Asserted by label.
+  it('both astral-plane vectors are present, at the key sort and at the member sort', () => {
+    expect((vectors.keyOrderVectors ?? []).map((v) => v.label)).toContain(
+      'key-order-astral-vs-bmp',
+    );
+    expect((vectors.multiValuedFieldVectors ?? []).map((v) => v.label)).toContain(
+      'condition-member-order-astral-vs-bmp',
+    );
+  });
+
+  for (const v of vectors.primitiveVectors) {
+    it(`primitiveVector: ${v.label}`, () => {
+      expect(deterministicUuid(v.input)).toBe(v.expectedUuid);
+    });
+  }
+
+  // Fed as a pre-flattened identity string, parsed back into fields. This
+  // checks the digest and the identity-string layout; the two groups below
+  // check the canonicalization that produces that string.
+  for (const v of vectors.contentHashedUriVectors) {
+    it(`contentHashedUriVector: ${v.label}`, () => {
+      const [resourceType, fieldsPart] = v.identityString.split('::');
+      const fields: Record<string, string> = {};
+      for (const pair of fieldsPart.split('|')) {
+        const eq = pair.indexOf('=');
+        fields[pair.slice(0, eq)] = pair.slice(eq + 1);
+      }
+      expect(contentHashedUri(resourceType, fields)).toBe(v.expectedUri);
+    });
+  }
+
+  for (const v of vectors.multiValuedFieldVectors ?? []) {
+    it(`multiValuedFieldVector: ${v.label} [${v.proves.join(', ')}]`, () => {
+      expect(contentHashedUri(v.resourceType, flatten(v.contentFields))).toBe(v.expectedUri);
+    });
+  }
+
+  for (const v of vectors.keyOrderVectors ?? []) {
+    it(`keyOrderVector: ${v.label} [${v.proves.join(', ')}]`, () => {
+      expect(contentHashedUri(v.resourceType, flatten(v.contentFields))).toBe(v.expectedUri);
+    });
+  }
+});


### PR DESCRIPTION
core v3.6 states the identity sort rule normatively on `cascade:cascadeUri`:

> Sort ascending by Unicode code point. (Code point, not locale collation: a locale-dependent order would make identity depend on the machine.)

This repository sorted identity keys with `(a < b ? -1 : a > b ? 1 : 0)` and set
members with a bare `.sort()`. Both compare UTF-16 **code units**, which is
code-point order everywhere on the Basic Multilingual Plane and not code-point
order once an astral-plane character (a surrogate pair, leading unit
U+D800..U+DBFF) meets a BMP character at or above U+E000: the leading surrogate
is the lower unit, so the astral character sorts first by code unit and last by
code point.

## Depends on the conformance PR

The member vector this branch asserts against comes from
`the-cascade-protocol/conformance#21`
(`multiValuedFieldVectors/condition-member-order-astral-vs-bmp`). The runs below
used `CASCADE_CONFORMANCE_DIR` pointed at that branch. Merge it first.

**CI on this PR is expected RED until conformance#21 merges.** This repository's CI
checks out `the-cascade-protocol/conformance` at its default branch, which does
not yet carry `condition-member-order-astral-vs-bmp`. The by-label presence
assertion is what fails, deliberately: it is the guard that stops a fixture
checkout without the astral vectors from reading as a green run. It goes green
the moment conformance#21 lands, with no change here.

## This repository had never read the shared vectors

That is half of what this PR fixes. cascade-cli mints CDP-UUIDs, and its
identity behaviour was pinned only by golden values written inside this
repository — a test of self-consistency, which catches a drift from yesterday's
build and cannot catch a disagreement with the protocol or with another
implementation, which is the failure that actually splits a record across two
tools.

`tests/identity-conformance-vectors.test.ts` executes **every group** in
`fixtures/deterministic-ids/test-vectors.json` — `primitiveVectors`,
`contentHashedUriVectors`, `multiValuedFieldVectors` and `keyOrderVectors` — not
a chosen subset, so a vector added upstream arrives here as a failing test
rather than as silence. It also asserts both astral vectors are present **by
label**: every other vector passes under either sort rule, so a checkout that had
lost them would leave the file fully green while proving nothing.

Array-valued fields are fed through `canonicalSetKey(members, ',')` before
`contentHashedUri`, because in this repository the separator is a per-site
parameter (`,` at two sites and `;` at one, each kept because changing it would
re-mint every identifier that site ever produced). That composition is exactly
what every real call site does, and it is what the vector measures.

## RED observed before the fix

Against main's comparators, with the conformance member vector in place:

```
FAIL tests/identity-conformance-vectors.test.ts > multiValuedFieldVector: condition-member-order-astral-vs-bmp
FAIL tests/identity-conformance-vectors.test.ts > keyOrderVector: key-order-astral-vs-bmp
     expected 'urn:uuid:3dabab92-db40-5b56-9d37-227d01b602db'
           to be 'urn:uuid:94048491-e370-5d1e-9372-25a5dfd23966'
 Test Files  1 failed (1)
      Tests  2 failed | 23 passed (25)
```

`3dabab92-…` is exactly the value the conformance corpus had already recorded
for this repository on 2026-09-03, so the RED is the known divergence and
nothing else.

## Vector pass matrix

| vector | group | before | after |
| --- | --- | --- | --- |
| `key-order-insertion-independence-a` | keyOrderVectors | PASS | PASS |
| `key-order-insertion-independence-b` | keyOrderVectors | PASS | PASS |
| `key-order-underscore-after-uppercase` | keyOrderVectors | PASS | PASS |
| `key-order-bmp-non-ascii-control` | keyOrderVectors | PASS | PASS |
| `key-order-astral-vs-bmp` | keyOrderVectors | **FAIL** | PASS |
| `condition-member-order-astral-vs-bmp` | multiValuedFieldVectors | **FAIL** | PASS |
| 7 other `multiValuedFieldVectors` | multiValuedFieldVectors | PASS | PASS |
| 8 `contentHashedUriVectors`, 1 `primitiveVectors` | — | PASS | PASS |

## URI-stability proof

Two independent checks.

**1. The corpus dump.** Every deterministic URI these functions mint over the
shared conformance corpus, sorted, one per line: 60,152 URIs across 166 fixture
files, covering each object's full field set, that set reversed, every single
field, and every unordered pair — pairs being where a comparator is actually
exercised, since a two-key identity string is decided by exactly one comparison,
so every key in the corpus lands on both sides of one. Array fields go through
`canonicalSetKey`, as every real call site does.

**7 rows move.** All seven are inside `deterministic-ids/test-vectors.json` and
all seven are the astral vectors themselves. Across the other 165 fixture files:
**59,507 URIs, zero differences.**

```
   2 < deterministic-ids/test-vectors.json  all
   2 < deterministic-ids/test-vectors.json  all-reversed
   1 < deterministic-ids/test-vectors.json  one:snomedCode
   1 < deterministic-ids/test-vectors.json  pair:patient+snomedCode
   1 < deterministic-ids/test-vectors.json  pair:𝔞+！
   (and the seven corresponding > lines)
```

The same dump taken from the TypeScript SDK at its matching branch agrees with
this one **row for row** on all 60,145 URIs both implementations mint
deterministically. The 7 remaining rows are ones where that SDK takes its
documented random fallback and this repository has a deterministic sentinel tier
instead — a pre-existing difference in tier coverage, not in ordering.

**2. The existing golden and migration suites.** `tests/uri-generation.test.ts`
pins both the key ordering and the resulting URIs; `tests/pathology-corpus.test.ts`
(177 golden cases), the C-CDA, FHIR-genomics, phenopacket, VRS and ClinVar
conformance suites and the reference-pod MCP tests all mint identities through
these two functions. All green, unchanged.

## Test counts

| run | files | tests | failed | skipped |
| --- | --- | --- | --- | --- |
| `origin/main`, baseline | 167 | 2693 | 0 | 0 |
| main comparators + the new vector test (RED) | 168 | 2718 | 2 | 0 |
| this branch | 168 | **2718** | **0** | **0** |

Built before every suite run (`npm run build`), and `npx tsc --noEmit` clean
alongside vitest — vitest does not typecheck, so a green suite is not a green
compile.

## What changed

- **`compareCodePoints(a, b)`** in `src/lib/fhir-converter/types.ts`. Iterates
  `codePointAt`, advancing two UTF-16 units for a code point above U+FFFF. A
  comment says it is a deliberate second copy of the TypeScript SDK's helper —
  this repository does not depend on that package, and a shared comparator only
  one of the two can reach would be worse than two copies the shared conformance
  vectors hold to the same answer. Unpaired surrogates compare by their own
  value; they are not valid scalars, no canonical order for them exists to be
  right about, and the comparison stays total and deterministic.
- Both sort sites use it: `contentHashedUri`'s key sort and `canonicalSetKey`'s
  member sort. The member sort was the latent half — it had no vector before the
  conformance PR, so a fix reaching only the keys would have read as fully green
  while still splitting a record whose field held an astral member.
- The existing comparator comment is rewritten to record all three states this
  line has been in (`localeCompare`, then `<`/`>`, now code point) and why each
  earlier one was wrong.

## Other sort sites found and deliberately left alone

Grepping `src/` for `localeCompare` and bare `.sort()` beyond the two identity
sites:

| site | what it orders | why left alone |
| --- | --- | --- |
| `src/lib/identity.ts` `stableStringify` | object keys of a canonical JSON digest | Identity-bearing, and the same latent code-unit divergence — worth a follow-up, but it is a different digest with its own golden pins and does not belong in this change. |
| `src/lib/vrs-converter/allele.ts` `canonicalize` | object keys of the VRS digest payload | Identity-bearing, but this one is a JCS-shaped canonicalization, and RFC 8785 specifies UTF-16 code-unit order, so a bare `.sort()` may be the CORRECT rule here. Changing it without settling that would be a guess. |
| `src/lib/reconciler.ts` (`parts.sort()` and six others) | fingerprint parts, candidate and id lists | Reconciliation grouping and display, not minted identity. |
| `src/lib/phenopacket-converter/variation-descriptor.ts` | content-seed object keys | Identity-bearing via `contentSeed`; same follow-up class as `stableStringify`. |
| `src/lib/shacl-validator.ts`, `src/commands/validate.ts`, `src/commands/pod/reconcile.ts`, `src/commands/pod/import.ts` (`localeCompare`) | report and console output ordering | Presentation. A collator is the right choice for something a person reads. |
| `src/lib/literal-lifting.ts`, `src/lib/shape-datatypes.ts`, `src/lib/pod-read.ts`, `src/lib/user-resolutions.ts`, `src/commands/sources.ts`, `src/commands/pod/graph.ts`, `src/lib/fhir-converter/field-coverage/*`, `src/lib/ccda-converter/sections/labs.ts` | file lists, candidate sets, coverage manifests, a min-date pick | None feeds an identifier. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
